### PR TITLE
Phase 52: nt_ui module skeleton + walker MVP

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -33,5 +33,5 @@ Checks: >
   -cert-int09-c,
   -bugprone-macro-parentheses
 WarningsAsErrors: '*'
-HeaderFilterRegex: '(engine|shared|tools|examples|tests)[/\\\\]'
+HeaderFilterRegex: '[/\\\\](engine|shared|tools|examples|tests)[/\\\\]'
 FormatStyle: file

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@ tools/research/*.exe
 .DS_Store
 Thumbs.db
 
+# Shell crash dumps (Cygwin/MSYS bash on Windows)
+*.stackdump
+
 # Node
 node_modules/
 package-lock.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,6 +7,7 @@ set(NT_ENGINE_ROOT "${CMAKE_CURRENT_SOURCE_DIR}" CACHE PATH "Engine source root"
 
 # Warning and sanitizer flag functions (applied per-target, not globally)
 include(cmake/warnings.cmake)
+include(cmake/test_target.cmake)
 include(cmake/nt_module.cmake)
 include(cmake/nt_shell.cmake)
 

--- a/cmake/test_target.cmake
+++ b/cmake/test_target.cmake
@@ -1,0 +1,32 @@
+# Shared per-test-target setup. Bundles the boilerplate repeated under
+# every add_executable in tests/CMakeLists.txt:
+#   - -U_DLL: MSVC CRT workaround (link against static CRT, not the DLL one)
+#   - nt_set_warning_flags / nt_set_sanitizer_flags
+#   - RUNTIME_OUTPUT_DIRECTORY: keep test binaries in build/tests/<preset>/
+#   - add_test for ctest registration
+#
+# Optional WORKING_DIRECTORY argument: sets the cwd for ctest invocation.
+# Tests that need to read files from the source tree use this.
+#
+# Usage:
+#   nt_setup_test_target(test_foo)
+#   nt_setup_test_target(test_foo WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
+
+function(nt_setup_test_target target_name)
+    cmake_parse_arguments(ARG "" "WORKING_DIRECTORY" "" ${ARGN})
+
+    target_compile_options(${target_name} PRIVATE -U_DLL)
+    nt_set_warning_flags(${target_name})
+    nt_set_sanitizer_flags(${target_name})
+    set_target_properties(${target_name} PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}"
+    )
+
+    if(ARG_WORKING_DIRECTORY)
+        add_test(NAME ${target_name} COMMAND ${target_name}
+            WORKING_DIRECTORY "${ARG_WORKING_DIRECTORY}"
+        )
+    else()
+        add_test(NAME ${target_name} COMMAND ${target_name})
+    endif()
+endfunction()

--- a/docs/neotolis_engine_spec_1.md
+++ b/docs/neotolis_engine_spec_1.md
@@ -235,12 +235,17 @@ resource_step         ← async loading processing
 game-defined resource sync helpers
     → e.g. sprite_comp_sync_resources() after resource publication changes
 audio_update          ← voice state management
+nt_mem_scratch_reset  ← frame scratch arena cleared (see §5.2)
 fixed_update loop
-game_update
+game_update           ← CLAY layout, NT_UI_DATA_* allocations
 transform_update
-game_render
-frame_temp_reset
+game_render           ← nt_ui_walk reads scratch pointers
 ```
+
+`nt_mem_scratch_reset()` MUST run before any scratch allocation in the
+current frame — typically right after `audio_update`. Allocating then
+resetting in the same frame invalidates pointers already handed to
+systems (e.g. `nt_ui` retains them through `nt_ui_walk`).
 
 ## 4.3 Fixed update loop
 
@@ -336,7 +341,20 @@ Examples: loaded pack blob, manifest read buffer, temporary decompression buffer
 
 Lifetime = single frame.
 
-Examples: render item arrays, temporary sort arrays, transient CPU batch buffers, build temp lists in render pass.
+Examples: render item arrays, temporary sort arrays, transient CPU batch buffers, build temp lists in render pass, `nt_ui_element_data_t` attached to CLAY elements via `NT_UI_DATA_*` macros.
+
+The engine provides a global bump arena in `engine/memory/nt_mem_scratch`:
+
+```c
+nt_mem_scratch_init(NT_MEM_SCRATCH_DEFAULT_SIZE_BYTES);  // boot, default 512 KB
+// per frame (see §4.2):
+nt_mem_scratch_reset();          // start of frame
+nt_mem_scratch_alloc(size, align);  // anywhere during the frame
+// pointers stay valid until the next nt_mem_scratch_reset()
+nt_mem_scratch_shutdown();       // exit
+```
+
+Type-safe macros: `NT_MEM_SCRATCH_ALLOC(T)`, `NT_MEM_SCRATCH_ALLOC_ARRAY(T, count)`.
 
 ## 5.3 Capacity policy
 

--- a/docs/neotolis_engine_spec_1.md
+++ b/docs/neotolis_engine_spec_1.md
@@ -339,7 +339,7 @@ Examples: loaded pack blob, manifest read buffer, temporary decompression buffer
 
 ### Frame scratch memory
 
-Lifetime = single frame.
+Lifetime: from allocation until the next `nt_mem_scratch_reset()` (typically the start of the next frame, see §4.2).
 
 Examples: render item arrays, temporary sort arrays, transient CPU batch buffers, build temp lists in render pass, `nt_ui_element_data_t` attached to CLAY elements via `NT_UI_DATA_*` macros.
 

--- a/docs/neotolis_engine_spec_1.md
+++ b/docs/neotolis_engine_spec_1.md
@@ -106,12 +106,23 @@ If a decision can be deferred without loss of base architecture — it is deferr
 - WebGPU backend implementation
 - scene editor / authoring editor
 - full UI framework (NOTE: Phase 51 introduces `nt_ui` — a minimal
-  immediate-mode layout + render bridge module that wraps Clay v0.14 as a
-  private layout backend. It is **not** a full UI framework — no widget
-  authoring tools, no styling pipeline beyond inline calls, no asset
-  hot-reload of UI definitions, no scene-graph integration. Game owns the
-  loop and render order; `nt_ui` provides building blocks per the engine's
-  "set of modules" principle. Clay does not leak into public headers.)
+  immediate-mode layout + render bridge module. It is **not** a full UI
+  framework — no widget authoring tools, no styling pipeline beyond
+  inline calls, no asset hot-reload of UI definitions, no scene-graph
+  integration. Game owns the loop and render order; `nt_ui` provides
+  building blocks per the engine's "set of modules" principle.
+
+  Clay v0.14 is vendored as a **public** dependency of `nt_ui`: game
+  code declares layout and widgets via `CLAY_*` macros directly,
+  while `nt_ui` owns lifecycle (contexts, themes, the walker that
+  turns Clay's render commands into sprite/text renderer calls). This
+  is a deliberate compromise — wrapping Clay's full surface in an
+  engine-owned adapter API would be ~100+ shim functions for no
+  benefit beyond hiding the dependency. The cost we accept is that
+  Clay's pinned API (`CLAY_PINNED_MAJOR/MINOR` enforced via
+  `_Static_assert` in `nt_ui.c`) becomes part of the engine's
+  publicly-promised surface; bumping Clay can require coordinated
+  game-side changes.)
 - hot reload of compiled native/WASM code
 - generic reflection-heavy system architecture
 - WebGL 1 support

--- a/engine/CMakeLists.txt
+++ b/engine/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_subdirectory(core)
+add_subdirectory(memory)
 add_subdirectory(pool)
 add_subdirectory(log)
 add_subdirectory(time)

--- a/engine/atlas/nt_atlas.c
+++ b/engine/atlas/nt_atlas.c
@@ -707,6 +707,24 @@ const uint16_t *nt_atlas_get_region_indices(nt_resource_t atlas, uint32_t region
     NT_ASSERT(region_index < ad->region_count && "nt_atlas_get_region_indices: region_index out of range");
     return &ad->indices[ad->regions[region_index].index_start];
 }
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+void nt_atlas_get_region_handles(nt_resource_t atlas, uint32_t region_index, nt_atlas_region_handles_t *out) {
+    NT_ASSERT(out != NULL && "nt_atlas_get_region_handles: out must be non-NULL");
+    NT_ASSERT(nt_resource_get_asset_type(atlas) == NT_ASSET_ATLAS && "nt_atlas_get_region_handles: handle is not an atlas resource");
+    const nt_atlas_data_t *ad = (const nt_atlas_data_t *)nt_resource_get_user_data(atlas);
+    NT_ASSERT(ad != NULL && "nt_atlas_get_region_handles on unresolved atlas");
+    NT_ASSERT(region_index < ad->region_count && "nt_atlas_get_region_handles: region_index out of range");
+    NT_ASSERT(ad->ipu > 0.0F && "atlas ipu must be set by atlas_on_post_resolve");
+
+    const nt_texture_region_t *r = &ad->regions[region_index];
+    out->region = r;
+    out->cached_pos = (const float(*)[2]) & ad->cached_pos[r->vertex_start];
+    out->raw_vertices = &ad->vertices[r->vertex_start];
+    out->indices = &ad->indices[r->index_start];
+    out->page_resource = ad->page_resources[r->page_index];
+    out->ipu = ad->ipu;
+}
 // #endregion
 // #endregion
 

--- a/engine/atlas/nt_atlas.c
+++ b/engine/atlas/nt_atlas.c
@@ -729,7 +729,7 @@ void nt_atlas_get_region_handles(nt_resource_t atlas, uint32_t region_index, nt_
 // #endregion
 
 // #region test access
-#ifdef NT_ATLAS_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
 
 const struct nt_atlas_data *nt_atlas_test_get_data(nt_resource_t atlas) { return (const nt_atlas_data_t *)nt_resource_get_user_data(atlas); }
 
@@ -826,5 +826,5 @@ void nt_atlas_test_set_ipu_and_recompute(struct nt_atlas_data *ad, float ipu) {
     atlas_precompute_all(ad);
 }
 
-#endif /* NT_ATLAS_TEST_ACCESS */
+#endif /* NT_TEST_ACCESS */
 // #endregion

--- a/engine/atlas/nt_atlas.h
+++ b/engine/atlas/nt_atlas.h
@@ -123,9 +123,8 @@ typedef struct {
 
 void nt_atlas_get_region_handles(nt_resource_t atlas, uint32_t region_index, nt_atlas_region_handles_t *out);
 
-/* ---- Test access (compiled only when NT_ATLAS_TEST_ACCESS is defined) ---- */
-
-#ifdef NT_ATLAS_TEST_ACCESS
+// #region test_access
+#ifdef NT_TEST_ACCESS
 
 /* Opaque forward declaration — the real nt_atlas_data_t lives in nt_atlas.c.
  * Tests poke at it via the raw-access helpers below, without needing a full
@@ -182,6 +181,7 @@ float nt_atlas_test_ipu(const struct nt_atlas_data *ad);
  * post_resolve metadata read path without standing up a resource system. */
 void nt_atlas_test_set_ipu_and_recompute(struct nt_atlas_data *ad, float ipu);
 
-#endif /* NT_ATLAS_TEST_ACCESS */
+#endif
+// #endregion
 
 #endif /* NT_ATLAS_H */

--- a/engine/atlas/nt_atlas.h
+++ b/engine/atlas/nt_atlas.h
@@ -107,11 +107,7 @@ const float (*nt_atlas_get_region_cached_pos(nt_resource_t atlas, uint32_t regio
 const nt_atlas_vertex_t *nt_atlas_get_region_raw_vertices(nt_resource_t atlas, uint32_t region_index);
 const uint16_t *nt_atlas_get_region_indices(nt_resource_t atlas, uint32_t region_index);
 
-/* Bundle accessor: every pointer a sprite-emit caller needs in one struct,
- * fetched by one resolve + one region lookup. Equivalent to calling
- * get_region + get_region_cached_pos + get_region_raw_vertices +
- * get_region_indices + get_page_resource + get_inverse_pixels_per_unit
- * individually, but does the atlas-data resolve once instead of six times. */
+/* One resolve + one region lookup; replaces six separate getters. */
 typedef struct {
     const nt_texture_region_t *region;
     const float (*cached_pos)[2];

--- a/engine/atlas/nt_atlas.h
+++ b/engine/atlas/nt_atlas.h
@@ -107,6 +107,22 @@ const float (*nt_atlas_get_region_cached_pos(nt_resource_t atlas, uint32_t regio
 const nt_atlas_vertex_t *nt_atlas_get_region_raw_vertices(nt_resource_t atlas, uint32_t region_index);
 const uint16_t *nt_atlas_get_region_indices(nt_resource_t atlas, uint32_t region_index);
 
+/* Bundle accessor: every pointer a sprite-emit caller needs in one struct,
+ * fetched by one resolve + one region lookup. Equivalent to calling
+ * get_region + get_region_cached_pos + get_region_raw_vertices +
+ * get_region_indices + get_page_resource + get_inverse_pixels_per_unit
+ * individually, but does the atlas-data resolve once instead of six times. */
+typedef struct {
+    const nt_texture_region_t *region;
+    const float (*cached_pos)[2];
+    const nt_atlas_vertex_t *raw_vertices;
+    const uint16_t *indices;
+    nt_resource_t page_resource;
+    float ipu;
+} nt_atlas_region_handles_t;
+
+void nt_atlas_get_region_handles(nt_resource_t atlas, uint32_t region_index, nt_atlas_region_handles_t *out);
+
 /* ---- Test access (compiled only when NT_ATLAS_TEST_ACCESS is defined) ---- */
 
 #ifdef NT_ATLAS_TEST_ACCESS

--- a/engine/basisu/CMakeLists.txt
+++ b/engine/basisu/CMakeLists.txt
@@ -7,7 +7,7 @@ add_library(nt_basisu_transcoder STATIC
     ${NT_ENGINE_ROOT}/deps/basisu/transcoder/basisu_transcoder.cpp
 )
 
-target_include_directories(nt_basisu_transcoder PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
+target_include_directories(nt_basisu_transcoder PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>)
 target_include_directories(nt_basisu_transcoder PRIVATE ${NT_ENGINE_ROOT}/deps/basisu/transcoder)
 
 # -fno-strict-aliasing required by Basis transcoder (TEX-10)

--- a/engine/core/nt_align.h
+++ b/engine/core/nt_align.h
@@ -1,0 +1,9 @@
+#ifndef NT_ALIGN_H
+#define NT_ALIGN_H
+
+/* Round x up to the next multiple of N. N MUST be a power of two
+ * (e.g. 8, 16, 64). Standard bit-trick: (x + N-1) masked to drop
+ * the low log2(N) bits. */
+#define NT_ALIGN_UP(x, N) (((x) + (N) - 1U) & ~((N) - 1U))
+
+#endif /* NT_ALIGN_H */

--- a/engine/core/nt_clamp.h
+++ b/engine/core/nt_clamp.h
@@ -1,0 +1,20 @@
+#ifndef NT_CLAMP_H
+#define NT_CLAMP_H
+
+#include <stdint.h>
+
+/* Saturate float to 0..255 and round-to-nearest. Input is already in
+ * 0..255 range; for 0..1 normalized input, scale first:
+ *   nt_clamp_f_to_u8(value * 255.0F).
+ * NaN propagates through the comparisons and produces 0 (safe default). */
+static inline uint8_t nt_clamp_f_to_u8(float v) {
+    if (v <= 0.0F) {
+        return 0U;
+    }
+    if (v >= 255.0F) {
+        return 255U;
+    }
+    return (uint8_t)(v + 0.5F);
+}
+
+#endif /* NT_CLAMP_H */

--- a/engine/drawable_comp/nt_drawable_comp.c
+++ b/engine/drawable_comp/nt_drawable_comp.c
@@ -5,6 +5,7 @@
 
 #include "comp_storage/nt_comp_storage.h"
 #include "core/nt_assert.h"
+#include "core/nt_clamp.h"
 #include "hash/nt_hash.h"
 
 static nt_comp_storage_t s_storage;
@@ -18,18 +19,9 @@ static uint32_t *s_colors_packed; /* RGBA8 mirror; setters keep in sync with s_c
 
 /* ---- Callbacks ---- */
 
-static inline uint8_t pack_u8_clamp(float c) {
-    if (c <= 0.0F) {
-        return 0;
-    }
-    if (c >= 1.0F) {
-        return 255;
-    }
-    return (uint8_t)((c * 255.0F) + 0.5F);
-}
-
+/* Normalized 0..1 input; scale to 0..255 then use the shared clamp. */
 static inline uint32_t pack_color_rgba(float r, float g, float b, float a) {
-    return (uint32_t)pack_u8_clamp(r) | ((uint32_t)pack_u8_clamp(g) << 8) | ((uint32_t)pack_u8_clamp(b) << 16) | ((uint32_t)pack_u8_clamp(a) << 24);
+    return (uint32_t)nt_clamp_f_to_u8(r * 255.0F) | ((uint32_t)nt_clamp_f_to_u8(g * 255.0F) << 8) | ((uint32_t)nt_clamp_f_to_u8(b * 255.0F) << 16) | ((uint32_t)nt_clamp_f_to_u8(a * 255.0F) << 24);
 }
 
 static void drawable_default(uint16_t idx) {

--- a/engine/font/nt_font.c
+++ b/engine/font/nt_font.c
@@ -1613,7 +1613,7 @@ static int16_t kern_with_left_in_slot(const nt_font_glyph_lookup_t *left, uint32
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-nt_text_size_t nt_font_measure_n(nt_font_t font, const char *utf8, size_t len, float size) {
+nt_text_size_t nt_font_measure_n(nt_font_t font, const char *utf8, size_t len, float size, float letter_spacing) {
     nt_text_size_t result = {0.0F, 0.0F};
 
     /* Edge cases. NULL utf8 with len > 0 is treated as empty input
@@ -1633,12 +1633,9 @@ nt_text_size_t nt_font_measure_n(nt_font_t font, const char *utf8, size_t len, f
         return result; /* font not yet resolved */
     }
 
-    /* Cache key — xxHash64 (upgraded from xxHash32 to eliminate false-positive
-     * cache hits over long sessions; see nt_font_measure_cache_t doc).
-     * When the cache is disabled (key_hashes == NULL — measure_cache_size
-     * was 0 at create), skip the key compute and go straight to the full
-     * measure path. */
-    const bool cache_enabled = (slot->measure_cache.key_hashes != NULL);
+    /* Non-zero letter_spacing changes the geometry per call; cache key
+     * doesn't include it (would double the SoA), so we skip the cache. */
+    const bool cache_enabled = (slot->measure_cache.key_hashes != NULL) && (letter_spacing == 0.0F);
     const uint64_t key_hash = cache_enabled ? nt_hash64((const void *)utf8, (uint32_t)len).value : 0U;
     const uint32_t size_bits = measure_size_bits(size);
     const uint32_t slot_index = (uint32_t)key_hash & slot->measure_cache_mask;
@@ -1681,6 +1678,7 @@ nt_text_size_t nt_font_measure_n(nt_font_t font, const char *utf8, size_t len, f
     float pen_x = 0.0F;
     float min_y = 0.0F;
     float max_y = 0.0F;
+    bool had_glyph = false;
 
     const uint8_t *p = (const uint8_t *)utf8;
     const uint8_t *end = p + len;
@@ -1691,6 +1689,10 @@ nt_text_size_t nt_font_measure_n(nt_font_t font, const char *utf8, size_t len, f
                 state = NT_UTF8_ACCEPT; /* recover: skip bad byte, continue parsing */
             }
             continue;
+        }
+
+        if (had_glyph) {
+            pen_x += letter_spacing;
         }
 
         /* Kern lookup — fully skipped on kerning-less fonts; for fonts that
@@ -1725,6 +1727,7 @@ nt_text_size_t nt_font_measure_n(nt_font_t font, const char *utf8, size_t len, f
         }
 
         prev_lookup = lookup;
+        had_glyph = true;
     }
 
     result.width = pen_x;
@@ -1746,7 +1749,7 @@ nt_text_size_t nt_font_measure_n(nt_font_t font, const char *utf8, size_t len, f
 }
 
 /* Wrapper — NUL-terminated convenience. */
-nt_text_size_t nt_font_measure(nt_font_t font, const char *utf8, float size) { return nt_font_measure_n(font, utf8, utf8 ? strlen(utf8) : 0U, size); }
+nt_text_size_t nt_font_measure(nt_font_t font, const char *utf8, float size, float letter_spacing) { return nt_font_measure_n(font, utf8, utf8 ? strlen(utf8) : 0U, size, letter_spacing); }
 // #endregion
 
 // #region Measure cache invalidation

--- a/engine/font/nt_font.c
+++ b/engine/font/nt_font.c
@@ -1613,7 +1613,7 @@ static int16_t kern_with_left_in_slot(const nt_font_glyph_lookup_t *left, uint32
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-nt_text_size_t nt_font_measure_n(nt_font_t font, const char *utf8, size_t len, float size, float letter_spacing) {
+nt_text_size_t nt_font_measure_n(nt_font_t font, const char *utf8, size_t len, float size, float letter_tracking) {
     nt_text_size_t result = {0.0F, 0.0F};
 
     /* Edge cases. NULL utf8 with len > 0 is treated as empty input
@@ -1633,9 +1633,9 @@ nt_text_size_t nt_font_measure_n(nt_font_t font, const char *utf8, size_t len, f
         return result; /* font not yet resolved */
     }
 
-    /* Non-zero letter_spacing changes the geometry per call; cache key
-     * doesn't include it (would double the SoA), so we skip the cache. */
-    const bool cache_enabled = (slot->measure_cache.key_hashes != NULL) && (letter_spacing == 0.0F);
+    /* Non-zero tracking changes geometry per call; cache key doesn't include
+     * it (would double the SoA), so we skip the cache. */
+    const bool cache_enabled = (slot->measure_cache.key_hashes != NULL) && (letter_tracking == 0.0F);
     const uint64_t key_hash = cache_enabled ? nt_hash64((const void *)utf8, (uint32_t)len).value : 0U;
     const uint32_t size_bits = measure_size_bits(size);
     const uint32_t slot_index = (uint32_t)key_hash & slot->measure_cache_mask;
@@ -1698,7 +1698,7 @@ nt_text_size_t nt_font_measure_n(nt_font_t font, const char *utf8, size_t len, f
         }
 
         if (had_glyph) {
-            pen_x += letter_spacing;
+            pen_x += letter_tracking;
         }
 
         /* Kern lookup — fully skipped on kerning-less fonts; for fonts that
@@ -1755,7 +1755,7 @@ nt_text_size_t nt_font_measure_n(nt_font_t font, const char *utf8, size_t len, f
 }
 
 /* Wrapper — NUL-terminated convenience. */
-nt_text_size_t nt_font_measure(nt_font_t font, const char *utf8, float size, float letter_spacing) { return nt_font_measure_n(font, utf8, utf8 ? strlen(utf8) : 0U, size, letter_spacing); }
+nt_text_size_t nt_font_measure(nt_font_t font, const char *utf8, float size, float letter_tracking) { return nt_font_measure_n(font, utf8, utf8 ? strlen(utf8) : 0U, size, letter_tracking); }
 // #endregion
 
 // #region Measure cache invalidation

--- a/engine/font/nt_font.c
+++ b/engine/font/nt_font.c
@@ -1691,6 +1691,12 @@ nt_text_size_t nt_font_measure_n(nt_font_t font, const char *utf8, size_t len, f
             continue;
         }
 
+        /* Match renderer: \r adds no width (nt_text_renderer_draw_n skips it).
+         * Clay splits on \n so multi-line slices may carry \r from CRLF. */
+        if (codepoint == '\r') {
+            continue;
+        }
+
         if (had_glyph) {
             pen_x += letter_spacing;
         }

--- a/engine/font/nt_font.c
+++ b/engine/font/nt_font.c
@@ -1648,13 +1648,13 @@ nt_text_size_t nt_font_measure_n(nt_font_t font, const char *utf8, size_t len, f
      * across all entries, so 8 adjacent slots' header data fits in one
      * cache line. values[] is only touched on a confirmed hit. */
     if (cache_enabled && slot->measure_cache.valid[slot_index] && slot->measure_cache.key_hashes[slot_index] == key_hash && slot->measure_cache.size_bits[slot_index] == size_bits) {
-#ifdef NT_FONT_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
         slot->test_measure_cache_hits++;
 #endif
         return slot->measure_cache.values[slot_index];
     }
 
-#ifdef NT_FONT_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
     if (cache_enabled) {
         slot->test_measure_cache_misses++;
     }
@@ -1786,7 +1786,7 @@ void nt_font_measure_invalidate(nt_font_t font) {
 
 /* ---- Test-only: register font data for headless testing ---- */
 
-#ifdef NT_FONT_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
 uint32_t nt_font_test_register_data(const uint8_t *data, uint32_t size) { return activate_font(data, size); }
 
 void nt_font_test_deactivate(uint32_t runtime_handle) { deactivate_font(runtime_handle); }

--- a/engine/font/nt_font.c
+++ b/engine/font/nt_font.c
@@ -1691,9 +1691,12 @@ nt_text_size_t nt_font_measure_n(nt_font_t font, const char *utf8, size_t len, f
             continue;
         }
 
-        /* Match renderer: \r adds no width (nt_text_renderer_draw_n skips it).
-         * Clay splits on \n so multi-line slices may carry \r from CRLF. */
+        /* Match renderer: \r adds no width AND breaks the kerning chain
+         * (nt_text_renderer_draw_n resets prev_cp on \r). Keep had_glyph
+         * so letter_tracking still applies on the next glyph. Clay splits
+         * on \n so multi-line slices may carry \r from CRLF. */
         if (codepoint == '\r') {
+            prev_lookup = (nt_font_glyph_lookup_t){0};
             continue;
         }
 

--- a/engine/font/nt_font.h
+++ b/engine/font/nt_font.h
@@ -95,10 +95,15 @@ typedef struct {
 /* Length-aware (Clay_StringSlice contract). NULL/len=0 → {0,0}; UTF-8 cut at
  * `len` boundary → trailing partial codepoint dropped; embedded NUL is a
  * normal codepoint (the NUL-terminated wrapper below stops at it via strlen).
- * letter_spacing adds N-1 extra pixels of horizontal gap for N visible
- * codepoints. Non-zero letter_spacing bypasses the measure cache. */
-nt_text_size_t nt_font_measure_n(nt_font_t font, const char *utf8, size_t len, float size, float letter_spacing);
-nt_text_size_t nt_font_measure(nt_font_t font, const char *utf8, float size, float letter_spacing);
+ * Single-line measurement (no \n handling -- Clay tokenizes per line).
+ *
+ * letter_tracking: EXTRA px added between glyphs (additive, NOT absolute).
+ *   0 = font's natural glyph advance. Positive = loose, negative = tight.
+ *   Adds (N-1) * tracking px for N visible codepoints.
+ *
+ * Non-zero tracking bypasses the measure cache. */
+nt_text_size_t nt_font_measure_n(nt_font_t font, const char *utf8, size_t len, float size, float letter_tracking);
+nt_text_size_t nt_font_measure(nt_font_t font, const char *utf8, float size, float letter_tracking);
 
 /* Both no-op on invalid/destroyed handles — safe to call from teardown. */
 void nt_font_measure_invalidate_cache(void);

--- a/engine/font/nt_font.h
+++ b/engine/font/nt_font.h
@@ -133,7 +133,8 @@ void nt_font_set_pre_flush_callback(nt_font_pre_flush_fn fn);
 
 int16_t nt_font_get_kern(nt_font_t font, uint32_t left_codepoint, uint32_t right_codepoint);
 
-#ifdef NT_FONT_TEST_ACCESS
+// #region test_access
+#ifdef NT_TEST_ACCESS
 uint32_t nt_font_test_register_data(const uint8_t *data, uint32_t size);
 
 /* Imitate the FILE-pack deactivator path (skipped for VIRTUAL packs). */
@@ -143,5 +144,6 @@ uint32_t nt_font_test_measure_cache_hits(nt_font_t font);
 uint32_t nt_font_test_measure_cache_misses(nt_font_t font);
 void nt_font_test_reset_measure_counters(void);
 #endif
+// #endregion
 
 #endif /* NT_FONT_H */

--- a/engine/font/nt_font.h
+++ b/engine/font/nt_font.h
@@ -94,9 +94,11 @@ typedef struct {
 
 /* Length-aware (Clay_StringSlice contract). NULL/len=0 → {0,0}; UTF-8 cut at
  * `len` boundary → trailing partial codepoint dropped; embedded NUL is a
- * normal codepoint (the NUL-terminated wrapper below stops at it via strlen). */
-nt_text_size_t nt_font_measure_n(nt_font_t font, const char *utf8, size_t len, float size);
-nt_text_size_t nt_font_measure(nt_font_t font, const char *utf8, float size);
+ * normal codepoint (the NUL-terminated wrapper below stops at it via strlen).
+ * letter_spacing adds N-1 extra pixels of horizontal gap for N visible
+ * codepoints. Non-zero letter_spacing bypasses the measure cache. */
+nt_text_size_t nt_font_measure_n(nt_font_t font, const char *utf8, size_t len, float size, float letter_spacing);
+nt_text_size_t nt_font_measure(nt_font_t font, const char *utf8, float size, float letter_spacing);
 
 /* Both no-op on invalid/destroyed handles — safe to call from teardown. */
 void nt_font_measure_invalidate_cache(void);

--- a/engine/font/nt_font_internal.h
+++ b/engine/font/nt_font_internal.h
@@ -71,7 +71,7 @@ struct nt_font_slot_s {
     uint16_t ascii_glyph_idx[128];
     uint8_t ascii_glyph_res[128];
 
-#ifdef NT_FONT_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
     uint32_t test_measure_cache_hits;
     uint32_t test_measure_cache_misses;
 #endif

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -90,7 +90,7 @@ static struct {
     uint8_t bound_index_type; /* index type of currently bound IBO (1=uint16, 2=uint32) */
     bool scissor_enabled;     /* mirrors GL_SCISSOR_TEST; read in begin_frame */
 
-    /* Mirrors of last set_scissor / set_viewport — only NT_GFX_TEST_ACCESS
+    /* Mirrors of last set_scissor / set_viewport — only NT_TEST_ACCESS
      * probes read them; production never does. */
     int scissor_rect[4];  /* GL bottom-left x,y,w,h */
     int viewport_rect[4]; /* GL bottom-left x,y,w,h */
@@ -627,7 +627,7 @@ nt_sampler_t nt_gfx_get_texture_default_sampler(nt_texture_t tex) {
     return s_gfx.texture_metas[nt_pool_slot_index(tex.id)].default_sampler;
 }
 
-#ifdef NT_GFX_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
 uint32_t nt_gfx_test_sampler_backend_id(nt_sampler_t s) {
     if (s.id == 0 || s.id > s_gfx.sampler_count) {
         return 0;

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -426,9 +426,8 @@ void nt_gfx_deactivate_shader(uint32_t handle);
 
 const nt_gfx_mesh_info_t *nt_gfx_get_mesh_info(nt_mesh_t mesh);
 
-/* ---- Test access (test-only) ---- */
-
-#ifdef NT_GFX_TEST_ACCESS
+// #region test_access
+#ifdef NT_TEST_ACCESS
 /* Read back the cached scissor enabled flag (last call to
  * nt_gfx_set_scissor_enabled). Default false at frame start. */
 bool nt_gfx_test_scissor_enabled(void);
@@ -439,5 +438,6 @@ void nt_gfx_test_scissor_rect(int out[4]);
  * nt_gfx_set_viewport call. Out-param must be a 4-element int array. */
 void nt_gfx_test_viewport_rect(int out[4]);
 #endif
+// #endregion
 
 #endif /* NT_GFX_H */

--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -100,14 +100,14 @@ bool nt_gfx_backend_is_gpu_timing_supported(void);
 void nt_gfx_backend_drop_timer_segments(void);
 // #endregion
 
-#ifdef NT_GFX_STUB_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
 /* Stub-only test hooks: inspect and reset bind_sampler observations. */
 uint32_t nt_gfx_stub_test_last_sampler(uint32_t slot);
 uint32_t nt_gfx_stub_test_bind_sampler_count(void);
 void nt_gfx_stub_test_reset(void);
 #endif
 
-#ifdef NT_GFX_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
 /* Real-backend test hook: inspect a sampler's GPU backend handle from the
  * dedup cache. Distinct from STUB_TEST_ACCESS — works against the real GL
  * (or any non-stub) backend, so a test running with the real backend can

--- a/engine/graphics/stub/nt_gfx_stub.c
+++ b/engine/graphics/stub/nt_gfx_stub.c
@@ -3,7 +3,7 @@
 /* No-op backend for headless builds and testing.
    Create functions return 1 (nonzero) so make_shader/pipeline/buffer succeed. */
 
-#ifdef NT_GFX_STUB_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
 #define NT_GFX_STUB_MAX_SLOTS 16
 static uint32_t s_stub_last_sampler[NT_GFX_STUB_MAX_SLOTS];
 static uint32_t s_stub_bind_sampler_count;
@@ -43,7 +43,7 @@ void nt_gfx_backend_begin_pass(const nt_pass_desc_t *desc) { (void)desc; }
 void nt_gfx_backend_end_pass(void) {}
 
 /* Scissor and viewport stub no-ops. State is cached in shared nt_gfx.c
- * so NT_GFX_TEST_ACCESS probes can read it back without GL. */
+ * so NT_TEST_ACCESS probes can read it back without GL. */
 void nt_gfx_backend_set_scissor(int x, int y, int w, int h) {
     (void)x;
     (void)y;
@@ -146,7 +146,7 @@ uint32_t nt_gfx_backend_create_sampler(const nt_sampler_desc_t *desc) {
 void nt_gfx_backend_destroy_sampler(uint32_t backend_handle) { (void)backend_handle; }
 
 void nt_gfx_backend_bind_sampler(uint32_t backend_handle, uint32_t slot) {
-#ifdef NT_GFX_STUB_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
     if (slot < NT_GFX_STUB_MAX_SLOTS) {
         s_stub_last_sampler[slot] = backend_handle;
     }

--- a/engine/log/nt_log.h
+++ b/engine/log/nt_log.h
@@ -32,12 +32,12 @@ void nt_log_write(nt_log_level_t level, const char *domain, const char *fmt, ...
 /* --- Once-per-callsite variants ---
  * Per-callsite static atomic_flag; logs on first call only. Not resettable.
  * Tests rely on per-process isolation (ctest runs each binary fresh). */
-#define NT_LOG_ONCE_(write_call)                                                  \
-    do {                                                                          \
-        static atomic_flag nt_log_once_flag_ = ATOMIC_FLAG_INIT;                  \
-        if (!atomic_flag_test_and_set_explicit(&nt_log_once_flag_, memory_order_relaxed)) { \
-            write_call;                                                           \
-        }                                                                         \
+#define NT_LOG_ONCE_(write_call)                                                                                                                                                                       \
+    do {                                                                                                                                                                                               \
+        static atomic_flag nt_log_once_flag_ = ATOMIC_FLAG_INIT;                                                                                                                                       \
+        if (!atomic_flag_test_and_set_explicit(&nt_log_once_flag_, memory_order_relaxed)) {                                                                                                            \
+            write_call;                                                                                                                                                                                \
+        }                                                                                                                                                                                              \
     } while (0)
 
 #define nt_log_info_once(...) NT_LOG_ONCE_(nt_log_write(NT_LOG_LEVEL_INFO, NULL, __VA_ARGS__))

--- a/engine/log/nt_log.h
+++ b/engine/log/nt_log.h
@@ -1,6 +1,8 @@
 #ifndef NT_LOG_H
 #define NT_LOG_H
 
+#include <stdatomic.h>
+
 /* Log levels (ordered by severity) */
 typedef enum {
     NT_LOG_LEVEL_INFO = 0,
@@ -27,6 +29,21 @@ void nt_log_write(nt_log_level_t level, const char *domain, const char *fmt, ...
 #define nt_log_warn(...) nt_log_write(NT_LOG_LEVEL_WARN, NULL, __VA_ARGS__)
 #define nt_log_error(...) nt_log_write(NT_LOG_LEVEL_ERROR, NULL, __VA_ARGS__)
 
+/* --- Once-per-callsite variants ---
+ * Per-callsite static atomic_flag; logs on first call only. Not resettable.
+ * Tests rely on per-process isolation (ctest runs each binary fresh). */
+#define NT_LOG_ONCE_(write_call)                                                  \
+    do {                                                                          \
+        static atomic_flag nt_log_once_flag_ = ATOMIC_FLAG_INIT;                  \
+        if (!atomic_flag_test_and_set_explicit(&nt_log_once_flag_, memory_order_relaxed)) { \
+            write_call;                                                           \
+        }                                                                         \
+    } while (0)
+
+#define nt_log_info_once(...) NT_LOG_ONCE_(nt_log_write(NT_LOG_LEVEL_INFO, NULL, __VA_ARGS__))
+#define nt_log_warn_once(...) NT_LOG_ONCE_(nt_log_write(NT_LOG_LEVEL_WARN, NULL, __VA_ARGS__))
+#define nt_log_error_once(...) NT_LOG_ONCE_(nt_log_write(NT_LOG_LEVEL_ERROR, NULL, __VA_ARGS__))
+
 /* --- Domain resolution --- */
 #ifndef NT_LOG_DOMAIN
 #ifdef NT_LOG_DOMAIN_DEFAULT
@@ -39,6 +56,9 @@ void nt_log_write(nt_log_level_t level, const char *domain, const char *fmt, ...
 #define NT_LOG_INFO(...) nt_log_write(NT_LOG_LEVEL_INFO, NT_LOG_DOMAIN, __VA_ARGS__)
 #define NT_LOG_WARN(...) nt_log_write(NT_LOG_LEVEL_WARN, NT_LOG_DOMAIN, __VA_ARGS__)
 #define NT_LOG_ERROR(...) nt_log_write(NT_LOG_LEVEL_ERROR, NT_LOG_DOMAIN, __VA_ARGS__)
+#define NT_LOG_INFO_ONCE(...) NT_LOG_ONCE_(NT_LOG_INFO(__VA_ARGS__))
+#define NT_LOG_WARN_ONCE(...) NT_LOG_ONCE_(NT_LOG_WARN(__VA_ARGS__))
+#define NT_LOG_ERROR_ONCE(...) NT_LOG_ONCE_(NT_LOG_ERROR(__VA_ARGS__))
 #else
 /* Compile error when domain macros used without domain defined */
 #define NT_LOG_INFO(...)                                                                                                                                                                               \

--- a/engine/log/nt_log.h
+++ b/engine/log/nt_log.h
@@ -1,7 +1,7 @@
 #ifndef NT_LOG_H
 #define NT_LOG_H
 
-#include <stdatomic.h>
+#include <stdbool.h>
 
 /* Log levels (ordered by severity) */
 typedef enum {
@@ -29,11 +29,15 @@ void nt_log_write(nt_log_level_t level, const char *domain, const char *fmt, ...
 #define nt_log_warn(...) nt_log_write(NT_LOG_LEVEL_WARN, NULL, __VA_ARGS__)
 #define nt_log_error(...) nt_log_write(NT_LOG_LEVEL_ERROR, NULL, __VA_ARGS__)
 
-/* --- Once-per-callsite variants (not resettable) --- */
+/* --- Once-per-callsite variants (not resettable) ---
+ * Single-threaded: WASM has one main thread, native debug/builder likewise.
+ * A race would produce at most a duplicate line, never UB. If multi-threaded
+ * logging is needed later, gate this on a build flag and switch to atomic_flag. */
 #define NT_LOG_ONCE_(write_call)                                                                                                                                                                       \
     do {                                                                                                                                                                                               \
-        static atomic_flag nt_log_once_flag_ = ATOMIC_FLAG_INIT;                                                                                                                                       \
-        if (!atomic_flag_test_and_set_explicit(&nt_log_once_flag_, memory_order_relaxed)) {                                                                                                            \
+        static bool nt_log_once_done_ = false;                                                                                                                                                         \
+        if (!nt_log_once_done_) {                                                                                                                                                                      \
+            nt_log_once_done_ = true;                                                                                                                                                                  \
             write_call;                                                                                                                                                                                \
         }                                                                                                                                                                                              \
     } while (0)

--- a/engine/log/nt_log.h
+++ b/engine/log/nt_log.h
@@ -29,9 +29,7 @@ void nt_log_write(nt_log_level_t level, const char *domain, const char *fmt, ...
 #define nt_log_warn(...) nt_log_write(NT_LOG_LEVEL_WARN, NULL, __VA_ARGS__)
 #define nt_log_error(...) nt_log_write(NT_LOG_LEVEL_ERROR, NULL, __VA_ARGS__)
 
-/* --- Once-per-callsite variants ---
- * Per-callsite static atomic_flag; logs on first call only. Not resettable.
- * Tests rely on per-process isolation (ctest runs each binary fresh). */
+/* --- Once-per-callsite variants (not resettable) --- */
 #define NT_LOG_ONCE_(write_call)                                                                                                                                                                       \
     do {                                                                                                                                                                                               \
         static atomic_flag nt_log_once_flag_ = ATOMIC_FLAG_INIT;                                                                                                                                       \

--- a/engine/math/CMakeLists.txt
+++ b/engine/math/CMakeLists.txt
@@ -13,7 +13,7 @@ target_compile_definitions(nt_math INTERFACE CGLM_ALL_UNALIGNED)
 # Mark cglm includes as SYSTEM so clang-tidy and -Werror skip them
 get_target_property(_cglm_inc cglm_headers INTERFACE_INCLUDE_DIRECTORIES)
 if(_cglm_inc)
-    target_include_directories(nt_math SYSTEM INTERFACE ${_cglm_inc})
+    target_include_directories(nt_math SYSTEM INTERFACE $<BUILD_INTERFACE:${_cglm_inc}>)
 endif()
 if(NOT WIN32)
     target_link_libraries(nt_math INTERFACE m)

--- a/engine/memory/CMakeLists.txt
+++ b/engine/memory/CMakeLists.txt
@@ -1,0 +1,5 @@
+nt_add_module(nt_mem_scratch LOG_DOMAIN "mem_scratch"
+    nt_mem_scratch.c
+    nt_mem_scratch.h
+)
+target_link_libraries(nt_mem_scratch PUBLIC nt_core)

--- a/engine/memory/nt_mem_scratch.c
+++ b/engine/memory/nt_mem_scratch.c
@@ -1,6 +1,7 @@
 #include "memory/nt_mem_scratch.h"
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdlib.h>
 
 #include "core/nt_assert.h"
@@ -40,12 +41,22 @@ void nt_mem_scratch_reset(void) {
 void *nt_mem_scratch_alloc(size_t size, size_t align) {
     NT_ASSERT(s_scratch.initialized && "nt_mem_scratch_alloc: call nt_mem_scratch_init first");
     NT_ASSERT(align > 0 && (align & (align - 1)) == 0 && "nt_mem_scratch_alloc: align must be power of 2");
+    /* malloc guarantees max_align_t alignment; higher would need over-allocate. */
+    NT_ASSERT(align <= _Alignof(max_align_t) && "nt_mem_scratch_alloc: align exceeds malloc guarantee");
     NT_ASSERT(size > 0 && "nt_mem_scratch_alloc: size must be > 0");
-    const size_t aligned = (s_scratch.used + (align - 1)) & ~(align - 1);
-    NT_ASSERT(aligned + size <= s_scratch.size && "nt_mem_scratch_alloc: out of space; raise nt_mem_scratch_init size");
+    NT_ASSERT(s_scratch.used <= SIZE_MAX - (align - 1U) && "nt_mem_scratch_alloc: align bump would overflow");
+    const size_t aligned = (s_scratch.used + (align - 1U)) & ~(align - 1U);
+    NT_ASSERT(aligned <= s_scratch.size && size <= s_scratch.size - aligned && "nt_mem_scratch_alloc: out of space; raise nt_mem_scratch_init size");
     void *p = s_scratch.base + aligned;
     s_scratch.used = aligned + size;
     return p;
+}
+
+void *nt_mem_scratch_alloc_array(size_t elem_size, size_t count, size_t align) {
+    NT_ASSERT(elem_size > 0 && "nt_mem_scratch_alloc_array: elem_size must be > 0");
+    NT_ASSERT(count > 0 && "nt_mem_scratch_alloc_array: count must be > 0");
+    NT_ASSERT(count <= SIZE_MAX / elem_size && "nt_mem_scratch_alloc_array: count * elem_size overflow");
+    return nt_mem_scratch_alloc(elem_size * count, align);
 }
 
 #ifdef NT_TEST_ACCESS

--- a/engine/memory/nt_mem_scratch.c
+++ b/engine/memory/nt_mem_scratch.c
@@ -10,6 +10,7 @@ static struct {
     uint8_t *base;
     size_t size;
     size_t used;
+    size_t high_water;
     bool initialized;
 } s_scratch;
 
@@ -20,6 +21,7 @@ void nt_mem_scratch_init(size_t size_bytes) {
     NT_ASSERT(s_scratch.base != NULL && "nt_mem_scratch_init: malloc failed");
     s_scratch.size = size_bytes;
     s_scratch.used = 0;
+    s_scratch.high_water = 0;
     s_scratch.initialized = true;
 }
 
@@ -29,6 +31,7 @@ void nt_mem_scratch_shutdown(void) {
     s_scratch.base = NULL;
     s_scratch.size = 0;
     s_scratch.used = 0;
+    s_scratch.high_water = 0;
     s_scratch.initialized = false;
 }
 
@@ -49,8 +52,13 @@ void *nt_mem_scratch_alloc(size_t size, size_t align) {
     NT_ASSERT(aligned <= s_scratch.size && size <= s_scratch.size - aligned && "nt_mem_scratch_alloc: out of space; raise nt_mem_scratch_init size");
     void *p = s_scratch.base + aligned;
     s_scratch.used = aligned + size;
+    if (s_scratch.used > s_scratch.high_water) {
+        s_scratch.high_water = s_scratch.used;
+    }
     return p;
 }
+
+size_t nt_mem_scratch_high_water_mark(void) { return s_scratch.high_water; }
 
 void *nt_mem_scratch_alloc_array(size_t elem_size, size_t count, size_t align) {
     NT_ASSERT(elem_size > 0 && "nt_mem_scratch_alloc_array: elem_size must be > 0");

--- a/engine/memory/nt_mem_scratch.c
+++ b/engine/memory/nt_mem_scratch.c
@@ -4,6 +4,7 @@
 #include <stddef.h>
 #include <stdlib.h>
 
+#include "core/nt_align.h"
 #include "core/nt_assert.h"
 
 static struct {
@@ -48,7 +49,7 @@ void *nt_mem_scratch_alloc(size_t size, size_t align) {
     NT_ASSERT(align <= _Alignof(max_align_t) && "nt_mem_scratch_alloc: align exceeds malloc guarantee");
     NT_ASSERT(size > 0 && "nt_mem_scratch_alloc: size must be > 0");
     NT_ASSERT(s_scratch.used <= SIZE_MAX - (align - 1U) && "nt_mem_scratch_alloc: align bump would overflow");
-    const size_t aligned = (s_scratch.used + (align - 1U)) & ~(align - 1U);
+    const size_t aligned = NT_ALIGN_UP(s_scratch.used, align);
     NT_ASSERT(aligned <= s_scratch.size && size <= s_scratch.size - aligned && "nt_mem_scratch_alloc: out of space; raise nt_mem_scratch_init size");
     void *p = s_scratch.base + aligned;
     s_scratch.used = aligned + size;

--- a/engine/memory/nt_mem_scratch.c
+++ b/engine/memory/nt_mem_scratch.c
@@ -1,0 +1,54 @@
+#include "memory/nt_mem_scratch.h"
+
+#include <stdbool.h>
+#include <stdlib.h>
+
+#include "core/nt_assert.h"
+
+static struct {
+    uint8_t *base;
+    size_t size;
+    size_t used;
+    bool initialized;
+} s_scratch;
+
+void nt_mem_scratch_init(size_t size_bytes) {
+    NT_ASSERT(!s_scratch.initialized && "nt_mem_scratch_init: already initialized");
+    NT_ASSERT(size_bytes > 0 && "nt_mem_scratch_init: size must be > 0");
+    s_scratch.base = (uint8_t *)malloc(size_bytes);
+    NT_ASSERT(s_scratch.base != NULL && "nt_mem_scratch_init: malloc failed");
+    s_scratch.size = size_bytes;
+    s_scratch.used = 0;
+    s_scratch.initialized = true;
+}
+
+void nt_mem_scratch_shutdown(void) {
+    NT_ASSERT(s_scratch.initialized && "nt_mem_scratch_shutdown: not initialized");
+    free(s_scratch.base);
+    s_scratch.base = NULL;
+    s_scratch.size = 0;
+    s_scratch.used = 0;
+    s_scratch.initialized = false;
+}
+
+void nt_mem_scratch_reset(void) {
+    NT_ASSERT(s_scratch.initialized && "nt_mem_scratch_reset: not initialized");
+    s_scratch.used = 0;
+}
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+void *nt_mem_scratch_alloc(size_t size, size_t align) {
+    NT_ASSERT(s_scratch.initialized && "nt_mem_scratch_alloc: call nt_mem_scratch_init first");
+    NT_ASSERT(align > 0 && (align & (align - 1)) == 0 && "nt_mem_scratch_alloc: align must be power of 2");
+    NT_ASSERT(size > 0 && "nt_mem_scratch_alloc: size must be > 0");
+    const size_t aligned = (s_scratch.used + (align - 1)) & ~(align - 1);
+    NT_ASSERT(aligned + size <= s_scratch.size && "nt_mem_scratch_alloc: out of space; raise nt_mem_scratch_init size");
+    void *p = s_scratch.base + aligned;
+    s_scratch.used = aligned + size;
+    return p;
+}
+
+#ifdef NT_TEST_ACCESS
+size_t nt_mem_scratch_test_used(void) { return s_scratch.used; }
+size_t nt_mem_scratch_test_size(void) { return s_scratch.size; }
+#endif

--- a/engine/memory/nt_mem_scratch.h
+++ b/engine/memory/nt_mem_scratch.h
@@ -41,6 +41,9 @@ void *nt_mem_scratch_alloc(size_t size, size_t align);
 /* Checked-multiply variant: asserts elem_size*count doesn't overflow. */
 void *nt_mem_scratch_alloc_array(size_t elem_size, size_t count, size_t align);
 
+/* Peak `used` since init. Survives resets so callers can size scratch budget. */
+size_t nt_mem_scratch_high_water_mark(void);
+
 #define NT_MEM_SCRATCH_ALLOC(T) ((T *)nt_mem_scratch_alloc(sizeof(T), _Alignof(T)))
 
 #define NT_MEM_SCRATCH_ALLOC_ARRAY(T, count) ((T *)nt_mem_scratch_alloc_array(sizeof(T), (size_t)(count), _Alignof(T)))

--- a/engine/memory/nt_mem_scratch.h
+++ b/engine/memory/nt_mem_scratch.h
@@ -1,0 +1,34 @@
+#ifndef NT_MEM_SCRATCH_H
+#define NT_MEM_SCRATCH_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+/* Default capacity if the game doesn't have a tighter budget. Override via
+ * #define NT_MEM_SCRATCH_DEFAULT_SIZE_BYTES before including this header. */
+#ifndef NT_MEM_SCRATCH_DEFAULT_SIZE_BYTES
+#define NT_MEM_SCRATCH_DEFAULT_SIZE_BYTES (512U * 1024U)
+#endif
+
+/* Bump arena reset every frame. Init once at boot; reset at frame start.
+ * All allocations live until the next reset -- pointers from a prior frame
+ * are stale. No per-alloc free; allocator is "single-shot per frame". */
+void nt_mem_scratch_init(size_t size_bytes);
+void nt_mem_scratch_shutdown(void);
+
+/* Reset usage to 0. Pointers handed out before the reset become stale. */
+void nt_mem_scratch_reset(void);
+
+/* align must be a power of 2. Asserts on overflow. */
+void *nt_mem_scratch_alloc(size_t size, size_t align);
+
+#define NT_MEM_SCRATCH_ALLOC(T) ((T *)nt_mem_scratch_alloc(sizeof(T), _Alignof(T)))
+
+#define NT_MEM_SCRATCH_ALLOC_ARRAY(T, count) ((T *)nt_mem_scratch_alloc(sizeof(T) * (size_t)(count), _Alignof(T)))
+
+#ifdef NT_TEST_ACCESS
+size_t nt_mem_scratch_test_used(void);
+size_t nt_mem_scratch_test_size(void);
+#endif
+
+#endif /* NT_MEM_SCRATCH_H */

--- a/engine/memory/nt_mem_scratch.h
+++ b/engine/memory/nt_mem_scratch.h
@@ -35,12 +35,15 @@ void nt_mem_scratch_shutdown(void);
 /* Reset usage to 0. Pointers handed out before the reset become stale. */
 void nt_mem_scratch_reset(void);
 
-/* align must be a power of 2. Asserts on overflow. */
+/* align: power of 2, <= _Alignof(max_align_t). Asserts on overflow / out-of-space. */
 void *nt_mem_scratch_alloc(size_t size, size_t align);
+
+/* Checked-multiply variant: asserts elem_size*count doesn't overflow. */
+void *nt_mem_scratch_alloc_array(size_t elem_size, size_t count, size_t align);
 
 #define NT_MEM_SCRATCH_ALLOC(T) ((T *)nt_mem_scratch_alloc(sizeof(T), _Alignof(T)))
 
-#define NT_MEM_SCRATCH_ALLOC_ARRAY(T, count) ((T *)nt_mem_scratch_alloc(sizeof(T) * (size_t)(count), _Alignof(T)))
+#define NT_MEM_SCRATCH_ALLOC_ARRAY(T, count) ((T *)nt_mem_scratch_alloc_array(sizeof(T), (size_t)(count), _Alignof(T)))
 
 #ifdef NT_TEST_ACCESS
 size_t nt_mem_scratch_test_used(void);

--- a/engine/memory/nt_mem_scratch.h
+++ b/engine/memory/nt_mem_scratch.h
@@ -10,9 +10,25 @@
 #define NT_MEM_SCRATCH_DEFAULT_SIZE_BYTES (512U * 1024U)
 #endif
 
-/* Bump arena reset every frame. Init once at boot; reset at frame start.
- * All allocations live until the next reset -- pointers from a prior frame
- * are stale. No per-alloc free; allocator is "single-shot per frame". */
+/* Bump arena reset every frame. All allocations live until the next reset --
+ * pointers from a prior frame are stale. No per-alloc free.
+ *
+ * Frame loop placement:
+ *
+ *   int main(void) {
+ *       nt_mem_scratch_init(NT_MEM_SCRATCH_DEFAULT_SIZE_BYTES);
+ *       while (running) {
+ *           nt_mem_scratch_reset();   // start of frame, BEFORE any alloc
+ *           game_update();            // CLAY({...}), NT_UI_DATA_*, etc.
+ *           nt_ui_walk(...);          // reads scratch pointers
+ *           // render done; scratch may sit unused until next reset
+ *       }
+ *       nt_mem_scratch_shutdown();
+ *   }
+ *
+ * Reset MUST happen BEFORE any allocation in the current frame -- never
+ * after. Calling alloc then reset in the same frame invalidates pointers
+ * already handed to systems (nt_ui) that retain them through walk. */
 void nt_mem_scratch_init(size_t size_bytes);
 void nt_mem_scratch_shutdown(void);
 

--- a/engine/platform/web/CMakeLists.txt
+++ b/engine/platform/web/CMakeLists.txt
@@ -2,7 +2,7 @@
 # OBJECT library: EM_JS symbols need direct linking, not static archive.
 
 add_library(nt_platform_web OBJECT nt_platform_web.c)
-target_include_directories(nt_platform_web PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/../..)
+target_include_directories(nt_platform_web PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/../..>)
 nt_set_warning_flags(nt_platform_web)
 nt_set_sanitizer_flags(nt_platform_web)
 target_link_libraries(nt_platform_web PUBLIC nt_core)

--- a/engine/renderers/nt_mesh_renderer.h
+++ b/engine/renderers/nt_mesh_renderer.h
@@ -23,11 +23,13 @@ void nt_mesh_renderer_restore_gpu(void);
  * the items array. */
 void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count);
 
-#ifdef NT_MESH_RENDERER_TEST_ACCESS
+// #region test_access
+#ifdef NT_TEST_ACCESS
 uint32_t nt_mesh_renderer_test_pipeline_cache_count(void);
 uint32_t nt_mesh_renderer_test_draw_call_count(void);
 uint32_t nt_mesh_renderer_test_instance_total(void);
 #endif
+// #endregion
 
 /* Stream type → vertex format mapping (used by pipeline builder, testable) */
 nt_vertex_format_t nt_stream_to_vertex_format(uint8_t type, uint8_t count, uint8_t normalized);

--- a/engine/renderers/nt_shape_renderer.h
+++ b/engine/renderers/nt_shape_renderer.h
@@ -104,9 +104,8 @@ void nt_shape_renderer_capsule_wire_rot(const float center[3], float radius, flo
 void nt_shape_renderer_mesh(const float *positions, uint32_t num_vertices, const nt_shape_index_t *indices, uint32_t num_indices, const float color[4]);
 void nt_shape_renderer_mesh_wire(const float *positions, uint32_t num_vertices, const nt_shape_index_t *indices, uint32_t num_indices, const float color[4]);
 
-/* ---- Test accessors (test builds only) ---- */
-
-#ifdef NT_SHAPE_RENDERER_TEST_ACCESS
+// #region test_access
+#ifdef NT_TEST_ACCESS
 
 /* Instanced shape types (for test_instance_count) */
 enum {
@@ -126,5 +125,6 @@ const float *nt_shape_renderer_test_cam_pos(void);
 float nt_shape_renderer_test_line_width(void);
 bool nt_shape_renderer_test_initialized(void);
 #endif
+// #endregion
 
 #endif /* NT_SHAPE_RENDERER_H */

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -508,6 +508,96 @@ void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, 
 }
 // #endregion
 
+// #region emit_geometry
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+void nt_sprite_renderer_emit_geometry(nt_resource_t atlas, uint32_t region_index, const float (*positions)[2], uint32_t vertex_count, const uint16_t *indices, uint32_t index_count,
+                                      const float *world_matrix, uint32_t color_packed) {
+    NT_ASSERT(s_sprite.initialized);
+    NT_ASSERT(positions != NULL && indices != NULL && world_matrix != NULL);
+    NT_ASSERT(atlas.id != 0 && "nt_sprite_renderer_emit_geometry: invalid atlas handle");
+    NT_ASSERT(nt_resource_is_ready(atlas) && "nt_sprite_renderer_emit_geometry: atlas must be READY");
+    NT_ASSERT(s_sprite.cmd_count > 0 && "nt_sprite_renderer_emit_geometry: call nt_sprite_renderer_set_material first");
+    NT_ASSERT(vertex_count > 0U && index_count > 0U && "nt_sprite_renderer_emit_geometry: empty geometry");
+    NT_ASSERT(vertex_count <= NT_SPRITE_RENDERER_MAX_VERTICES && "nt_sprite_renderer_emit_geometry: vertex_count exceeds staging capacity");
+    NT_ASSERT(index_count <= NT_SPRITE_RENDERER_MAX_INDICES && "nt_sprite_renderer_emit_geometry: index_count exceeds staging capacity");
+
+    nt_atlas_region_handles_t h;
+    nt_atlas_get_region_handles(atlas, region_index, &h);
+    if (h.region->vertex_count == 0U) {
+        return; /* tombstone */
+    }
+    const uint32_t page_tex = nt_resource_get(h.page_resource);
+    if (!ensure_current_cmd_page_texture(page_tex)) {
+        return;
+    }
+
+    /* Overflow handling mirrors emit_region_resolved: snapshot the open
+     * cmd, flush, reopen with the same state. */
+    if (s_sprite.vertex_count + vertex_count > NT_SPRITE_RENDERER_MAX_VERTICES || s_sprite.index_count + index_count > NT_SPRITE_RENDERER_MAX_INDICES) {
+        nt_sprite_draw_cmd_t snapshot = s_sprite.cmds[s_sprite.cmd_count - 1];
+        nt_sprite_renderer_flush();
+        open_cmd_from_snapshot(&snapshot);
+    }
+
+    /* Sample at the region's UV centroid -- the corner of vertex 0 would
+     * land at the texel boundary and bleed into neighbours under linear
+     * filtering. Centroid is safely inside the region for any convex
+     * polygon, and exactly the pixel center for a 4-vert axis-aligned
+     * white region. uint16 atlas_u/v sums fit uint32 for the polygon
+     * worst case (8 verts * 65535 << 2^32). */
+    uint32_t sum_u = 0;
+    uint32_t sum_v = 0;
+    for (uint8_t i = 0; i < h.region->vertex_count; i++) {
+        sum_u += h.raw_vertices[i].atlas_u;
+        sum_v += h.raw_vertices[i].atlas_v;
+    }
+    const uint16_t shared_u = (uint16_t)(sum_u / h.region->vertex_count);
+    const uint16_t shared_v = (uint16_t)(sum_v / h.region->vertex_count);
+
+    const uint8_t cr = (uint8_t)(color_packed & 0xFFU);
+    const uint8_t cg = (uint8_t)((color_packed >> 8) & 0xFFU);
+    const uint8_t cb = (uint8_t)((color_packed >> 16) & 0xFFU);
+    const uint8_t ca = (uint8_t)((color_packed >> 24) & 0xFFU);
+
+    const float *m = world_matrix;
+    const float tx = m[12];
+    const float ty = m[13];
+    const float tz = m[14];
+
+    const uint32_t base = s_sprite.vertex_count;
+    for (uint32_t i = 0; i < vertex_count; i++) {
+        const float px = positions[i][0];
+        const float py = positions[i][1];
+        nt_sprite_vertex_t *v = &s_sprite.vertices[base + i];
+        v->position[0] = (m[0] * px) + (m[4] * py) + tx;
+        v->position[1] = (m[1] * px) + (m[5] * py) + ty;
+        v->position[2] = (m[2] * px) + (m[6] * py) + tz;
+        v->texcoord[0] = shared_u;
+        v->texcoord[1] = shared_v;
+        v->color[0] = cr;
+        v->color[1] = cg;
+        v->color[2] = cb;
+        v->color[3] = ca;
+    }
+    s_sprite.vertex_count += vertex_count;
+
+    uint16_t *out_idx = &s_sprite.indices[s_sprite.index_count];
+    for (uint32_t i = 0; i < index_count; i++) {
+        const uint32_t rebased = base + (uint32_t)indices[i];
+        NT_ASSERT(rebased <= UINT16_MAX && "sprite uint16 index chunk overflow");
+        NT_ASSERT(indices[i] < vertex_count && "nt_sprite_renderer_emit_geometry: index out of range");
+        out_idx[i] = (uint16_t)rebased;
+    }
+    s_sprite.index_count += index_count;
+
+#ifdef NT_TEST_ACCESS
+    s_sprite.last_emit_vertex_count = vertex_count;
+    s_sprite.last_emit_index_count = index_count;
+    s_sprite.last_emit_first_vertex = base;
+#endif
+}
+// #endregion
+
 // #region draw_list
 /* Phase 1: open a cmd per batch_key, stream verts into staging via
  * emit_one. Phase 2 = nt_sprite_renderer_flush. */
@@ -682,6 +772,13 @@ void nt_sprite_renderer_test_last_emit_position(uint32_t v_idx, float out[3]) {
     out[0] = v->position[0];
     out[1] = v->position[1];
     out[2] = v->position[2];
+}
+
+void nt_sprite_renderer_test_last_emit_texcoord(uint32_t v_idx, uint16_t out[2]) {
+    NT_ASSERT(v_idx < s_sprite.last_emit_vertex_count && "last_emit_texcoord: index out of range");
+    const nt_sprite_vertex_t *v = &s_sprite.vertices[s_sprite.last_emit_first_vertex + v_idx];
+    out[0] = v->texcoord[0];
+    out[1] = v->texcoord[1];
 }
 bool nt_sprite_renderer_test_initialized(void) { return s_sprite.initialized; }
 #endif

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -360,7 +360,7 @@ NT_SPRITE_EMIT_INLINE void emit_region_resolved(const nt_texture_region_t *r, co
                                                 float origin_x, float origin_y, uint32_t color_packed, uint8_t flip_bits) {
     NT_ASSERT(r != NULL && cpos != NULL && vraw != NULL && idx != NULL);
     NT_ASSERT(m != NULL);
-    if (r->vertex_count == 0u) {
+    if (r->vertex_count == 0U) {
         return; /* tombstone — silent no-op (matches old emit_one behaviour) */
     }
     if (!ensure_current_cmd_page_texture(page_tex)) {
@@ -512,6 +512,7 @@ NT_SPRITE_EMIT_INLINE void emit_region_resolved(const nt_texture_region_t *r, co
  * write body lives in one canonical place. No extra atlas lookup vs the old
  * monolithic emit_one — resolved-region pointers come straight from
  * sv->resolved[s_idx]. */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *sv, const nt_transform_comp_view_t *tv, const nt_drawable_comp_view_t *dv) {
     nt_entity_t e = {.id = item->entity};
     uint16_t eidx = nt_entity_index(e);
@@ -559,6 +560,7 @@ static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *
  * Asserts the renderer + atlas are in a usable state. Caller must have an
  * open cmd (set via nt_sprite_renderer_set_material). Tombstoned regions
  * silently no-op (vertex_count == 0 short-circuits emit_region_resolved). */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, const float *world_matrix, float origin_x, float origin_y, uint32_t color_packed, uint8_t flip_bits) {
     NT_ASSERT(s_sprite.initialized);
     NT_ASSERT(world_matrix != NULL);
@@ -567,7 +569,7 @@ void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, 
     NT_ASSERT(s_sprite.cmd_count > 0 && "nt_sprite_renderer_emit_region: call nt_sprite_renderer_set_material first");
 
     const nt_texture_region_t *r = nt_atlas_get_region(atlas, region_index);
-    if (r == NULL || r->vertex_count == 0u) {
+    if (r == NULL || r->vertex_count == 0U) {
         return; /* tombstone or out-of-range — silent no-op */
     }
     const float(*cpos)[2] = nt_atlas_get_region_cached_pos(atlas, region_index);

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -532,8 +532,11 @@ static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *
 // #endregion
 
 // #region emit_region
-/* One extra atlas lookup per call vs the ECS path -- acceptable for the
- * walker / debug-draw / gizmo use cases that have no SoA cache. */
+/* One bundled atlas lookup (vs 6 separate get_region/cached_pos/raw_vertices/
+ * indices/page_resource/ipu calls). Resolves the atlas user_data once and
+ * fills the handle struct -- no SoA cache like the ECS path, but the
+ * single-resolve form keeps the hot path tight enough for walker /
+ * debug-draw / gizmo use. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, const float *world_matrix, float origin_x, float origin_y, uint32_t color_packed, uint8_t flip_bits) {
     NT_ASSERT(s_sprite.initialized);
@@ -542,18 +545,12 @@ void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, 
     NT_ASSERT(nt_resource_is_ready(atlas) && "nt_sprite_renderer_emit_region: atlas must be READY");
     NT_ASSERT(s_sprite.cmd_count > 0 && "nt_sprite_renderer_emit_region: call nt_sprite_renderer_set_material first");
 
-    const nt_texture_region_t *r = nt_atlas_get_region(atlas, region_index);
-    if (r == NULL || r->vertex_count == 0U) {
+    nt_atlas_region_handles_t h;
+    nt_atlas_get_region_handles(atlas, region_index, &h);
+    if (h.region->vertex_count == 0U) {
         return; /* tombstone or out-of-range */
     }
-    const float(*cpos)[2] = nt_atlas_get_region_cached_pos(atlas, region_index);
-    const nt_atlas_vertex_t *vraw = nt_atlas_get_region_raw_vertices(atlas, region_index);
-    const uint16_t *idx = nt_atlas_get_region_indices(atlas, region_index);
-    nt_resource_t page_res = nt_atlas_get_page_resource(atlas, r->page_index);
-    uint32_t page_tex = nt_resource_get(page_res);
-    const float ipu = nt_atlas_get_inverse_pixels_per_unit(atlas);
-
-    emit_region_resolved(r, cpos, vraw, idx, page_tex, ipu, world_matrix, origin_x, origin_y, color_packed, flip_bits);
+    emit_region_resolved(h.region, h.cached_pos, h.raw_vertices, h.indices, nt_resource_get(h.page_resource), h.ipu, world_matrix, origin_x, origin_y, color_packed, flip_bits);
 }
 // #endregion
 

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -287,13 +287,15 @@ void nt_sprite_renderer_set_material(nt_material_t mat) {
     NT_ASSERT(s_sprite.initialized);
     NT_ASSERT(mat.id != 0 && "nt_sprite_renderer_set_material: invalid material handle");
 
+    /* Validate BEFORE same-handle early return: stale handle (destroyed material,
+     * bumped generation) must assert even if the id still matches the cached one. */
+    const nt_material_info_t *mat_info = nt_material_get_info(mat);
+    NT_ASSERT(mat_info != NULL && mat_info->ready && mat_info->resolved_vs != 0 && mat_info->resolved_fs != 0 && "nt_sprite_renderer_set_material: material not ready");
+
     /* Same-handle no-op only when cmd is still live; flush resets cmd_count. */
     if (mat.id == s_sprite.current_mat.id && s_sprite.cmd_count > 0) {
         return;
     }
-
-    const nt_material_info_t *mat_info = nt_material_get_info(mat);
-    NT_ASSERT(mat_info != NULL && mat_info->ready && mat_info->resolved_vs != 0 && mat_info->resolved_fs != 0 && "nt_sprite_renderer_set_material: material not ready");
 
     if (s_sprite.cmd_count > 0) {
         nt_sprite_renderer_flush();

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -58,18 +58,13 @@ static struct {
     nt_sprite_draw_cmd_t cmds[NT_SPRITE_RENDERER_MAX_DRAW_CMDS];
     uint32_t cmd_count;
 
-    /* Test counter — reset at the start of each nt_sprite_renderer_draw_list
-     * call, holds the GPU draw count from that call only. SEPARATE from
-     * nt_gfx_get_frame_draw_calls (which is engine-wide and frame-scoped). */
+    /* Reset per draw_list call; SEPARATE from nt_gfx_get_frame_draw_calls. */
     uint32_t last_draw_list_calls;
 
-    /* Material bound for the non-ECS public emit path. Auto-flushes on
-     * .id change. The ECS draw_list path does NOT touch this -- it
-     * opens/closes cmds per batch_key directly. */
+    /* Non-ECS path only; draw_list opens cmds per batch_key. */
     nt_material_t current_mat;
 #ifdef NT_TEST_ACCESS
-    /* Captured before flush resets vertex_count, so tests can read back
-     * what the last emit wrote (positions via last_emit_first_vertex). */
+    /* Captured pre-flush so tests can read back the last emit. */
     uint32_t last_emit_vertex_count;
     uint32_t last_emit_index_count;
     uint32_t last_emit_first_vertex;
@@ -288,18 +283,11 @@ static bool ensure_current_cmd_page_texture(uint32_t page_tex) {
 // #endregion
 
 // #region set_material
-/* Mirrors nt_text_renderer_set_material: same-handle reentry is a no-op;
- * .id change auto-flushes and opens a fresh cmd.
- *
- * The ECS draw_list path opens cmds per batch_key directly and does not
- * touch current_mat, so the two call paths cannot interfere. */
 void nt_sprite_renderer_set_material(nt_material_t mat) {
     NT_ASSERT(s_sprite.initialized);
     NT_ASSERT(mat.id != 0 && "nt_sprite_renderer_set_material: invalid material handle");
 
-    /* Same-handle is a no-op only when the cmd is still live. After an
-     * explicit flush (or restore_gpu) cmd_count drops to 0 and we MUST
-     * reopen, otherwise the next emit trips "no open cmd". */
+    /* Same-handle no-op only when cmd is still live; flush resets cmd_count. */
     if (mat.id == s_sprite.current_mat.id && s_sprite.cmd_count > 0) {
         return;
     }
@@ -467,27 +455,18 @@ NT_SPRITE_EMIT_INLINE void emit_region_resolved(const nt_texture_region_t *r, co
 }
 // #endregion
 
-// #region emit_one (ECS extractor — delegates to emit_region_resolved)
-/* Caller passes pre-fetched SoA views; sparse_indices[entity_index] → dense slot.
- *
- * emit_one is a thin ECS extractor: resolves origin/flip/color from the
- * components and forwards to emit_region_resolved. Resolved region
- * pointers come straight from sv->resolved[s_idx] -- no extra atlas
- * lookup. */
+// #region emit_one
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *sv, const nt_transform_comp_view_t *tv, const nt_drawable_comp_view_t *dv) {
     nt_entity_t e = {.id = item->entity};
     uint16_t eidx = nt_entity_index(e);
 
-    /* Inlined sparse->dense lookups vs three function calls each doing a
-     * liveness assert + the same array read. */
+    /* Inlined vs three calls each doing the same liveness assert + array read. */
     uint16_t s_idx = sv->sparse_indices[eidx];
     uint16_t t_idx = tv->sparse_indices[eidx];
     uint16_t d_idx = dv->sparse_indices[eidx];
 
-    /* NT_INVALID_COMP_INDEX (0xFFFF) would index SoA arrays out of bounds
-     * -- catches stale render items, items for entities missing a
-     * component, items built after entity destruction. */
+    /* NT_INVALID_COMP_INDEX would index SoA OOB -- catches stale items. */
     NT_ASSERT(s_idx != NT_INVALID_COMP_INDEX && "sprite render item: entity has no sprite component");
     NT_ASSERT(t_idx != NT_INVALID_COMP_INDEX && "sprite render item: entity has no transform component");
     NT_ASSERT(d_idx != NT_INVALID_COMP_INDEX && "sprite render item: entity has no drawable component");
@@ -512,11 +491,6 @@ static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *
 // #endregion
 
 // #region emit_region
-/* One bundled atlas lookup (vs 6 separate get_region/cached_pos/raw_vertices/
- * indices/page_resource/ipu calls). Resolves the atlas user_data once and
- * fills the handle struct -- no SoA cache like the ECS path, but the
- * single-resolve form keeps the hot path tight enough for walker /
- * debug-draw / gizmo use. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, const float *world_matrix, float origin_x, float origin_y, uint32_t color_packed, uint8_t flip_bits) {
     NT_ASSERT(s_sprite.initialized);

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -708,6 +708,9 @@ void nt_sprite_renderer_flush(void) {
     s_sprite.vertex_count = 0;
     s_sprite.index_count = 0;
     s_sprite.cmd_count = 0;
+    /* draw_list opens cmds per batch_key, not via current_mat. Reset
+     * the fence so a following same-handle set_material() re-opens. */
+    s_sprite.current_mat = (nt_material_t){0};
 }
 // #endregion
 

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -67,7 +67,7 @@ static struct {
      * .id change. The ECS draw_list path does NOT touch this -- it
      * opens/closes cmds per batch_key directly. */
     nt_material_t current_mat;
-#ifdef NT_SPRITE_RENDERER_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
     /* Captured before flush resets vertex_count, so tests can read back
      * what the last emit wrote (positions via last_emit_first_vertex). */
     uint32_t last_emit_vertex_count;
@@ -476,7 +476,7 @@ NT_SPRITE_EMIT_INLINE void emit_region_resolved(const nt_texture_region_t *r, co
     }
     s_sprite.index_count += r->index_count;
 
-#ifdef NT_SPRITE_RENDERER_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
     /* Capture per-emit counts + first-vertex offset so tests can read
      * back emitted positions after draw_list completes (flush resets
      * vertex_count but leaves the array data intact). */
@@ -712,7 +712,7 @@ void nt_sprite_renderer_flush(void) {
 // #endregion
 
 // #region test accessors
-#ifdef NT_SPRITE_RENDERER_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
 uint32_t nt_sprite_renderer_test_pipeline_cache_count(void) { return s_sprite.count; }
 uint32_t nt_sprite_renderer_test_draw_call_count(void) { return s_sprite.last_draw_list_calls; }
 uint32_t nt_sprite_renderer_test_vertex_count(void) { return s_sprite.vertex_count; }

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -62,6 +62,14 @@ static struct {
      * call, holds the GPU draw count from that call only. SEPARATE from
      * nt_gfx_get_frame_draw_calls (which is engine-wide and frame-scoped). */
     uint32_t last_draw_list_calls;
+
+    /* Currently-bound material for the non-ECS public emit path
+     * (nt_sprite_renderer_set_material + nt_sprite_renderer_emit_region).
+     * Mirrors nt_text_renderer's s_text.material — auto-flushes on .id
+     * change. NT_MATERIAL_INVALID until first set_material call.
+     * NOTE: ECS path (draw_list -> emit_one) does NOT touch this field —
+     * it opens/closes cmds per batch_key directly. */
+    nt_material_t current_mat;
 #ifdef NT_SPRITE_RENDERER_TEST_ACCESS
     /* Test-only: last emit_one() vertex/index counts captured BEFORE flush
      * resets s_sprite.vertex_count. Read by polygon-emit test to verify
@@ -287,39 +295,74 @@ static bool ensure_current_cmd_page_texture(uint32_t page_tex) {
 }
 // #endregion
 
-// #region emit_one (per-sprite vertex/index emit)
-/* Caller passes pre-fetched SoA views; sparse_indices[entity_index] → dense slot. */
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
-static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *sv, const nt_transform_comp_view_t *tv, const nt_drawable_comp_view_t *dv) {
-    nt_entity_t e = {.id = item->entity};
-    uint16_t eidx = nt_entity_index(e);
+// #region set_material (non-ECS public state setter — Drift 4 resolution)
+/* Bind a material for subsequent nt_sprite_renderer_emit_region() calls.
+ * Mirrors nt_text_renderer_set_material: same-handle reentry is a no-op;
+ * .id-change closes the current cmd (auto-flushes pending emits) and opens
+ * a fresh cmd with the new pipeline + material info.
+ *
+ * Same-handle short-circuit reads s_sprite.current_mat.id WITHOUT closing
+ * the open cmd — this preserves batching when the game calls set_material
+ * defensively each walker frame. The ECS path (draw_list -> emit_one) opens
+ * cmds directly per batch_key and does not touch current_mat, so the two
+ * call paths cannot interfere. */
+void nt_sprite_renderer_set_material(nt_material_t mat) {
+    NT_ASSERT(s_sprite.initialized);
+    NT_ASSERT(mat.id != 0 && "nt_sprite_renderer_set_material: invalid material handle");
 
-    /* Inline sparse->dense lookups — three array reads vs three function
-     * calls each doing a liveness assert + the same lookup. */
-    uint16_t s_idx = sv->sparse_indices[eidx];
-    uint16_t t_idx = tv->sparse_indices[eidx];
-    uint16_t d_idx = dv->sparse_indices[eidx];
-
-    /* AGENTS.md "fail early, prefer asserts": dense indices must be valid.
-     * NT_INVALID_COMP_INDEX (0xFFFF) would index SoA arrays out of bounds.
-     * Catches stale render items, items for entities missing a component,
-     * items built after entity destruction. Compiles out in release. */
-    NT_ASSERT(s_idx != NT_INVALID_COMP_INDEX && "sprite render item: entity has no sprite component");
-    NT_ASSERT(t_idx != NT_INVALID_COMP_INDEX && "sprite render item: entity has no transform component");
-    NT_ASSERT(d_idx != NT_INVALID_COMP_INDEX && "sprite render item: entity has no drawable component");
-
-    /* Resolve atlas + region. Tombstone → zero-draw early-out. */
-    nt_resource_t atlas = sv->atlas[s_idx];
-    const nt_sprite_resolved_region_t *resolved = &sv->resolved[s_idx];
-    if ((sv->flags[s_idx] & NT_SPRITE_FLAG_RESOLVED) == 0 || resolved->region == NULL || resolved->region->vertex_count == 0) {
+    /* Same-handle reentry is a no-op ONLY when the cmd we'd reopen is still
+     * live. After an explicit flush() (or restore_gpu) cmd_count drops to 0
+     * and we MUST reopen even for the same handle, otherwise the next emit
+     * trips the "no open cmd" assert. */
+    if (mat.id == s_sprite.current_mat.id && s_sprite.cmd_count > 0) {
         return;
     }
-    const nt_texture_region_t *r = resolved->region;
-    const float(*cpos)[2] = resolved->cached_pos;
-    const nt_atlas_vertex_t *vraw = resolved->raw_vertices;
-    const uint16_t *idx = resolved->indices;
-    NT_ASSERT(cpos != NULL && vraw != NULL && idx != NULL);
-    uint32_t page_tex = nt_resource_get(resolved->page_resource);
+
+    const nt_material_info_t *mat_info = nt_material_get_info(mat);
+    NT_ASSERT(mat_info != NULL && mat_info->ready && mat_info->resolved_vs != 0 && mat_info->resolved_fs != 0 && "nt_sprite_renderer_set_material: material not ready");
+
+    /* Auto-flush staging on material change. close_current_cmd() pops empty
+     * cmds (no indices written) so re-binding a material before any emit is
+     * cheap — flush() short-circuits when cmd_count == 0. */
+    if (s_sprite.cmd_count > 0) {
+        nt_sprite_renderer_flush();
+    }
+
+    nt_pipeline_t pip = find_or_create_pipeline(mat_info);
+    open_cmd(pip, mat_info, mat);
+    s_sprite.current_mat = mat;
+}
+// #endregion
+
+// #region emit_region_resolved (canonical staging-write body — shared ECS + non-ECS)
+/* Single canonical staging-write body for one atlas region at one mat4.
+ *
+ * Caller supplies pre-resolved region pointers and the atlas's inverse pixels-
+ * per-unit (ipu) directly — this is the no-extra-lookup hot path. The ECS
+ * emit_one() reads these straight from the resolved-region SoA slot; the
+ * non-ECS public nt_sprite_renderer_emit_region() does one nt_atlas_*() lookup
+ * per call and forwards.
+ *
+ * Marked `static inline` + ALWAYS_INLINE so the bunnymark ECS hot path keeps
+ * the same single-frame inlined shape it had before the refactor (D-52-02
+ * ≤2% regression gate). Compilers without an always_inline attribute simply
+ * see a `static inline` request — same behaviour as before. */
+#if defined(__GNUC__) || defined(__clang__)
+#define NT_SPRITE_EMIT_INLINE static inline __attribute__((always_inline))
+#elif defined(_MSC_VER)
+#define NT_SPRITE_EMIT_INLINE static inline __forceinline
+#else
+#define NT_SPRITE_EMIT_INLINE static inline
+#endif
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+NT_SPRITE_EMIT_INLINE void emit_region_resolved(const nt_texture_region_t *r, const float (*cpos)[2], const nt_atlas_vertex_t *vraw, const uint16_t *idx, uint32_t page_tex, float ipu, const float *m,
+                                                float origin_x, float origin_y, uint32_t color_packed, uint8_t flip_bits) {
+    NT_ASSERT(r != NULL && cpos != NULL && vraw != NULL && idx != NULL);
+    NT_ASSERT(m != NULL);
+    if (r->vertex_count == 0u) {
+        return; /* tombstone — silent no-op (matches old emit_one behaviour) */
+    }
     if (!ensure_current_cmd_page_texture(page_tex)) {
         return;
     }
@@ -330,7 +373,7 @@ static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *
      * same state at first_index=0. The caller sees no state change; the GPU
      * just gets another chunk draw instead of UNSIGNED_INT indices. */
     if (s_sprite.vertex_count + r->vertex_count > NT_SPRITE_RENDERER_MAX_VERTICES || s_sprite.index_count + r->index_count > NT_SPRITE_RENDERER_MAX_INDICES) {
-        NT_ASSERT(s_sprite.cmd_count > 0 && "emit_one called with no open cmd");
+        NT_ASSERT(s_sprite.cmd_count > 0 && "emit_region_resolved called with no open cmd");
         nt_sprite_draw_cmd_t snapshot = s_sprite.cmds[s_sprite.cmd_count - 1];
         nt_sprite_renderer_flush();
         open_cmd_from_snapshot(&snapshot);
@@ -341,18 +384,13 @@ static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *
      * share vertex data; the per-region pivot lives entirely in tx/ty/tz.
      * Same formula whether origin is the region default or a runtime override
      * — only the source differs. */
-    const float *m = tv->world_matrices[t_idx];
     float tx = m[12];
     float ty = m[13];
     float tz = m[14];
-    uint8_t flags = sv->flags[s_idx];
-    const float origin_x = (flags & NT_SPRITE_FLAG_ORIGIN_OV) ? sv->origin[s_idx][0] : r->origin_x;
-    const float origin_y = (flags & NT_SPRITE_FLAG_ORIGIN_OV) ? sv->origin[s_idx][1] : r->origin_y;
-    const float ipu = nt_atlas_get_inverse_pixels_per_unit(atlas);
 
     /* Flip flags — per-vertex negate of cached_pos */
-    bool fx = (flags & NT_SPRITE_FLAG_FLIP_X) != 0;
-    bool fy = (flags & NT_SPRITE_FLAG_FLIP_Y) != 0;
+    bool fx = (flip_bits & NT_SPRITE_FLAG_FLIP_X) != 0;
+    bool fy = (flip_bits & NT_SPRITE_FLAG_FLIP_Y) != 0;
 
     /* Origin offset baked into translation. cached_pos is source-space, so
      * the vertex loop's per-vertex flip negates source-space x — to mirror
@@ -370,11 +408,10 @@ static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *
     ty -= (m[1] * dx) + (m[5] * dy);
     tz -= (m[2] * dx) + (m[6] * dy);
 
-    uint32_t color32 = dv->colors_packed[d_idx];
-    uint8_t cr = (uint8_t)(color32 & 0xFFU);
-    uint8_t cg = (uint8_t)((color32 >> 8) & 0xFFU);
-    uint8_t cb = (uint8_t)((color32 >> 16) & 0xFFU);
-    uint8_t ca = (uint8_t)((color32 >> 24) & 0xFFU);
+    uint8_t cr = (uint8_t)(color_packed & 0xFFU);
+    uint8_t cg = (uint8_t)((color_packed >> 8) & 0xFFU);
+    uint8_t cb = (uint8_t)((color_packed >> 16) & 0xFFU);
+    uint8_t ca = (uint8_t)((color_packed >> 24) & 0xFFU);
 
     uint32_t base = s_sprite.vertex_count;
 #ifdef __wasm_simd128__
@@ -464,6 +501,83 @@ static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *
     s_sprite.last_emit_index_count = r->index_count;
     s_sprite.last_emit_first_vertex = base;
 #endif
+}
+// #endregion
+
+// #region emit_one (ECS extractor — delegates to emit_region_resolved)
+/* Caller passes pre-fetched SoA views; sparse_indices[entity_index] → dense slot.
+ *
+ * D-52-02: emit_one is now a thin extractor that resolves origin/flip/color
+ * from the ECS components and forwards to emit_region_resolved. The staging-
+ * write body lives in one canonical place. No extra atlas lookup vs the old
+ * monolithic emit_one — resolved-region pointers come straight from
+ * sv->resolved[s_idx]. */
+static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *sv, const nt_transform_comp_view_t *tv, const nt_drawable_comp_view_t *dv) {
+    nt_entity_t e = {.id = item->entity};
+    uint16_t eidx = nt_entity_index(e);
+
+    /* Inline sparse->dense lookups — three array reads vs three function
+     * calls each doing a liveness assert + the same lookup. */
+    uint16_t s_idx = sv->sparse_indices[eidx];
+    uint16_t t_idx = tv->sparse_indices[eidx];
+    uint16_t d_idx = dv->sparse_indices[eidx];
+
+    /* AGENTS.md "fail early, prefer asserts": dense indices must be valid.
+     * NT_INVALID_COMP_INDEX (0xFFFF) would index SoA arrays out of bounds.
+     * Catches stale render items, items for entities missing a component,
+     * items built after entity destruction. Compiles out in release. */
+    NT_ASSERT(s_idx != NT_INVALID_COMP_INDEX && "sprite render item: entity has no sprite component");
+    NT_ASSERT(t_idx != NT_INVALID_COMP_INDEX && "sprite render item: entity has no transform component");
+    NT_ASSERT(d_idx != NT_INVALID_COMP_INDEX && "sprite render item: entity has no drawable component");
+
+    /* Resolve atlas + region. Tombstone → zero-draw early-out. */
+    nt_resource_t atlas = sv->atlas[s_idx];
+    const nt_sprite_resolved_region_t *resolved = &sv->resolved[s_idx];
+    if ((sv->flags[s_idx] & NT_SPRITE_FLAG_RESOLVED) == 0 || resolved->region == NULL || resolved->region->vertex_count == 0) {
+        return;
+    }
+    const nt_texture_region_t *r = resolved->region;
+    NT_ASSERT(resolved->cached_pos != NULL && resolved->raw_vertices != NULL && resolved->indices != NULL);
+    uint32_t page_tex = nt_resource_get(resolved->page_resource);
+
+    uint8_t flags = sv->flags[s_idx];
+    const float origin_x = (flags & NT_SPRITE_FLAG_ORIGIN_OV) ? sv->origin[s_idx][0] : r->origin_x;
+    const float origin_y = (flags & NT_SPRITE_FLAG_ORIGIN_OV) ? sv->origin[s_idx][1] : r->origin_y;
+    const uint8_t flip_bits = flags & (NT_SPRITE_FLAG_FLIP_X | NT_SPRITE_FLAG_FLIP_Y);
+    const float ipu = nt_atlas_get_inverse_pixels_per_unit(atlas);
+
+    emit_region_resolved(r, resolved->cached_pos, resolved->raw_vertices, resolved->indices, page_tex, ipu, tv->world_matrices[t_idx], origin_x, origin_y, dv->colors_packed[d_idx], flip_bits);
+}
+// #endregion
+
+// #region emit_region (non-ECS public emit — D-52-01)
+/* Public single-region emit. Resolves the region + page texture + ipu via the
+ * atlas handle, then forwards to the canonical emit_region_resolved body. One
+ * extra atlas lookup per call vs the ECS path — acceptable for the walker /
+ * debug-draw / gizmo use cases where there is no SoA cache.
+ *
+ * Asserts the renderer + atlas are in a usable state. Caller must have an
+ * open cmd (set via nt_sprite_renderer_set_material). Tombstoned regions
+ * silently no-op (vertex_count == 0 short-circuits emit_region_resolved). */
+void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, const float *world_matrix, float origin_x, float origin_y, uint32_t color_packed, uint8_t flip_bits) {
+    NT_ASSERT(s_sprite.initialized);
+    NT_ASSERT(world_matrix != NULL);
+    NT_ASSERT(atlas.id != 0 && "nt_sprite_renderer_emit_region: invalid atlas handle");
+    NT_ASSERT(nt_resource_is_ready(atlas) && "nt_sprite_renderer_emit_region: atlas must be READY");
+    NT_ASSERT(s_sprite.cmd_count > 0 && "nt_sprite_renderer_emit_region: call nt_sprite_renderer_set_material first");
+
+    const nt_texture_region_t *r = nt_atlas_get_region(atlas, region_index);
+    if (r == NULL || r->vertex_count == 0u) {
+        return; /* tombstone or out-of-range — silent no-op */
+    }
+    const float(*cpos)[2] = nt_atlas_get_region_cached_pos(atlas, region_index);
+    const nt_atlas_vertex_t *vraw = nt_atlas_get_region_raw_vertices(atlas, region_index);
+    const uint16_t *idx = nt_atlas_get_region_indices(atlas, region_index);
+    nt_resource_t page_res = nt_atlas_get_page_resource(atlas, r->page_index);
+    uint32_t page_tex = nt_resource_get(page_res);
+    const float ipu = nt_atlas_get_inverse_pixels_per_unit(atlas);
+
+    emit_region_resolved(r, cpos, vraw, idx, page_tex, ipu, world_matrix, origin_x, origin_y, color_packed, flip_bits);
 }
 // #endregion
 

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -371,10 +371,14 @@ NT_SPRITE_EMIT_INLINE void emit_region_resolved(const nt_texture_region_t *r, co
     bool fx = (flip_bits & NT_SPRITE_FLAG_FLIP_X) != 0;
     bool fy = (flip_bits & NT_SPRITE_FLAG_FLIP_Y) != 0;
 
-    /* Origin offset baked into translation. cached_pos is source-space, so
-     * the vertex loop's per-vertex flip negates source-space x — to mirror
-     * around the pivot rather than around source x=0, sign-flip dx/dy here
-     * before they get folded into tx/ty/tz. */
+    /* Bake the origin pivot into translation: world = m * (local - pivot)
+     * + t expands to world = m * local + (t - m * pivot). Subtracting
+     * m*pivot from tx/ty/tz folds the pivot offset into translation so
+     * the per-vertex multiply doesn't have to subtract it.
+     *
+     * cached_pos is source-space; the per-vertex flip negates source-x.
+     * Sign-flipping dx/dy here mirrors around the pivot instead of around
+     * source x=0. */
     float dx = origin_x * (float)r->source_w * ipu;
     float dy = origin_y * (float)r->source_h * ipu;
     if (fx) {
@@ -611,12 +615,9 @@ void nt_sprite_renderer_flush(void) {
         return;
     }
 
-    /* Single upload for the whole frame's worth of geometry — vs the previous
-     * implementation that did one update_buffer per 4096-sprite flush
-     * (16 uploads on 60k bunnies), each potentially stalling the WebGL
-     * driver's dynamic VBO. orphan_buffer hints the driver to allocate fresh
-     * storage on every rewrite so the GPU can keep consuming the previous
-     * frame while we're staging the next one. */
+    /* orphan_buffer asks the driver to allocate fresh storage instead of
+     * mutating the bound VBO in place, so the GPU can keep consuming the
+     * previous frame's draws while we stage the next one. */
     nt_gfx_orphan_buffer(s_sprite.vbo, s_sprite.vertices, s_sprite.vertex_count * (uint32_t)sizeof(nt_sprite_vertex_t));
     if (s_sprite.index_count > 0) {
         nt_gfx_orphan_buffer(s_sprite.ibo, s_sprite.indices, s_sprite.index_count * (uint32_t)sizeof(uint16_t));

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -318,14 +318,7 @@ void nt_sprite_renderer_set_material(nt_material_t mat) {
 // #endregion
 
 // #region emit_region_resolved
-/* Canonical staging-write body shared by ECS emit_one and the non-ECS
- * public emit_region. Caller supplies pre-resolved region pointers + ipu;
- * the ECS hot path passes these straight from its SoA cache (no extra
- * lookups), the non-ECS public emit_region does one nt_atlas_*() lookup
- * per call and forwards.
- *
- * always_inline so the ECS bunnymark path keeps the same inlined shape
- * it had before the refactor -- no perf regression. */
+/* always_inline keeps the ECS hot path's inlined shape. */
 #if defined(__GNUC__) || defined(__clang__)
 #define NT_SPRITE_EMIT_INLINE static inline __attribute__((always_inline))
 #elif defined(_MSC_VER)
@@ -346,11 +339,8 @@ NT_SPRITE_EMIT_INLINE void emit_region_resolved(const nt_texture_region_t *r, co
         return;
     }
 
-    /* Capacity guard: if this sprite would overflow staging, or exceed the
-     * uint16 indexable vertex range, snapshot the open cmd's state, flush()
-     * (uploads + replays cmds + resets), then re-open a fresh cmd with the
-     * same state at first_index=0. The caller sees no state change; the GPU
-     * just gets another chunk draw instead of UNSIGNED_INT indices. */
+    /* Snapshot+flush+reopen on staging overflow keeps the caller's open
+     * cmd state across the chunk boundary. */
     if (s_sprite.vertex_count + r->vertex_count > NT_SPRITE_RENDERER_MAX_VERTICES || s_sprite.index_count + r->index_count > NT_SPRITE_RENDERER_MAX_INDICES) {
         NT_ASSERT(s_sprite.cmd_count > 0 && "emit_region_resolved called with no open cmd");
         nt_sprite_draw_cmd_t snapshot = s_sprite.cmds[s_sprite.cmd_count - 1];
@@ -358,27 +348,17 @@ NT_SPRITE_EMIT_INLINE void emit_region_resolved(const nt_texture_region_t *r, co
         open_cmd_from_snapshot(&snapshot);
     }
 
-    /* Apply origin offset to translation. cached_pos stores source-space
-     * positions (no origin baked) so dedup'd regions with different origins
-     * share vertex data; the per-region pivot lives entirely in tx/ty/tz.
-     * Same formula whether origin is the region default or a runtime override
-     * — only the source differs. */
+    /* cached_pos is source-space (no origin baked) -- regions with
+     * different origins can share vertex data. */
     float tx = m[12];
     float ty = m[13];
     float tz = m[14];
 
-    /* Flip flags — per-vertex negate of cached_pos */
     bool fx = (flip_bits & NT_SPRITE_FLAG_FLIP_X) != 0;
     bool fy = (flip_bits & NT_SPRITE_FLAG_FLIP_Y) != 0;
 
-    /* Bake the origin pivot into translation: world = m * (local - pivot)
-     * + t expands to world = m * local + (t - m * pivot). Subtracting
-     * m*pivot from tx/ty/tz folds the pivot offset into translation so
-     * the per-vertex multiply doesn't have to subtract it.
-     *
-     * cached_pos is source-space; the per-vertex flip negates source-x.
-     * Sign-flipping dx/dy here mirrors around the pivot instead of around
-     * source x=0. */
+    /* Bake pivot into translation: world = m*local + (t - m*pivot).
+     * Flip mirrors around the pivot by sign-flipping dx/dy. */
     float dx = origin_x * (float)r->source_w * ipu;
     float dy = origin_y * (float)r->source_h * ipu;
     if (fx) {

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -63,21 +63,13 @@ static struct {
      * nt_gfx_get_frame_draw_calls (which is engine-wide and frame-scoped). */
     uint32_t last_draw_list_calls;
 
-    /* Currently-bound material for the non-ECS public emit path
-     * (nt_sprite_renderer_set_material + nt_sprite_renderer_emit_region).
-     * Mirrors nt_text_renderer's s_text.material — auto-flushes on .id
-     * change. NT_MATERIAL_INVALID until first set_material call.
-     * NOTE: ECS path (draw_list -> emit_one) does NOT touch this field —
-     * it opens/closes cmds per batch_key directly. */
+    /* Material bound for the non-ECS public emit path. Auto-flushes on
+     * .id change. The ECS draw_list path does NOT touch this -- it
+     * opens/closes cmds per batch_key directly. */
     nt_material_t current_mat;
 #ifdef NT_SPRITE_RENDERER_TEST_ACCESS
-    /* Test-only: last emit_one() vertex/index counts captured BEFORE flush
-     * resets s_sprite.vertex_count. Read by polygon-emit test to verify
-     * region.vertex_count==N polygons emit N vertices.
-     *
-     * last_emit_first_vertex is the staging offset where the last emit
-     * wrote its vertices — flush only resets vertex_count, not the array
-     * data, so tests can still read positions back via this offset. */
+    /* Captured before flush resets vertex_count, so tests can read back
+     * what the last emit wrote (positions via last_emit_first_vertex). */
     uint32_t last_emit_vertex_count;
     uint32_t last_emit_index_count;
     uint32_t last_emit_first_vertex;
@@ -295,25 +287,19 @@ static bool ensure_current_cmd_page_texture(uint32_t page_tex) {
 }
 // #endregion
 
-// #region set_material (non-ECS public state setter — Drift 4 resolution)
-/* Bind a material for subsequent nt_sprite_renderer_emit_region() calls.
- * Mirrors nt_text_renderer_set_material: same-handle reentry is a no-op;
- * .id-change closes the current cmd (auto-flushes pending emits) and opens
- * a fresh cmd with the new pipeline + material info.
+// #region set_material
+/* Mirrors nt_text_renderer_set_material: same-handle reentry is a no-op;
+ * .id change auto-flushes and opens a fresh cmd.
  *
- * Same-handle short-circuit reads s_sprite.current_mat.id WITHOUT closing
- * the open cmd — this preserves batching when the game calls set_material
- * defensively each walker frame. The ECS path (draw_list -> emit_one) opens
- * cmds directly per batch_key and does not touch current_mat, so the two
- * call paths cannot interfere. */
+ * The ECS draw_list path opens cmds per batch_key directly and does not
+ * touch current_mat, so the two call paths cannot interfere. */
 void nt_sprite_renderer_set_material(nt_material_t mat) {
     NT_ASSERT(s_sprite.initialized);
     NT_ASSERT(mat.id != 0 && "nt_sprite_renderer_set_material: invalid material handle");
 
-    /* Same-handle reentry is a no-op ONLY when the cmd we'd reopen is still
-     * live. After an explicit flush() (or restore_gpu) cmd_count drops to 0
-     * and we MUST reopen even for the same handle, otherwise the next emit
-     * trips the "no open cmd" assert. */
+    /* Same-handle is a no-op only when the cmd is still live. After an
+     * explicit flush (or restore_gpu) cmd_count drops to 0 and we MUST
+     * reopen, otherwise the next emit trips "no open cmd". */
     if (mat.id == s_sprite.current_mat.id && s_sprite.cmd_count > 0) {
         return;
     }
@@ -321,9 +307,6 @@ void nt_sprite_renderer_set_material(nt_material_t mat) {
     const nt_material_info_t *mat_info = nt_material_get_info(mat);
     NT_ASSERT(mat_info != NULL && mat_info->ready && mat_info->resolved_vs != 0 && mat_info->resolved_fs != 0 && "nt_sprite_renderer_set_material: material not ready");
 
-    /* Auto-flush staging on material change. close_current_cmd() pops empty
-     * cmds (no indices written) so re-binding a material before any emit is
-     * cheap — flush() short-circuits when cmd_count == 0. */
     if (s_sprite.cmd_count > 0) {
         nt_sprite_renderer_flush();
     }
@@ -334,19 +317,15 @@ void nt_sprite_renderer_set_material(nt_material_t mat) {
 }
 // #endregion
 
-// #region emit_region_resolved (canonical staging-write body — shared ECS + non-ECS)
-/* Single canonical staging-write body for one atlas region at one mat4.
- *
- * Caller supplies pre-resolved region pointers and the atlas's inverse pixels-
- * per-unit (ipu) directly — this is the no-extra-lookup hot path. The ECS
- * emit_one() reads these straight from the resolved-region SoA slot; the
- * non-ECS public nt_sprite_renderer_emit_region() does one nt_atlas_*() lookup
+// #region emit_region_resolved
+/* Canonical staging-write body shared by ECS emit_one and the non-ECS
+ * public emit_region. Caller supplies pre-resolved region pointers + ipu;
+ * the ECS hot path passes these straight from its SoA cache (no extra
+ * lookups), the non-ECS public emit_region does one nt_atlas_*() lookup
  * per call and forwards.
  *
- * Marked `static inline` + ALWAYS_INLINE so the bunnymark ECS hot path keeps
- * the same single-frame inlined shape it had before the refactor (D-52-02
- * ≤2% regression gate). Compilers without an always_inline attribute simply
- * see a `static inline` request — same behaviour as before. */
+ * always_inline so the ECS bunnymark path keeps the same inlined shape
+ * it had before the refactor -- no perf regression. */
 #if defined(__GNUC__) || defined(__clang__)
 #define NT_SPRITE_EMIT_INLINE static inline __attribute__((always_inline))
 #elif defined(_MSC_VER)
@@ -507,35 +486,32 @@ NT_SPRITE_EMIT_INLINE void emit_region_resolved(const nt_texture_region_t *r, co
 // #region emit_one (ECS extractor — delegates to emit_region_resolved)
 /* Caller passes pre-fetched SoA views; sparse_indices[entity_index] → dense slot.
  *
- * D-52-02: emit_one is now a thin extractor that resolves origin/flip/color
- * from the ECS components and forwards to emit_region_resolved. The staging-
- * write body lives in one canonical place. No extra atlas lookup vs the old
- * monolithic emit_one — resolved-region pointers come straight from
- * sv->resolved[s_idx]. */
+ * emit_one is a thin ECS extractor: resolves origin/flip/color from the
+ * components and forwards to emit_region_resolved. Resolved region
+ * pointers come straight from sv->resolved[s_idx] -- no extra atlas
+ * lookup. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *sv, const nt_transform_comp_view_t *tv, const nt_drawable_comp_view_t *dv) {
     nt_entity_t e = {.id = item->entity};
     uint16_t eidx = nt_entity_index(e);
 
-    /* Inline sparse->dense lookups — three array reads vs three function
-     * calls each doing a liveness assert + the same lookup. */
+    /* Inlined sparse->dense lookups vs three function calls each doing a
+     * liveness assert + the same array read. */
     uint16_t s_idx = sv->sparse_indices[eidx];
     uint16_t t_idx = tv->sparse_indices[eidx];
     uint16_t d_idx = dv->sparse_indices[eidx];
 
-    /* AGENTS.md "fail early, prefer asserts": dense indices must be valid.
-     * NT_INVALID_COMP_INDEX (0xFFFF) would index SoA arrays out of bounds.
-     * Catches stale render items, items for entities missing a component,
-     * items built after entity destruction. Compiles out in release. */
+    /* NT_INVALID_COMP_INDEX (0xFFFF) would index SoA arrays out of bounds
+     * -- catches stale render items, items for entities missing a
+     * component, items built after entity destruction. */
     NT_ASSERT(s_idx != NT_INVALID_COMP_INDEX && "sprite render item: entity has no sprite component");
     NT_ASSERT(t_idx != NT_INVALID_COMP_INDEX && "sprite render item: entity has no transform component");
     NT_ASSERT(d_idx != NT_INVALID_COMP_INDEX && "sprite render item: entity has no drawable component");
 
-    /* Resolve atlas + region. Tombstone → zero-draw early-out. */
     nt_resource_t atlas = sv->atlas[s_idx];
     const nt_sprite_resolved_region_t *resolved = &sv->resolved[s_idx];
     if ((sv->flags[s_idx] & NT_SPRITE_FLAG_RESOLVED) == 0 || resolved->region == NULL || resolved->region->vertex_count == 0) {
-        return;
+        return; /* tombstone */
     }
     const nt_texture_region_t *r = resolved->region;
     NT_ASSERT(resolved->cached_pos != NULL && resolved->raw_vertices != NULL && resolved->indices != NULL);
@@ -551,15 +527,9 @@ static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *
 }
 // #endregion
 
-// #region emit_region (non-ECS public emit — D-52-01)
-/* Public single-region emit. Resolves the region + page texture + ipu via the
- * atlas handle, then forwards to the canonical emit_region_resolved body. One
- * extra atlas lookup per call vs the ECS path — acceptable for the walker /
- * debug-draw / gizmo use cases where there is no SoA cache.
- *
- * Asserts the renderer + atlas are in a usable state. Caller must have an
- * open cmd (set via nt_sprite_renderer_set_material). Tombstoned regions
- * silently no-op (vertex_count == 0 short-circuits emit_region_resolved). */
+// #region emit_region
+/* One extra atlas lookup per call vs the ECS path -- acceptable for the
+ * walker / debug-draw / gizmo use cases that have no SoA cache. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, const float *world_matrix, float origin_x, float origin_y, uint32_t color_packed, uint8_t flip_bits) {
     NT_ASSERT(s_sprite.initialized);
@@ -570,7 +540,7 @@ void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, 
 
     const nt_texture_region_t *r = nt_atlas_get_region(atlas, region_index);
     if (r == NULL || r->vertex_count == 0U) {
-        return; /* tombstone or out-of-range — silent no-op */
+        return; /* tombstone or out-of-range */
     }
     const float(*cpos)[2] = nt_atlas_get_region_cached_pos(atlas, region_index);
     const nt_atlas_vertex_t *vraw = nt_atlas_get_region_raw_vertices(atlas, region_index);
@@ -584,8 +554,8 @@ void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, 
 // #endregion
 
 // #region draw_list
-/* Phase 1 of the two-phase pipeline: open a cmd per batch_key,
- * stream verts into staging via emit_one. Phase 2 = nt_sprite_renderer_flush. */
+/* Phase 1: open a cmd per batch_key, stream verts into staging via
+ * emit_one. Phase 2 = nt_sprite_renderer_flush. */
 void nt_sprite_renderer_draw_list(const nt_render_item_t *items, uint32_t count) {
     NT_ASSERT(s_sprite.initialized);
     if (count == 0) {

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -61,7 +61,7 @@ static struct {
     /* Reset per draw_list call; SEPARATE from nt_gfx_get_frame_draw_calls. */
     uint32_t last_draw_list_calls;
 
-    /* Non-ECS path only; draw_list opens cmds per batch_key. */
+    /* Material of the most recently opened cmd; reset on flush. */
     nt_material_t current_mat;
 #ifdef NT_TEST_ACCESS
     /* Captured pre-flush so tests can read back the last emit. */
@@ -224,6 +224,7 @@ static void open_cmd(nt_pipeline_t pip, const nt_material_info_t *mi, nt_materia
     memset(c, 0, sizeof(*c)); /* slots reuse across frames; clear stale fields */
     c->pipeline = pip;
     c->material = mat;
+    s_sprite.current_mat = mat;
     c->tex_count = mi->tex_count;
     for (uint8_t i = 0; i < mi->tex_count; i++) {
         c->resolved_tex[i] = mi->resolved_tex[i];
@@ -303,7 +304,6 @@ void nt_sprite_renderer_set_material(nt_material_t mat) {
 
     nt_pipeline_t pip = find_or_create_pipeline(mat_info);
     open_cmd(pip, mat_info, mat);
-    s_sprite.current_mat = mat;
 }
 // #endregion
 

--- a/engine/renderers/nt_sprite_renderer.h
+++ b/engine/renderers/nt_sprite_renderer.h
@@ -2,7 +2,9 @@
 #define NT_SPRITE_RENDERER_H
 
 #include "core/nt_types.h"
+#include "material/nt_material.h"
 #include "render/nt_render_defs.h"
+#include "resource/nt_resource.h"
 
 /* Staging buffers for one flush. uint16 indices cap MAX_VERTICES at 65536.
  * Default index ratio (9/4) sized for 8-vertex polygon worst case (18 idx /
@@ -77,6 +79,31 @@ void nt_sprite_renderer_draw_list(const nt_render_item_t *items, uint32_t count)
  * flush() without preservation either trips the "no open cmd" assert on
  * the next emit or silently drops the state binding. */
 void nt_sprite_renderer_flush(void);
+
+/* ---- Non-ECS public emit surface (Phase 52, Drift 4 resolution) ----
+ *
+ * Bind material for subsequent nt_sprite_renderer_emit_region() calls. Auto-
+ * flushes staging on change to a material with a different .id (mirrors
+ * nt_text_renderer_set_material). Call exactly once between draw_list runs or
+ * non-ECS emit sequences. Asserts the renderer is initialized and the material
+ * resolves via nt_material_get_info() with .ready == true. Same-handle reentry
+ * is a no-op. */
+void nt_sprite_renderer_set_material(nt_material_t mat);
+
+/* Non-ECS emit path: one atlas region at one mat4 transform.
+ *
+ *   atlas         - must be a READY atlas resource (asserted).
+ *   region_index  - index into the atlas; tombstoned regions silently no-op.
+ *   world_matrix  - 16-float mat4 row-major (engine convention; emit_region
+ *                   reads only m[0/1/2/4/5/6/12/13/14]).
+ *   origin_x, _y  - pivot in normalized region-space (e.g. {0.5, 0.5} centers).
+ *   color_packed  - 0xAABBGGRR (premultiplied by caller if needed).
+ *   flip_bits     - NT_SPRITE_FLAG_FLIP_X | _FLIP_Y combination, 0 = none.
+ *
+ * Caller must call nt_sprite_renderer_set_material(...) FIRST so the renderer
+ * has an open cmd to write into. Capacity overflow is handled internally
+ * (auto flush + reopen with cmd state preserved). */
+void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, const float *world_matrix, float origin_x, float origin_y, uint32_t color_packed, uint8_t flip_bits);
 
 /* ---- Test access (compiled only when NT_SPRITE_RENDERER_TEST_ACCESS is defined) ---- */
 

--- a/engine/renderers/nt_sprite_renderer.h
+++ b/engine/renderers/nt_sprite_renderer.h
@@ -103,6 +103,29 @@ void nt_sprite_renderer_set_material(nt_material_t mat);
  * overflow is handled internally (auto flush + reopen, state preserved). */
 void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, const float *world_matrix, float origin_x, float origin_y, uint32_t color_packed, uint8_t flip_bits);
 
+/* Emit an arbitrary triangle list sampling a single UV from the given
+ * atlas region. Intended for solid-color shapes drawn against a
+ * white-pixel region (rounded corners, ring sectors, custom fan/strip).
+ *
+ *   atlas, region_index - the region whose UV centroid is sampled by
+ *                         every emitted vertex. Centroid (mean of region
+ *                         vertex UVs) avoids texel-corner sampling that
+ *                         would bleed neighbours under linear filtering.
+ *                         Region must be READY and have vertex_count > 0;
+ *                         tombstones no-op.
+ *   positions           - vertex_count XY pairs in local space.
+ *   indices             - index_count uint16s, local to this emit (rebased
+ *                         to staging base internally). Must reference
+ *                         indices < vertex_count.
+ *   world_matrix        - 16-float column-major mat4 (cglm convention),
+ *                         same subset read as emit_region.
+ *   color_packed        - 0xAABBGGRR.
+ *
+ * Capacity overflow handled internally (snapshot + flush + reopen).
+ * Caller MUST have called set_material first. */
+void nt_sprite_renderer_emit_geometry(nt_resource_t atlas, uint32_t region_index, const float (*positions)[2], uint32_t vertex_count, const uint16_t *indices, uint32_t index_count,
+                                      const float *world_matrix, uint32_t color_packed);
+
 // #region test_access
 #ifdef NT_TEST_ACCESS
 uint32_t nt_sprite_renderer_test_pipeline_cache_count(void);
@@ -118,6 +141,9 @@ uint32_t nt_sprite_renderer_test_last_emit_index_count(void);
  * Flush only resets vertex_count, not the staging array data, so positions
  * are still readable post-draw_list via the captured first_vertex offset. */
 void nt_sprite_renderer_test_last_emit_position(uint32_t v_idx, float out[3]);
+/* Atlas texcoord of the i-th vertex of the last emit, in raw uint16 0..65535
+ * units (the shader normalizes to [0,1] via USHORT2N). */
+void nt_sprite_renderer_test_last_emit_texcoord(uint32_t v_idx, uint16_t out[2]);
 bool nt_sprite_renderer_test_initialized(void);
 #endif
 // #endregion

--- a/engine/renderers/nt_sprite_renderer.h
+++ b/engine/renderers/nt_sprite_renderer.h
@@ -94,8 +94,10 @@ void nt_sprite_renderer_set_material(nt_material_t mat);
  *
  *   atlas         - must be a READY atlas resource (asserted).
  *   region_index  - index into the atlas; tombstoned regions silently no-op.
- *   world_matrix  - 16-float mat4 row-major (engine convention; emit_region
- *                   reads only m[0/1/2/4/5/6/12/13/14]).
+ *   world_matrix  - 16-float mat4 COLUMN-major (cglm engine convention).
+ *                   emit_region reads only m[0/1/2/4/5/6/12/13/14] --
+ *                   columns 0+1 carry the 2D rotation/scale, m[12/13/14]
+ *                   carry translation.
  *   origin_x, _y  - pivot in normalized region-space (e.g. {0.5, 0.5} centers).
  *   color_packed  - 0xAABBGGRR (premultiplied by caller if needed).
  *   flip_bits     - NT_SPRITE_FLAG_FLIP_X | _FLIP_Y combination, 0 = none.

--- a/engine/renderers/nt_sprite_renderer.h
+++ b/engine/renderers/nt_sprite_renderer.h
@@ -80,31 +80,27 @@ void nt_sprite_renderer_draw_list(const nt_render_item_t *items, uint32_t count)
  * the next emit or silently drops the state binding. */
 void nt_sprite_renderer_flush(void);
 
-/* ---- Non-ECS public emit surface (Phase 52, Drift 4 resolution) ----
+/* ---- Non-ECS public emit surface ----
  *
- * Bind material for subsequent nt_sprite_renderer_emit_region() calls. Auto-
- * flushes staging on change to a material with a different .id (mirrors
- * nt_text_renderer_set_material). Call exactly once between draw_list runs or
- * non-ECS emit sequences. Asserts the renderer is initialized and the material
- * resolves via nt_material_get_info() with .ready == true. Same-handle reentry
- * is a no-op. */
+ * Bind material for subsequent emit_region calls. Auto-flushes staging
+ * on change to a different .id (mirrors nt_text_renderer_set_material).
+ * Same-handle reentry is a no-op. Asserts the material resolves with
+ * .ready == true. */
 void nt_sprite_renderer_set_material(nt_material_t mat);
 
-/* Non-ECS emit path: one atlas region at one mat4 transform.
+/* Emit one atlas region at one mat4 transform.
  *
  *   atlas         - must be a READY atlas resource (asserted).
- *   region_index  - index into the atlas; tombstoned regions silently no-op.
- *   world_matrix  - 16-float mat4 COLUMN-major (cglm engine convention).
- *                   emit_region reads only m[0/1/2/4/5/6/12/13/14] --
- *                   columns 0+1 carry the 2D rotation/scale, m[12/13/14]
- *                   carry translation.
- *   origin_x, _y  - pivot in normalized region-space (e.g. {0.5, 0.5} centers).
+ *   region_index  - tombstoned regions silently no-op.
+ *   world_matrix  - 16-float column-major mat4 (cglm convention). Only
+ *                   m[0/1/2/4/5/6/12/13/14] are read: columns 0+1 carry
+ *                   2D rotation/scale, m[12/13/14] carry translation.
+ *   origin_x, _y  - pivot in normalized region-space (e.g. {0.5, 0.5}).
  *   color_packed  - 0xAABBGGRR (premultiplied by caller if needed).
- *   flip_bits     - NT_SPRITE_FLAG_FLIP_X | _FLIP_Y combination, 0 = none.
+ *   flip_bits     - NT_SPRITE_FLAG_FLIP_X | _FLIP_Y, 0 = none.
  *
- * Caller must call nt_sprite_renderer_set_material(...) FIRST so the renderer
- * has an open cmd to write into. Capacity overflow is handled internally
- * (auto flush + reopen with cmd state preserved). */
+ * Caller MUST have called set_material first so a cmd is open. Capacity
+ * overflow is handled internally (auto flush + reopen, state preserved). */
 void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, const float *world_matrix, float origin_x, float origin_y, uint32_t color_packed, uint8_t flip_bits);
 
 /* ---- Test access (compiled only when NT_SPRITE_RENDERER_TEST_ACCESS is defined) ---- */

--- a/engine/renderers/nt_sprite_renderer.h
+++ b/engine/renderers/nt_sprite_renderer.h
@@ -103,9 +103,8 @@ void nt_sprite_renderer_set_material(nt_material_t mat);
  * overflow is handled internally (auto flush + reopen, state preserved). */
 void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, const float *world_matrix, float origin_x, float origin_y, uint32_t color_packed, uint8_t flip_bits);
 
-/* ---- Test access (compiled only when NT_SPRITE_RENDERER_TEST_ACCESS is defined) ---- */
-
-#ifdef NT_SPRITE_RENDERER_TEST_ACCESS
+// #region test_access
+#ifdef NT_TEST_ACCESS
 uint32_t nt_sprite_renderer_test_pipeline_cache_count(void);
 /* Per-renderer test counter (separate from nt_gfx_get_frame_draw_calls). */
 uint32_t nt_sprite_renderer_test_draw_call_count(void);
@@ -121,5 +120,6 @@ uint32_t nt_sprite_renderer_test_last_emit_index_count(void);
 void nt_sprite_renderer_test_last_emit_position(uint32_t v_idx, float out[3]);
 bool nt_sprite_renderer_test_initialized(void);
 #endif
+// #endregion
 
 #endif /* NT_SPRITE_RENDERER_H */

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -44,7 +44,7 @@ static struct {
 
     bool initialized;
 
-#ifdef NT_TEXT_RENDERER_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
     /* Count every set_material / set_font entry regardless of early-out so
      * nt_stats tests can prove explicit calls. */
     uint32_t test_set_material_calls;
@@ -193,7 +193,7 @@ void nt_text_renderer_restore_gpu(void) {
 // #region State setters
 void nt_text_renderer_set_material(nt_material_t mat) {
     NT_ASSERT(s_text.initialized);
-#ifdef NT_TEXT_RENDERER_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
     s_text.test_set_material_calls++;
 #endif
     if (s_text.material.id == mat.id) {
@@ -212,7 +212,7 @@ void nt_text_renderer_set_material(nt_material_t mat) {
 
 void nt_text_renderer_set_font(nt_font_t font) {
     NT_ASSERT(s_text.initialized);
-#ifdef NT_TEXT_RENDERER_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
     s_text.test_set_font_calls++;
 #endif
     if (s_text.font.id == font.id) {
@@ -433,7 +433,7 @@ void nt_text_renderer_flush(void) {
 // #endregion
 
 // #region Test accessors
-#ifdef NT_TEXT_RENDERER_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
 uint32_t nt_text_renderer_test_vertex_count(void) { return s_text.vertex_count; }
 uint32_t nt_text_renderer_test_glyph_count(void) { return s_text.glyph_count; }
 const void *nt_text_renderer_test_vertices(void) { return s_text.vertices; }

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -312,7 +312,7 @@ static void emit_quad(const nt_glyph_cache_entry_t *g, const float model[16], fl
 
 // #region Draw
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16], float size, const float color[4], float letter_spacing) {
+void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16], float size, const float color[4], float letter_tracking, float line_leading) {
     NT_ASSERT(s_text.initialized);
     if (len == 0U || utf8 == NULL) {
         return;
@@ -337,7 +337,9 @@ void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16]
     uint32_t prev_cp = 0;
     float pen_x = 0.0F;
     float pen_y = 0.0F;
-    const float line_advance = (metrics.line_height != 0) ? ((float)metrics.line_height * scale) : size;
+    /* Natural line advance from font metrics, plus user-supplied leading. */
+    const float natural_line_advance = (metrics.line_height != 0) ? ((float)metrics.line_height * scale) : size;
+    const float line_advance = natural_line_advance + line_leading;
     bool had_glyph_on_line = false;
 
     const uint8_t *p = (const uint8_t *)utf8;
@@ -364,7 +366,7 @@ void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16]
         }
 
         if (had_glyph_on_line) {
-            pen_x += letter_spacing;
+            pen_x += letter_tracking;
         }
 
         /* Apply kern pair */
@@ -390,8 +392,8 @@ void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16]
     }
 }
 
-void nt_text_renderer_draw(const char *utf8, const float model[16], float size, const float color[4], float letter_spacing) {
-    nt_text_renderer_draw_n(utf8, utf8 ? strlen(utf8) : 0U, model, size, color, letter_spacing);
+void nt_text_renderer_draw(const char *utf8, const float model[16], float size, const float color[4], float letter_tracking, float line_leading) {
+    nt_text_renderer_draw_n(utf8, utf8 ? strlen(utf8) : 0U, model, size, color, letter_tracking, line_leading);
 }
 // #endregion
 

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -307,17 +307,12 @@ static void emit_quad(const nt_glyph_cache_entry_t *g, const float model[16], fl
 
 // #region Draw
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16], float size, const float color[4]) {
+void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16], float size, const float color[4], float letter_spacing) {
     NT_ASSERT(s_text.initialized);
     if (len == 0U || utf8 == NULL) {
         return;
     }
-    if (s_text.font.id == 0) {
-        /* Legitimate "no font configured" state; slot == NULL below is the
-         * bug case (destroyed handle, etc.). */
-        NT_LOG_WARN("nt_text_renderer_draw_n: no font set");
-        return;
-    }
+    NT_ASSERT(s_text.font.id != 0 && "nt_text_renderer_draw_n: call set_font before draw");
 
     nt_font_metrics_t metrics = nt_font_get_metrics(s_text.font);
     if (metrics.units_per_em == 0) {
@@ -338,6 +333,7 @@ void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16]
     float pen_x = 0.0F;
     float pen_y = 0.0F;
     const float line_advance = (metrics.line_height != 0) ? ((float)metrics.line_height * scale) : size;
+    bool had_glyph_on_line = false;
 
     const uint8_t *p = (const uint8_t *)utf8;
     const uint8_t *end = p + len;
@@ -358,7 +354,12 @@ void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16]
             pen_x = 0.0F;
             pen_y -= line_advance;
             prev_cp = 0;
+            had_glyph_on_line = false;
             continue;
+        }
+
+        if (had_glyph_on_line) {
+            pen_x += letter_spacing;
         }
 
         /* Apply kern pair */
@@ -380,10 +381,13 @@ void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16]
 
         pen_x += (float)g->advance * scale;
         prev_cp = codepoint;
+        had_glyph_on_line = true;
     }
 }
 
-void nt_text_renderer_draw(const char *utf8, const float model[16], float size, const float color[4]) { nt_text_renderer_draw_n(utf8, utf8 ? strlen(utf8) : 0U, model, size, color); }
+void nt_text_renderer_draw(const char *utf8, const float model[16], float size, const float color[4], float letter_spacing) {
+    nt_text_renderer_draw_n(utf8, utf8 ? strlen(utf8) : 0U, model, size, color, letter_spacing);
+}
 // #endregion
 
 // #region Flush

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -200,13 +200,16 @@ void nt_text_renderer_set_material(nt_material_t mat) {
         return;
     }
 
-    /* Auto-flush on material change */
+    const nt_material_info_t *info = nt_material_get_info(mat);
+    NT_ASSERT(info != NULL && "nt_text_renderer_set_material: invalid material handle");
+    NT_ASSERT(info->ready && "nt_text_renderer_set_material: material not ready");
+
     if (s_text.glyph_count > 0) {
         nt_text_renderer_flush();
     }
 
     s_text.material = mat;
-    s_text.pipeline_material_version = 0; /* force pipeline recreation */
+    s_text.pipeline_material_version = 0;
     create_pipeline();
 }
 

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -196,13 +196,15 @@ void nt_text_renderer_set_material(nt_material_t mat) {
 #ifdef NT_TEST_ACCESS
     s_text.test_set_material_calls++;
 #endif
-    if (s_text.material.id == mat.id) {
-        return;
-    }
-
+    /* Validate BEFORE same-handle early return: stale handle (destroyed material,
+     * bumped generation) must assert even if the id still matches what we cached. */
     const nt_material_info_t *info = nt_material_get_info(mat);
     NT_ASSERT(info != NULL && "nt_text_renderer_set_material: invalid material handle");
     NT_ASSERT(info->ready && "nt_text_renderer_set_material: material not ready");
+
+    if (s_text.material.id == mat.id) {
+        return;
+    }
 
     if (s_text.glyph_count > 0) {
         nt_text_renderer_flush();

--- a/engine/renderers/nt_text_renderer.h
+++ b/engine/renderers/nt_text_renderer.h
@@ -26,9 +26,11 @@ void nt_text_renderer_set_material(nt_material_t mat);
 void nt_text_renderer_set_font(nt_font_t font);
 
 /* NULL/len=0 → no-op. UTF-8 cut at `len` boundary → trailing partial
- * codepoint dropped (no over-read past utf8+len). */
-void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16], float size, const float color[4]);
-void nt_text_renderer_draw(const char *utf8, const float model[16], float size, const float color[4]);
+ * codepoint dropped (no over-read past utf8+len). letter_spacing adds
+ * N-1 extra pixels of pen advance for N visible glyphs (newlines reset
+ * pen_x and do not count as glyphs). */
+void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16], float size, const float color[4], float letter_spacing);
+void nt_text_renderer_draw(const char *utf8, const float model[16], float size, const float color[4], float letter_spacing);
 
 void nt_text_renderer_flush(void);
 

--- a/engine/renderers/nt_text_renderer.h
+++ b/engine/renderers/nt_text_renderer.h
@@ -32,7 +32,8 @@ void nt_text_renderer_draw(const char *utf8, const float model[16], float size, 
 
 void nt_text_renderer_flush(void);
 
-#ifdef NT_TEXT_RENDERER_TEST_ACCESS
+// #region test_access
+#ifdef NT_TEST_ACCESS
 uint32_t nt_text_renderer_test_vertex_count(void);
 uint32_t nt_text_renderer_test_glyph_count(void);
 const void *nt_text_renderer_test_vertices(void);
@@ -43,5 +44,6 @@ uint32_t nt_text_renderer_test_set_material_calls(void);
 uint32_t nt_text_renderer_test_set_font_calls(void);
 void nt_text_renderer_test_reset_call_counters(void);
 #endif
+// #endregion
 
 #endif /* NT_TEXT_RENDERER_H */

--- a/engine/renderers/nt_text_renderer.h
+++ b/engine/renderers/nt_text_renderer.h
@@ -26,11 +26,14 @@ void nt_text_renderer_set_material(nt_material_t mat);
 void nt_text_renderer_set_font(nt_font_t font);
 
 /* NULL/len=0 → no-op. UTF-8 cut at `len` boundary → trailing partial
- * codepoint dropped (no over-read past utf8+len). letter_spacing adds
- * N-1 extra pixels of pen advance for N visible glyphs (newlines reset
- * pen_x and do not count as glyphs). */
-void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16], float size, const float color[4], float letter_spacing);
-void nt_text_renderer_draw(const char *utf8, const float model[16], float size, const float color[4], float letter_spacing);
+ * codepoint dropped (no over-read past utf8+len).
+ *
+ * letter_tracking: EXTRA px between glyphs (additive, NOT absolute).
+ *   0 = font's natural advance. Positive = loose, negative = tight.
+ * line_leading:    EXTRA px between lines on \n (additive, NOT absolute).
+ *   0 = font's natural line advance. Positive = loose, negative = tight. */
+void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16], float size, const float color[4], float letter_tracking, float line_leading);
+void nt_text_renderer_draw(const char *utf8, const float model[16], float size, const float color[4], float letter_tracking, float line_leading);
 
 void nt_text_renderer_flush(void);
 

--- a/engine/resource/nt_resource.c
+++ b/engine/resource/nt_resource.c
@@ -1506,7 +1506,7 @@ void nt_resource_dump_pack(nt_hash32_t pack_id) {
 
 /* ---- Test access (test-only) ---- */
 
-#ifdef NT_RESOURCE_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
 
 void nt_resource_test_set_asset_state(nt_hash64_t resource_id, uint16_t pack_index, uint8_t state, uint32_t runtime_handle) {
     for (uint32_t i = 0; i < s_resource.asset_hwm; i++) {
@@ -1519,4 +1519,4 @@ void nt_resource_test_set_asset_state(nt_hash64_t resource_id, uint16_t pack_ind
     }
 }
 
-#endif /* NT_RESOURCE_TEST_ACCESS */
+#endif /* NT_TEST_ACCESS */

--- a/engine/resource/nt_resource.h
+++ b/engine/resource/nt_resource.h
@@ -199,10 +199,10 @@ void nt_resource_invalidate(uint8_t asset_type);
 
 void nt_resource_dump_pack(nt_hash32_t pack_id);
 
-/* ---- Test access (test-only) ---- */
-
-#ifdef NT_RESOURCE_TEST_ACCESS
+// #region test_access
+#ifdef NT_TEST_ACCESS
 void nt_resource_test_set_asset_state(nt_hash64_t resource_id, uint16_t pack_index, uint8_t state, uint32_t runtime_handle);
 #endif
+// #endregion
 
 #endif /* NT_RESOURCE_H */

--- a/engine/stats/nt_stats.c
+++ b/engine/stats/nt_stats.c
@@ -183,7 +183,7 @@ void nt_stats_draw(nt_material_t material, nt_font_t font, const float model[16]
      * regardless of prior frame state. */
     nt_text_renderer_set_material(material);
     nt_text_renderer_set_font(font);
-    nt_text_renderer_draw(buf, model, size, color);
+    nt_text_renderer_draw(buf, model, size, color, 0.0F);
 }
 // #endregion
 

--- a/engine/stats/nt_stats.c
+++ b/engine/stats/nt_stats.c
@@ -188,7 +188,7 @@ void nt_stats_draw(nt_material_t material, nt_font_t font, const float model[16]
 // #endregion
 
 // #region Test access
-#ifdef NT_STATS_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
 void nt_stats_test_inject_frame(float dt_seconds) {
     NT_ASSERT(s_stats.initialized);
     s_stats.last_cpu_ms = dt_seconds * 1000.0F;

--- a/engine/stats/nt_stats.c
+++ b/engine/stats/nt_stats.c
@@ -183,7 +183,7 @@ void nt_stats_draw(nt_material_t material, nt_font_t font, const float model[16]
      * regardless of prior frame state. */
     nt_text_renderer_set_material(material);
     nt_text_renderer_set_font(font);
-    nt_text_renderer_draw(buf, model, size, color, 0.0F);
+    nt_text_renderer_draw(buf, model, size, color, 0.0F, 0.0F);
 }
 // #endregion
 

--- a/engine/stats/nt_stats.h
+++ b/engine/stats/nt_stats.h
@@ -68,12 +68,13 @@ uint32_t nt_stats_format_lines(char *buf, uint32_t size);
  * state. */
 void nt_stats_draw(nt_material_t material, nt_font_t font, const float model[16], float size, const float color[4]);
 
-/* ---- Test access (test builds only) ----
- * Inject a synthetic per-frame seconds value directly into the FPS ring +
- * cpu/draw bookkeeping, bypassing the real wall clock. Used by unit tests to
- * assert the rolling-avg formula deterministically. */
-#ifdef NT_STATS_TEST_ACCESS
+// #region test_access
+/* Inject a synthetic per-frame seconds value directly into the FPS ring +
+ * cpu/draw bookkeeping, bypassing the real wall clock. Used by unit tests
+ * to assert the rolling-avg formula deterministically. */
+#ifdef NT_TEST_ACCESS
 void nt_stats_test_inject_frame(float dt_seconds);
 #endif
+// #endregion
 
 #endif /* NT_STATS_H */

--- a/engine/ui/CMakeLists.txt
+++ b/engine/ui/CMakeLists.txt
@@ -69,6 +69,7 @@ target_link_libraries(nt_ui
         nt_font
         nt_material
         nt_input
+        nt_mem_scratch
     PRIVATE
         nt_gfx
         nt_sprite_renderer

--- a/engine/ui/CMakeLists.txt
+++ b/engine/ui/CMakeLists.txt
@@ -34,6 +34,7 @@ set(_clay_minor "${CMAKE_MATCH_2}")
 nt_add_module(nt_ui LOG_DOMAIN "ui"
     nt_ui.c
     nt_ui.h
+    nt_ui_internal.h
 )
 
 # Clay vendored header -- PRIVATE include (only nt_ui.c sees clay.h).
@@ -41,14 +42,33 @@ nt_add_module(nt_ui LOG_DOMAIN "ui"
 # precedent). Clay's source is excluded from clang-tidy via scripts/tidy.sh.
 # Use NT_ENGINE_ROOT so the include resolves correctly when nt_ui is
 # consumed from a parent CMake project (submodule scenario).
+#
+# Phase 52 Task 2.2: nt_ui_internal.h includes "clay.h", and test TUs
+# compiled with NT_UI_TEST_ACCESS pull that internal header in. The
+# include directory therefore needs to be visible to consumers of nt_ui
+# that opt into test access.
 target_include_directories(nt_ui SYSTEM PRIVATE
     ${NT_ENGINE_ROOT}/deps/clay
+)
+target_include_directories(nt_ui SYSTEM INTERFACE
+    $<BUILD_INTERFACE:${NT_ENGINE_ROOT}/deps/clay>
 )
 
 # Version pin propagated to the _Static_assert in nt_ui.c
 target_compile_definitions(nt_ui PRIVATE
     CLAY_PINNED_MAJOR=${_clay_major}
     CLAY_PINNED_MINOR=${_clay_minor}
+)
+
+# Phase 52 Task 2.2: nt_ui needs nt_core (asserts/logging/types), nt_resource
+# (handle types referenced in public headers), nt_font (font handle),
+# nt_material (material handle), nt_input (pointer state struct).
+target_link_libraries(nt_ui PUBLIC
+    nt_core
+    nt_resource
+    nt_font
+    nt_material
+    nt_input
 )
 
 # nt_log is PRIVATE-linked by nt_add_module via the LOG_DOMAIN injection.

--- a/engine/ui/CMakeLists.txt
+++ b/engine/ui/CMakeLists.txt
@@ -37,17 +37,14 @@ nt_add_module(nt_ui LOG_DOMAIN "ui"
     nt_ui_internal.h
 )
 
-# Clay vendored header -- PRIVATE include (only nt_ui.c sees clay.h).
-# SYSTEM suppresses -Werror on Clay-internal warnings (matches engine/math/cglm
-# precedent). Clay's source is excluded from clang-tidy via scripts/tidy.sh.
-# Use NT_ENGINE_ROOT so the include resolves when nt_ui is consumed from a
-# parent CMake project. INTERFACE-include is needed because test TUs
-# compiled with NT_UI_TEST_ACCESS pull in nt_ui_internal.h which #includes
-# "clay.h".
-target_include_directories(nt_ui SYSTEM PRIVATE
-    ${NT_ENGINE_ROOT}/deps/clay
-)
-target_include_directories(nt_ui SYSTEM INTERFACE
+# Clay vendored header -- PUBLIC include. Clay is part of the engine's
+# public surface: nt_ui wraps lifecycle (context, walker, themes) but
+# game code drives layout/widgets via CLAY_* macros directly. SYSTEM
+# suppresses -Werror on Clay-internal warnings (matches engine/math/cglm).
+# Clay's source is excluded from clang-tidy via scripts/tidy.sh. Use
+# NT_ENGINE_ROOT so the include resolves when nt_ui is consumed from a
+# parent CMake project.
+target_include_directories(nt_ui SYSTEM PUBLIC
     $<BUILD_INTERFACE:${NT_ENGINE_ROOT}/deps/clay>
 )
 

--- a/engine/ui/CMakeLists.txt
+++ b/engine/ui/CMakeLists.txt
@@ -40,13 +40,10 @@ nt_add_module(nt_ui LOG_DOMAIN "ui"
 # Clay vendored header -- PRIVATE include (only nt_ui.c sees clay.h).
 # SYSTEM suppresses -Werror on Clay-internal warnings (matches engine/math/cglm
 # precedent). Clay's source is excluded from clang-tidy via scripts/tidy.sh.
-# Use NT_ENGINE_ROOT so the include resolves correctly when nt_ui is
-# consumed from a parent CMake project (submodule scenario).
-#
-# Phase 52 Task 2.2: nt_ui_internal.h includes "clay.h", and test TUs
-# compiled with NT_UI_TEST_ACCESS pull that internal header in. The
-# include directory therefore needs to be visible to consumers of nt_ui
-# that opt into test access.
+# Use NT_ENGINE_ROOT so the include resolves when nt_ui is consumed from a
+# parent CMake project. INTERFACE-include is needed because test TUs
+# compiled with NT_UI_TEST_ACCESS pull in nt_ui_internal.h which #includes
+# "clay.h".
 target_include_directories(nt_ui SYSTEM PRIVATE
     ${NT_ENGINE_ROOT}/deps/clay
 )
@@ -60,19 +57,14 @@ target_compile_definitions(nt_ui PRIVATE
     CLAY_PINNED_MINOR=${_clay_minor}
 )
 
-# Phase 52 Task 2.2: nt_ui needs nt_core (asserts/logging/types), nt_resource
-# (handle types referenced in public headers), nt_font (font handle),
-# nt_material (material handle), nt_input (pointer state struct).
+# PUBLIC: types referenced in nt_ui.h (handles + pointer state struct).
+# PRIVATE: walker implementation deps (renderer + gfx + atlas).
 #
-# Phase 52 Plan 04: walker private deps. The walker translates Clay render
-# commands into sprite/text renderer emits + gfx scissor/viewport state. These
-# stay PRIVATE because nothing in nt_ui's public surface references them.
-#
-# nt_ui has NO dependency on nt_stats. Per-walk metrics are exposed via
-# nt_ui_get_last_walk_* getters; the application chooses to publish them
-# into nt_stats (debug overlay) or consume privately. This keeps nt_ui's
-# direction-of-deps aligned with nt_gfx <-- nt_stats (observability pulls
-# from rendering modules, never the reverse).
+# nt_stats is intentionally NOT a dependency. Per-walk metrics are
+# exposed via nt_ui_get_last_walk_* getters; apps that want them in the
+# debug overlay forward into nt_stats themselves. Direction-of-deps
+# matches nt_gfx <- nt_stats: observability pulls from rendering, never
+# the reverse.
 target_link_libraries(nt_ui
     PUBLIC
         nt_core

--- a/engine/ui/CMakeLists.txt
+++ b/engine/ui/CMakeLists.txt
@@ -68,9 +68,11 @@ target_compile_definitions(nt_ui PRIVATE
 # commands into sprite/text renderer emits + gfx scissor/viewport state. These
 # stay PRIVATE because nothing in nt_ui's public surface references them.
 #
-# Phase 52 Plan 05: nt_stats added for per-walk ui_draw_calls + ui_element_count
-# user-counter wiring (WALK-09 / D-52-20). Stays PRIVATE because nt_ui's public
-# API does not reference any nt_stats type.
+# nt_ui has NO dependency on nt_stats. Per-walk metrics are exposed via
+# nt_ui_get_last_walk_* getters; the application chooses to publish them
+# into nt_stats (debug overlay) or consume privately. This keeps nt_ui's
+# direction-of-deps aligned with nt_gfx <-- nt_stats (observability pulls
+# from rendering modules, never the reverse).
 target_link_libraries(nt_ui
     PUBLIC
         nt_core
@@ -83,7 +85,6 @@ target_link_libraries(nt_ui
         nt_sprite_renderer
         nt_text_renderer
         nt_atlas
-        nt_stats
 )
 
 # nt_log is PRIVATE-linked by nt_add_module via the LOG_DOMAIN injection.

--- a/engine/ui/CMakeLists.txt
+++ b/engine/ui/CMakeLists.txt
@@ -67,6 +67,10 @@ target_compile_definitions(nt_ui PRIVATE
 # Phase 52 Plan 04: walker private deps. The walker translates Clay render
 # commands into sprite/text renderer emits + gfx scissor/viewport state. These
 # stay PRIVATE because nothing in nt_ui's public surface references them.
+#
+# Phase 52 Plan 05: nt_stats added for per-walk ui_draw_calls + ui_element_count
+# user-counter wiring (WALK-09 / D-52-20). Stays PRIVATE because nt_ui's public
+# API does not reference any nt_stats type.
 target_link_libraries(nt_ui
     PUBLIC
         nt_core
@@ -79,6 +83,7 @@ target_link_libraries(nt_ui
         nt_sprite_renderer
         nt_text_renderer
         nt_atlas
+        nt_stats
 )
 
 # nt_log is PRIVATE-linked by nt_add_module via the LOG_DOMAIN injection.

--- a/engine/ui/CMakeLists.txt
+++ b/engine/ui/CMakeLists.txt
@@ -63,12 +63,22 @@ target_compile_definitions(nt_ui PRIVATE
 # Phase 52 Task 2.2: nt_ui needs nt_core (asserts/logging/types), nt_resource
 # (handle types referenced in public headers), nt_font (font handle),
 # nt_material (material handle), nt_input (pointer state struct).
-target_link_libraries(nt_ui PUBLIC
-    nt_core
-    nt_resource
-    nt_font
-    nt_material
-    nt_input
+#
+# Phase 52 Plan 04: walker private deps. The walker translates Clay render
+# commands into sprite/text renderer emits + gfx scissor/viewport state. These
+# stay PRIVATE because nothing in nt_ui's public surface references them.
+target_link_libraries(nt_ui
+    PUBLIC
+        nt_core
+        nt_resource
+        nt_font
+        nt_material
+        nt_input
+    PRIVATE
+        nt_gfx
+        nt_sprite_renderer
+        nt_text_renderer
+        nt_atlas
 )
 
 # nt_log is PRIVATE-linked by nt_add_module via the LOG_DOMAIN injection.

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -467,6 +467,21 @@ static void emit_custom(const nt_ui_context_t *ctx, const Clay_RenderCommand *c)
 // #endregion
 
 // #region walk
+/* True iff the command participates in same-zIndex batch reordering.
+ * SCISSOR_START/END, CUSTOM, and NONE are hard barriers / no-ops -- they
+ * always emit in original sequence and never go through the bucket pass. */
+static bool is_segmentable(Clay_RenderCommandType cmd_type) {
+    switch (cmd_type) {
+    case CLAY_RENDER_COMMAND_TYPE_RECTANGLE:
+    case CLAY_RENDER_COMMAND_TYPE_BORDER:
+    case CLAY_RENDER_COMMAND_TYPE_IMAGE:
+    case CLAY_RENDER_COMMAND_TYPE_TEXT:
+        return true;
+    default:
+        return false;
+    }
+}
+
 static void dispatch_command(nt_ui_context_t *ctx, const Clay_RenderCommand *c, sscissor_rect_t *scissor_stack, int *depth, const nt_ui_target_t *target) {
     switch (c->commandType) {
     case CLAY_RENDER_COMMAND_TYPE_NONE:
@@ -553,10 +568,52 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
      * lazily inside emit_text just before draw_n. */
     nt_sprite_renderer_set_material(ctx->sprite_material);
 
-    /* Clay's frozen array is already zIndex-ascending sorted. */
+    /* Clay's frozen array is zIndex-ascending sorted. Walker contract:
+     * within a maximal run of same-zIndex, barrier-free commands
+     * (a "segment"), reorderable types (RECT/BORDER/IMAGE/TEXT) emit in
+     * two passes -- sprite-bound first, text second -- so interleaved
+     * RECT/TEXT in the same layer don't fragment renderer batches. Hard
+     * barriers (SCISSOR_START/END, CUSTOM) always emit in original order
+     * and never enter a segment. Game code that relies on strict painter
+     * order within same-z must put overlapping elements on different
+     * zIndex layers. */
     const Clay_RenderCommandArray *arr = &ctx->frozen_cmds;
-    for (int32_t i = 0; i < arr->length; ++i) {
-        dispatch_command(ctx, &arr->internalArray[i], scissor_stack, &depth, target);
+    int32_t i = 0;
+    while (i < arr->length) {
+        const Clay_RenderCommand *c = &arr->internalArray[i];
+        if (!is_segmentable(c->commandType)) {
+            dispatch_command(ctx, c, scissor_stack, &depth, target);
+            ++i;
+            continue;
+        }
+        const int16_t seg_z = c->zIndex;
+        int32_t seg_end = i + 1;
+        while (seg_end < arr->length) {
+            const Clay_RenderCommand *next = &arr->internalArray[seg_end];
+            if (next->zIndex != seg_z || !is_segmentable(next->commandType)) {
+                break;
+            }
+            ++seg_end;
+        }
+        /* Pass 1: sprite-bound (RECT/BORDER/IMAGE). All share the same
+         * ctx->sprite_material; sprite_renderer auto-flushes on atlas
+         * page change (RECT/BORDER use ctx->atlas, IMAGE uses payload). */
+        for (int32_t j = i; j < seg_end; ++j) {
+            const Clay_RenderCommand *cc = &arr->internalArray[j];
+            if (cc->commandType != CLAY_RENDER_COMMAND_TYPE_TEXT) {
+                dispatch_command(ctx, cc, scissor_stack, &depth, target);
+            }
+        }
+        /* Pass 2: TEXT. emit_text's prologue flushes sprite_renderer at
+         * the first text in the segment, so painter order across the
+         * sprite->text transition is preserved. */
+        for (int32_t j = i; j < seg_end; ++j) {
+            const Clay_RenderCommand *cc = &arr->internalArray[j];
+            if (cc->commandType == CLAY_RENDER_COMMAND_TYPE_TEXT) {
+                dispatch_command(ctx, cc, scissor_stack, &depth, target);
+            }
+        }
+        i = seg_end;
     }
 
     nt_sprite_renderer_flush();

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -79,13 +79,13 @@ static void nt_ui_clay_error_cb(Clay_ErrorData err) {
 // #endregion
 
 // #region measure_cb
-/* Returns {0,0} on every defensive path: no ctx mid-frame, NULL config,
- * out-of-range fontId, invalid font handle. Clay tolerates zero dims. */
 static Clay_Dimensions nt_ui_measure_text_cb(Clay_StringSlice text, Clay_TextElementConfig *config, void *user_data) {
     (void)user_data;
+    NT_ASSERT(g_nt_ui_inframe_ctx != NULL && "measure_cb: Clay called outside begin/end");
+    NT_ASSERT(config != NULL && "measure_cb: Clay passed NULL config");
 
     nt_ui_context_t *ctx = g_nt_ui_inframe_ctx;
-    if (ctx == NULL || config == NULL || config->fontId >= NT_UI_MAX_FONTS) {
+    if (config->fontId >= NT_UI_MAX_FONTS) {
         return (Clay_Dimensions){0};
     }
     nt_font_t font = ctx->fonts[config->fontId];
@@ -277,8 +277,8 @@ static void emit_image(const Clay_RenderCommand *c) {
     const uint32_t col = default_untinted ? 0xFFFFFFFFU : nt_color_pack_clay(tint);
 
     const nt_texture_region_t *r = nt_atlas_get_region(p->atlas, p->region_index);
-    if (r == NULL || r->vertex_count == 0U) {
-        return; /* tombstone or out-of-range */
+    if (r->vertex_count == 0U) {
+        return; /* tombstone */
     }
     const float ipu = nt_atlas_get_inverse_pixels_per_unit(p->atlas);
     const float src_w = (float)r->source_w * ipu;

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -501,7 +501,8 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
      * does not consume it; if Phase 5x grows the walker to upload Globals
      * UBO from this field, callers writing into it expecting "old"
      * behaviour would silently get the wrong projection. */
-    NT_ASSERT(target->projection[0] == 0.0F && target->projection[5] == 0.0F && target->projection[10] == 0.0F && target->projection[15] == 0.0F && "nt_ui_walk: target->projection is reserved -- must be all-zero (caller owns Globals UBO)");
+    NT_ASSERT(target->projection[0] == 0.0F && target->projection[5] == 0.0F && target->projection[10] == 0.0F && target->projection[15] == 0.0F &&
+              "nt_ui_walk: target->projection is reserved -- must be all-zero (caller owns Globals UBO)");
     NT_ASSERT(ctx->atlas.id != 0 && "nt_ui_set_atlas_white_region(ctx,...) required before nt_ui_walk");
     NT_ASSERT(nt_resource_is_ready(ctx->atlas) && "nt_ui_walk: ctx atlas must be READY");
     NT_ASSERT(ctx->sprite_material.id != 0 && "nt_ui_set_sprite_material(ctx,...) required before nt_ui_walk");

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -170,13 +170,18 @@ size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc) {
     NT_ASSERT(desc->max_scissor_depth > 0U && "nt_ui_min_arena_size: desc->max_scissor_depth must be > 0");
     /* Clay_SetMaxElementCount writes to GLOBAL Clay__defaultMaxElementCount
      * when no current context exists, or to current context otherwise. We
-     * want to size against desc-> max_elements WITHOUT mutating any active
-     * ctx -- save current, null it, set, query, restore. */
-    Clay_Context *saved = Clay_GetCurrentContext();
+     * want to size against desc->max_elements WITHOUT mutating any active
+     * ctx AND without leaving Clay's global default at our temporary value
+     * (pure-query contract). Snapshot current ctx + global default, set,
+     * query, restore both. Direct read of Clay__defaultMaxElementCount is
+     * legal because CLAY_IMPLEMENTATION is in this TU. */
+    Clay_Context *saved_ctx = Clay_GetCurrentContext();
+    const int32_t saved_default = Clay__defaultMaxElementCount;
     Clay_SetCurrentContext(NULL);
     Clay_SetMaxElementCount((int32_t)desc->max_elements);
     const size_t clay_bytes = (size_t)Clay_MinMemorySize();
-    Clay_SetCurrentContext(saved);
+    Clay__defaultMaxElementCount = saved_default;
+    Clay_SetCurrentContext(saved_ctx);
     return nt_ui_ctx_size_aligned() + clay_bytes;
 }
 
@@ -200,9 +205,12 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_u
     const size_t clay_size = arena_size - ctx_size;
 
     /* Stage desc->max_elements into Clay's global default so Clay_Initialize
-     * inherits it for this new context. Save/restore current ctx so this
-     * does not bleed into an active sibling. */
-    Clay_Context *saved = Clay_GetCurrentContext();
+     * inherits it for this new context. Snapshot BOTH current ctx and the
+     * Clay__defaultMaxElementCount global, then restore both -- otherwise
+     * the temporary mutation persists across create_context calls and
+     * leaks our internals into any Clay consumer outside nt_ui. */
+    Clay_Context *saved_ctx = Clay_GetCurrentContext();
+    const int32_t saved_default = Clay__defaultMaxElementCount;
     Clay_SetCurrentContext(NULL);
     Clay_SetMaxElementCount((int32_t)desc->max_elements);
 
@@ -210,11 +218,12 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_u
     ctx->clay_arena = Clay_CreateArenaWithCapacityAndMemory(clay_size, clay_mem);
     ctx->clay = Clay_Initialize(ctx->clay_arena, (Clay_Dimensions){.width = 1.0F, .height = 1.0F}, (Clay_ErrorHandler){.errorHandlerFunction = nt_ui_clay_error_cb, .userData = ctx});
 
-    /* Restore the pre-create current ctx (may be NULL). Clay_Initialize
-     * sets current to the new ctx; without this restore the caller would
-     * inherit our new ctx as active without ever calling nt_ui_begin --
-     * breaks the contract that nt_ui_begin owns active-ctx selection. */
-    Clay_SetCurrentContext(saved);
+    /* Restore both pre-create state. Clay_Initialize sets current to the
+     * new ctx; without restore the caller would inherit our new ctx as
+     * active without ever calling nt_ui_begin -- breaks the contract that
+     * nt_ui_begin owns active-ctx selection. */
+    Clay__defaultMaxElementCount = saved_default;
+    Clay_SetCurrentContext(saved_ctx);
 
     return ctx;
 }
@@ -804,22 +813,31 @@ static bool is_segmentable(Clay_RenderCommandType cmd_type) {
 }
 
 static void dispatch_command(nt_ui_context_t *ctx, const Clay_RenderCommand *c, sscissor_rect_t *scissor_stack, int *depth, const nt_ui_target_t *target) {
+    /* emit_text drains pending sprite at its top; mirror that here so a
+     * sprite-backed command after a TEXT sees an empty text staging. Without
+     * this, text staging persists until walker exit (flushes sprite then
+     * text in that order) and a sprite-after-text declared between two TEXTs
+     * would render UNDER the text, violating declaration-order semantics.
+     * Empty-staging text_flush is a cheap no-op (early-returns on glyph_count==0). */
     switch (c->commandType) {
     case CLAY_RENDER_COMMAND_TYPE_NONE:
         return;
     case CLAY_RENDER_COMMAND_TYPE_RECTANGLE: {
+        nt_text_renderer_flush();
         const Clay_RectangleRenderData *r = &c->renderData.rectangle;
         const uint32_t col = nt_color_pack_clay(r->backgroundColor);
         emit_rounded_rect(ctx->atlas, ctx->white_region, c->boundingBox.x, c->boundingBox.y, c->boundingBox.width, c->boundingBox.height, r->cornerRadius, col);
         return;
     }
     case CLAY_RENDER_COMMAND_TYPE_BORDER:
+        nt_text_renderer_flush();
         emit_border(ctx, c);
         return;
     case CLAY_RENDER_COMMAND_TYPE_TEXT:
         emit_text(ctx, c);
         return;
     case CLAY_RENDER_COMMAND_TYPE_IMAGE:
+        nt_text_renderer_flush();
         emit_image(c);
         return;
     case CLAY_RENDER_COMMAND_TYPE_SCISSOR_START:
@@ -845,6 +863,14 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(isfinite(target->viewport[0]) && isfinite(target->viewport[1]) && isfinite(target->viewport[2]) && isfinite(target->viewport[3]) && "nt_ui_walk: target->viewport must be finite");
     NT_ASSERT(target->viewport[0] >= 0.0F && target->viewport[1] >= 0.0F && "nt_ui_walk: target->viewport origin (x,y) must be non-negative");
     NT_ASSERT(target->viewport[2] >= 0.0F && target->viewport[3] >= 0.0F && "nt_ui_walk: target->viewport (w,h) must be non-negative");
+
+    /* Drain caller-side pending geometry unconditionally -- BEFORE the
+     * zero-viewport early-return so leaked staging from a prior scene
+     * can't survive a minimized frame and render later under unrelated
+     * GL state. Both flushes early-out on empty staging. */
+    nt_sprite_renderer_flush();
+    nt_text_renderer_flush();
+
     /* Zero-size viewport is a legitimate runtime state (minimized browser
      * tab, mobile orientation transition). Silent no-op rather than assert,
      * but reset per-walk stats so callers don't read stale values from the
@@ -866,12 +892,6 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
      * share state. VLA sized per ctx (max_scissor_depth from create desc). */
     sscissor_rect_t scissor_stack[ctx->max_scissor_depth];
     int depth = 0;
-
-    /* Drain caller-side pending geometry BEFORE mutating GL state, so
-     * leftover staging from a prior scene isn't rendered under our
-     * viewport. Both flushes early-out on empty staging. */
-    nt_sprite_renderer_flush();
-    nt_text_renderer_flush();
 
     /* Snapshot AFTER the entry flushes so the per-walk delta excludes the
      * caller's drained geometry. */
@@ -1041,6 +1061,8 @@ nt_material_t nt_ui_test_text_material(const nt_ui_context_t *ctx) {
     NT_ASSERT(ctx != NULL);
     return ctx->text_material;
 }
+
+int32_t nt_ui_test_clay_default_max_element_count(void) { return Clay__defaultMaxElementCount; }
 
 uint32_t nt_ui_test_last_walk_unlayered_count(const nt_ui_context_t *ctx) {
     NT_ASSERT(ctx != NULL);

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -277,6 +277,12 @@ static void emit_image(const Clay_RenderCommand *c) {
         return; /* tolerate missing payload -- Clay does not enforce */
     }
 
+    /* Payload's atlas is independent of the walker's white-region atlas.
+     * Validate it here so the failure points at the IMAGE call site, not
+     * deep inside nt_atlas_get_region or the sprite renderer's emit. */
+    NT_ASSERT(p->atlas.id != 0 && "nt_ui IMAGE payload: invalid atlas handle");
+    NT_ASSERT(nt_resource_is_ready(p->atlas) && "nt_ui IMAGE payload: atlas not READY");
+
     const Clay_BoundingBox bb = c->boundingBox;
 
     /* Clay's default backgroundColor for IMAGE is {0,0,0,0} == untinted

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -111,8 +111,8 @@ void nt_ui_module_shutdown(void) {
 // #endregion
 
 // #region create_destroy
-/* Cache-line aligned so Clay's arena starts on a clean boundary. */
-static size_t nt_ui_ctx_size_aligned(void) { return NT_ALIGN_UP(sizeof(struct nt_ui_context), (size_t)64U); }
+/* ctx struct gets padded to cache line so Clay's arena starts on a clean boundary. */
+#define NT_UI_CACHE_LINE ((size_t)64U)
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc) {
@@ -128,7 +128,7 @@ size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc) {
     const size_t clay_bytes = (size_t)Clay_MinMemorySize();
     Clay_SetMaxElementCount(saved_default);
     Clay_SetCurrentContext(saved_ctx);
-    return nt_ui_ctx_size_aligned() + clay_bytes;
+    return NT_ALIGN_UP(sizeof(struct nt_ui_context), NT_UI_CACHE_LINE) + clay_bytes;
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
@@ -142,7 +142,7 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_u
     nt_ui_context_t *ctx = (nt_ui_context_t *)arena;
     memset(ctx, 0, sizeof(*ctx));
 
-    const size_t ctx_size = nt_ui_ctx_size_aligned();
+    const size_t ctx_size = NT_ALIGN_UP(sizeof(struct nt_ui_context), NT_UI_CACHE_LINE);
     /* Layout: [ctx struct][Clay arena], both NT_UI_ARENA_ALIGN aligned. */
     ctx->max_elements = desc->max_elements;
     void *clay_mem = (char *)arena + ctx_size;

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -491,9 +491,11 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(ctx != NULL && "nt_ui_walk: ctx must be non-NULL");
     NT_ASSERT(target != NULL && "nt_ui_walk: target must be non-NULL");
     NT_ASSERT(!ctx->in_frame && "nt_ui_walk: ctx is mid-frame (call nt_ui_end first)");
-    /* Catch the create -> walk shortcut: frozen_cmds is zero-init'd until
-     * nt_ui_end populates it. Without this, the loop is a silent no-op. */
-    NT_ASSERT((ctx->frozen_cmds.internalArray != NULL || ctx->frozen_cmds.length == 0) && "nt_ui_walk: frozen_cmds not populated (call nt_ui_end before walk)");
+    /* frozen_cmds.internalArray is zero-init'd until nt_ui_end populates
+     * it (Clay returns a valid pointer even for an empty layout). Without
+     * this guard, a create -> walk skipping begin/end would be a silent
+     * no-op. */
+    NT_ASSERT(ctx->frozen_cmds.internalArray != NULL && "nt_ui_walk: frozen_cmds not populated (call nt_ui_end before walk)");
     /* Viewport must be non-negative -- the cast to int below would
      * otherwise turn NaN / -inf into garbage GL state. */
     NT_ASSERT(target->viewport[0] >= 0.0F && target->viewport[1] >= 0.0F && target->viewport[2] >= 0.0F && target->viewport[3] >= 0.0F && "nt_ui_walk: target->viewport must be non-negative");

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -420,9 +420,15 @@ static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c
 
     stack[(*depth)++] = (sscissor_rect_t){.x = x, .y = y, .w = wp, .h = hp};
 
-    /* Y-flip top-left -> GL bottom-left (PP-03 / D-51-04). */
-    const int fb_h = (int)target->viewport[3];
-    nt_gfx_set_scissor(x, fb_h - y - hp, wp, hp);
+    /* Y-flip top-left -> GL bottom-left, applied WITHIN the target viewport
+     * (PP-03 / D-51-04). Clay's bounding box is target-local, so the GL
+     * scissor must shift by viewport.{x,y} and Y-flip relative to viewport.h
+     * (not raw framebuffer height). Without the offset, split-screen panes
+     * and sub-FBO targets would clip the wrong pixels. */
+    const int vx = (int)target->viewport[0];
+    const int vy = (int)target->viewport[1];
+    const int vh = (int)target->viewport[3];
+    nt_gfx_set_scissor(vx + x, vy + vh - y - hp, wp, hp);
     nt_gfx_set_scissor_enabled(true);
 
     /* Re-open sprite cmd so the next RECT/BORDER/IMAGE can emit. */
@@ -438,8 +444,10 @@ static void scissor_pop(const nt_ui_context_t *ctx, sscissor_rect_t *stack, int 
         nt_gfx_set_scissor_enabled(false);
     } else {
         sscissor_rect_t r = stack[*depth - 1];
-        const int fb_h = (int)target->viewport[3];
-        nt_gfx_set_scissor(r.x, fb_h - r.y - r.h, r.w, r.h);
+        const int vx = (int)target->viewport[0];
+        const int vy = (int)target->viewport[1];
+        const int vh = (int)target->viewport[3];
+        nt_gfx_set_scissor(vx + r.x, vy + vh - r.y - r.h, r.w, r.h);
     }
     /* Re-open sprite cmd so the next RECT/BORDER/IMAGE can emit. */
     rebind_sprite_after_flush(ctx);

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -34,6 +34,8 @@ _Static_assert(CLAY_PINNED_MAJOR == 0 && CLAY_PINNED_MINOR == 14, "Clay v0.14 re
 // #region module_state
 /* Only one ctx may be in-frame at a time; nt_ui_begin asserts NULL on entry. */
 static nt_ui_context_t *g_nt_ui_inframe_ctx = NULL;
+/* Set true between nt_ui_module_init / nt_ui_module_shutdown. */
+static bool s_nt_ui_module_initialized = false;
 // #endregion
 
 // #region clay_error_handler
@@ -95,19 +97,20 @@ static void nt_ui_init_arc_lut(void) {
     }
 }
 
-/* Clay__MeasureText doubles as the "module initialized" flag. */
 void nt_ui_module_init(void) {
-    NT_ASSERT(Clay__MeasureText == NULL && "nt_ui_module_init: already initialized; call nt_ui_module_shutdown first");
+    NT_ASSERT(!s_nt_ui_module_initialized && "nt_ui_module_init: already initialized; call nt_ui_module_shutdown first");
     Clay__MeasureText = nt_ui_measure_text_cb;
     g_nt_ui_inframe_ctx = NULL;
     Clay_SetCurrentContext(NULL);
     nt_ui_init_arc_lut();
+    s_nt_ui_module_initialized = true;
 }
 void nt_ui_module_shutdown(void) {
-    NT_ASSERT(Clay__MeasureText != NULL && "nt_ui_module_shutdown: not initialized");
+    NT_ASSERT(s_nt_ui_module_initialized && "nt_ui_module_shutdown: not initialized");
     Clay__MeasureText = NULL;
     g_nt_ui_inframe_ctx = NULL;
     Clay_SetCurrentContext(NULL);
+    s_nt_ui_module_initialized = false;
 }
 // #endregion
 
@@ -136,7 +139,7 @@ size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc) {
 nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_ui_create_desc_t *desc) {
     NT_ASSERT(arena != NULL && "nt_ui_create_context: arena must be non-NULL");
     NT_ASSERT(desc != NULL && "nt_ui_create_context: desc must be non-NULL");
-    NT_ASSERT(Clay__MeasureText == nt_ui_measure_text_cb && "nt_ui_create_context: call nt_ui_module_init() once before any create_context");
+    NT_ASSERT(s_nt_ui_module_initialized && "nt_ui_create_context: call nt_ui_module_init() once before any create_context");
     NT_ASSERT(((uintptr_t)arena & (NT_UI_ARENA_ALIGN - 1U)) == 0U && "nt_ui_create_context: arena must be NT_UI_ARENA_ALIGN-aligned (alignas(NT_UI_ARENA_ALIGN) static uint8_t arena[N])");
     NT_ASSERT(arena_size >= nt_ui_min_arena_size(desc) && "nt_ui_create_context: arena_size < nt_ui_min_arena_size(desc)");
 
@@ -192,7 +195,7 @@ void nt_ui_set_font(nt_ui_context_t *ctx, uint16_t font_id, nt_font_t font) {
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, const nt_pointer_t *mouse) {
     NT_ASSERT(ctx != NULL && "nt_ui_begin: ctx must be non-NULL");
-    NT_ASSERT(Clay__MeasureText == nt_ui_measure_text_cb && "nt_ui_begin: nt_ui_module_init() must be called before begin");
+    NT_ASSERT(s_nt_ui_module_initialized && "nt_ui_begin: nt_ui_module_init() must be called before begin");
     NT_ASSERT(mouse != NULL && "nt_ui_begin: mouse must be non-NULL");
     /* isfinite() rejects NaN + +-inf which `>= 0.0F` alone lets through. */
     NT_ASSERT(isfinite(screen_w) && screen_w >= 0.0F && "nt_ui_begin: screen_w must be finite and non-negative");

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -126,7 +126,7 @@ size_t nt_ui_min_arena_size(void) { return nt_ui_ctx_size_aligned() + (size_t)Cl
 
 nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size) {
     NT_ASSERT(arena != NULL && "nt_ui_create_context: arena must be non-NULL");
-    NT_ASSERT(((uintptr_t)arena & 7U) == 0U && "nt_ui_create_context: arena must be 8-byte aligned");
+    NT_ASSERT(((uintptr_t)arena & (NT_UI_ARENA_ALIGN - 1U)) == 0U && "nt_ui_create_context: arena must be NT_UI_ARENA_ALIGN-aligned (alignas(NT_UI_ARENA_ALIGN) static uint8_t arena[N])");
     NT_ASSERT(arena_size >= nt_ui_min_arena_size() && "nt_ui_create_context: arena_size < nt_ui_min_arena_size()");
 
     nt_ui_context_t *ctx = (nt_ui_context_t *)arena;

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -352,14 +352,38 @@ static void rebind_sprite_after_flush(const nt_ui_context_t *ctx) { nt_sprite_re
 static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, sscissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
     NT_ASSERT(*depth < NT_UI_WALKER_MAX_SCISSOR_DEPTH && "scissor stack overflow");
 
-    /* floor min / ceil max: a (int)truncate would clip subpixel-aligned
-     * UI by 1px at the right/bottom edge. */
-    const float bx = c->boundingBox.x;
-    const float by = c->boundingBox.y;
-    int x = (int)floorf(bx);
-    int y = (int)floorf(by);
-    int wp = (int)ceilf(bx + c->boundingBox.width) - x;
-    int hp = (int)ceilf(by + c->boundingBox.height) - y;
+    /* clip.horizontal / .vertical flag the axes that should be clipped.
+     * On an unclipped axis we use the target viewport extent so the GL
+     * scissor still has well-defined bounds; the nested-intersect step
+     * below will narrow it to the parent on that axis if there is one.
+     *
+     * floor min / ceil max on the clipped axis: a (int)truncate would
+     * clip subpixel-aligned UI by 1px at the right/bottom edge. */
+    const Clay_ClipRenderData *clip = &c->renderData.clip;
+    const int vx = (int)target->viewport[0];
+    const int vy = (int)target->viewport[1];
+    const int vw = (int)target->viewport[2];
+    const int vh = (int)target->viewport[3];
+    int x;
+    int y;
+    int wp;
+    int hp;
+    if (clip->horizontal) {
+        const float bx = c->boundingBox.x;
+        x = (int)floorf(bx);
+        wp = (int)ceilf(bx + c->boundingBox.width) - x;
+    } else {
+        x = 0;
+        wp = vw;
+    }
+    if (clip->vertical) {
+        const float by = c->boundingBox.y;
+        y = (int)floorf(by);
+        hp = (int)ceilf(by + c->boundingBox.height) - y;
+    } else {
+        y = 0;
+        hp = vh;
+    }
 
     /* Nested scissor intersects with stack top -- REPLACE semantics would
      * let an inner widget paint outside its parent's clip (e.g. scroll
@@ -387,9 +411,6 @@ static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c
     /* Clay's bbox is target-local; shift by viewport.{x,y} and Y-flip
      * against viewport.h, NOT raw framebuffer height. Without the offset,
      * split-screen panes and sub-FBO targets clip the wrong pixels. */
-    const int vx = (int)target->viewport[0];
-    const int vy = (int)target->viewport[1];
-    const int vh = (int)target->viewport[3];
     nt_gfx_set_scissor(vx + x, vy + vh - y - hp, wp, hp);
     nt_gfx_set_scissor_enabled(true);
 

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -341,6 +341,11 @@ static void rebind_sprite_after_flush(const nt_ui_context_t *ctx);
  * material/pipeline boundary), then binds the text font + text material
  * and forwards to nt_text_renderer_draw_n (Phase 51 length-aware API). */
 static void emit_text(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
+    /* Lazy walker contract: text_material is asserted ONLY when an actual
+     * TEXT command appears -- a pure-RECT UI never enters this path so
+     * never needs the setter call. */
+    NT_ASSERT(ctx->text_material.id != 0 && "nt_ui_set_text_material(ctx,...) required before walking a UI that contains TEXT commands");
+
     /* State boundary: sprite material/pipeline must flush before text
      * binds its own pipeline. Auto-flush on font/material change happens
      * inside the text renderer, but the sprite renderer's own staging
@@ -527,9 +532,12 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(!ctx->in_frame && "nt_ui_walk: ctx is mid-frame (call nt_ui_end first)");
     NT_ASSERT(ctx->atlas.id != 0 && "nt_ui_set_atlas_white_region(ctx,...) required before nt_ui_walk");
     NT_ASSERT(nt_resource_is_ready(ctx->atlas) && "nt_ui_walk: ctx atlas must be READY");
-    /* Revision Issue 1: sprite + text materials are separate; assert BOTH. */
+    /* Revision Issue 1: sprite + text materials are separate. Sprite is
+     * asserted at entry because RECT/BORDER/IMAGE need it eagerly (the
+     * walker binds it before the dispatch loop). Text material is asserted
+     * lazily inside emit_text -- a pure-RECT UI doesn't need it. This lets
+     * games with no UI text skip set_text_material entirely. */
     NT_ASSERT(ctx->sprite_material.id != 0 && "nt_ui_set_sprite_material(ctx,...) required before nt_ui_walk");
-    NT_ASSERT(ctx->text_material.id != 0 && "nt_ui_set_text_material(ctx,...) required before nt_ui_walk");
 
     /* Walker-local scissor stack -- D-52-17 (on C stack, NOT in ctx, so
      * multiple walks against the same ctx don't share state). */

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -489,7 +489,19 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     sscissor_rect_t scissor_stack[NT_UI_WALKER_MAX_SCISSOR_DEPTH];
     int depth = 0;
 
-    /* Snapshot draw-call counter for the delta -- routed to nt_stats below. */
+    /* Entry boundary: drain any caller-side pending geometry BEFORE we
+     * mutate viewport / scissor state. Otherwise pending sprite or text
+     * staging produced under the caller's prior viewport would be flushed
+     * later (inside the walker or at the next caller flush) under our UI
+     * viewport, drawing the wrong pixels at the wrong place. Cheap when
+     * the renderers are already drained -- both flushes early-out on
+     * empty staging. */
+    nt_sprite_renderer_flush();
+    nt_text_renderer_flush();
+
+    /* Snapshot draw-call counter for the delta -- routed to nt_stats below.
+     * Snapshot AFTER the entry flushes so the delta reflects only walk
+     * work, not the caller's drained pending geometry. */
     const uint32_t calls_at_entry = nt_gfx_get_frame_draw_calls();
 
     /* Apply viewport from target (UI-07). Bottom-left GL convention. */

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -7,18 +7,12 @@
 #include "renderers/nt_text_renderer.h"
 
 /*
- * Clay v0.14 implementation TU.
+ * Exactly one TU in the build defines CLAY_IMPLEMENTATION -- this one.
  *
- * One TU in the entire build defines CLAY_IMPLEMENTATION. This is it.
- *
- * Version pin (per Drift 1 Option D):
- *   - deps/clay/VERSION is the single source of truth.
- *   - engine/ui/CMakeLists.txt parses major/minor and passes them as
- *     CLAY_PINNED_MAJOR / CLAY_PINNED_MINOR via target_compile_definitions.
- *   - The _Static_assert below catches accidental dev-time drift (e.g.,
- *     someone hand-edits deps/clay/VERSION to 0.13 without re-vendoring).
- *   - CLAY_VERSION_MAJOR / CLAY_VERSION_MINOR macros do NOT exist in Clay
- *     v0.14 upstream -- verified by direct read of the v0.14 header.
+ * Clay version is pinned via deps/clay/VERSION; CMake parses major.minor
+ * and passes CLAY_PINNED_MAJOR / CLAY_PINNED_MINOR. The _Static_assert
+ * below catches dev-time drift where deps/clay/VERSION is hand-edited
+ * without re-vendoring (Clay itself has no CLAY_VERSION_* macros).
  */
 
 #if !defined(CLAY_PINNED_MAJOR) || !defined(CLAY_PINNED_MINOR)
@@ -40,23 +34,18 @@ _Static_assert(CLAY_PINNED_MAJOR == 0 && CLAY_PINNED_MINOR == 14, "Clay v0.14 re
 #include "ui/nt_ui_internal.h"
 
 // #region module_state
-/* g_nt_ui_inframe_ctx -- module-level pointer enforcing the multi-context
- * invariant (D-52-12). Exactly one ctx may be in-frame at a time; nt_ui_begin
- * asserts this is NULL on entry and assigns ctx; nt_ui_end clears it.
- *
- * This is the only module-level state. Walker bindings (atlas, materials,
- * custom handler) and per-walk stats live in nt_ui_context_t -- the walker
- * is fully per-context. */
+/* Only one ctx may be in-frame at a time; nt_ui_begin asserts NULL on
+ * entry and assigns, nt_ui_end clears. All other walker state lives in
+ * nt_ui_context_t -- this is the single piece of module-level state. */
 static nt_ui_context_t *g_nt_ui_inframe_ctx = NULL;
 // #endregion
 
 // #region clay_error_handler
-/* Returns true if a Clay error code is a recoverable visual bug (Clay
- * safely no-ops it; the UI still renders, just with the buggy element
- * missing or mis-styled). Everything else -- including capacity overflows
- * that SILENTLY TRUNCATE the UI -- is a fatal invariant violation.
- * Defaulting unknown to fatal prevents a future Clay version from silently
- * demoting new invariants. */
+/* Recoverable: Clay safely no-ops the error and the rest of the UI still
+ * renders correctly. Fatal: capacity overflow silently truncates the UI,
+ * missing measure callback or internal Clay errors mean broken state.
+ * Unknown defaults to fatal so a Clay version bump can't silently demote
+ * a new invariant violation. */
 static bool nt_ui_clay_error_is_recoverable(Clay_ErrorType type) {
     switch (type) {
     case CLAY_ERROR_TYPE_DUPLICATE_ID:
@@ -65,16 +54,12 @@ static bool nt_ui_clay_error_is_recoverable(Clay_ErrorType type) {
         return true;
     case CLAY_ERROR_TYPE_TEXT_MEASUREMENT_FUNCTION_NOT_PROVIDED:
     case CLAY_ERROR_TYPE_ARENA_CAPACITY_EXCEEDED:
-    /* Capacity exceeded silently truncates the UI -- caller declared
-     * more than Clay's internal arrays could hold. That's a sizing bug
-     * the developer must fix (raise Clay's limits or simplify the UI),
-     * not a runtime condition to tolerate. */
     case CLAY_ERROR_TYPE_ELEMENTS_CAPACITY_EXCEEDED:
     case CLAY_ERROR_TYPE_TEXT_MEASUREMENT_CAPACITY_EXCEEDED:
     case CLAY_ERROR_TYPE_INTERNAL_ERROR:
         return false;
     }
-    return false; /* unknown -> fatal */
+    return false;
 }
 
 /* errorText is a Clay_String with .length + .chars -- not NUL-terminated. */
@@ -94,19 +79,10 @@ static void nt_ui_clay_error_cb(Clay_ErrorData err) {
 // #endregion
 
 // #region measure_cb
-/* Clay measure callback (CLAY-03 / D-52-14).
- *
- * Forwards to the Phase 51 length-aware measure path through the per-ctx
- * font registry. Phase 51's 256-entry xxHash measure cache (37x hit speedup)
- * is the MP-07 amplification mitigation.
- *
- * Returns {0,0} (no crash) when ctx is not mid-frame, config is NULL, the
- * font slot is out of range, or the slot holds an invalid/destroyed handle.
- *
- * user_data is reserved (NULL in Phase 52); D-52-14 keeps it for future
- * per-context font tables that bypass g_nt_ui_inframe_ctx. */
+/* Returns {0,0} on every defensive path: no ctx mid-frame, NULL config,
+ * out-of-range fontId, invalid font handle. Clay tolerates zero dims. */
 static Clay_Dimensions nt_ui_measure_text_cb(Clay_StringSlice text, Clay_TextElementConfig *config, void *user_data) {
-    (void)user_data; /* Phase 52 reserves user_data; Plan 03 ships NULL */
+    (void)user_data;
 
     nt_ui_context_t *ctx = g_nt_ui_inframe_ctx;
     if (ctx == NULL || config == NULL || config->fontId >= NT_UI_MAX_FONTS) {
@@ -122,8 +98,7 @@ static Clay_Dimensions nt_ui_measure_text_cb(Clay_StringSlice text, Clay_TextEle
 // #endregion
 
 // #region create_destroy
-/* Pattern 2 from 52-RESEARCH.md: caller-owned arena, ctx struct lives in
- * the first ~256 bytes (cache-line aligned), Clay arena takes the rest. */
+/* ctx struct rounded up to cache-line so Clay's arena starts aligned. */
 static size_t nt_ui_ctx_size_aligned(void) { return (sizeof(struct nt_ui_context) + 63U) & ~(size_t)63U; }
 
 size_t nt_ui_min_arena_size(void) { return nt_ui_ctx_size_aligned() + (size_t)Clay_MinMemorySize(); }
@@ -146,8 +121,7 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size) {
     ctx->clay_arena = Clay_CreateArenaWithCapacityAndMemory(clay_size, clay_mem);
     ctx->clay = Clay_Initialize(ctx->clay_arena, (Clay_Dimensions){.width = 1.0F, .height = 1.0F}, (Clay_ErrorHandler){.errorHandlerFunction = nt_ui_clay_error_cb, .userData = ctx});
 
-    /* Clay_SetMeasureTextFunction is idempotent -- always wire (cheap pointer
-     * assignment in Clay v0.14). Avoids any lazy-init state of our own. */
+    /* Clay_SetMeasureTextFunction is idempotent; wire unconditionally. */
     Clay_SetMeasureTextFunction(nt_ui_measure_text_cb, NULL);
 
     return ctx;
@@ -156,8 +130,6 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size) {
 void nt_ui_destroy_context(nt_ui_context_t *ctx) {
     NT_ASSERT(ctx != NULL && "nt_ui_destroy_context: ctx must be non-NULL");
     NT_ASSERT(!ctx->in_frame && "nt_ui_destroy_context: ctx is mid-frame (call nt_ui_end first)");
-
-    /* Caller owns the arena memory -- only zero the ctx struct portion. */
     memset(ctx, 0, sizeof(*ctx));
 }
 // #endregion
@@ -175,12 +147,11 @@ void nt_ui_set_font(nt_ui_context_t *ctx, uint16_t font_id, nt_font_t font) {
 void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, const nt_pointer_t *mouse) {
     NT_ASSERT(ctx != NULL && "nt_ui_begin: ctx must be non-NULL");
     NT_ASSERT(mouse != NULL && "nt_ui_begin: mouse must be non-NULL");
-    NT_ASSERT(g_nt_ui_inframe_ctx == NULL && "nt_ui_begin: another ctx is mid-frame (D-52-12 violation)");
-    NT_ASSERT(!ctx->in_frame && "nt_ui_begin: ctx already in_frame (CP-03 footgun)");
+    NT_ASSERT(g_nt_ui_inframe_ctx == NULL && "nt_ui_begin: another ctx is mid-frame");
+    NT_ASSERT(!ctx->in_frame && "nt_ui_begin: ctx already in_frame");
 
-    /* FIRST executable: switch Clay's global current-context pointer to
-     * this ctx's Clay context (UI-04 / CP-03 prevention). Every Clay call
-     * below operates on ctx->clay. */
+    /* MUST be first: switches Clay's current-context global so every
+     * subsequent Clay call below operates on ctx->clay. */
     Clay_SetCurrentContext(ctx->clay);
 
     ctx->in_frame = true;
@@ -188,10 +159,8 @@ void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, const nt_
 
     Clay_SetLayoutDimensions((Clay_Dimensions){.width = screen_w, .height = screen_h});
 
-    /* Pointer state (CLAY-04 / D-52-16). Left-button only is intentional in
-     * v1.8 — right/middle/wheel are not consumed by Clay v0.14. Multi-pointer
-     * is deferred: the game caller chooses which pointer to feed (typically
-     * pointers[0]; split-screen uses pointers[N]). */
+    /* Left-button only; Clay v0.14 does not consume right/middle/wheel.
+     * Caller picks which pointer to feed -- typically pointers[0]. */
     Clay_SetPointerState((Clay_Vector2){.x = mouse->x, .y = mouse->y}, mouse->buttons[NT_BUTTON_LEFT].is_down);
 
     Clay_BeginLayout();
@@ -209,10 +178,9 @@ void nt_ui_end(nt_ui_context_t *ctx) {
 // #endregion
 
 // #region helpers_color_pack
-/* Clay packs RGBA as 0..255 floats (clay.h:481). Walker emits as 0xAABBGGRR
- * uint32 (sprite-renderer vertex format -- nt_sprite_vertex_t.color[4]).
- * Saturate at uint8 because Clay does not clamp -- a theme that wrote
- * 256.0f or -1.0f would otherwise wrap around. */
+/* Clay stores RGBA as 0..255 floats with no clamping; sprite vertex
+ * format is 0xAABBGGRR uint32. Saturate so a theme that wrote 256 or -1
+ * doesn't wrap around the uint8 cast. */
 static inline uint8_t clamp_u8(float v) {
     if (v <= 0.0F) {
         return 0U;
@@ -228,31 +196,29 @@ static inline uint32_t nt_color_pack_clay(Clay_Color c) {
     uint32_t g = clamp_u8(c.g);
     uint32_t b = clamp_u8(c.b);
     uint32_t a = clamp_u8(c.a);
-    return r | (g << 8) | (b << 16) | (a << 24); /* 0xAABBGGRR */
+    return r | (g << 8) | (b << 16) | (a << 24);
 }
 // #endregion
 
 // #region helper_emit_screen_rect
-/* D-52-03: 2D-ortho mat4 (scale x,y by w,h; translate to x,y) onto the sprite
- * renderer. Origin {0,0} and flip 0 -- the rect already covers (x,y..x+w,y+h)
- * directly because cached_pos for a 1x1 white region is (0,0)..(1,1) in
- * source space, and the scale m[0]=w / m[5]=h folds that into the target rect. */
+/* Builds a column-major 2D-ortho mat4 (scale by w,h; translate to x,y)
+ * directly onto the renderer. cached_pos for a 1x1 white region is the
+ * unit square in source space, so m[0]=w / m[5]=h folds straight into
+ * the target rect with no per-corner work. */
 static inline void emit_screen_rect(nt_resource_t atlas, uint32_t region_index, float x, float y, float w, float h, uint32_t color_packed) {
-    /* Column-major layout: m[0..3]=col0, m[4..7]=col1, m[8..11]=col2, m[12..15]=col3. */
     const float m[16] = {
         w,    0.0F, 0.0F, 0.0F, /* col0: scale x */
         0.0F, h,    0.0F, 0.0F, /* col1: scale y */
         0.0F, 0.0F, 1.0F, 0.0F, /* col2 */
-        x,    y,    0.0F, 1.0F  /* col3: translate */
+        x,    y,    0.0F, 1.0F, /* col3: translate */
     };
     nt_sprite_renderer_emit_region(atlas, region_index, m, 0.0F, 0.0F, color_packed, 0U);
 }
 // #endregion
 
 // #region helper_emit_border
-/* WALK-04 / D-52-03: BORDER -> up to 4 thin RECT quads via emit_screen_rect.
- * Top/bottom run the full width; left/right are inset by top/bottom heights
- * to avoid double-blending corners (matches 52-RESEARCH.md §BORDER emit). */
+/* Up to 4 thin RECT quads. Top/bottom run the full width; left/right are
+ * inset by top/bottom heights so corners don't double-blend. */
 static void emit_border(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
     const Clay_BorderRenderData *b = &c->renderData.border;
     const Clay_BoundingBox bb = c->boundingBox;
@@ -276,52 +242,38 @@ static void emit_border(const nt_ui_context_t *ctx, const Clay_RenderCommand *c)
 // #endregion
 
 // #region helper_emit_image
-/* D-52-07 + D-52-08: IMAGE -> read nt_ui_image_payload_t* from imageData,
- * emit one region at bbox.
- *
- * IMPORTANT: image uses the PAYLOAD's atlas, not g_nt_ui_atlas. Different
- * atlas pages auto-flush via the sprite renderer's
- * ensure_current_cmd_page_texture path.
- *
- * slice9_lrtb is reserved in Phase 52 and silently ignored (plain quad emit)
- * until Phase 54 adds the slice9 path. The header documents this contract. */
+/* IMAGE uses the PAYLOAD's atlas, not ctx->atlas (the latter is for
+ * RECT/BORDER's white region). Different atlas pages auto-flush via the
+ * sprite renderer's ensure_current_cmd_page_texture path. */
 static void emit_image(const Clay_RenderCommand *c) {
     const nt_ui_image_payload_t *p = (const nt_ui_image_payload_t *)c->renderData.image.imageData;
     if (p == NULL) {
-        return; /* tolerate missing payload -- Clay does not enforce */
+        return; /* Clay does not enforce non-NULL imageData */
     }
 
-    /* Payload's atlas is independent of the walker's white-region atlas.
-     *
-     * id == 0 is a caller bug -- never a legitimate runtime state -- so
-     * assert. nt_resource_is_ready == false IS a legitimate state when an
-     * image atlas is still loading asynchronously; the IMAGE element just
-     * draws nothing this frame and the UI continues. AGENTS.md "runtime
-     * is a safety net" applies. */
+    /* id == 0 is a caller bug. not-READY is a legitimate transient state
+     * (async load), so silently skip this frame -- next frame will draw. */
     NT_ASSERT(p->atlas.id != 0 && "nt_ui IMAGE payload: invalid atlas handle (zero id)");
     if (!nt_resource_is_ready(p->atlas)) {
-        return; /* atlas still loading -- silent no-op, render next frame */
+        return;
     }
 
     const Clay_BoundingBox bb = c->boundingBox;
 
-    /* Clay's default backgroundColor for IMAGE is {0,0,0,0} == untinted
-     * (clay.h:481 comment). Map that to 0xFFFFFFFF so the sprite shader's
-     * per-vertex tint is a no-op. */
+    /* Clay default backgroundColor for IMAGE is {0,0,0,0} == untinted. Map
+     * to 0xFFFFFFFF so the per-vertex tint multiply is a no-op. */
     Clay_Color tint = c->renderData.image.backgroundColor;
     const uint32_t col = (tint.r == 0.0F && tint.g == 0.0F && tint.b == 0.0F && tint.a == 0.0F) ? 0xFFFFFFFFU : nt_color_pack_clay(tint);
 
-    /* Resolve region via the payload's atlas. Tombstones / out-of-range
-     * silently no-op via the sprite renderer's emit_region_resolved. */
     const nt_texture_region_t *r = nt_atlas_get_region(p->atlas, p->region_index);
     if (r == NULL || r->vertex_count == 0U) {
-        return;
+        return; /* tombstone or out-of-range */
     }
     const float ipu = nt_atlas_get_inverse_pixels_per_unit(p->atlas);
     const float src_w = (float)r->source_w * ipu;
     const float src_h = (float)r->source_h * ipu;
-    /* Guard against degenerate source dim (avoid div-by-zero on tombstoned
-     * regions that slipped through the vertex_count gate). */
+    /* Guard against degenerate src dim (tombstoned region slipping the
+     * vertex_count gate) -- div-by-zero protection. */
     const float sx = (src_w > 0.0F) ? (bb.width / src_w) : bb.width;
     const float sy = (src_h > 0.0F) ? (bb.height / src_h) : bb.height;
 
@@ -332,19 +284,13 @@ static void emit_image(const Clay_RenderCommand *c) {
 }
 // #endregion
 
-/* Forward declaration -- defined alongside the scissor stack helpers. */
 static void rebind_sprite_after_flush(const nt_ui_context_t *ctx);
 
 // #region helper_emit_text
-/* D-52-18: TEXT command emit. Flushes sprite renderer first (different
- * material/pipeline boundary), then binds the text font + text material
- * and forwards to nt_text_renderer_draw_n (Phase 51 length-aware API). */
 static void emit_text(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
-    /* State boundary: sprite material/pipeline must flush before text
-     * binds its own pipeline. Auto-flush on font/material change happens
-     * inside the text renderer, but the sprite renderer's own staging
-     * needs to drain here. The matching sprite-rebind happens at the
-     * tail so the next RECT/BORDER/IMAGE has a live cmd. */
+    /* Sprite cmd is open at entry; text uses a different pipeline. Drain
+     * sprite staging first; rebind at the tail so subsequent RECT/BORDER
+     * /IMAGE has a live cmd. */
     nt_sprite_renderer_flush();
 
     const Clay_TextRenderData *t = &c->renderData.text;
@@ -361,14 +307,11 @@ static void emit_text(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
     nt_text_renderer_set_font(font);
     nt_text_renderer_set_material(ctx->text_material);
 
-    /* Translation-only model mat4 -- font size is the scale argument
-     * to draw_n, not folded into the model. */
+    /* Translation-only model -- font size is the scale arg to draw_n. */
     const float m[16] = {
         1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, c->boundingBox.x, c->boundingBox.y, 0.0F, 1.0F,
     };
-    /* Text renderer color contract: float[4] in 0..1 range (engine/renderers
-     * /nt_text_renderer.c writes it straight into vertex color via memcpy at
-     * line 281). Clay stores 0..255 floats -- divide. */
+    /* nt_text_renderer expects color in 0..1; Clay stores 0..255. */
     const float color[4] = {
         t->textColor.r / 255.0F,
         t->textColor.g / 255.0F,
@@ -388,19 +331,16 @@ typedef struct {
     int h;
 } sscissor_rect_t;
 
-/* Re-bind the sprite material after a flush. nt_sprite_renderer_flush closes
- * the current cmd (cmd_count -> 0), so the next nt_sprite_renderer_emit_region
- * would trip "call nt_sprite_renderer_set_material first" without this. The
- * sprite renderer's set_material is cheap when cmd_count == 0 with same
- * handle: it just re-opens the cmd from the cached pipeline + mat_info. */
+/* nt_sprite_renderer_flush closes the current cmd; the next emit would
+ * otherwise trip "no open cmd". Same-handle re-open is cheap (caches
+ * pipeline + mat_info). */
 static void rebind_sprite_after_flush(const nt_ui_context_t *ctx) { nt_sprite_renderer_set_material(ctx->sprite_material); }
 
 static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, sscissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
     NT_ASSERT(*depth < NT_UI_WALKER_MAX_SCISSOR_DEPTH && "scissor stack overflow");
 
-    /* Conservative integer rectangle: floor the min corner, ceil the max
-     * corner. (int)truncate would clip subpixel-aligned UI by 1px at the
-     * right/bottom edge. */
+    /* floor min / ceil max: a (int)truncate would clip subpixel-aligned
+     * UI by 1px at the right/bottom edge. */
     const float bx = c->boundingBox.x;
     const float by = c->boundingBox.y;
     int x = (int)floorf(bx);
@@ -408,9 +348,9 @@ static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c
     int wp = (int)ceilf(bx + c->boundingBox.width) - x;
     int hp = (int)ceilf(by + c->boundingBox.height) - y;
 
-    /* Nested scissor -> intersect with top (D-52-17). REPLACE would let an
-     * inner widget paint outside its parent's clip, e.g. scroll-content
-     * leaking past a modal backdrop. */
+    /* Nested scissor intersects with stack top -- REPLACE semantics would
+     * let an inner widget paint outside its parent's clip (e.g. scroll
+     * content leaking past a modal backdrop). */
     if (*depth > 0) {
         sscissor_rect_t t = stack[*depth - 1];
         int x2 = (x > t.x) ? x : t.x;
@@ -423,26 +363,23 @@ static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c
         hp = (b2 > y2) ? (b2 - y2) : 0;
     }
 
-    /* FLUSH both renderers BEFORE changing GL scissor state. Pending
-     * staging written under the prior scissor would otherwise be drawn
-     * under the new one. */
+    /* MUST flush before changing GL scissor state -- pending staging
+     * written under the prior scissor would otherwise be drawn under
+     * the new one. */
     nt_sprite_renderer_flush();
     nt_text_renderer_flush();
 
     stack[(*depth)++] = (sscissor_rect_t){.x = x, .y = y, .w = wp, .h = hp};
 
-    /* Y-flip top-left -> GL bottom-left, applied WITHIN the target viewport
-     * (PP-03 / D-51-04). Clay's bounding box is target-local, so the GL
-     * scissor must shift by viewport.{x,y} and Y-flip relative to viewport.h
-     * (not raw framebuffer height). Without the offset, split-screen panes
-     * and sub-FBO targets would clip the wrong pixels. */
+    /* Clay's bbox is target-local; shift by viewport.{x,y} and Y-flip
+     * against viewport.h, NOT raw framebuffer height. Without the offset,
+     * split-screen panes and sub-FBO targets clip the wrong pixels. */
     const int vx = (int)target->viewport[0];
     const int vy = (int)target->viewport[1];
     const int vh = (int)target->viewport[3];
     nt_gfx_set_scissor(vx + x, vy + vh - y - hp, wp, hp);
     nt_gfx_set_scissor_enabled(true);
 
-    /* Re-open sprite cmd so the next RECT/BORDER/IMAGE can emit. */
     rebind_sprite_after_flush(ctx);
 }
 
@@ -460,16 +397,14 @@ static void scissor_pop(const nt_ui_context_t *ctx, sscissor_rect_t *stack, int 
         const int vh = (int)target->viewport[3];
         nt_gfx_set_scissor(vx + r.x, vy + vh - r.y - r.h, r.w, r.h);
     }
-    /* Re-open sprite cmd so the next RECT/BORDER/IMAGE can emit. */
     rebind_sprite_after_flush(ctx);
 }
 // #endregion
 
 // #region helper_emit_custom
-/* WALK-05 / D-52-09: CUSTOM -> flush both renderers then invoke the
- * registered handler (NULL handler == silent skip). The handler may bind
- * its own pipeline; on return, we re-bind the sprite material so the next
- * RECT/BORDER/IMAGE has a live cmd. */
+/* Flush both renderers so the handler sees clean state; it may bind its
+ * own pipeline. On return, re-bind sprite so the next RECT/BORDER/IMAGE
+ * has a live cmd. */
 static void emit_custom(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
     nt_sprite_renderer_flush();
     nt_text_renderer_flush();
@@ -481,13 +416,12 @@ static void emit_custom(const nt_ui_context_t *ctx, const Clay_RenderCommand *c)
 // #endregion
 
 // #region walk
-/* Per-command dispatch helper. Pulled out of nt_ui_walk so that function
- * stays under clang-tidy's cognitive-complexity threshold -- the switch
- * over commandType is itself a heavy branch tree. */
+/* Extracted from nt_ui_walk so the loop body stays under clang-tidy's
+ * cognitive-complexity threshold. */
 static void dispatch_command(nt_ui_context_t *ctx, const Clay_RenderCommand *c, sscissor_rect_t *scissor_stack, int *depth, const nt_ui_target_t *target) {
     switch (c->commandType) {
     case CLAY_RENDER_COMMAND_TYPE_NONE:
-        return; /* silent skip -- Clay sentinel */
+        return;
     case CLAY_RENDER_COMMAND_TYPE_RECTANGLE: {
         const Clay_RectangleRenderData *r = &c->renderData.rectangle;
         const uint32_t col = nt_color_pack_clay(r->backgroundColor);
@@ -515,10 +449,9 @@ static void dispatch_command(nt_ui_context_t *ctx, const Clay_RenderCommand *c, 
     }
 }
 
-/* D-52-05 / Revision Issue 2: depth test/write are pipeline-baked.
- * UI materials must use pipelines with depth_test=false, depth_write=false.
- * Walker takes no per-frame depth action — nt_gfx has no such API
- * (verified against engine/graphics/nt_gfx.h at plan-write time). */
+/* Depth test/write must be baked into the UI material's pipeline
+ * (depth_test=false, depth_write=false). nt_gfx has no per-frame depth
+ * API, so the walker can't enforce this -- it's a caller contract. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(ctx != NULL && "nt_ui_walk: ctx must be non-NULL");
@@ -526,65 +459,44 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(!ctx->in_frame && "nt_ui_walk: ctx is mid-frame (call nt_ui_end first)");
     NT_ASSERT(ctx->atlas.id != 0 && "nt_ui_set_atlas_white_region(ctx,...) required before nt_ui_walk");
     NT_ASSERT(nt_resource_is_ready(ctx->atlas) && "nt_ui_walk: ctx atlas must be READY");
-    /* Revision Issue 1: sprite + text materials are separate; assert BOTH
-     * eagerly at entry. The nt_ui module's design contract is that both
-     * sprite and text rendering are fundamental capabilities -- practical
-     * UIs always have text -- so requiring both materials upfront gives
-     * the developer a single ergonomic invariant ("bind 4 things, call
-     * walk") rather than per-command-type lazy surprises. */
     NT_ASSERT(ctx->sprite_material.id != 0 && "nt_ui_set_sprite_material(ctx,...) required before nt_ui_walk");
     NT_ASSERT(ctx->text_material.id != 0 && "nt_ui_set_text_material(ctx,...) required before nt_ui_walk");
 
-    /* Walker-local scissor stack -- D-52-17 (on C stack, NOT in ctx, so
-     * multiple walks against the same ctx don't share state). */
+    /* On C stack, NOT in ctx, so multi-walk against the same ctx doesn't
+     * share state. */
     sscissor_rect_t scissor_stack[NT_UI_WALKER_MAX_SCISSOR_DEPTH];
     int depth = 0;
 
-    /* Entry boundary: drain any caller-side pending geometry BEFORE we
-     * mutate viewport / scissor state. Otherwise pending sprite or text
-     * staging produced under the caller's prior viewport would be flushed
-     * later (inside the walker or at the next caller flush) under our UI
-     * viewport, drawing the wrong pixels at the wrong place. Cheap when
-     * the renderers are already drained -- both flushes early-out on
-     * empty staging. */
+    /* Drain caller-side pending geometry BEFORE mutating GL state, so
+     * leftover staging from a prior scene isn't rendered under our
+     * viewport. Both flushes early-out on empty staging. */
     nt_sprite_renderer_flush();
     nt_text_renderer_flush();
 
-    /* Snapshot draw-call counter for the delta -- routed to nt_stats below.
-     * Snapshot AFTER the entry flushes so the delta reflects only walk
-     * work, not the caller's drained pending geometry. */
+    /* Snapshot AFTER the entry flushes so the per-walk delta excludes the
+     * caller's drained geometry. */
     const uint32_t calls_at_entry = nt_gfx_get_frame_draw_calls();
 
-    /* Apply viewport from target (UI-07). Bottom-left GL convention. */
     nt_gfx_set_viewport((int)target->viewport[0], (int)target->viewport[1], (int)target->viewport[2], (int)target->viewport[3]);
-
-    /* Defensive scissor disable at entry (CP-04 prevention). */
     nt_gfx_set_scissor_enabled(false);
 
-    /* Revision Issue 1: bind SPRITE material for RECT/BORDER/IMAGE emits.
-     * TEXT material binds lazily inside emit_text just before draw_n
-     * (auto-flush handles the boundary). */
+    /* Sprite material bound up-front (most commands need it); text binds
+     * lazily inside emit_text just before draw_n. */
     nt_sprite_renderer_set_material(ctx->sprite_material);
 
-    /* Iterate Clay's frozen command array -- already zIndex-ascending sorted. */
+    /* Clay's frozen array is already zIndex-ascending sorted. */
     const Clay_RenderCommandArray *arr = &ctx->frozen_cmds;
     for (int32_t i = 0; i < arr->length; ++i) {
         dispatch_command(ctx, &arr->internalArray[i], scissor_stack, &depth, target);
     }
 
-    /* Final flushes + invariant check (WALK-06 + CP-04). */
     nt_sprite_renderer_flush();
     nt_text_renderer_flush();
     NT_ASSERT(depth == 0 && "unbalanced scissor stack at walk exit");
     nt_gfx_set_scissor_enabled(false);
 
-    /* Per-walk metrics (D-52-20 / WALK-09). Captured into the ctx; the app
-     * reads them via nt_ui_get_last_walk_* and decides whether to publish
-     * to nt_stats for the debug overlay. nt_ui does NOT depend on nt_stats.
-     *
-     * Guard against a CUSTOM handler resetting frame draw-call stats
-     * mid-walk: unsigned wrap on (calls_after - calls_at_entry) would
-     * produce a spurious huge delta. */
+    /* Guard underflow if a CUSTOM handler reset frame stats mid-walk --
+     * unsigned wrap would produce a spurious huge delta. */
     const uint32_t calls_after = nt_gfx_get_frame_draw_calls();
     NT_ASSERT(calls_after >= calls_at_entry && "nt_ui_walk: frame draw-call counter went backwards (CUSTOM handler reset stats?)");
     ctx->last_walk_draw_call_delta = calls_after - calls_at_entry;
@@ -593,17 +505,10 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
 // #endregion
 
 // #region setters
-/* Walker entry asserts these were set; setters validate at call time so the
- * developer sees the bad input at the call site, not at first walk.
- *
- * Atlas setter: requires non-zero, READY (Drift 5 -- nt_resource_is_ready),
- * AND the named region resolves with vertex_count > 0 (Q4 -- catches a
- * mis-baked atlas one frame earlier than the walker would).
- *
- * Material setters: only check .id != 0 -- Phase 52 doesn't synchronously
- * resolve material pipelines (nt_material_step happens elsewhere); the
- * sprite/text renderers' own set_material asserts material.ready when
- * actually consumed inside the walker. */
+/* Atlas setter asserts the white region resolves with vertex_count > 0
+ * so a mis-baked atlas surfaces here, not one frame later in the walker.
+ * Material setters only check .id != 0 -- pipeline readiness is checked
+ * later when the renderer's set_material actually consumes the handle. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_ui_set_atlas_white_region(nt_ui_context_t *ctx, nt_resource_t atlas, uint32_t white_region_idx) {
     NT_ASSERT(ctx != NULL && "nt_ui_set_atlas_white_region: ctx must be non-NULL");
@@ -629,8 +534,7 @@ void nt_ui_set_text_material(nt_ui_context_t *ctx, nt_material_t text_material) 
 
 void nt_ui_set_custom_handler(nt_ui_context_t *ctx, nt_ui_custom_handler_t fn, void *userdata) {
     NT_ASSERT(ctx != NULL && "nt_ui_set_custom_handler: ctx must be non-NULL");
-    /* NULL fn is allowed -- D-52-09 says CUSTOM with no handler is a
-     * silent skip (legitimate "reserved space" pattern). */
+    /* NULL fn is allowed -- legitimate "reserved space" pattern. */
     ctx->custom_fn = fn;
     ctx->custom_user = userdata;
 }
@@ -652,9 +556,6 @@ uint32_t nt_ui_get_last_walk_element_count(const nt_ui_context_t *ctx) {
 #ifdef NT_UI_TEST_ACCESS
 nt_ui_context_t *nt_ui_test_inframe_ctx(void) { return g_nt_ui_inframe_ctx; }
 
-/* Walker setter introspection: verifies the per-context setters wrote what
- * was passed in. "Setter not called before walk" death-tests simply create
- * a fresh context (all fields zero-initialised) and walk -- no reset probe. */
 nt_resource_t nt_ui_test_atlas(const nt_ui_context_t *ctx) {
     NT_ASSERT(ctx != NULL);
     return ctx->atlas;
@@ -672,9 +573,8 @@ nt_material_t nt_ui_test_text_material(const nt_ui_context_t *ctx) {
     return ctx->text_material;
 }
 
-/* CLAY-04 / D-52-16 verification probes. ctx->clay is a Clay_Context whose
- * struct definition is only visible to this TU (CLAY_IMPLEMENTATION above);
- * tests cannot read pointerInfo directly. These getters bridge that gap. */
+/* Clay_Context is only defined inside this TU (CLAY_IMPLEMENTATION),
+ * so tests need these to read pointerInfo. */
 float nt_ui_test_clay_pointer_x(const nt_ui_context_t *ctx) {
     NT_ASSERT(ctx != NULL && "nt_ui_test_clay_pointer_x: ctx must be non-NULL");
     return ctx->clay->pointerInfo.position.x;
@@ -688,5 +588,5 @@ int nt_ui_test_clay_pointer_down(const nt_ui_context_t *ctx) {
     const Clay_PointerDataInteractionState s = ctx->clay->pointerInfo.state;
     return (s == CLAY_POINTER_DATA_PRESSED || s == CLAY_POINTER_DATA_PRESSED_THIS_FRAME) ? 1 : 0;
 }
-#endif /* NT_UI_TEST_ACCESS */
+#endif
 // #endregion

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -5,7 +5,6 @@
 #include "material/nt_material.h"
 #include "renderers/nt_sprite_renderer.h"
 #include "renderers/nt_text_renderer.h"
-#include "stats/nt_stats.h"
 
 /*
  * Clay v0.14 implementation TU.
@@ -579,19 +578,17 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(depth == 0 && "unbalanced scissor stack at walk exit");
     nt_gfx_set_scissor_enabled(false);
 
-    /* Stats (D-52-20 / WALK-09). Counters live in ctx for the test probes;
-     * nt_stats_count routes them to the overlay alongside FPS/CPU/GPU/Draws.
+    /* Per-walk metrics (D-52-20 / WALK-09). Captured into the ctx; the app
+     * reads them via nt_ui_get_last_walk_* and decides whether to publish
+     * to nt_stats for the debug overlay. nt_ui does NOT depend on nt_stats.
      *
-     * Guard against a CUSTOM handler resetting frame stats mid-walk:
-     * unsigned wrap on (calls_after - calls_at_entry) would produce a
-     * spurious huge delta. */
+     * Guard against a CUSTOM handler resetting frame draw-call stats
+     * mid-walk: unsigned wrap on (calls_after - calls_at_entry) would
+     * produce a spurious huge delta. */
     const uint32_t calls_after = nt_gfx_get_frame_draw_calls();
     NT_ASSERT(calls_after >= calls_at_entry && "nt_ui_walk: frame draw-call counter went backwards (CUSTOM handler reset stats?)");
-    const uint32_t delta = calls_after - calls_at_entry;
-    ctx->last_walk_draw_call_delta = delta;
+    ctx->last_walk_draw_call_delta = calls_after - calls_at_entry;
     ctx->last_walk_element_count = (uint32_t)arr->length;
-    nt_stats_count("ui_draw_calls", (uint64_t)delta);
-    nt_stats_count("ui_element_count", (uint64_t)arr->length);
 }
 // #endregion
 
@@ -639,18 +636,21 @@ void nt_ui_set_custom_handler(nt_ui_context_t *ctx, nt_ui_custom_handler_t fn, v
 }
 // #endregion
 
+// #region public_metrics
+uint32_t nt_ui_get_last_walk_draw_calls(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_draw_calls: ctx must be non-NULL");
+    return ctx->last_walk_draw_call_delta;
+}
+
+uint32_t nt_ui_get_last_walk_element_count(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_element_count: ctx must be non-NULL");
+    return ctx->last_walk_element_count;
+}
+// #endregion
+
 // #region test_access
 #ifdef NT_UI_TEST_ACCESS
 nt_ui_context_t *nt_ui_test_inframe_ctx(void) { return g_nt_ui_inframe_ctx; }
-
-uint32_t nt_ui_test_last_walk_draw_call_delta(const nt_ui_context_t *ctx) {
-    NT_ASSERT(ctx != NULL);
-    return ctx->last_walk_draw_call_delta;
-}
-uint32_t nt_ui_test_last_walk_element_count(const nt_ui_context_t *ctx) {
-    NT_ASSERT(ctx != NULL);
-    return ctx->last_walk_element_count;
-}
 
 /* Walker setter introspection: verifies the per-context setters wrote what
  * was passed in. "Setter not called before walk" death-tests simply create

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -145,6 +145,11 @@ void nt_ui_set_font(nt_ui_context_t *ctx, uint16_t font_id, nt_font_t font) {
 void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, const nt_pointer_t *mouse) {
     NT_ASSERT(ctx != NULL && "nt_ui_begin: ctx must be non-NULL");
     NT_ASSERT(mouse != NULL && "nt_ui_begin: mouse must be non-NULL");
+    /* Layout dimensions go straight into Clay; NaN / -inf / negative would
+     * silently corrupt layout calculations downstream. Match the boundary
+     * check nt_ui_walk applies to target->viewport. */
+    NT_ASSERT(screen_w >= 0.0F && screen_w == screen_w && "nt_ui_begin: screen_w must be finite and non-negative");
+    NT_ASSERT(screen_h >= 0.0F && screen_h == screen_h && "nt_ui_begin: screen_h must be finite and non-negative");
     NT_ASSERT(g_nt_ui_inframe_ctx == NULL && "nt_ui_begin: another ctx is mid-frame");
     NT_ASSERT(!ctx->in_frame && "nt_ui_begin: ctx already in_frame");
 
@@ -224,17 +229,29 @@ static void emit_border(const nt_ui_context_t *ctx, const Clay_RenderCommand *c)
     const nt_resource_t atlas = ctx->atlas;
     const uint32_t wr = ctx->white_region;
 
+    /* Clay's BorderWidth fields are uint16_t and unvalidated -- caller could
+     * set top+bottom > bbox.height (or left+right > bbox.width) and the
+     * left/right edge geometry below would emit a negative-height rect.
+     * Fail early on that contract violation rather than feeding garbage to
+     * the sprite renderer. */
+    const float _top = (float)b->width.top;
+    const float _bot = (float)b->width.bottom;
+    const float _lft = (float)b->width.left;
+    const float _rgt = (float)b->width.right;
+    NT_ASSERT(_top + _bot <= bb.height && "nt_ui BORDER: top+bottom widths exceed bbox.height");
+    NT_ASSERT(_lft + _rgt <= bb.width && "nt_ui BORDER: left+right widths exceed bbox.width");
+
     if (b->width.top) {
-        emit_screen_rect(atlas, wr, bb.x, bb.y, bb.width, (float)b->width.top, col);
+        emit_screen_rect(atlas, wr, bb.x, bb.y, bb.width, _top, col);
     }
     if (b->width.bottom) {
-        emit_screen_rect(atlas, wr, bb.x, bb.y + bb.height - (float)b->width.bottom, bb.width, (float)b->width.bottom, col);
+        emit_screen_rect(atlas, wr, bb.x, bb.y + bb.height - _bot, bb.width, _bot, col);
     }
     if (b->width.left) {
-        emit_screen_rect(atlas, wr, bb.x, bb.y + (float)b->width.top, (float)b->width.left, bb.height - (float)b->width.top - (float)b->width.bottom, col);
+        emit_screen_rect(atlas, wr, bb.x, bb.y + _top, _lft, bb.height - _top - _bot, col);
     }
     if (b->width.right) {
-        emit_screen_rect(atlas, wr, bb.x + bb.width - (float)b->width.right, bb.y + (float)b->width.top, (float)b->width.right, bb.height - (float)b->width.top - (float)b->width.bottom, col);
+        emit_screen_rect(atlas, wr, bb.x + bb.width - _rgt, bb.y + _top, _rgt, bb.height - _top - _bot, col);
     }
 }
 // #endregion
@@ -497,12 +514,18 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     /* Viewport must be non-negative -- the cast to int below would
      * otherwise turn NaN / -inf into garbage GL state. */
     NT_ASSERT(target->viewport[0] >= 0.0F && target->viewport[1] >= 0.0F && target->viewport[2] >= 0.0F && target->viewport[3] >= 0.0F && "nt_ui_walk: target->viewport must be non-negative");
-    /* projection is reserved -- caller MUST keep it all-zero. The walker
-     * does not consume it; if Phase 5x grows the walker to upload Globals
-     * UBO from this field, callers writing into it expecting "old"
-     * behaviour would silently get the wrong projection. */
-    NT_ASSERT(target->projection[0] == 0.0F && target->projection[5] == 0.0F && target->projection[10] == 0.0F && target->projection[15] == 0.0F &&
-              "nt_ui_walk: target->projection is reserved -- must be all-zero (caller owns Globals UBO)");
+    /* projection is reserved -- caller MUST keep ALL 16 floats zero. The
+     * walker does not consume the field; if a later phase grows the walker
+     * to upload Globals UBO from it, callers who wrote non-zero off-diagonal
+     * values expecting "old" behaviour would silently get the wrong matrix. */
+    bool _projection_all_zero = true;
+    for (int _pi = 0; _pi < 16; ++_pi) {
+        if (target->projection[_pi] != 0.0F) {
+            _projection_all_zero = false;
+            break;
+        }
+    }
+    NT_ASSERT(_projection_all_zero && "nt_ui_walk: target->projection is reserved -- must be all-zero (caller owns Globals UBO)");
     NT_ASSERT(ctx->atlas.id != 0 && "nt_ui_set_atlas_white_region(ctx,...) required before nt_ui_walk");
     NT_ASSERT(nt_resource_is_ready(ctx->atlas) && "nt_ui_walk: ctx atlas must be READY");
     NT_ASSERT(ctx->sprite_material.id != 0 && "nt_ui_set_sprite_material(ctx,...) required before nt_ui_walk");

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -736,10 +736,13 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(target->viewport[0] >= 0.0F && target->viewport[1] >= 0.0F && "nt_ui_walk: target->viewport origin must be non-negative");
     NT_ASSERT(target->viewport[2] >= 0.0F && target->viewport[3] >= 0.0F && "nt_ui_walk: target->viewport (w,h) must be non-negative");
 
-    /* Drain BEFORE zero-viewport early return so leaked staging doesn't
-     * survive a minimized frame. No-op on empty. */
+    /* Walker owns GL scissor state: disables on entry, manages via
+     * SCISSOR_START/END pushes, disables on exit. Caller's scissor is
+     * not preserved across nt_ui_walk(). Drains BEFORE zero-viewport
+     * early return so leaked staging doesn't survive a minimized frame. */
     nt_sprite_renderer_flush();
     nt_text_renderer_flush();
+    nt_gfx_set_scissor_enabled(false);
 
     /* Zero viewport (minimized tab, orientation change): silent no-op. */
     if (target->viewport[2] == 0.0F || target->viewport[3] == 0.0F) {
@@ -762,7 +765,6 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     const uint32_t calls_at_entry = nt_gfx_get_frame_draw_calls();
 
     nt_gfx_set_viewport((int)target->viewport[0], (int)target->viewport[1], (int)target->viewport[2], (int)target->viewport[3]);
-    nt_gfx_set_scissor_enabled(false);
 
     /* Sprite material up-front; text binds lazily inside emit_text. */
     nt_sprite_renderer_set_material(ctx->sprite_material);

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -341,11 +341,6 @@ static void rebind_sprite_after_flush(const nt_ui_context_t *ctx);
  * material/pipeline boundary), then binds the text font + text material
  * and forwards to nt_text_renderer_draw_n (Phase 51 length-aware API). */
 static void emit_text(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
-    /* Lazy walker contract: text_material is asserted ONLY when an actual
-     * TEXT command appears -- a pure-RECT UI never enters this path so
-     * never needs the setter call. */
-    NT_ASSERT(ctx->text_material.id != 0 && "nt_ui_set_text_material(ctx,...) required before walking a UI that contains TEXT commands");
-
     /* State boundary: sprite material/pipeline must flush before text
      * binds its own pipeline. Auto-flush on font/material change happens
      * inside the text renderer, but the sprite renderer's own staging
@@ -532,12 +527,14 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(!ctx->in_frame && "nt_ui_walk: ctx is mid-frame (call nt_ui_end first)");
     NT_ASSERT(ctx->atlas.id != 0 && "nt_ui_set_atlas_white_region(ctx,...) required before nt_ui_walk");
     NT_ASSERT(nt_resource_is_ready(ctx->atlas) && "nt_ui_walk: ctx atlas must be READY");
-    /* Revision Issue 1: sprite + text materials are separate. Sprite is
-     * asserted at entry because RECT/BORDER/IMAGE need it eagerly (the
-     * walker binds it before the dispatch loop). Text material is asserted
-     * lazily inside emit_text -- a pure-RECT UI doesn't need it. This lets
-     * games with no UI text skip set_text_material entirely. */
+    /* Revision Issue 1: sprite + text materials are separate; assert BOTH
+     * eagerly at entry. The nt_ui module's design contract is that both
+     * sprite and text rendering are fundamental capabilities -- practical
+     * UIs always have text -- so requiring both materials upfront gives
+     * the developer a single ergonomic invariant ("bind 4 things, call
+     * walk") rather than per-command-type lazy surprises. */
     NT_ASSERT(ctx->sprite_material.id != 0 && "nt_ui_set_sprite_material(ctx,...) required before nt_ui_walk");
+    NT_ASSERT(ctx->text_material.id != 0 && "nt_ui_set_text_material(ctx,...) required before nt_ui_walk");
 
     /* Walker-local scissor stack -- D-52-17 (on C stack, NOT in ctx, so
      * multiple walks against the same ctx don't share state). */

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -531,9 +531,13 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     /* Stats (D-52-20 / WALK-09). Plan 04 captures the per-walk deltas
      * into BSS for test probes; Plan 05 routes them through nt_stats so
      * the overlay surfaces walker overhead alongside FPS/CPU/GPU/Draws.
-     * Counter names are conventional strings; nt_stats default capacity
-     * (16 slots) is plenty for these two. */
-    const uint32_t delta = nt_gfx_get_frame_draw_calls() - calls_at_entry;
+     *
+     * Guard against a CUSTOM handler resetting frame stats mid-walk:
+     * unsigned wrap on (calls_after - calls_at_entry) would produce a
+     * spurious huge delta. */
+    const uint32_t calls_after = nt_gfx_get_frame_draw_calls();
+    NT_ASSERT(calls_after >= calls_at_entry && "nt_ui_walk: frame draw-call counter went backwards (CUSTOM handler reset stats?)");
+    const uint32_t delta = calls_after - calls_at_entry;
     s_last_walk_draw_call_delta = delta;
     s_last_walk_element_count = (uint32_t)arr->length;
     nt_stats_count("ui_draw_calls", (uint64_t)delta);

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -744,10 +744,22 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
 #endif
         return;
     }
-    NT_ASSERT(ctx->atlas.id != 0 && "nt_ui_set_atlas_white_region(ctx,...) required before nt_ui_walk");
-    NT_ASSERT(nt_resource_is_ready(ctx->atlas) && "nt_ui_walk: ctx atlas must be READY");
     NT_ASSERT(ctx->sprite_material.id != 0 && "nt_ui_set_sprite_material(ctx,...) required before nt_ui_walk");
     NT_ASSERT(ctx->text_material.id != 0 && "nt_ui_set_text_material(ctx,...) required before nt_ui_walk");
+
+    /* Async-friendly: skip the walk silently if the ctx atlas is not
+     * yet bound or still loading. Same policy as IMAGE p->atlas. Game
+     * can start the main loop immediately; bind atlas once it reaches
+     * READY (set_atlas_white_region needs resolved region data), UI
+     * starts drawing on the next walk. */
+    if (ctx->atlas.id == 0 || !nt_resource_is_ready(ctx->atlas)) {
+        ctx->last_walk_draw_call_delta = 0;
+        ctx->last_walk_command_count = 0;
+#ifdef NT_TEST_ACCESS
+        ctx->test_last_walk_unlayered_count = 0;
+#endif
+        return;
+    }
 
     scissor_rect_t scissor_stack[NT_UI_WALKER_SCISSOR_DEPTH_CAP];
     int depth = 0;

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -120,13 +120,13 @@ static Clay_Dimensions nt_ui_measure_text_cb(Clay_StringSlice text, Clay_TextEle
 // #region create_destroy
 /* Pattern 2 from 52-RESEARCH.md: caller-owned arena, ctx struct lives in
  * the first ~256 bytes (cache-line aligned), Clay arena takes the rest. */
-static size_t nt_ui_ctx_size_aligned(void) { return (sizeof(struct nt_ui_context) + 63u) & ~(size_t)63u; }
+static size_t nt_ui_ctx_size_aligned(void) { return (sizeof(struct nt_ui_context) + 63U) & ~(size_t)63U; }
 
 size_t nt_ui_min_arena_size(void) { return nt_ui_ctx_size_aligned() + (size_t)Clay_MinMemorySize(); }
 
 nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size) {
     NT_ASSERT(arena != NULL && "nt_ui_create_context: arena must be non-NULL");
-    NT_ASSERT(((uintptr_t)arena & 7u) == 0u && "nt_ui_create_context: arena must be 8-byte aligned");
+    NT_ASSERT(((uintptr_t)arena & 7U) == 0U && "nt_ui_create_context: arena must be 8-byte aligned");
     NT_ASSERT(arena_size >= nt_ui_min_arena_size() && "nt_ui_create_context: arena_size < nt_ui_min_arena_size()");
 
     nt_ui_context_t *ctx = (nt_ui_context_t *)arena;
@@ -140,7 +140,7 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size) {
     ctx->arena_size = arena_size;
     ctx->in_frame = false;
     ctx->clay_arena = Clay_CreateArenaWithCapacityAndMemory(clay_size, clay_mem);
-    ctx->clay = Clay_Initialize(ctx->clay_arena, (Clay_Dimensions){.width = 1.0f, .height = 1.0f}, (Clay_ErrorHandler){.errorHandlerFunction = nt_ui_clay_error_cb, .userData = ctx});
+    ctx->clay = Clay_Initialize(ctx->clay_arena, (Clay_Dimensions){.width = 1.0F, .height = 1.0F}, (Clay_ErrorHandler){.errorHandlerFunction = nt_ui_clay_error_cb, .userData = ctx});
 
     /* Clay_SetMeasureTextFunction is idempotent -- always wire (cheap pointer
      * assignment in Clay v0.14). Avoids any lazy-init state of our own. */
@@ -167,6 +167,7 @@ void nt_ui_set_font(nt_ui_context_t *ctx, uint16_t font_id, nt_font_t font) {
 // #endregion
 
 // #region begin_end
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, const nt_pointer_t *mouse) {
     NT_ASSERT(ctx != NULL && "nt_ui_begin: ctx must be non-NULL");
     NT_ASSERT(mouse != NULL && "nt_ui_begin: mouse must be non-NULL");
@@ -209,11 +210,11 @@ void nt_ui_end(nt_ui_context_t *ctx) {
  * Saturate at uint8 because Clay does not clamp -- a theme that wrote
  * 256.0f or -1.0f would otherwise wrap around. */
 static inline uint8_t clamp_u8(float v) {
-    if (v <= 0.0f) {
-        return 0u;
+    if (v <= 0.0F) {
+        return 0U;
     }
-    if (v >= 255.0f) {
-        return 255u;
+    if (v >= 255.0F) {
+        return 255U;
     }
     return (uint8_t)v;
 }
@@ -235,12 +236,12 @@ static inline uint32_t nt_color_pack_clay(Clay_Color c) {
 static inline void emit_screen_rect(nt_resource_t atlas, uint32_t region_index, float x, float y, float w, float h, uint32_t color_packed) {
     /* Column-major layout: m[0..3]=col0, m[4..7]=col1, m[8..11]=col2, m[12..15]=col3. */
     const float m[16] = {
-        w,    0.0f, 0.0f, 0.0f, /* col0: scale x */
-        0.0f, h,    0.0f, 0.0f, /* col1: scale y */
-        0.0f, 0.0f, 1.0f, 0.0f, /* col2 */
-        x,    y,    0.0f, 1.0f  /* col3: translate */
+        w,    0.0F, 0.0F, 0.0F, /* col0: scale x */
+        0.0F, h,    0.0F, 0.0F, /* col1: scale y */
+        0.0F, 0.0F, 1.0F, 0.0F, /* col2 */
+        x,    y,    0.0F, 1.0F  /* col3: translate */
     };
-    nt_sprite_renderer_emit_region(atlas, region_index, m, 0.0f, 0.0f, color_packed, 0u);
+    nt_sprite_renderer_emit_region(atlas, region_index, m, 0.0F, 0.0F, color_packed, 0U);
 }
 // #endregion
 
@@ -298,12 +299,12 @@ static void emit_image(const Clay_RenderCommand *c) {
      * (clay.h:481 comment). Map that to 0xFFFFFFFF so the sprite shader's
      * per-vertex tint is a no-op. */
     Clay_Color tint = c->renderData.image.backgroundColor;
-    const uint32_t col = (tint.r == 0.0f && tint.g == 0.0f && tint.b == 0.0f && tint.a == 0.0f) ? 0xFFFFFFFFu : nt_color_pack_clay(tint);
+    const uint32_t col = (tint.r == 0.0F && tint.g == 0.0F && tint.b == 0.0F && tint.a == 0.0F) ? 0xFFFFFFFFU : nt_color_pack_clay(tint);
 
     /* Resolve region via the payload's atlas. Tombstones / out-of-range
      * silently no-op via the sprite renderer's emit_region_resolved. */
     const nt_texture_region_t *r = nt_atlas_get_region(p->atlas, p->region_index);
-    if (r == NULL || r->vertex_count == 0u) {
+    if (r == NULL || r->vertex_count == 0U) {
         return;
     }
     const float ipu = nt_atlas_get_inverse_pixels_per_unit(p->atlas);
@@ -311,13 +312,13 @@ static void emit_image(const Clay_RenderCommand *c) {
     const float src_h = (float)r->source_h * ipu;
     /* Guard against degenerate source dim (avoid div-by-zero on tombstoned
      * regions that slipped through the vertex_count gate). */
-    const float sx = (src_w > 0.0f) ? (bb.width / src_w) : bb.width;
-    const float sy = (src_h > 0.0f) ? (bb.height / src_h) : bb.height;
+    const float sx = (src_w > 0.0F) ? (bb.width / src_w) : bb.width;
+    const float sy = (src_h > 0.0F) ? (bb.height / src_h) : bb.height;
 
     const float m[16] = {
-        sx, 0.0f, 0.0f, 0.0f, 0.0f, sy, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, bb.x, bb.y, 0.0f, 1.0f,
+        sx, 0.0F, 0.0F, 0.0F, 0.0F, sy, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, bb.x, bb.y, 0.0F, 1.0F,
     };
-    nt_sprite_renderer_emit_region(p->atlas, p->region_index, m, 0.0f, 0.0f, col, p->flip_bits);
+    nt_sprite_renderer_emit_region(p->atlas, p->region_index, m, 0.0F, 0.0F, col, p->flip_bits);
 }
 // #endregion
 
@@ -353,16 +354,16 @@ static void emit_text(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
     /* Translation-only model mat4 -- font size is the scale argument
      * to draw_n, not folded into the model. */
     const float m[16] = {
-        1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, c->boundingBox.x, c->boundingBox.y, 0.0f, 1.0f,
+        1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, c->boundingBox.x, c->boundingBox.y, 0.0F, 1.0F,
     };
     /* Text renderer color contract: float[4] in 0..1 range (engine/renderers
      * /nt_text_renderer.c writes it straight into vertex color via memcpy at
      * line 281). Clay stores 0..255 floats -- divide. */
     const float color[4] = {
-        t->textColor.r / 255.0f,
-        t->textColor.g / 255.0f,
-        t->textColor.b / 255.0f,
-        t->textColor.a / 255.0f,
+        t->textColor.r / 255.0F,
+        t->textColor.g / 255.0F,
+        t->textColor.b / 255.0F,
+        t->textColor.a / 255.0F,
     };
     nt_text_renderer_draw_n(t->stringContents.chars, (size_t)t->stringContents.length, m, (float)t->fontSize, color);
     rebind_sprite_after_flush(ctx);
@@ -470,10 +471,45 @@ static void emit_custom(const nt_ui_context_t *ctx, const Clay_RenderCommand *c)
 // #endregion
 
 // #region walk
+/* Per-command dispatch helper. Pulled out of nt_ui_walk so that function
+ * stays under clang-tidy's cognitive-complexity threshold -- the switch
+ * over commandType is itself a heavy branch tree. */
+static void dispatch_command(nt_ui_context_t *ctx, const Clay_RenderCommand *c, sscissor_rect_t *scissor_stack, int *depth, const nt_ui_target_t *target) {
+    switch (c->commandType) {
+    case CLAY_RENDER_COMMAND_TYPE_NONE:
+        return; /* silent skip -- Clay sentinel */
+    case CLAY_RENDER_COMMAND_TYPE_RECTANGLE: {
+        const Clay_RectangleRenderData *r = &c->renderData.rectangle;
+        const uint32_t col = nt_color_pack_clay(r->backgroundColor);
+        emit_screen_rect(ctx->atlas, ctx->white_region, c->boundingBox.x, c->boundingBox.y, c->boundingBox.width, c->boundingBox.height, col);
+        return;
+    }
+    case CLAY_RENDER_COMMAND_TYPE_BORDER:
+        emit_border(ctx, c);
+        return;
+    case CLAY_RENDER_COMMAND_TYPE_TEXT:
+        emit_text(ctx, c);
+        return;
+    case CLAY_RENDER_COMMAND_TYPE_IMAGE:
+        emit_image(c);
+        return;
+    case CLAY_RENDER_COMMAND_TYPE_SCISSOR_START:
+        scissor_push(ctx, c, scissor_stack, depth, target);
+        return;
+    case CLAY_RENDER_COMMAND_TYPE_SCISSOR_END:
+        scissor_pop(ctx, scissor_stack, depth, target);
+        return;
+    case CLAY_RENDER_COMMAND_TYPE_CUSTOM:
+        emit_custom(ctx, c);
+        return;
+    }
+}
+
 /* D-52-05 / Revision Issue 2: depth test/write are pipeline-baked.
  * UI materials must use pipelines with depth_test=false, depth_write=false.
  * Walker takes no per-frame depth action — nt_gfx has no such API
  * (verified against engine/graphics/nt_gfx.h at plan-write time). */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(ctx != NULL && "nt_ui_walk: ctx must be non-NULL");
     NT_ASSERT(target != NULL && "nt_ui_walk: target must be non-NULL");
@@ -518,35 +554,7 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     /* Iterate Clay's frozen command array -- already zIndex-ascending sorted. */
     const Clay_RenderCommandArray *arr = &ctx->frozen_cmds;
     for (int32_t i = 0; i < arr->length; ++i) {
-        const Clay_RenderCommand *c = &arr->internalArray[i];
-        switch (c->commandType) {
-        case CLAY_RENDER_COMMAND_TYPE_NONE:
-            break; /* silent skip -- Clay sentinel */
-        case CLAY_RENDER_COMMAND_TYPE_RECTANGLE: {
-            const Clay_RectangleRenderData *r = &c->renderData.rectangle;
-            const uint32_t col = nt_color_pack_clay(r->backgroundColor);
-            emit_screen_rect(ctx->atlas, ctx->white_region, c->boundingBox.x, c->boundingBox.y, c->boundingBox.width, c->boundingBox.height, col);
-            break;
-        }
-        case CLAY_RENDER_COMMAND_TYPE_BORDER:
-            emit_border(ctx, c);
-            break;
-        case CLAY_RENDER_COMMAND_TYPE_TEXT:
-            emit_text(ctx, c);
-            break;
-        case CLAY_RENDER_COMMAND_TYPE_IMAGE:
-            emit_image(c);
-            break;
-        case CLAY_RENDER_COMMAND_TYPE_SCISSOR_START:
-            scissor_push(ctx, c, scissor_stack, &depth, target);
-            break;
-        case CLAY_RENDER_COMMAND_TYPE_SCISSOR_END:
-            scissor_pop(ctx, scissor_stack, &depth, target);
-            break;
-        case CLAY_RENDER_COMMAND_TYPE_CUSTOM:
-            emit_custom(ctx, c);
-            break;
-        }
+        dispatch_command(ctx, &arr->internalArray[i], scissor_stack, &depth, target);
     }
 
     /* Final flushes + invariant check (WALK-06 + CP-04). */
@@ -583,12 +591,13 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
  * resolve material pipelines (nt_material_step happens elsewhere); the
  * sprite/text renderers' own set_material asserts material.ready when
  * actually consumed inside the walker. */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_ui_set_atlas_white_region(nt_ui_context_t *ctx, nt_resource_t atlas, uint32_t white_region_idx) {
     NT_ASSERT(ctx != NULL && "nt_ui_set_atlas_white_region: ctx must be non-NULL");
     NT_ASSERT(atlas.id != 0 && "nt_ui_set_atlas_white_region: invalid atlas handle");
     NT_ASSERT(nt_resource_is_ready(atlas) && "nt_ui_set_atlas_white_region: atlas must be READY");
     const nt_texture_region_t *r = nt_atlas_get_region(atlas, white_region_idx);
-    NT_ASSERT(r != NULL && r->vertex_count > 0u && "nt_ui_set_atlas_white_region: white region missing / tombstoned (mis-baked atlas)");
+    NT_ASSERT(r != NULL && r->vertex_count > 0U && "nt_ui_set_atlas_white_region: white region missing / tombstoned (mis-baked atlas)");
     ctx->atlas = atlas;
     ctx->white_region = white_region_idx;
 }

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -57,14 +57,31 @@ static void nt_ui_clay_error_cb(Clay_ErrorData err) {
 }
 // #endregion
 
-// #region measure_cb_stub
-/* Clay measure callback stub. Plan 03 fills the body (look up font by
- * config->fontId in g_nt_ui_inframe_ctx->fonts and call nt_font_measure_n). */
+// #region measure_cb
+/* Clay measure callback (CLAY-03 / D-52-14).
+ *
+ * Forwards to the Phase 51 length-aware measure path through the per-ctx
+ * font registry. Phase 51's 256-entry xxHash measure cache (37x hit speedup)
+ * is the MP-07 amplification mitigation.
+ *
+ * Returns {0,0} (no crash) when ctx is not mid-frame, config is NULL, the
+ * font slot is out of range, or the slot holds an invalid/destroyed handle.
+ *
+ * user_data is reserved (NULL in Phase 52); D-52-14 keeps it for future
+ * per-context font tables that bypass g_nt_ui_inframe_ctx. */
 static Clay_Dimensions nt_ui_measure_text_cb(Clay_StringSlice text, Clay_TextElementConfig *config, void *user_data) {
-    (void)text;
-    (void)config;
-    (void)user_data;
-    return (Clay_Dimensions){.width = 0.0f, .height = 0.0f};
+    (void)user_data; /* Phase 52 reserves user_data; Plan 03 ships NULL */
+
+    nt_ui_context_t *ctx = g_nt_ui_inframe_ctx;
+    if (ctx == NULL || config == NULL || config->fontId >= NT_UI_MAX_FONTS) {
+        return (Clay_Dimensions){0};
+    }
+    nt_font_t font = ctx->fonts[config->fontId];
+    if (!nt_font_valid(font)) {
+        return (Clay_Dimensions){0};
+    }
+    nt_text_size_t s = nt_font_measure_n(font, text.chars, (size_t)text.length, (float)config->fontSize);
+    return (Clay_Dimensions){.width = s.width, .height = s.height};
 }
 // #endregion
 
@@ -93,8 +110,8 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size) {
     ctx->clay_arena = Clay_CreateArenaWithCapacityAndMemory(clay_size, clay_mem);
     ctx->clay = Clay_Initialize(ctx->clay_arena, (Clay_Dimensions){.width = 1.0f, .height = 1.0f}, (Clay_ErrorHandler){.errorHandlerFunction = nt_ui_clay_error_cb, .userData = ctx});
 
-    /* Clay_SetMeasureTextFunction is a global hook -- wire it once. Plan 03
-     * fills the callback body with font-registry lookup + nt_font_measure_n. */
+    /* Clay_SetMeasureTextFunction is a global hook -- wire it once. The
+     * callback (nt_ui_measure_text_cb above) handles font lookup + measure. */
     if (!g_nt_ui_measure_wired) {
         Clay_SetMeasureTextFunction(nt_ui_measure_text_cb, NULL);
         g_nt_ui_measure_wired = true;
@@ -143,8 +160,11 @@ void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, const nt_
 
     Clay_SetLayoutDimensions((Clay_Dimensions){.width = screen_w, .height = screen_h});
 
-    /* Pointer-state wiring is Plan 03 territory (D-52-16). */
-    (void)mouse;
+    /* Pointer state (CLAY-04 / D-52-16). Left-button only is intentional in
+     * v1.8 — right/middle/wheel are not consumed by Clay v0.14. Multi-pointer
+     * is deferred: the game caller chooses which pointer to feed (typically
+     * pointers[0]; split-screen uses pointers[N]). */
+    Clay_SetPointerState((Clay_Vector2){.x = mouse->x, .y = mouse->y}, mouse->buttons[NT_BUTTON_LEFT].is_down);
 
     Clay_BeginLayout();
 }

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -566,8 +566,6 @@ typedef struct {
     int h;
 } scissor_rect_t;
 
-static void rebind_sprite_after_flush(const nt_ui_context_t *ctx) { nt_sprite_renderer_set_material(ctx->sprite_material); }
-
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void scissor_push(const Clay_RenderCommand *c, scissor_rect_t *stack, int *depth, const nt_ui_target_t *target, bool *sprite_pipeline_dirty) {
     NT_ASSERT((uint32_t)*depth < NT_UI_WALKER_SCISSOR_DEPTH_CAP && "scissor stack overflow; restructure nested clip");
@@ -675,7 +673,7 @@ static bool is_segmentable(Clay_RenderCommandType cmd_type) {
 static inline void prep_sprite_dispatch(const nt_ui_context_t *ctx, bool *sprite_pipeline_dirty) {
     nt_text_renderer_flush();
     if (*sprite_pipeline_dirty) {
-        rebind_sprite_after_flush(ctx);
+        nt_sprite_renderer_set_material(ctx->sprite_material);
         *sprite_pipeline_dirty = false;
     }
 }

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -1,6 +1,7 @@
 #include "ui/nt_ui.h"
 
 #include "atlas/nt_atlas.h"
+#include "core/nt_builtins.h"
 #include "graphics/nt_gfx.h"
 #include "material/nt_material.h"
 #include "renderers/nt_sprite_renderer.h"
@@ -92,25 +93,57 @@ static Clay_Dimensions nt_ui_measure_text_cb(Clay_StringSlice text, Clay_TextEle
     if (!nt_font_valid(font)) {
         return (Clay_Dimensions){0};
     }
-    nt_text_size_t s = nt_font_measure_n(font, text.chars, (size_t)text.length, (float)config->fontSize);
+    const float ls = (float)config->letterSpacing;
+    nt_text_size_t s = nt_font_measure_n(font, text.chars, (size_t)text.length, (float)config->fontSize, ls);
+    /* Clay convention: callback returns word width WITH one trailing
+     * letterSpacing slot, then Clay subtracts a single trailing slot at
+     * end-of-line (clay.h Clay__MeasureTextCached line 1677). Our
+     * nt_font_measure_n returns the CSS-style (N-1) gap width, so add one
+     * trailing slot here when the measurement produced any width. Without
+     * this, Clay's bbox is short by exactly one letterSpacing relative to
+     * the rendered text. */
+    if (s.width > 0.0F && ls != 0.0F) {
+        s.width += ls;
+    }
     return (Clay_Dimensions){.width = s.width, .height = s.height};
 }
+// #endregion
+
+// #region module_init
+/* Wire measure callback into Clay's global function pointer. Bypasses
+ * Clay_SetMeasureTextFunction (which requires an active Clay context) by
+ * writing directly to the global -- legal because CLAY_IMPLEMENTATION
+ * places Clay's internals in this TU. */
+void nt_ui_module_init(void) { Clay__MeasureText = nt_ui_measure_text_cb; }
+void nt_ui_module_shutdown(void) { Clay__MeasureText = NULL; }
 // #endregion
 
 // #region create_destroy
 /* ctx struct rounded up to cache-line so Clay's arena starts aligned. */
 static size_t nt_ui_ctx_size_aligned(void) { return (sizeof(struct nt_ui_context) + 63U) & ~(size_t)63U; }
 
-size_t nt_ui_min_arena_size(void) {
-    /* Lock element-count default before Clay_MinMemorySize reads it. */
-    Clay_SetMaxElementCount(NT_UI_DEFAULT_MAX_ELEMENT_COUNT);
-    return nt_ui_ctx_size_aligned() + (size_t)Clay_MinMemorySize();
+size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc) {
+    NT_ASSERT(desc != NULL && "nt_ui_min_arena_size: desc must be non-NULL");
+    NT_ASSERT(desc->max_elements > 0U && "nt_ui_min_arena_size: desc->max_elements must be > 0");
+    /* Clay_SetMaxElementCount writes to GLOBAL Clay__defaultMaxElementCount
+     * when no current context exists, or to current context otherwise. We
+     * want to size against desc-> max_elements WITHOUT mutating any active
+     * ctx -- save current, null it, set, query, restore. */
+    Clay_Context *saved = Clay_GetCurrentContext();
+    Clay_SetCurrentContext(NULL);
+    Clay_SetMaxElementCount((int32_t)desc->max_elements);
+    const size_t clay_bytes = (size_t)Clay_MinMemorySize();
+    Clay_SetCurrentContext(saved);
+    return nt_ui_ctx_size_aligned() + clay_bytes;
 }
 
-nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size) {
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_ui_create_desc_t *desc) {
     NT_ASSERT(arena != NULL && "nt_ui_create_context: arena must be non-NULL");
+    NT_ASSERT(desc != NULL && "nt_ui_create_context: desc must be non-NULL");
+    NT_ASSERT(Clay__MeasureText == nt_ui_measure_text_cb && "nt_ui_create_context: call nt_ui_module_init() once before any create_context");
     NT_ASSERT(((uintptr_t)arena & (NT_UI_ARENA_ALIGN - 1U)) == 0U && "nt_ui_create_context: arena must be NT_UI_ARENA_ALIGN-aligned (alignas(NT_UI_ARENA_ALIGN) static uint8_t arena[N])");
-    NT_ASSERT(arena_size >= nt_ui_min_arena_size() && "nt_ui_create_context: arena_size < nt_ui_min_arena_size()");
+    NT_ASSERT(arena_size >= nt_ui_min_arena_size(desc) && "nt_ui_create_context: arena_size < nt_ui_min_arena_size(desc)");
 
     nt_ui_context_t *ctx = (nt_ui_context_t *)arena;
     memset(ctx, 0, sizeof(*ctx));
@@ -119,12 +152,22 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size) {
     void *clay_mem = (char *)arena + ctx_size;
     const size_t clay_size = arena_size - ctx_size;
 
+    /* Stage desc->max_elements into Clay's global default so Clay_Initialize
+     * inherits it for this new context. Save/restore current ctx so this
+     * does not bleed into an active sibling. */
+    Clay_Context *saved = Clay_GetCurrentContext();
+    Clay_SetCurrentContext(NULL);
+    Clay_SetMaxElementCount((int32_t)desc->max_elements);
+
     ctx->in_frame = false;
     ctx->clay_arena = Clay_CreateArenaWithCapacityAndMemory(clay_size, clay_mem);
     ctx->clay = Clay_Initialize(ctx->clay_arena, (Clay_Dimensions){.width = 1.0F, .height = 1.0F}, (Clay_ErrorHandler){.errorHandlerFunction = nt_ui_clay_error_cb, .userData = ctx});
 
-    /* Clay_SetMeasureTextFunction is idempotent; wire unconditionally. */
-    Clay_SetMeasureTextFunction(nt_ui_measure_text_cb, NULL);
+    /* Restore the previously-current context (if any). The caller picks
+     * which ctx is "current" via nt_ui_begin for each frame anyway. */
+    if (saved != NULL) {
+        Clay_SetCurrentContext(saved);
+    }
 
     return ctx;
 }
@@ -222,37 +265,285 @@ static inline void emit_screen_rect(nt_resource_t atlas, uint32_t region_index, 
 }
 // #endregion
 
+// #region helper_emit_rounded_rect
+/* Per-quarter-arc segment count. 6 keeps the triangle count low (28 tris
+ * for a fully rounded rect) while staying smooth at typical UI radii.
+ *
+ * Hot-path note: trig (cosf/sinf) dominates here -- ~28 calls per rounded
+ * rect, ~56 per rounded border. If profiling shows this in the top hot
+ * path, precompute a (SEG+1) x 4 sin/cos LUT at startup and table-lookup
+ * here instead of computing each frame. UV centroid in emit_geometry is
+ * orders of magnitude cheaper and not worth caching first. */
+#define NT_UI_CORNER_SEGMENTS 6
+_Static_assert(NT_UI_CORNER_SEGMENTS >= 2 && NT_UI_CORNER_SEGMENTS <= 32, "NT_UI_CORNER_SEGMENTS must be in [2, 32]: lower degenerate, higher wastes stack and staging");
+#define NT_UI_PI_F 3.14159265358979323846F
+
+/* Triangle fan from rect center to the boundary. Each corner contributes
+ * either 1 vertex (radius 0) or NT_UI_CORNER_SEGMENTS+1 arc vertices.
+ * Boundary order is screen-CW starting at TL arc entry on the left edge. */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+static void emit_rounded_rect(nt_resource_t atlas, uint32_t region_index, float x, float y, float w, float h, Clay_CornerRadius cr, uint32_t color_packed) {
+    /* Clamp radii so opposite corners can't overlap. Negative input is
+     * treated as zero. */
+    const float half_w = w * 0.5F;
+    const float half_h = h * 0.5F;
+    const float clamp = (half_w < half_h) ? half_w : half_h;
+    float tl = (cr.topLeft > 0.0F) ? cr.topLeft : 0.0F;
+    float tr = (cr.topRight > 0.0F) ? cr.topRight : 0.0F;
+    float bl = (cr.bottomLeft > 0.0F) ? cr.bottomLeft : 0.0F;
+    float br = (cr.bottomRight > 0.0F) ? cr.bottomRight : 0.0F;
+    if (tl > clamp) {
+        tl = clamp;
+    }
+    if (tr > clamp) {
+        tr = clamp;
+    }
+    if (bl > clamp) {
+        bl = clamp;
+    }
+    if (br > clamp) {
+        br = clamp;
+    }
+
+    /* All-square fast path stays on emit_screen_rect (1 quad, 4 verts). */
+    if (tl == 0.0F && tr == 0.0F && bl == 0.0F && br == 0.0F) {
+        emit_screen_rect(atlas, region_index, x, y, w, h, color_packed);
+        return;
+    }
+
+    /* Worst case: center + 4 * (segments+1) boundary verts. */
+    float positions[1 + (4 * (NT_UI_CORNER_SEGMENTS + 1))][2];
+    uint16_t indices[4 * (NT_UI_CORNER_SEGMENTS + 1) * 3];
+
+    positions[0][0] = x + half_w;
+    positions[0][1] = y + half_h;
+    uint32_t vi = 1;
+
+    /* TL arc: math angle π → 1.5π (sweeps from west to north of corner center). */
+    if (tl == 0.0F) {
+        positions[vi][0] = x;
+        positions[vi][1] = y;
+        vi++;
+    } else {
+        const float cx = x + tl;
+        const float cy = y + tl;
+        for (uint32_t s = 0; s <= NT_UI_CORNER_SEGMENTS; s++) {
+            const float t = (float)s / (float)NT_UI_CORNER_SEGMENTS;
+            const float a = NT_UI_PI_F * (1.0F + 0.5F * t);
+            positions[vi][0] = cx + tl * cosf(a);
+            positions[vi][1] = cy + tl * sinf(a);
+            vi++;
+        }
+    }
+    /* TR arc: 1.5π → 2π. */
+    if (tr == 0.0F) {
+        positions[vi][0] = x + w;
+        positions[vi][1] = y;
+        vi++;
+    } else {
+        const float cx = x + w - tr;
+        const float cy = y + tr;
+        for (uint32_t s = 0; s <= NT_UI_CORNER_SEGMENTS; s++) {
+            const float t = (float)s / (float)NT_UI_CORNER_SEGMENTS;
+            const float a = NT_UI_PI_F * (1.5F + 0.5F * t);
+            positions[vi][0] = cx + tr * cosf(a);
+            positions[vi][1] = cy + tr * sinf(a);
+            vi++;
+        }
+    }
+    /* BR arc: 0 → 0.5π. */
+    if (br == 0.0F) {
+        positions[vi][0] = x + w;
+        positions[vi][1] = y + h;
+        vi++;
+    } else {
+        const float cx = x + w - br;
+        const float cy = y + h - br;
+        for (uint32_t s = 0; s <= NT_UI_CORNER_SEGMENTS; s++) {
+            const float t = (float)s / (float)NT_UI_CORNER_SEGMENTS;
+            const float a = NT_UI_PI_F * (0.5F * t);
+            positions[vi][0] = cx + br * cosf(a);
+            positions[vi][1] = cy + br * sinf(a);
+            vi++;
+        }
+    }
+    /* BL arc: 0.5π → π. */
+    if (bl == 0.0F) {
+        positions[vi][0] = x;
+        positions[vi][1] = y + h;
+        vi++;
+    } else {
+        const float cx = x + bl;
+        const float cy = y + h - bl;
+        for (uint32_t s = 0; s <= NT_UI_CORNER_SEGMENTS; s++) {
+            const float t = (float)s / (float)NT_UI_CORNER_SEGMENTS;
+            const float a = NT_UI_PI_F * (0.5F + 0.5F * t);
+            positions[vi][0] = cx + bl * cosf(a);
+            positions[vi][1] = cy + bl * sinf(a);
+            vi++;
+        }
+    }
+
+    /* Triangle fan: (center=0, i, i+1) for i in [1..vi-1], wrap last to 1. */
+    uint32_t ii = 0;
+    for (uint32_t i = 1; i < vi; i++) {
+        const uint16_t next = (uint16_t)((i + 1 < vi) ? (i + 1) : 1);
+        indices[ii++] = 0U;
+        indices[ii++] = (uint16_t)i;
+        indices[ii++] = next;
+    }
+
+    const float identity[16] = {
+        1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F,
+    };
+    nt_sprite_renderer_emit_geometry(atlas, region_index, positions, vi, indices, ii, identity, color_packed);
+}
+// #endregion
+
 // #region helper_emit_border
-/* Up to 4 thin RECT quads. Top/bottom run the full width; left/right are
- * inset by top/bottom heights so corners don't double-blend. */
+/* Square-corner fast path: up to 4 thin RECT quads. Top/bottom run the
+ * full width; left/right are inset by top/bottom so corners don't blend. */
+static void emit_square_border(nt_resource_t atlas, uint32_t region_index, Clay_BoundingBox bb, Clay_BorderWidth widths, uint32_t col) {
+    const float top = (float)widths.top;
+    const float bot = (float)widths.bottom;
+    const float lft = (float)widths.left;
+    const float rgt = (float)widths.right;
+    if (widths.top) {
+        emit_screen_rect(atlas, region_index, bb.x, bb.y, bb.width, top, col);
+    }
+    if (widths.bottom) {
+        emit_screen_rect(atlas, region_index, bb.x, bb.y + bb.height - bot, bb.width, bot, col);
+    }
+    if (widths.left) {
+        emit_screen_rect(atlas, region_index, bb.x, bb.y + top, lft, bb.height - top - bot, col);
+    }
+    if (widths.right) {
+        emit_screen_rect(atlas, region_index, bb.x + bb.width - rgt, bb.y + top, rgt, bb.height - top - bot, col);
+    }
+}
+
+/* Append one corner's (outer,inner) vertex pair(s) into the strip array.
+ * a_start_factor scales by π for the arc start (1.0=TL/π, 1.5=TR/3π/2,
+ * 0.0=BR/0, 0.5=BL/π/2). a_start_factor sweep is always +0.5π. radius==0
+ * collapses to a single sharp pair at (sharp_x, sharp_y) (outer) and
+ * (sharp_x + sx*wx, sharp_y + sy*wy) (inner). */
+static uint32_t emit_corner_strip_pairs(float (*pos)[2], uint32_t vi, float radius, float cx, float cy, float w_perp_x, float w_perp_y, float sharp_x, float sharp_y, float sign_x, float sign_y,
+                                        float a_start_factor) {
+    if (radius == 0.0F) {
+        pos[vi][0] = sharp_x;
+        pos[vi][1] = sharp_y;
+        vi++;
+        pos[vi][0] = sharp_x + (sign_x * w_perp_x);
+        pos[vi][1] = sharp_y + (sign_y * w_perp_y);
+        vi++;
+        return vi;
+    }
+    /* Clamp inner radii to 0 -- when border width exceeds the corner radius,
+     * the inner curve degenerates to a flat segment through the corner
+     * center on that axis. Matches CSS/Godot/Skia behaviour. */
+    const float irx = (radius > w_perp_x) ? (radius - w_perp_x) : 0.0F;
+    const float iry = (radius > w_perp_y) ? (radius - w_perp_y) : 0.0F;
+    const float a_start = NT_UI_PI_F * a_start_factor;
+    for (uint32_t s = 0; s <= NT_UI_CORNER_SEGMENTS; s++) {
+        const float t = (float)s / (float)NT_UI_CORNER_SEGMENTS;
+        const float a = a_start + (NT_UI_PI_F * 0.5F * t);
+        const float cc = cosf(a);
+        const float ss = sinf(a);
+        pos[vi][0] = cx + (radius * cc);
+        pos[vi][1] = cy + (radius * ss);
+        vi++;
+        pos[vi][0] = cx + (irx * cc);
+        pos[vi][1] = cy + (iry * ss);
+        vi++;
+    }
+    return vi;
+}
+
+/* Tessellated ring between the outer rounded-rect boundary and the inner
+ * boundary (inset by per-side widths). Inner radius on each axis clamps
+ * to max(0, radius - adjacent_width); a zero-width side produces a
+ * zero-area strip segment (visually skipped). Matches CSS/Godot/Skia.
+ * Top+bottom widths must still fit bbox height (and left+right the width). */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+static void emit_rounded_border(nt_resource_t atlas, uint32_t region_index, Clay_BoundingBox bb, Clay_BorderWidth widths, Clay_CornerRadius cr_in, uint32_t color_packed) {
+    const float x = bb.x;
+    const float y = bb.y;
+    const float w = bb.width;
+    const float h = bb.height;
+    const float top = (float)widths.top;
+    const float bot = (float)widths.bottom;
+    const float lft = (float)widths.left;
+    const float rgt = (float)widths.right;
+    NT_ASSERT(top + bot <= h && "nt_ui BORDER: top+bottom widths exceed bbox.height");
+    NT_ASSERT(lft + rgt <= w && "nt_ui BORDER: left+right widths exceed bbox.width");
+
+    const float half_w = w * 0.5F;
+    const float half_h = h * 0.5F;
+    const float clamp_r = (half_w < half_h) ? half_w : half_h;
+    float tl = (cr_in.topLeft > 0.0F) ? cr_in.topLeft : 0.0F;
+    float tr = (cr_in.topRight > 0.0F) ? cr_in.topRight : 0.0F;
+    float bl = (cr_in.bottomLeft > 0.0F) ? cr_in.bottomLeft : 0.0F;
+    float br = (cr_in.bottomRight > 0.0F) ? cr_in.bottomRight : 0.0F;
+    if (tl > clamp_r) {
+        tl = clamp_r;
+    }
+    if (tr > clamp_r) {
+        tr = clamp_r;
+    }
+    if (bl > clamp_r) {
+        bl = clamp_r;
+    }
+    if (br > clamp_r) {
+        br = clamp_r;
+    }
+
+    if (tl == 0.0F && tr == 0.0F && bl == 0.0F && br == 0.0F) {
+        emit_square_border(atlas, region_index, bb, widths, color_packed);
+        return;
+    }
+
+    /* Rounded path supports partial borders: a zero side width collapses
+     * its strip to zero-area triangles (no visible stroke). A side width
+     * larger than the corner radius clamps the inner curve to 0 on that
+     * axis (corner becomes "filled" inside). CSS/Godot/Skia parity. */
+
+    /* Worst case: 4 * (SEG+1) pairs * 2 verts = 56 for SEG=6. */
+    float positions[4 * (NT_UI_CORNER_SEGMENTS + 1) * 2][2];
+    uint32_t vi = 0;
+
+    vi = emit_corner_strip_pairs(positions, vi, tl, x + tl, y + tl, lft, top, x, y, 1.0F, 1.0F, 1.0F);
+    vi = emit_corner_strip_pairs(positions, vi, tr, x + w - tr, y + tr, rgt, top, x + w, y, -1.0F, 1.0F, 1.5F);
+    vi = emit_corner_strip_pairs(positions, vi, br, x + w - br, y + h - br, rgt, bot, x + w, y + h, -1.0F, -1.0F, 0.0F);
+    vi = emit_corner_strip_pairs(positions, vi, bl, x + bl, y + h - bl, lft, bot, x, y + h, 1.0F, -1.0F, 0.5F);
+
+    /* Triangle strip with wrap. Each pair k: outer at 2k, inner at 2k+1. */
+    const uint32_t pair_count = vi / 2;
+    uint16_t indices[4 * (NT_UI_CORNER_SEGMENTS + 1) * 6];
+    uint32_t ii = 0;
+    for (uint32_t k = 0; k < pair_count; k++) {
+        const uint32_t k_next = (k + 1 < pair_count) ? (k + 1) : 0;
+        const uint16_t out_k = (uint16_t)(2 * k);
+        const uint16_t in_k = (uint16_t)((2 * k) + 1);
+        const uint16_t out_n = (uint16_t)(2 * k_next);
+        const uint16_t in_n = (uint16_t)((2 * k_next) + 1);
+        indices[ii++] = out_k;
+        indices[ii++] = in_k;
+        indices[ii++] = out_n;
+        indices[ii++] = in_k;
+        indices[ii++] = in_n;
+        indices[ii++] = out_n;
+    }
+
+    const float identity[16] = {
+        1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F,
+    };
+    nt_sprite_renderer_emit_geometry(atlas, region_index, positions, vi, indices, ii, identity, color_packed);
+}
+
 static void emit_border(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
     const Clay_BorderRenderData *b = &c->renderData.border;
-    const Clay_BoundingBox bb = c->boundingBox;
     const uint32_t col = nt_color_pack_clay(b->color);
-    const nt_resource_t atlas = ctx->atlas;
-    const uint32_t wr = ctx->white_region;
-
-    /* Clay borders are uint16_t -- top+bot > bb.height (or lft+rgt >
-     * bb.width) would emit a negative-size rect downstream. */
-    const float top = (float)b->width.top;
-    const float bot = (float)b->width.bottom;
-    const float lft = (float)b->width.left;
-    const float rgt = (float)b->width.right;
-    NT_ASSERT(top + bot <= bb.height && "nt_ui BORDER: top+bottom widths exceed bbox.height");
-    NT_ASSERT(lft + rgt <= bb.width && "nt_ui BORDER: left+right widths exceed bbox.width");
-
-    if (b->width.top) {
-        emit_screen_rect(atlas, wr, bb.x, bb.y, bb.width, top, col);
-    }
-    if (b->width.bottom) {
-        emit_screen_rect(atlas, wr, bb.x, bb.y + bb.height - bot, bb.width, bot, col);
-    }
-    if (b->width.left) {
-        emit_screen_rect(atlas, wr, bb.x, bb.y + top, lft, bb.height - top - bot, col);
-    }
-    if (b->width.right) {
-        emit_screen_rect(atlas, wr, bb.x + bb.width - rgt, bb.y + top, rgt, bb.height - top - bot, col);
-    }
+    emit_rounded_border(ctx->atlas, ctx->white_region, c->boundingBox, b->width, b->cornerRadius, col);
 }
 // #endregion
 
@@ -263,6 +554,11 @@ static void emit_image(const Clay_RenderCommand *c) {
     const nt_ui_image_payload_t *p = (const nt_ui_image_payload_t *)c->renderData.image.imageData;
     NT_ASSERT(p != NULL && "nt_ui IMAGE: imageData must point to nt_ui_image_payload_t");
     NT_ASSERT(p->atlas.id != 0 && "nt_ui IMAGE payload: invalid atlas handle (zero id)");
+    /* IMAGE corner radius is not supported -- bake rounded edges into the
+     * atlas instead. Polygon atlas regions would already escape any
+     * bbox-aligned corner clip. */
+    const Clay_CornerRadius cr = c->renderData.image.cornerRadius;
+    NT_ASSERT(cr.topLeft == 0.0F && cr.topRight == 0.0F && cr.bottomLeft == 0.0F && cr.bottomRight == 0.0F && "nt_ui IMAGE: cornerRadius unsupported; pre-bake into atlas");
     /* Async-loading atlas: skip this frame. */
     if (!nt_resource_is_ready(p->atlas)) {
         return;
@@ -305,17 +601,9 @@ static void emit_text(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
     nt_sprite_renderer_flush();
 
     const Clay_TextRenderData *t = &c->renderData.text;
-    if ((uint32_t)t->fontId >= NT_UI_MAX_FONTS) {
-        NT_LOG_WARN_ONCE("nt_ui TEXT: fontId %u >= NT_UI_MAX_FONTS=%u; skipping (further occurrences silenced)", (unsigned)t->fontId, (unsigned)NT_UI_MAX_FONTS);
-        rebind_sprite_after_flush(ctx);
-        return;
-    }
+    NT_ASSERT((uint32_t)t->fontId < NT_UI_MAX_FONTS && "nt_ui TEXT: fontId out of range; check CLAY_TEXT_CONFIG vs NT_UI_MAX_FONTS");
     nt_font_t font = ctx->fonts[t->fontId];
-    if (!nt_font_valid(font)) {
-        NT_LOG_WARN_ONCE("nt_ui TEXT: fontId %u resolves to an invalid font handle; skipping (further occurrences silenced)", (unsigned)t->fontId);
-        rebind_sprite_after_flush(ctx);
-        return;
-    }
+    NT_ASSERT(nt_font_valid(font) && "nt_ui TEXT: font slot empty; call nt_ui_set_font(ctx, fontId, font) before declaring TEXT with this fontId");
 
     nt_text_renderer_set_font(font);
     nt_text_renderer_set_material(ctx->text_material);
@@ -331,7 +619,7 @@ static void emit_text(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
         t->textColor.b / 255.0F,
         t->textColor.a / 255.0F,
     };
-    nt_text_renderer_draw_n(t->stringContents.chars, (size_t)t->stringContents.length, m, (float)t->fontSize, color);
+    nt_text_renderer_draw_n(t->stringContents.chars, (size_t)t->stringContents.length, m, (float)t->fontSize, color, (float)t->letterSpacing);
     rebind_sprite_after_flush(ctx);
 }
 // #endregion
@@ -472,7 +760,7 @@ static void dispatch_command(nt_ui_context_t *ctx, const Clay_RenderCommand *c, 
     case CLAY_RENDER_COMMAND_TYPE_RECTANGLE: {
         const Clay_RectangleRenderData *r = &c->renderData.rectangle;
         const uint32_t col = nt_color_pack_clay(r->backgroundColor);
-        emit_screen_rect(ctx->atlas, ctx->white_region, c->boundingBox.x, c->boundingBox.y, c->boundingBox.width, c->boundingBox.height, col);
+        emit_rounded_rect(ctx->atlas, ctx->white_region, c->boundingBox.x, c->boundingBox.y, c->boundingBox.width, c->boundingBox.height, r->cornerRadius, col);
         return;
     }
     case CLAY_RENDER_COMMAND_TYPE_BORDER:
@@ -506,7 +794,11 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
      * vh==0 (GL undefined). Origin x/y may be zero. */
     NT_ASSERT(isfinite(target->viewport[0]) && isfinite(target->viewport[1]) && isfinite(target->viewport[2]) && isfinite(target->viewport[3]) && "nt_ui_walk: target->viewport must be finite");
     NT_ASSERT(target->viewport[0] >= 0.0F && target->viewport[1] >= 0.0F && "nt_ui_walk: target->viewport origin (x,y) must be non-negative");
-    NT_ASSERT(target->viewport[2] > 0.0F && target->viewport[3] > 0.0F && "nt_ui_walk: target->viewport (w,h) must be > 0 (zero-size walk is not a supported no-op)");
+    /* Zero-size viewport is a legitimate runtime state (minimized browser
+     * tab, mobile orientation transition). Silent no-op rather than assert. */
+    if (target->viewport[2] <= 0.0F || target->viewport[3] <= 0.0F) {
+        return;
+    }
     NT_ASSERT(ctx->atlas.id != 0 && "nt_ui_set_atlas_white_region(ctx,...) required before nt_ui_walk");
     NT_ASSERT(nt_resource_is_ready(ctx->atlas) && "nt_ui_walk: ctx atlas must be READY");
     NT_ASSERT(ctx->sprite_material.id != 0 && "nt_ui_set_sprite_material(ctx,...) required before nt_ui_walk");
@@ -534,8 +826,17 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
      * lazily inside emit_text just before draw_n. */
     nt_sprite_renderer_set_material(ctx->sprite_material);
 
-    /* Segment-aware dispatch -- see nt_ui_walk header doc for contract. */
+    /* Segment-aware dispatch -- see nt_ui_walk header doc for contract.
+     * Within a segment (same z, no SCISSOR/CUSTOM barrier crossed):
+     *   pass 1: scan for layer range [min..max] used in this segment.
+     *   pass 2: for each layer in that range, emit commands matching it
+     *           in declaration order. NULL userData -> layer 0.
+     * For the common single-layer case (all userData NULL), min==max so
+     * pass 2 runs once -- O(N) total. */
     const Clay_RenderCommandArray *arr = &ctx->frozen_cmds;
+#ifdef NT_TEST_ACCESS
+    uint32_t unlayered_count = 0U;
+#endif
     int32_t i = 0;
     while (i < arr->length) {
         const Clay_RenderCommand *c = &arr->internalArray[i];
@@ -553,16 +854,30 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
             }
             ++seg_end;
         }
+        uint8_t min_layer = 255U;
+        uint8_t max_layer = 0U;
         for (int32_t j = i; j < seg_end; ++j) {
             const Clay_RenderCommand *cc = &arr->internalArray[j];
-            if (cc->commandType != CLAY_RENDER_COMMAND_TYPE_TEXT) {
-                dispatch_command(ctx, cc, scissor_stack, &depth, target);
+            const uint8_t layer = cc->userData ? ((const nt_ui_element_data_t *)cc->userData)->layer : 0U;
+#ifdef NT_TEST_ACCESS
+            if (cc->userData == NULL) {
+                ++unlayered_count;
+            }
+#endif
+            if (layer < min_layer) {
+                min_layer = layer;
+            }
+            if (layer > max_layer) {
+                max_layer = layer;
             }
         }
-        for (int32_t j = i; j < seg_end; ++j) {
-            const Clay_RenderCommand *cc = &arr->internalArray[j];
-            if (cc->commandType == CLAY_RENDER_COMMAND_TYPE_TEXT) {
-                dispatch_command(ctx, cc, scissor_stack, &depth, target);
+        for (uint32_t layer = (uint32_t)min_layer; layer <= (uint32_t)max_layer; ++layer) {
+            for (int32_t j = i; j < seg_end; ++j) {
+                const Clay_RenderCommand *cc = &arr->internalArray[j];
+                const uint8_t cmd_layer = cc->userData ? ((const nt_ui_element_data_t *)cc->userData)->layer : 0U;
+                if ((uint32_t)cmd_layer == layer) {
+                    dispatch_command(ctx, cc, scissor_stack, &depth, target);
+                }
             }
         }
         i = seg_end;
@@ -579,6 +894,9 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(calls_after >= calls_at_entry && "nt_ui_walk: frame draw-call counter went backwards (CUSTOM handler reset stats?)");
     ctx->last_walk_draw_call_delta = calls_after - calls_at_entry;
     ctx->last_walk_element_count = (uint32_t)arr->length;
+#ifdef NT_TEST_ACCESS
+    ctx->test_last_walk_unlayered_count = unlayered_count;
+#endif
 }
 // #endregion
 
@@ -651,6 +969,11 @@ nt_material_t nt_ui_test_sprite_material(const nt_ui_context_t *ctx) {
 nt_material_t nt_ui_test_text_material(const nt_ui_context_t *ctx) {
     NT_ASSERT(ctx != NULL);
     return ctx->text_material;
+}
+
+uint32_t nt_ui_test_last_walk_unlayered_count(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL);
+    return ctx->test_last_walk_unlayered_count;
 }
 
 /* Clay_Context is only defined inside this TU (CLAY_IMPLEMENTATION),

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -564,7 +564,9 @@ static void emit_text(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
         t->textColor.b / 255.0F,
         t->textColor.a / 255.0F,
     };
-    nt_text_renderer_draw_n(t->stringContents.chars, (size_t)t->stringContents.length, m, (float)t->fontSize, color, (float)t->letterSpacing);
+    /* Clay's letterSpacing/lineHeight are additive extras (per Clay docs);
+     * direct passthrough to our tracking/leading params. */
+    nt_text_renderer_draw_n(t->stringContents.chars, (size_t)t->stringContents.length, m, (float)t->fontSize, color, (float)t->letterSpacing, (float)t->lineHeight);
 }
 // #endregion
 

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -69,16 +69,40 @@ static uint32_t s_last_walk_element_count;
 // #endregion
 
 // #region clay_error_handler
-/* Forward a Clay error to NT_LOG_WARN. errorText is a Clay_String with
- * .length + .chars (not necessarily NUL-terminated). */
+/* Returns true if a Clay error code is a recoverable caller-author bug
+ * (Clay safely no-ops it). Everything else is treated as a fatal invariant
+ * violation -- arena too small, missing measure callback, internal Clay
+ * bug, or an unknown type from a future Clay version. Defaulting unknown
+ * to fatal prevents a Clay upgrade from silently demoting new invariants. */
+static bool nt_ui_clay_error_is_recoverable(Clay_ErrorType type) {
+    switch (type) {
+    case CLAY_ERROR_TYPE_ELEMENTS_CAPACITY_EXCEEDED:
+    case CLAY_ERROR_TYPE_TEXT_MEASUREMENT_CAPACITY_EXCEEDED:
+    case CLAY_ERROR_TYPE_DUPLICATE_ID:
+    case CLAY_ERROR_TYPE_FLOATING_CONTAINER_PARENT_NOT_FOUND:
+    case CLAY_ERROR_TYPE_PERCENTAGE_OVER_1:
+        return true;
+    case CLAY_ERROR_TYPE_TEXT_MEASUREMENT_FUNCTION_NOT_PROVIDED:
+    case CLAY_ERROR_TYPE_ARENA_CAPACITY_EXCEEDED:
+    case CLAY_ERROR_TYPE_INTERNAL_ERROR:
+        return false;
+    }
+    return false; /* unknown -> fatal */
+}
+
+/* errorText is a Clay_String with .length + .chars -- not NUL-terminated. */
 static void nt_ui_clay_error_cb(Clay_ErrorData err) {
-    int len = err.errorText.length;
-    const char *chars = err.errorText.chars;
-    if (chars == NULL || len <= 0) {
-        NT_LOG_WARN("clay error type=%d (no text)", (int)err.errorType);
+    const int len = err.errorText.length;
+    const char *const chars = (err.errorText.chars != NULL && len > 0) ? err.errorText.chars : "(no text)";
+    const int safe_len = (err.errorText.chars != NULL && len > 0) ? len : 9;
+    const int type = (int)err.errorType;
+
+    if (nt_ui_clay_error_is_recoverable(err.errorType)) {
+        NT_LOG_WARN("clay error type=%d: %.*s", type, safe_len, chars);
         return;
     }
-    NT_LOG_WARN("clay error type=%d: %.*s", (int)err.errorType, len, chars);
+    NT_LOG_ERROR("clay fatal error type=%d: %.*s", type, safe_len, chars);
+    NT_ASSERT(false && "nt_ui: Clay reported a fatal invariant violation (see preceding log line)");
 }
 // #endregion
 

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -118,8 +118,6 @@ size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc) {
     NT_ASSERT(desc != NULL && "nt_ui_min_arena_size: desc must be non-NULL");
     NT_ASSERT(desc->max_elements > 0U && "nt_ui_min_arena_size: desc->max_elements must be > 0");
     NT_ASSERT(desc->max_elements <= UINT16_MAX && "nt_ui_min_arena_size: desc->max_elements exceeds uint16 sorted-index range");
-    NT_ASSERT(desc->max_scissor_depth > 0U && "nt_ui_min_arena_size: desc->max_scissor_depth must be > 0");
-    NT_ASSERT(desc->max_scissor_depth <= NT_UI_WALKER_SCISSOR_DEPTH_CAP && "nt_ui_min_arena_size: desc->max_scissor_depth > cap");
     /* Clay_SetMaxElementCount(N) also writes defaultMaxMeasureTextWordCacheCount
      * = N*2 (clay.h:4332); restore via the same call so both come back. */
     Clay_Context *saved_ctx = Clay_GetCurrentContext();
@@ -146,7 +144,6 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_u
     const size_t ctx_size = nt_ui_ctx_size_aligned();
     /* Layout: [ctx struct][Clay arena], both NT_UI_ARENA_ALIGN aligned. */
     ctx->max_elements = desc->max_elements;
-    ctx->max_scissor_depth = desc->max_scissor_depth;
     void *clay_mem = (char *)arena + ctx_size;
     const size_t clay_size = arena_size - ctx_size;
 
@@ -581,9 +578,8 @@ typedef struct {
 static void rebind_sprite_after_flush(const nt_ui_context_t *ctx) { nt_sprite_renderer_set_material(ctx->sprite_material); }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, scissor_rect_t *stack, int *depth, const nt_ui_target_t *target, bool *sprite_pipeline_dirty) {
-    (void)ctx;
-    NT_ASSERT((uint32_t)*depth < ctx->max_scissor_depth && "scissor stack overflow; raise desc->max_scissor_depth or restructure nested clip");
+static void scissor_push(const Clay_RenderCommand *c, scissor_rect_t *stack, int *depth, const nt_ui_target_t *target, bool *sprite_pipeline_dirty) {
+    NT_ASSERT((uint32_t)*depth < NT_UI_WALKER_SCISSOR_DEPTH_CAP && "scissor stack overflow; restructure nested clip");
 
     /* Unclipped axis falls back to viewport; floor/ceil avoid 1px right/bottom bite. */
     const Clay_ClipRenderData *clip = &c->renderData.clip;
@@ -719,7 +715,7 @@ static void dispatch_command(const nt_ui_context_t *ctx, const Clay_RenderComman
         emit_image(c);
         return;
     case CLAY_RENDER_COMMAND_TYPE_SCISSOR_START:
-        scissor_push(ctx, c, scissor_stack, depth, target, sprite_pipeline_dirty);
+        scissor_push(c, scissor_stack, depth, target, sprite_pipeline_dirty);
         return;
     case CLAY_RENDER_COMMAND_TYPE_SCISSOR_END:
         scissor_pop(scissor_stack, depth, target, sprite_pipeline_dirty);
@@ -901,23 +897,6 @@ uint32_t nt_ui_get_last_walk_command_count(const nt_ui_context_t *ctx) {
 // #region test_access
 #ifdef NT_TEST_ACCESS
 nt_ui_context_t *nt_ui_test_inframe_ctx(void) { return g_nt_ui_inframe_ctx; }
-
-nt_resource_t nt_ui_test_atlas(const nt_ui_context_t *ctx) {
-    NT_ASSERT(ctx != NULL);
-    return ctx->atlas;
-}
-uint32_t nt_ui_test_white_region(const nt_ui_context_t *ctx) {
-    NT_ASSERT(ctx != NULL);
-    return ctx->white_region;
-}
-nt_material_t nt_ui_test_sprite_material(const nt_ui_context_t *ctx) {
-    NT_ASSERT(ctx != NULL);
-    return ctx->sprite_material;
-}
-nt_material_t nt_ui_test_text_material(const nt_ui_context_t *ctx) {
-    NT_ASSERT(ctx != NULL);
-    return ctx->text_material;
-}
 
 int32_t nt_ui_test_clay_default_max_element_count(void) { return Clay__defaultMaxElementCount; }
 int32_t nt_ui_test_clay_default_max_measure_text_word_cache_count(void) { return Clay__defaultMaxMeasureTextWordCacheCount; }

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -80,19 +80,16 @@ static void nt_ui_clay_error_cb(Clay_ErrorData err) {
 // #endregion
 
 // #region measure_cb
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static Clay_Dimensions nt_ui_measure_text_cb(Clay_StringSlice text, Clay_TextElementConfig *config, void *user_data) {
     (void)user_data;
     NT_ASSERT(g_nt_ui_inframe_ctx != NULL && "measure_cb: Clay called outside begin/end");
     NT_ASSERT(config != NULL && "measure_cb: Clay passed NULL config");
 
     nt_ui_context_t *ctx = g_nt_ui_inframe_ctx;
-    if (config->fontId >= NT_UI_MAX_FONTS) {
-        return (Clay_Dimensions){0};
-    }
+    NT_ASSERT((uint32_t)config->fontId < NT_UI_MAX_FONTS && "nt_ui measure_cb: fontId out of range; check CLAY_TEXT_CONFIG vs NT_UI_MAX_FONTS");
     nt_font_t font = ctx->fonts[config->fontId];
-    if (!nt_font_valid(font)) {
-        return (Clay_Dimensions){0};
-    }
+    NT_ASSERT(nt_font_valid(font) && "nt_ui measure_cb: font slot empty; call nt_ui_set_font before declaring TEXT with this fontId");
     const float ls = (float)config->letterSpacing;
     nt_text_size_t s = nt_font_measure_n(font, text.chars, (size_t)text.length, (float)config->fontSize, ls);
     /* Clay convention: callback returns word width WITH one trailing
@@ -110,21 +107,72 @@ static Clay_Dimensions nt_ui_measure_text_cb(Clay_StringSlice text, Clay_TextEle
 // #endregion
 
 // #region module_init
+/* Per-quarter-arc segment count (rounded RECT/BORDER). Defined here so the
+ * LUT below sizes correctly. Helpers below use the same #define. */
+#define NT_UI_CORNER_SEGMENTS 6
+_Static_assert(NT_UI_CORNER_SEGMENTS >= 2 && NT_UI_CORNER_SEGMENTS <= 32, "NT_UI_CORNER_SEGMENTS must be in [2, 32]: lower degenerate, higher wastes stack and staging");
+#define NT_UI_PI_F 3.14159265358979323846F
+
+/* Precomputed (cos, sin) per arc segment per corner quadrant.
+ * Quadrant index encodes the starting angle (a_start = q * π/2):
+ *   q=0 -> BR (angle 0 → π/2)
+ *   q=1 -> BL (π/2 → π)
+ *   q=2 -> TL (π → 3π/2)
+ *   q=3 -> TR (3π/2 → 2π)
+ * Populated once at module init; .rodata-sized 4 * (SEG+1) * 8 = 224 B for SEG=6.
+ * Replaces 28-56 cosf/sinf calls per rounded element on the walker hot path. */
+typedef struct {
+    float cos;
+    float sin;
+} nt_ui_trig_pair_t;
+static nt_ui_trig_pair_t s_arc_lut[4][NT_UI_CORNER_SEGMENTS + 1];
+
+static void nt_ui_init_arc_lut(void) {
+    for (uint32_t q = 0U; q < 4U; ++q) {
+        const float a_start = NT_UI_PI_F * 0.5F * (float)q;
+        for (uint32_t s = 0U; s <= NT_UI_CORNER_SEGMENTS; ++s) {
+            const float t = (float)s / (float)NT_UI_CORNER_SEGMENTS;
+            const float a = a_start + (NT_UI_PI_F * 0.5F * t);
+            s_arc_lut[q][s].cos = cosf(a);
+            s_arc_lut[q][s].sin = sinf(a);
+        }
+    }
+}
+
 /* Wire measure callback into Clay's global function pointer. Bypasses
  * Clay_SetMeasureTextFunction (which requires an active Clay context) by
  * writing directly to the global -- legal because CLAY_IMPLEMENTATION
- * places Clay's internals in this TU. */
-void nt_ui_module_init(void) { Clay__MeasureText = nt_ui_measure_text_cb; }
-void nt_ui_module_shutdown(void) { Clay__MeasureText = NULL; }
+ * places Clay's internals in this TU. Also clears the module-global
+ * in-frame ctx tracker (death-test longjmp through nt_ui_end leaves it
+ * stale; module init/shutdown is the natural reset point). */
+void nt_ui_module_init(void) {
+    Clay__MeasureText = nt_ui_measure_text_cb;
+    g_nt_ui_inframe_ctx = NULL;
+    Clay_SetCurrentContext(NULL);
+    nt_ui_init_arc_lut();
+}
+void nt_ui_module_shutdown(void) {
+    Clay__MeasureText = NULL;
+    g_nt_ui_inframe_ctx = NULL;
+    Clay_SetCurrentContext(NULL);
+}
 // #endregion
 
 // #region create_destroy
 /* ctx struct rounded up to cache-line so Clay's arena starts aligned. */
 static size_t nt_ui_ctx_size_aligned(void) { return (sizeof(struct nt_ui_context) + 63U) & ~(size_t)63U; }
 
+/* Counting-sort scratch buffer in the arena: uint16_t per cmd, aligned up
+ * to NT_UI_ARENA_ALIGN so the Clay arena that follows stays aligned. */
+static size_t nt_ui_sorted_size_aligned(uint32_t max_elements) {
+    const size_t bytes = (size_t)max_elements * sizeof(uint16_t);
+    return (bytes + (NT_UI_ARENA_ALIGN - 1U)) & ~(size_t)(NT_UI_ARENA_ALIGN - 1U);
+}
+
 size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc) {
     NT_ASSERT(desc != NULL && "nt_ui_min_arena_size: desc must be non-NULL");
     NT_ASSERT(desc->max_elements > 0U && "nt_ui_min_arena_size: desc->max_elements must be > 0");
+    NT_ASSERT(desc->max_elements <= UINT16_MAX && "nt_ui_min_arena_size: desc->max_elements exceeds uint16 sorted-index range");
     /* Clay_SetMaxElementCount writes to GLOBAL Clay__defaultMaxElementCount
      * when no current context exists, or to current context otherwise. We
      * want to size against desc-> max_elements WITHOUT mutating any active
@@ -134,7 +182,7 @@ size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc) {
     Clay_SetMaxElementCount((int32_t)desc->max_elements);
     const size_t clay_bytes = (size_t)Clay_MinMemorySize();
     Clay_SetCurrentContext(saved);
-    return nt_ui_ctx_size_aligned() + clay_bytes;
+    return nt_ui_ctx_size_aligned() + nt_ui_sorted_size_aligned(desc->max_elements) + clay_bytes;
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
@@ -149,8 +197,13 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_u
     memset(ctx, 0, sizeof(*ctx));
 
     const size_t ctx_size = nt_ui_ctx_size_aligned();
-    void *clay_mem = (char *)arena + ctx_size;
-    const size_t clay_size = arena_size - ctx_size;
+    const size_t sorted_size = nt_ui_sorted_size_aligned(desc->max_elements);
+    /* Layout: [ctx struct][sorted buffer][Clay arena]. Each block is sized
+     * to keep the next block's start at NT_UI_ARENA_ALIGN-aligned offset. */
+    ctx->sorted = (uint16_t *)((char *)arena + ctx_size);
+    ctx->max_elements = desc->max_elements;
+    void *clay_mem = (char *)arena + ctx_size + sorted_size;
+    const size_t clay_size = arena_size - ctx_size - sorted_size;
 
     /* Stage desc->max_elements into Clay's global default so Clay_Initialize
      * inherits it for this new context. Save/restore current ctx so this
@@ -163,11 +216,11 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_u
     ctx->clay_arena = Clay_CreateArenaWithCapacityAndMemory(clay_size, clay_mem);
     ctx->clay = Clay_Initialize(ctx->clay_arena, (Clay_Dimensions){.width = 1.0F, .height = 1.0F}, (Clay_ErrorHandler){.errorHandlerFunction = nt_ui_clay_error_cb, .userData = ctx});
 
-    /* Restore the previously-current context (if any). The caller picks
-     * which ctx is "current" via nt_ui_begin for each frame anyway. */
-    if (saved != NULL) {
-        Clay_SetCurrentContext(saved);
-    }
+    /* Restore the pre-create current ctx (may be NULL). Clay_Initialize
+     * sets current to the new ctx; without this restore the caller would
+     * inherit our new ctx as active without ever calling nt_ui_begin --
+     * breaks the contract that nt_ui_begin owns active-ctx selection. */
+    Clay_SetCurrentContext(saved);
 
     return ctx;
 }
@@ -175,6 +228,13 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_u
 void nt_ui_destroy_context(nt_ui_context_t *ctx) {
     NT_ASSERT(ctx != NULL && "nt_ui_destroy_context: ctx must be non-NULL");
     NT_ASSERT(!ctx->in_frame && "nt_ui_destroy_context: ctx is mid-frame (call nt_ui_end first)");
+    /* nt_ui_begin sets Clay's global current_ptr to ctx->clay; that pointer
+     * lives inside ctx's arena and becomes dangling after memset below.
+     * Null Clay's current if it points at us so subsequent Clay API calls
+     * either short-circuit (Clay_MinMemorySize) or assert cleanly. */
+    if (Clay_GetCurrentContext() == ctx->clay) {
+        Clay_SetCurrentContext(NULL);
+    }
     memset(ctx, 0, sizeof(*ctx));
 }
 // #endregion
@@ -266,17 +326,7 @@ static inline void emit_screen_rect(nt_resource_t atlas, uint32_t region_index, 
 // #endregion
 
 // #region helper_emit_rounded_rect
-/* Per-quarter-arc segment count. 6 keeps the triangle count low (28 tris
- * for a fully rounded rect) while staying smooth at typical UI radii.
- *
- * Hot-path note: trig (cosf/sinf) dominates here -- ~28 calls per rounded
- * rect, ~56 per rounded border. If profiling shows this in the top hot
- * path, precompute a (SEG+1) x 4 sin/cos LUT at startup and table-lookup
- * here instead of computing each frame. UV centroid in emit_geometry is
- * orders of magnitude cheaper and not worth caching first. */
-#define NT_UI_CORNER_SEGMENTS 6
-_Static_assert(NT_UI_CORNER_SEGMENTS >= 2 && NT_UI_CORNER_SEGMENTS <= 32, "NT_UI_CORNER_SEGMENTS must be in [2, 32]: lower degenerate, higher wastes stack and staging");
-#define NT_UI_PI_F 3.14159265358979323846F
+/* NT_UI_CORNER_SEGMENTS, NT_UI_PI_F and s_arc_lut declared above in module_init. */
 
 /* Triangle fan from rect center to the boundary. Each corner contributes
  * either 1 vertex (radius 0) or NT_UI_CORNER_SEGMENTS+1 arc vertices.
@@ -319,7 +369,7 @@ static void emit_rounded_rect(nt_resource_t atlas, uint32_t region_index, float 
     positions[0][1] = y + half_h;
     uint32_t vi = 1;
 
-    /* TL arc: math angle π → 1.5π (sweeps from west to north of corner center). */
+    /* TL arc: quadrant 2 (π → 1.5π) -- sweeps west to north of corner center. */
     if (tl == 0.0F) {
         positions[vi][0] = x;
         positions[vi][1] = y;
@@ -328,14 +378,12 @@ static void emit_rounded_rect(nt_resource_t atlas, uint32_t region_index, float 
         const float cx = x + tl;
         const float cy = y + tl;
         for (uint32_t s = 0; s <= NT_UI_CORNER_SEGMENTS; s++) {
-            const float t = (float)s / (float)NT_UI_CORNER_SEGMENTS;
-            const float a = NT_UI_PI_F * (1.0F + 0.5F * t);
-            positions[vi][0] = cx + tl * cosf(a);
-            positions[vi][1] = cy + tl * sinf(a);
+            positions[vi][0] = cx + (tl * s_arc_lut[2][s].cos);
+            positions[vi][1] = cy + (tl * s_arc_lut[2][s].sin);
             vi++;
         }
     }
-    /* TR arc: 1.5π → 2π. */
+    /* TR arc: quadrant 3 (1.5π → 2π). */
     if (tr == 0.0F) {
         positions[vi][0] = x + w;
         positions[vi][1] = y;
@@ -344,14 +392,12 @@ static void emit_rounded_rect(nt_resource_t atlas, uint32_t region_index, float 
         const float cx = x + w - tr;
         const float cy = y + tr;
         for (uint32_t s = 0; s <= NT_UI_CORNER_SEGMENTS; s++) {
-            const float t = (float)s / (float)NT_UI_CORNER_SEGMENTS;
-            const float a = NT_UI_PI_F * (1.5F + 0.5F * t);
-            positions[vi][0] = cx + tr * cosf(a);
-            positions[vi][1] = cy + tr * sinf(a);
+            positions[vi][0] = cx + (tr * s_arc_lut[3][s].cos);
+            positions[vi][1] = cy + (tr * s_arc_lut[3][s].sin);
             vi++;
         }
     }
-    /* BR arc: 0 → 0.5π. */
+    /* BR arc: quadrant 0 (0 → 0.5π). */
     if (br == 0.0F) {
         positions[vi][0] = x + w;
         positions[vi][1] = y + h;
@@ -360,14 +406,12 @@ static void emit_rounded_rect(nt_resource_t atlas, uint32_t region_index, float 
         const float cx = x + w - br;
         const float cy = y + h - br;
         for (uint32_t s = 0; s <= NT_UI_CORNER_SEGMENTS; s++) {
-            const float t = (float)s / (float)NT_UI_CORNER_SEGMENTS;
-            const float a = NT_UI_PI_F * (0.5F * t);
-            positions[vi][0] = cx + br * cosf(a);
-            positions[vi][1] = cy + br * sinf(a);
+            positions[vi][0] = cx + (br * s_arc_lut[0][s].cos);
+            positions[vi][1] = cy + (br * s_arc_lut[0][s].sin);
             vi++;
         }
     }
-    /* BL arc: 0.5π → π. */
+    /* BL arc: quadrant 1 (0.5π → π). */
     if (bl == 0.0F) {
         positions[vi][0] = x;
         positions[vi][1] = y + h;
@@ -376,10 +420,8 @@ static void emit_rounded_rect(nt_resource_t atlas, uint32_t region_index, float 
         const float cx = x + bl;
         const float cy = y + h - bl;
         for (uint32_t s = 0; s <= NT_UI_CORNER_SEGMENTS; s++) {
-            const float t = (float)s / (float)NT_UI_CORNER_SEGMENTS;
-            const float a = NT_UI_PI_F * (0.5F + 0.5F * t);
-            positions[vi][0] = cx + bl * cosf(a);
-            positions[vi][1] = cy + bl * sinf(a);
+            positions[vi][0] = cx + (bl * s_arc_lut[1][s].cos);
+            positions[vi][1] = cy + (bl * s_arc_lut[1][s].sin);
             vi++;
         }
     }
@@ -423,12 +465,12 @@ static void emit_square_border(nt_resource_t atlas, uint32_t region_index, Clay_
 }
 
 /* Append one corner's (outer,inner) vertex pair(s) into the strip array.
- * a_start_factor scales by π for the arc start (1.0=TL/π, 1.5=TR/3π/2,
- * 0.0=BR/0, 0.5=BL/π/2). a_start_factor sweep is always +0.5π. radius==0
- * collapses to a single sharp pair at (sharp_x, sharp_y) (outer) and
+ * quadrant picks the LUT row: 2=TL (π → 1.5π), 3=TR (1.5π → 2π),
+ * 0=BR (0 → 0.5π), 1=BL (0.5π → π). radius==0 collapses to a single
+ * sharp pair at (sharp_x, sharp_y) (outer) and
  * (sharp_x + sx*wx, sharp_y + sy*wy) (inner). */
 static uint32_t emit_corner_strip_pairs(float (*pos)[2], uint32_t vi, float radius, float cx, float cy, float w_perp_x, float w_perp_y, float sharp_x, float sharp_y, float sign_x, float sign_y,
-                                        float a_start_factor) {
+                                        uint32_t quadrant) {
     if (radius == 0.0F) {
         pos[vi][0] = sharp_x;
         pos[vi][1] = sharp_y;
@@ -443,12 +485,9 @@ static uint32_t emit_corner_strip_pairs(float (*pos)[2], uint32_t vi, float radi
      * center on that axis. Matches CSS/Godot/Skia behaviour. */
     const float irx = (radius > w_perp_x) ? (radius - w_perp_x) : 0.0F;
     const float iry = (radius > w_perp_y) ? (radius - w_perp_y) : 0.0F;
-    const float a_start = NT_UI_PI_F * a_start_factor;
     for (uint32_t s = 0; s <= NT_UI_CORNER_SEGMENTS; s++) {
-        const float t = (float)s / (float)NT_UI_CORNER_SEGMENTS;
-        const float a = a_start + (NT_UI_PI_F * 0.5F * t);
-        const float cc = cosf(a);
-        const float ss = sinf(a);
+        const float cc = s_arc_lut[quadrant][s].cos;
+        const float ss = s_arc_lut[quadrant][s].sin;
         pos[vi][0] = cx + (radius * cc);
         pos[vi][1] = cy + (radius * ss);
         vi++;
@@ -511,10 +550,11 @@ static void emit_rounded_border(nt_resource_t atlas, uint32_t region_index, Clay
     float positions[4 * (NT_UI_CORNER_SEGMENTS + 1) * 2][2];
     uint32_t vi = 0;
 
-    vi = emit_corner_strip_pairs(positions, vi, tl, x + tl, y + tl, lft, top, x, y, 1.0F, 1.0F, 1.0F);
-    vi = emit_corner_strip_pairs(positions, vi, tr, x + w - tr, y + tr, rgt, top, x + w, y, -1.0F, 1.0F, 1.5F);
-    vi = emit_corner_strip_pairs(positions, vi, br, x + w - br, y + h - br, rgt, bot, x + w, y + h, -1.0F, -1.0F, 0.0F);
-    vi = emit_corner_strip_pairs(positions, vi, bl, x + bl, y + h - bl, lft, bot, x, y + h, 1.0F, -1.0F, 0.5F);
+    /* Quadrant: 2=TL (π → 1.5π), 3=TR (1.5π → 2π), 0=BR (0 → 0.5π), 1=BL (0.5π → π). */
+    vi = emit_corner_strip_pairs(positions, vi, tl, x + tl, y + tl, lft, top, x, y, 1.0F, 1.0F, 2U);
+    vi = emit_corner_strip_pairs(positions, vi, tr, x + w - tr, y + tr, rgt, top, x + w, y, -1.0F, 1.0F, 3U);
+    vi = emit_corner_strip_pairs(positions, vi, br, x + w - br, y + h - br, rgt, bot, x + w, y + h, -1.0F, -1.0F, 0U);
+    vi = emit_corner_strip_pairs(positions, vi, bl, x + bl, y + h - bl, lft, bot, x, y + h, 1.0F, -1.0F, 1U);
 
     /* Triangle strip with wrap. Each pair k: outer at 2k, inner at 2k+1. */
     const uint32_t pair_count = vi / 2;
@@ -794,9 +834,17 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
      * vh==0 (GL undefined). Origin x/y may be zero. */
     NT_ASSERT(isfinite(target->viewport[0]) && isfinite(target->viewport[1]) && isfinite(target->viewport[2]) && isfinite(target->viewport[3]) && "nt_ui_walk: target->viewport must be finite");
     NT_ASSERT(target->viewport[0] >= 0.0F && target->viewport[1] >= 0.0F && "nt_ui_walk: target->viewport origin (x,y) must be non-negative");
+    NT_ASSERT(target->viewport[2] >= 0.0F && target->viewport[3] >= 0.0F && "nt_ui_walk: target->viewport (w,h) must be non-negative");
     /* Zero-size viewport is a legitimate runtime state (minimized browser
-     * tab, mobile orientation transition). Silent no-op rather than assert. */
-    if (target->viewport[2] <= 0.0F || target->viewport[3] <= 0.0F) {
+     * tab, mobile orientation transition). Silent no-op rather than assert,
+     * but reset per-walk stats so callers don't read stale values from the
+     * previous non-empty walk. */
+    if (target->viewport[2] == 0.0F || target->viewport[3] == 0.0F) {
+        ctx->last_walk_draw_call_delta = 0;
+        ctx->last_walk_element_count = 0;
+#ifdef NT_TEST_ACCESS
+        ctx->test_last_walk_unlayered_count = 0;
+#endif
         return;
     }
     NT_ASSERT(ctx->atlas.id != 0 && "nt_ui_set_atlas_white_region(ctx,...) required before nt_ui_walk");
@@ -828,11 +876,14 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
 
     /* Segment-aware dispatch -- see nt_ui_walk header doc for contract.
      * Within a segment (same z, no SCISSOR/CUSTOM barrier crossed):
-     *   pass 1: scan for layer range [min..max] used in this segment.
-     *   pass 2: for each layer in that range, emit commands matching it
-     *           in declaration order. NULL userData -> layer 0.
-     * For the common single-layer case (all userData NULL), min==max so
-     * pass 2 runs once -- O(N) total. */
+     *   counting sort by layer (stable). 4 passes over N segment commands:
+     *     1) count[layer]++ per cmd
+     *     2) prefix-sum count[] into offset[]
+     *     3) place cmd index into ctx->sorted[offset[layer]++]
+     *     4) iterate ctx->sorted[] in order, dispatch
+     * O(N + 256) total per segment, ~6N ops dominant. count[256] and
+     * offset[256] live on this stack (2 KB); ctx->sorted lives in the
+     * per-ctx arena sized for ctx->max_elements. */
     const Clay_RenderCommandArray *arr = &ctx->frozen_cmds;
 #ifdef NT_TEST_ACCESS
     uint32_t unlayered_count = 0U;
@@ -854,31 +905,33 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
             }
             ++seg_end;
         }
-        uint8_t min_layer = 255U;
-        uint8_t max_layer = 0U;
+        const int32_t seg_n = seg_end - i;
+        NT_ASSERT((uint32_t)seg_n <= ctx->max_elements && "nt_ui_walk: segment size exceeds ctx->max_elements; raise desc->max_elements or split via SCISSOR");
+
+        uint32_t count[256] = {0};
         for (int32_t j = i; j < seg_end; ++j) {
             const Clay_RenderCommand *cc = &arr->internalArray[j];
             const uint8_t layer = cc->userData ? ((const nt_ui_element_data_t *)cc->userData)->layer : 0U;
+            count[layer]++;
 #ifdef NT_TEST_ACCESS
             if (cc->userData == NULL) {
                 ++unlayered_count;
             }
 #endif
-            if (layer < min_layer) {
-                min_layer = layer;
-            }
-            if (layer > max_layer) {
-                max_layer = layer;
-            }
         }
-        for (uint32_t layer = (uint32_t)min_layer; layer <= (uint32_t)max_layer; ++layer) {
-            for (int32_t j = i; j < seg_end; ++j) {
-                const Clay_RenderCommand *cc = &arr->internalArray[j];
-                const uint8_t cmd_layer = cc->userData ? ((const nt_ui_element_data_t *)cc->userData)->layer : 0U;
-                if ((uint32_t)cmd_layer == layer) {
-                    dispatch_command(ctx, cc, scissor_stack, &depth, target);
-                }
-            }
+        uint32_t offset[256];
+        uint32_t total = 0U;
+        for (uint32_t l = 0U; l < 256U; ++l) {
+            offset[l] = total;
+            total += count[l];
+        }
+        for (int32_t j = i; j < seg_end; ++j) {
+            const Clay_RenderCommand *cc = &arr->internalArray[j];
+            const uint8_t layer = cc->userData ? ((const nt_ui_element_data_t *)cc->userData)->layer : 0U;
+            ctx->sorted[offset[layer]++] = (uint16_t)j;
+        }
+        for (uint32_t k = 0U; k < total; ++k) {
+            dispatch_command(ctx, &arr->internalArray[ctx->sorted[k]], scissor_stack, &depth, target);
         }
         i = seg_end;
     }

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -115,8 +115,6 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size) {
     void *clay_mem = (char *)arena + ctx_size;
     const size_t clay_size = arena_size - ctx_size;
 
-    ctx->arena_base = arena;
-    ctx->arena_size = arena_size;
     ctx->in_frame = false;
     ctx->clay_arena = Clay_CreateArenaWithCapacityAndMemory(clay_size, clay_mem);
     ctx->clay = Clay_Initialize(ctx->clay_arena, (Clay_Dimensions){.width = 1.0F, .height = 1.0F}, (Clay_ErrorHandler){.errorHandlerFunction = nt_ui_clay_error_cb, .userData = ctx});
@@ -245,25 +243,30 @@ static void emit_border(const nt_ui_context_t *ctx, const Clay_RenderCommand *c)
 /* IMAGE uses the PAYLOAD's atlas, not ctx->atlas (the latter is for
  * RECT/BORDER's white region). Different atlas pages auto-flush via the
  * sprite renderer's ensure_current_cmd_page_texture path. */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void emit_image(const Clay_RenderCommand *c) {
     const nt_ui_image_payload_t *p = (const nt_ui_image_payload_t *)c->renderData.image.imageData;
-    if (p == NULL) {
-        return; /* Clay does not enforce non-NULL imageData */
-    }
-
-    /* id == 0 is a caller bug. not-READY is a legitimate transient state
-     * (async load), so silently skip this frame -- next frame will draw. */
+    NT_ASSERT(p != NULL && "nt_ui IMAGE: imageData must point to nt_ui_image_payload_t");
     NT_ASSERT(p->atlas.id != 0 && "nt_ui IMAGE payload: invalid atlas handle (zero id)");
+    /* Reserved field -- caller writing into it indicates a feature
+     * expectation we don't yet meet. Assert until slice9 emit lands. */
+    NT_ASSERT(p->slice9_lrtb[0] == 0 && p->slice9_lrtb[1] == 0 && p->slice9_lrtb[2] == 0 && p->slice9_lrtb[3] == 0 && "nt_ui IMAGE payload: slice9_lrtb is reserved");
+
+    /* Async-loading atlas is a legitimate runtime state -- skip this
+     * frame, next frame will draw. */
     if (!nt_resource_is_ready(p->atlas)) {
         return;
     }
 
     const Clay_BoundingBox bb = c->boundingBox;
 
-    /* Clay default backgroundColor for IMAGE is {0,0,0,0} == untinted. Map
-     * to 0xFFFFFFFF so the per-vertex tint multiply is a no-op. */
+    /* Clay's IMAGE default backgroundColor is {0,0,0,0}. Caller intent is
+     * "untinted" (the default-constructed Clay struct), not "draw nothing".
+     * Distinguishing on alpha==0 alone keeps legitimate transparent tints
+     * (e.g. {0,0,0,128} half-alpha black) working as expected. */
     Clay_Color tint = c->renderData.image.backgroundColor;
-    const uint32_t col = (tint.r == 0.0F && tint.g == 0.0F && tint.b == 0.0F && tint.a == 0.0F) ? 0xFFFFFFFFU : nt_color_pack_clay(tint);
+    const bool default_untinted = (tint.r == 0.0F && tint.g == 0.0F && tint.b == 0.0F && tint.a == 0.0F);
+    const uint32_t col = default_untinted ? 0xFFFFFFFFU : nt_color_pack_clay(tint);
 
     const nt_texture_region_t *r = nt_atlas_get_region(p->atlas, p->region_index);
     if (r == NULL || r->vertex_count == 0U) {
@@ -295,11 +298,21 @@ static void emit_text(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
 
     const Clay_TextRenderData *t = &c->renderData.text;
     if ((uint32_t)t->fontId >= NT_UI_MAX_FONTS) {
+        static bool warned = false;
+        if (!warned) {
+            NT_LOG_WARN("nt_ui TEXT: fontId %u >= NT_UI_MAX_FONTS=%u; skipping (further occurrences silenced)", (unsigned)t->fontId, (unsigned)NT_UI_MAX_FONTS);
+            warned = true;
+        }
         rebind_sprite_after_flush(ctx);
         return;
     }
     nt_font_t font = ctx->fonts[t->fontId];
     if (!nt_font_valid(font)) {
+        static bool warned_invalid = false;
+        if (!warned_invalid) {
+            NT_LOG_WARN("nt_ui TEXT: fontId %u resolves to an invalid font handle; skipping (further occurrences silenced)", (unsigned)t->fontId);
+            warned_invalid = true;
+        }
         rebind_sprite_after_flush(ctx);
         return;
     }
@@ -457,6 +470,12 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(ctx != NULL && "nt_ui_walk: ctx must be non-NULL");
     NT_ASSERT(target != NULL && "nt_ui_walk: target must be non-NULL");
     NT_ASSERT(!ctx->in_frame && "nt_ui_walk: ctx is mid-frame (call nt_ui_end first)");
+    /* Catch the create -> walk shortcut: frozen_cmds is zero-init'd until
+     * nt_ui_end populates it. Without this, the loop is a silent no-op. */
+    NT_ASSERT((ctx->frozen_cmds.internalArray != NULL || ctx->frozen_cmds.length == 0) && "nt_ui_walk: frozen_cmds not populated (call nt_ui_end before walk)");
+    /* Viewport must be non-negative -- the cast to int below would
+     * otherwise turn NaN / -inf into garbage GL state. */
+    NT_ASSERT(target->viewport[0] >= 0.0F && target->viewport[1] >= 0.0F && target->viewport[2] >= 0.0F && target->viewport[3] >= 0.0F && "nt_ui_walk: target->viewport must be non-negative");
     NT_ASSERT(ctx->atlas.id != 0 && "nt_ui_set_atlas_white_region(ctx,...) required before nt_ui_walk");
     NT_ASSERT(nt_resource_is_ready(ctx->atlas) && "nt_ui_walk: ctx atlas must be READY");
     NT_ASSERT(ctx->sprite_material.id != 0 && "nt_ui_set_sprite_material(ctx,...) required before nt_ui_walk");
@@ -516,6 +535,10 @@ void nt_ui_set_atlas_white_region(nt_ui_context_t *ctx, nt_resource_t atlas, uin
     NT_ASSERT(nt_resource_is_ready(atlas) && "nt_ui_set_atlas_white_region: atlas must be READY");
     const nt_texture_region_t *r = nt_atlas_get_region(atlas, white_region_idx);
     NT_ASSERT(r != NULL && r->vertex_count > 0U && "nt_ui_set_atlas_white_region: white region missing / tombstoned (mis-baked atlas)");
+    /* emit_screen_rect assumes a unit-square white region so that its
+     * mat4(scale=w,h; translate=x,y) maps cached_pos {0,1}x{0,1} directly
+     * onto the target rect. A non-unit region would mis-scale RECT/BORDER. */
+    NT_ASSERT(r->source_w == 1 && r->source_h == 1 && "nt_ui_set_atlas_white_region: white region must be 1x1 source");
     ctx->atlas = atlas;
     ctx->white_region = white_region_idx;
 }

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -263,26 +263,18 @@ static void emit_border(const Clay_RenderCommand *c) {
 
 // #region helper_emit_image
 /* D-52-07 + D-52-08: IMAGE -> read nt_ui_image_payload_t* from imageData,
- * emit one region at bbox. slice9 fields are reserved-but-inactive in
- * Phase 52 -- warn-once and fall through to a plain quad emit.
+ * emit one region at bbox.
  *
  * IMPORTANT: image uses the PAYLOAD's atlas, not g_nt_ui_atlas. Different
  * atlas pages auto-flush via the sprite renderer's
- * ensure_current_cmd_page_texture path. */
+ * ensure_current_cmd_page_texture path.
+ *
+ * slice9_lrtb is reserved in Phase 52 and silently ignored (plain quad emit)
+ * until Phase 54 adds the slice9 path. The header documents this contract. */
 static void emit_image(const Clay_RenderCommand *c) {
     const nt_ui_image_payload_t *p = (const nt_ui_image_payload_t *)c->renderData.image.imageData;
     if (p == NULL) {
-        return; /* tolerate missing payload — Clay does not enforce */
-    }
-
-    const bool slice9 = (p->slice9_lrtb[0] | p->slice9_lrtb[1] | p->slice9_lrtb[2] | p->slice9_lrtb[3]) != 0u;
-    if (slice9) {
-        static bool s_slice9_warned = false;
-        if (!s_slice9_warned) {
-            NT_LOG_WARN("nt_ui slice9 payload set in Phase 52 — Phase 54 required; emitting plain quad");
-            s_slice9_warned = true;
-        }
-        /* fall through -- emit as plain quad */
+        return; /* tolerate missing payload -- Clay does not enforce */
     }
 
     const Clay_BoundingBox bb = c->boundingBox;

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -142,6 +142,7 @@ size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc) {
     NT_ASSERT(desc->max_elements > 0U && "nt_ui_min_arena_size: desc->max_elements must be > 0");
     NT_ASSERT(desc->max_elements <= UINT16_MAX && "nt_ui_min_arena_size: desc->max_elements exceeds uint16 sorted-index range");
     NT_ASSERT(desc->max_scissor_depth > 0U && "nt_ui_min_arena_size: desc->max_scissor_depth must be > 0");
+    NT_ASSERT(desc->max_scissor_depth <= 256U && "nt_ui_min_arena_size: desc->max_scissor_depth > 256 (likely uninit garbage; walker stack VLA would be huge)");
     /* Pure-query contract: Clay_SetMaxElementCount(N) writes globals (no
      * current ctx) AND sets defaultMaxMeasureTextWordCacheCount = N*2
      * (clay.h:4332). Restore via the SAME public call so BOTH side-effect
@@ -251,6 +252,10 @@ void nt_ui_end(nt_ui_context_t *ctx) {
     ctx->frozen_cmds = Clay_EndLayout();
     ctx->in_frame = false;
     g_nt_ui_inframe_ctx = NULL;
+    /* Symmetric with begin's Clay_SetCurrentContext(ctx->clay): a stray
+     * CLAY_* call between end and the next begin now NULL-derefs in Clay
+     * instead of silently corrupting the just-frozen layout. */
+    Clay_SetCurrentContext(NULL);
 }
 // #endregion
 
@@ -286,35 +291,45 @@ static inline void emit_screen_rect(nt_resource_t atlas, uint32_t region_index, 
 }
 // #endregion
 
+// #region helper_clamp_radii_css3
+/* CSS3 border-radius §5.5 proportional clamp: negative -> 0, then if any
+ * adjacent-pair sum exceeds the side, scale all four by the smallest factor. */
+static inline void clamp_radii_css3(float w, float h, float *tl, float *tr, float *bl, float *br) {
+    *tl = (*tl > 0.0F) ? *tl : 0.0F;
+    *tr = (*tr > 0.0F) ? *tr : 0.0F;
+    *bl = (*bl > 0.0F) ? *bl : 0.0F;
+    *br = (*br > 0.0F) ? *br : 0.0F;
+    float factor = 1.0F;
+    if (*tl + *tr > w) {
+        factor = fminf(factor, w / (*tl + *tr));
+    }
+    if (*bl + *br > w) {
+        factor = fminf(factor, w / (*bl + *br));
+    }
+    if (*tl + *bl > h) {
+        factor = fminf(factor, h / (*tl + *bl));
+    }
+    if (*tr + *br > h) {
+        factor = fminf(factor, h / (*tr + *br));
+    }
+    if (factor < 1.0F) {
+        *tl *= factor;
+        *tr *= factor;
+        *bl *= factor;
+        *br *= factor;
+    }
+}
+// #endregion
+
 // #region helper_emit_rounded_rect
 /* Triangle fan from rect center: 1 vert per zero corner, SEG+1 per rounded. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void emit_rounded_rect(nt_resource_t atlas, uint32_t region_index, float x, float y, float w, float h, Clay_CornerRadius cr, uint32_t color_packed) {
-    float tl = (cr.topLeft > 0.0F) ? cr.topLeft : 0.0F;
-    float tr = (cr.topRight > 0.0F) ? cr.topRight : 0.0F;
-    float bl = (cr.bottomLeft > 0.0F) ? cr.bottomLeft : 0.0F;
-    float br = (cr.bottomRight > 0.0F) ? cr.bottomRight : 0.0F;
-    /* CSS3 border-radius §5.5 proportional clamp -- when adjacent-pair sums
-     * exceed the side, scale ALL radii by the smallest needed factor. */
-    float factor = 1.0F;
-    if (tl + tr > w) {
-        factor = fminf(factor, w / (tl + tr));
-    }
-    if (bl + br > w) {
-        factor = fminf(factor, w / (bl + br));
-    }
-    if (tl + bl > h) {
-        factor = fminf(factor, h / (tl + bl));
-    }
-    if (tr + br > h) {
-        factor = fminf(factor, h / (tr + br));
-    }
-    if (factor < 1.0F) {
-        tl *= factor;
-        tr *= factor;
-        bl *= factor;
-        br *= factor;
-    }
+    float tl = cr.topLeft;
+    float tr = cr.topRight;
+    float bl = cr.bottomLeft;
+    float br = cr.bottomRight;
+    clamp_radii_css3(w, h, &tl, &tr, &bl, &br);
     const float half_w = w * 0.5F;
     const float half_h = h * 0.5F;
 
@@ -467,30 +482,11 @@ static void emit_rounded_border(nt_resource_t atlas, uint32_t region_index, Clay
     NT_ASSERT(top + bot <= h && "nt_ui BORDER: top+bottom widths exceed bbox.height");
     NT_ASSERT(lft + rgt <= w && "nt_ui BORDER: left+right widths exceed bbox.width");
 
-    float tl = (cr_in.topLeft > 0.0F) ? cr_in.topLeft : 0.0F;
-    float tr = (cr_in.topRight > 0.0F) ? cr_in.topRight : 0.0F;
-    float bl = (cr_in.bottomLeft > 0.0F) ? cr_in.bottomLeft : 0.0F;
-    float br = (cr_in.bottomRight > 0.0F) ? cr_in.bottomRight : 0.0F;
-    /* Same CSS3 §5.5 proportional clamp as emit_rounded_rect. */
-    float factor = 1.0F;
-    if (tl + tr > w) {
-        factor = fminf(factor, w / (tl + tr));
-    }
-    if (bl + br > w) {
-        factor = fminf(factor, w / (bl + br));
-    }
-    if (tl + bl > h) {
-        factor = fminf(factor, h / (tl + bl));
-    }
-    if (tr + br > h) {
-        factor = fminf(factor, h / (tr + br));
-    }
-    if (factor < 1.0F) {
-        tl *= factor;
-        tr *= factor;
-        bl *= factor;
-        br *= factor;
-    }
+    float tl = cr_in.topLeft;
+    float tr = cr_in.topRight;
+    float bl = cr_in.bottomLeft;
+    float br = cr_in.bottomRight;
+    clamp_radii_css3(w, h, &tl, &tr, &bl, &br);
 
     if (tl == 0.0F && tr == 0.0F && bl == 0.0F && br == 0.0F) {
         emit_square_border(atlas, region_index, bb, widths, color_packed);
@@ -618,12 +614,14 @@ typedef struct {
 /* sprite_flush closed the cmd; reopen for the next emit. */
 static void rebind_sprite_after_flush(const nt_ui_context_t *ctx) { nt_sprite_renderer_set_material(ctx->sprite_material); }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, sscissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
     NT_ASSERT((uint32_t)*depth < ctx->max_scissor_depth && "scissor stack overflow; raise desc->max_scissor_depth or restructure nested clip");
 
     /* Unclipped axis falls back to viewport extent; floor/ceil avoid a 1px
      * truncation bite at the right/bottom edge on subpixel-aligned UI. */
     const Clay_ClipRenderData *clip = &c->renderData.clip;
+    NT_ASSERT((clip->horizontal || clip->vertical) && "nt_ui SCISSOR_START with both axes unclipped is a no-op; check Clay clip config");
     const int vx = (int)target->viewport[0];
     const int vy = (int)target->viewport[1];
     const int vw = (int)target->viewport[2];
@@ -720,7 +718,7 @@ static bool is_segmentable(Clay_RenderCommandType cmd_type) {
     }
 }
 
-static void dispatch_command(nt_ui_context_t *ctx, const Clay_RenderCommand *c, sscissor_rect_t *scissor_stack, int *depth, const nt_ui_target_t *target) {
+static void dispatch_command(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, sscissor_rect_t *scissor_stack, int *depth, const nt_ui_target_t *target) {
     /* Sprite cmds drain pending text first (mirror of emit_text's sprite_flush)
      * so declaration order survives text→sprite transitions. No-op if empty. */
     switch (c->commandType) {
@@ -775,7 +773,7 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
      * reset per-walk stats so callers don't read stale values. */
     if (target->viewport[2] == 0.0F || target->viewport[3] == 0.0F) {
         ctx->last_walk_draw_call_delta = 0;
-        ctx->last_walk_element_count = 0;
+        ctx->last_walk_command_count = 0;
 #ifdef NT_TEST_ACCESS
         ctx->test_last_walk_unlayered_count = 0;
 #endif
@@ -801,7 +799,12 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     nt_sprite_renderer_set_material(ctx->sprite_material);
 
     /* Per segment: bitmask of active layers in 8 uint32s (256 bits), then
-     * one pass per set bit dispatching matching cmds in declaration order. */
+     * one pass per set bit dispatching matching cmds in declaration order.
+     * O(L_active × N) per segment. Counting sort (O(N)) was prototyped but
+     * shelved -- real UIs hold ~5-6 active layers per segment, the bitmask
+     * costs 32 B stack vs ~2 KB for counting, and sequential rescans cache
+     * better than scatter writes at small L_active. Revisit if a profile
+     * shows L_active > 16 in practice. */
     const Clay_RenderCommandArray *arr = &ctx->frozen_cmds;
 #ifdef NT_TEST_ACCESS
     uint32_t unlayered_count = 0U;
@@ -868,7 +871,7 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     const uint32_t calls_after = nt_gfx_get_frame_draw_calls();
     NT_ASSERT(calls_after >= calls_at_entry && "nt_ui_walk: frame draw-call counter went backwards");
     ctx->last_walk_draw_call_delta = calls_after - calls_at_entry;
-    ctx->last_walk_element_count = (uint32_t)arr->length;
+    ctx->last_walk_command_count = (uint32_t)arr->length;
 #ifdef NT_TEST_ACCESS
     ctx->test_last_walk_unlayered_count = unlayered_count;
 #endif
@@ -921,9 +924,9 @@ uint32_t nt_ui_get_last_walk_draw_calls(const nt_ui_context_t *ctx) {
     return ctx->last_walk_draw_call_delta;
 }
 
-uint32_t nt_ui_get_last_walk_element_count(const nt_ui_context_t *ctx) {
-    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_element_count: ctx must be non-NULL");
-    return ctx->last_walk_element_count;
+uint32_t nt_ui_get_last_walk_command_count(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_command_count: ctx must be non-NULL");
+    return ctx->last_walk_command_count;
 }
 // #endregion
 

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -450,8 +450,6 @@ static void emit_custom(const nt_ui_context_t *ctx, const Clay_RenderCommand *c)
 // #endregion
 
 // #region walk
-/* Extracted from nt_ui_walk so the loop body stays under clang-tidy's
- * cognitive-complexity threshold. */
 static void dispatch_command(nt_ui_context_t *ctx, const Clay_RenderCommand *c, sscissor_rect_t *scissor_stack, int *depth, const nt_ui_target_t *target) {
     switch (c->commandType) {
     case CLAY_RENDER_COMMAND_TYPE_NONE:

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -43,29 +43,12 @@ _Static_assert(CLAY_PINNED_MAJOR == 0 && CLAY_PINNED_MINOR == 14, "Clay v0.14 re
 // #region module_state
 /* g_nt_ui_inframe_ctx -- module-level pointer enforcing the multi-context
  * invariant (D-52-12). Exactly one ctx may be in-frame at a time; nt_ui_begin
- * asserts this is NULL on entry and assigns ctx; nt_ui_end clears it. */
+ * asserts this is NULL on entry and assigns ctx; nt_ui_end clears it.
+ *
+ * This is the only module-level state. Walker bindings (atlas, materials,
+ * custom handler) and per-walk stats live in nt_ui_context_t -- the walker
+ * is fully per-context. */
 static nt_ui_context_t *g_nt_ui_inframe_ctx = NULL;
-
-/* Plan 04 / Revision Issue 1: walker globals set by nt_ui_set_* APIs.
- *
- * Sprite and text materials are SEPARATE globals -- they map to different
- * nt_material_t handles (different shaders / pipelines), so a single shared
- * slot would force a flush+rebind on every TEXT command. Walker asserts
- * BOTH are valid at entry.
- *
- * g_nt_ui_atlas + g_nt_ui_white_region drive RECT/BORDER emit (and IMAGE's
- * fallback when the payload has no atlas of its own -- D-52-06). */
-static nt_resource_t g_nt_ui_atlas;
-static uint32_t g_nt_ui_white_region;
-static nt_material_t g_nt_ui_sprite_material;
-static nt_material_t g_nt_ui_text_material;
-static nt_ui_custom_handler_t g_nt_ui_custom_fn;
-static void *g_nt_ui_custom_user;
-
-/* Walker stats (D-52-20 / WALK-09). Plan 05 wires them into nt_stats; Plan
- * 04 captures the values into BSS so the test probes can read them. */
-static uint32_t s_last_walk_draw_call_delta;
-static uint32_t s_last_walk_element_count;
 // #endregion
 
 // #region clay_error_handler
@@ -265,23 +248,24 @@ static inline void emit_screen_rect(nt_resource_t atlas, uint32_t region_index, 
 /* WALK-04 / D-52-03: BORDER -> up to 4 thin RECT quads via emit_screen_rect.
  * Top/bottom run the full width; left/right are inset by top/bottom heights
  * to avoid double-blending corners (matches 52-RESEARCH.md §BORDER emit). */
-static void emit_border(const Clay_RenderCommand *c) {
+static void emit_border(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
     const Clay_BorderRenderData *b = &c->renderData.border;
     const Clay_BoundingBox bb = c->boundingBox;
     const uint32_t col = nt_color_pack_clay(b->color);
+    const nt_resource_t atlas = ctx->atlas;
+    const uint32_t wr = ctx->white_region;
 
     if (b->width.top) {
-        emit_screen_rect(g_nt_ui_atlas, g_nt_ui_white_region, bb.x, bb.y, bb.width, (float)b->width.top, col);
+        emit_screen_rect(atlas, wr, bb.x, bb.y, bb.width, (float)b->width.top, col);
     }
     if (b->width.bottom) {
-        emit_screen_rect(g_nt_ui_atlas, g_nt_ui_white_region, bb.x, bb.y + bb.height - (float)b->width.bottom, bb.width, (float)b->width.bottom, col);
+        emit_screen_rect(atlas, wr, bb.x, bb.y + bb.height - (float)b->width.bottom, bb.width, (float)b->width.bottom, col);
     }
     if (b->width.left) {
-        emit_screen_rect(g_nt_ui_atlas, g_nt_ui_white_region, bb.x, bb.y + (float)b->width.top, (float)b->width.left, bb.height - (float)b->width.top - (float)b->width.bottom, col);
+        emit_screen_rect(atlas, wr, bb.x, bb.y + (float)b->width.top, (float)b->width.left, bb.height - (float)b->width.top - (float)b->width.bottom, col);
     }
     if (b->width.right) {
-        emit_screen_rect(g_nt_ui_atlas, g_nt_ui_white_region, bb.x + bb.width - (float)b->width.right, bb.y + (float)b->width.top, (float)b->width.right,
-                         bb.height - (float)b->width.top - (float)b->width.bottom, col);
+        emit_screen_rect(atlas, wr, bb.x + bb.width - (float)b->width.right, bb.y + (float)b->width.top, (float)b->width.right, bb.height - (float)b->width.top - (float)b->width.bottom, col);
     }
 }
 // #endregion
@@ -338,13 +322,13 @@ static void emit_image(const Clay_RenderCommand *c) {
 // #endregion
 
 /* Forward declaration -- defined alongside the scissor stack helpers. */
-static void rebind_sprite_after_flush(void);
+static void rebind_sprite_after_flush(const nt_ui_context_t *ctx);
 
 // #region helper_emit_text
 /* D-52-18: TEXT command emit. Flushes sprite renderer first (different
  * material/pipeline boundary), then binds the text font + text material
  * and forwards to nt_text_renderer_draw_n (Phase 51 length-aware API). */
-static void emit_text(nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
+static void emit_text(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
     /* State boundary: sprite material/pipeline must flush before text
      * binds its own pipeline. Auto-flush on font/material change happens
      * inside the text renderer, but the sprite renderer's own staging
@@ -354,17 +338,17 @@ static void emit_text(nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
 
     const Clay_TextRenderData *t = &c->renderData.text;
     if ((uint32_t)t->fontId >= NT_UI_MAX_FONTS) {
-        rebind_sprite_after_flush();
+        rebind_sprite_after_flush(ctx);
         return;
     }
     nt_font_t font = ctx->fonts[t->fontId];
     if (!nt_font_valid(font)) {
-        rebind_sprite_after_flush();
+        rebind_sprite_after_flush(ctx);
         return;
     }
 
     nt_text_renderer_set_font(font);
-    nt_text_renderer_set_material(g_nt_ui_text_material);
+    nt_text_renderer_set_material(ctx->text_material);
 
     /* Translation-only model mat4 -- font size is the scale argument
      * to draw_n, not folded into the model. */
@@ -381,7 +365,7 @@ static void emit_text(nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
         t->textColor.a / 255.0f,
     };
     nt_text_renderer_draw_n(t->stringContents.chars, (size_t)t->stringContents.length, m, (float)t->fontSize, color);
-    rebind_sprite_after_flush();
+    rebind_sprite_after_flush(ctx);
 }
 // #endregion
 
@@ -398,9 +382,9 @@ typedef struct {
  * would trip "call nt_sprite_renderer_set_material first" without this. The
  * sprite renderer's set_material is cheap when cmd_count == 0 with same
  * handle: it just re-opens the cmd from the cached pipeline + mat_info. */
-static void rebind_sprite_after_flush(void) { nt_sprite_renderer_set_material(g_nt_ui_sprite_material); }
+static void rebind_sprite_after_flush(const nt_ui_context_t *ctx) { nt_sprite_renderer_set_material(ctx->sprite_material); }
 
-static void scissor_push(const Clay_RenderCommand *c, sscissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
+static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, sscissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
     NT_ASSERT(*depth < NT_UI_WALKER_MAX_SCISSOR_DEPTH && "scissor stack overflow");
 
     /* Conservative integer rectangle: floor the min corner, ceil the max
@@ -442,10 +426,10 @@ static void scissor_push(const Clay_RenderCommand *c, sscissor_rect_t *stack, in
     nt_gfx_set_scissor_enabled(true);
 
     /* Re-open sprite cmd so the next RECT/BORDER/IMAGE can emit. */
-    rebind_sprite_after_flush();
+    rebind_sprite_after_flush(ctx);
 }
 
-static void scissor_pop(sscissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
+static void scissor_pop(const nt_ui_context_t *ctx, sscissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
     NT_ASSERT(*depth > 0 && "scissor underflow");
     nt_sprite_renderer_flush();
     nt_text_renderer_flush();
@@ -458,7 +442,7 @@ static void scissor_pop(sscissor_rect_t *stack, int *depth, const nt_ui_target_t
         nt_gfx_set_scissor(r.x, fb_h - r.y - r.h, r.w, r.h);
     }
     /* Re-open sprite cmd so the next RECT/BORDER/IMAGE can emit. */
-    rebind_sprite_after_flush();
+    rebind_sprite_after_flush(ctx);
 }
 // #endregion
 
@@ -467,13 +451,13 @@ static void scissor_pop(sscissor_rect_t *stack, int *depth, const nt_ui_target_t
  * registered handler (NULL handler == silent skip). The handler may bind
  * its own pipeline; on return, we re-bind the sprite material so the next
  * RECT/BORDER/IMAGE has a live cmd. */
-static void emit_custom(const Clay_RenderCommand *c) {
+static void emit_custom(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
     nt_sprite_renderer_flush();
     nt_text_renderer_flush();
-    if (g_nt_ui_custom_fn != NULL) {
-        g_nt_ui_custom_fn((const void *)c, g_nt_ui_custom_user);
+    if (ctx->custom_fn != NULL) {
+        ctx->custom_fn((const void *)c, ctx->custom_user);
     }
-    rebind_sprite_after_flush();
+    rebind_sprite_after_flush(ctx);
 }
 // #endregion
 
@@ -486,19 +470,18 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(ctx != NULL && "nt_ui_walk: ctx must be non-NULL");
     NT_ASSERT(target != NULL && "nt_ui_walk: target must be non-NULL");
     NT_ASSERT(!ctx->in_frame && "nt_ui_walk: ctx is mid-frame (call nt_ui_end first)");
-    NT_ASSERT(g_nt_ui_atlas.id != 0 && "nt_ui_set_atlas_white_region required before nt_ui_walk");
-    NT_ASSERT(nt_resource_is_ready(g_nt_ui_atlas) && "nt_ui_walk: UI atlas must be READY");
+    NT_ASSERT(ctx->atlas.id != 0 && "nt_ui_set_atlas_white_region(ctx,...) required before nt_ui_walk");
+    NT_ASSERT(nt_resource_is_ready(ctx->atlas) && "nt_ui_walk: ctx atlas must be READY");
     /* Revision Issue 1: sprite + text materials are separate; assert BOTH. */
-    NT_ASSERT(g_nt_ui_sprite_material.id != 0 && "nt_ui_set_sprite_material required before nt_ui_walk");
-    NT_ASSERT(g_nt_ui_text_material.id != 0 && "nt_ui_set_text_material required before nt_ui_walk");
+    NT_ASSERT(ctx->sprite_material.id != 0 && "nt_ui_set_sprite_material(ctx,...) required before nt_ui_walk");
+    NT_ASSERT(ctx->text_material.id != 0 && "nt_ui_set_text_material(ctx,...) required before nt_ui_walk");
 
     /* Walker-local scissor stack -- D-52-17 (on C stack, NOT in ctx, so
      * multiple walks against the same ctx don't share state). */
     sscissor_rect_t scissor_stack[NT_UI_WALKER_MAX_SCISSOR_DEPTH];
     int depth = 0;
 
-    /* Snapshot draw-call counter for the delta (Plan 05 will route to
-     * nt_stats_count; Plan 04 captures into static module state). */
+    /* Snapshot draw-call counter for the delta -- routed to nt_stats below. */
     const uint32_t calls_at_entry = nt_gfx_get_frame_draw_calls();
 
     /* Apply viewport from target (UI-07). Bottom-left GL convention. */
@@ -510,7 +493,7 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     /* Revision Issue 1: bind SPRITE material for RECT/BORDER/IMAGE emits.
      * TEXT material binds lazily inside emit_text just before draw_n
      * (auto-flush handles the boundary). */
-    nt_sprite_renderer_set_material(g_nt_ui_sprite_material);
+    nt_sprite_renderer_set_material(ctx->sprite_material);
 
     /* Iterate Clay's frozen command array -- already zIndex-ascending sorted. */
     const Clay_RenderCommandArray *arr = &ctx->frozen_cmds;
@@ -518,15 +501,15 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
         const Clay_RenderCommand *c = &arr->internalArray[i];
         switch (c->commandType) {
         case CLAY_RENDER_COMMAND_TYPE_NONE:
-            break; /* silent skip — Clay sentinel */
+            break; /* silent skip -- Clay sentinel */
         case CLAY_RENDER_COMMAND_TYPE_RECTANGLE: {
             const Clay_RectangleRenderData *r = &c->renderData.rectangle;
             const uint32_t col = nt_color_pack_clay(r->backgroundColor);
-            emit_screen_rect(g_nt_ui_atlas, g_nt_ui_white_region, c->boundingBox.x, c->boundingBox.y, c->boundingBox.width, c->boundingBox.height, col);
+            emit_screen_rect(ctx->atlas, ctx->white_region, c->boundingBox.x, c->boundingBox.y, c->boundingBox.width, c->boundingBox.height, col);
             break;
         }
         case CLAY_RENDER_COMMAND_TYPE_BORDER:
-            emit_border(c);
+            emit_border(ctx, c);
             break;
         case CLAY_RENDER_COMMAND_TYPE_TEXT:
             emit_text(ctx, c);
@@ -535,13 +518,13 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
             emit_image(c);
             break;
         case CLAY_RENDER_COMMAND_TYPE_SCISSOR_START:
-            scissor_push(c, scissor_stack, &depth, target);
+            scissor_push(ctx, c, scissor_stack, &depth, target);
             break;
         case CLAY_RENDER_COMMAND_TYPE_SCISSOR_END:
-            scissor_pop(scissor_stack, &depth, target);
+            scissor_pop(ctx, scissor_stack, &depth, target);
             break;
         case CLAY_RENDER_COMMAND_TYPE_CUSTOM:
-            emit_custom(c);
+            emit_custom(ctx, c);
             break;
         }
     }
@@ -552,9 +535,8 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(depth == 0 && "unbalanced scissor stack at walk exit");
     nt_gfx_set_scissor_enabled(false);
 
-    /* Stats (D-52-20 / WALK-09). Plan 04 captures the per-walk deltas
-     * into BSS for test probes; Plan 05 routes them through nt_stats so
-     * the overlay surfaces walker overhead alongside FPS/CPU/GPU/Draws.
+    /* Stats (D-52-20 / WALK-09). Counters live in ctx for the test probes;
+     * nt_stats_count routes them to the overlay alongside FPS/CPU/GPU/Draws.
      *
      * Guard against a CUSTOM handler resetting frame stats mid-walk:
      * unsigned wrap on (calls_after - calls_at_entry) would produce a
@@ -562,8 +544,8 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     const uint32_t calls_after = nt_gfx_get_frame_draw_calls();
     NT_ASSERT(calls_after >= calls_at_entry && "nt_ui_walk: frame draw-call counter went backwards (CUSTOM handler reset stats?)");
     const uint32_t delta = calls_after - calls_at_entry;
-    s_last_walk_draw_call_delta = delta;
-    s_last_walk_element_count = (uint32_t)arr->length;
+    ctx->last_walk_draw_call_delta = delta;
+    ctx->last_walk_element_count = (uint32_t)arr->length;
     nt_stats_count("ui_draw_calls", (uint64_t)delta);
     nt_stats_count("ui_element_count", (uint64_t)arr->length);
 }
@@ -581,30 +563,34 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
  * resolve material pipelines (nt_material_step happens elsewhere); the
  * sprite/text renderers' own set_material asserts material.ready when
  * actually consumed inside the walker. */
-void nt_ui_set_atlas_white_region(nt_resource_t atlas, uint32_t white_region_idx) {
+void nt_ui_set_atlas_white_region(nt_ui_context_t *ctx, nt_resource_t atlas, uint32_t white_region_idx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_set_atlas_white_region: ctx must be non-NULL");
     NT_ASSERT(atlas.id != 0 && "nt_ui_set_atlas_white_region: invalid atlas handle");
     NT_ASSERT(nt_resource_is_ready(atlas) && "nt_ui_set_atlas_white_region: atlas must be READY");
     const nt_texture_region_t *r = nt_atlas_get_region(atlas, white_region_idx);
     NT_ASSERT(r != NULL && r->vertex_count > 0u && "nt_ui_set_atlas_white_region: white region missing / tombstoned (mis-baked atlas)");
-    g_nt_ui_atlas = atlas;
-    g_nt_ui_white_region = white_region_idx;
+    ctx->atlas = atlas;
+    ctx->white_region = white_region_idx;
 }
 
-void nt_ui_set_sprite_material(nt_material_t sprite_material) {
+void nt_ui_set_sprite_material(nt_ui_context_t *ctx, nt_material_t sprite_material) {
+    NT_ASSERT(ctx != NULL && "nt_ui_set_sprite_material: ctx must be non-NULL");
     NT_ASSERT(sprite_material.id != 0 && "nt_ui_set_sprite_material: invalid material handle");
-    g_nt_ui_sprite_material = sprite_material;
+    ctx->sprite_material = sprite_material;
 }
 
-void nt_ui_set_text_material(nt_material_t text_material) {
+void nt_ui_set_text_material(nt_ui_context_t *ctx, nt_material_t text_material) {
+    NT_ASSERT(ctx != NULL && "nt_ui_set_text_material: ctx must be non-NULL");
     NT_ASSERT(text_material.id != 0 && "nt_ui_set_text_material: invalid material handle");
-    g_nt_ui_text_material = text_material;
+    ctx->text_material = text_material;
 }
 
-void nt_ui_set_custom_handler(nt_ui_custom_handler_t fn, void *userdata) {
+void nt_ui_set_custom_handler(nt_ui_context_t *ctx, nt_ui_custom_handler_t fn, void *userdata) {
+    NT_ASSERT(ctx != NULL && "nt_ui_set_custom_handler: ctx must be non-NULL");
     /* NULL fn is allowed -- D-52-09 says CUSTOM with no handler is a
      * silent skip (legitimate "reserved space" pattern). */
-    g_nt_ui_custom_fn = fn;
-    g_nt_ui_custom_user = userdata;
+    ctx->custom_fn = fn;
+    ctx->custom_user = userdata;
 }
 // #endregion
 
@@ -612,30 +598,33 @@ void nt_ui_set_custom_handler(nt_ui_custom_handler_t fn, void *userdata) {
 #ifdef NT_UI_TEST_ACCESS
 nt_ui_context_t *nt_ui_test_inframe_ctx(void) { return g_nt_ui_inframe_ctx; }
 
-/* Plan 04 captures the per-walk deltas; Plan 05 will route them to nt_stats. */
-uint32_t nt_ui_test_last_walk_draw_call_delta(void) { return s_last_walk_draw_call_delta; }
-uint32_t nt_ui_test_last_walk_element_count(void) { return s_last_walk_element_count; }
+uint32_t nt_ui_test_last_walk_draw_call_delta(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL);
+    return ctx->last_walk_draw_call_delta;
+}
+uint32_t nt_ui_test_last_walk_element_count(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL);
+    return ctx->last_walk_element_count;
+}
 
-/* Plan 04 probes: walker setter state introspection. Tests need these to
- * verify (a) reset semantics for walk_without_* death tests and (b) that
- * setters actually wrote what was passed in. */
-nt_resource_t nt_ui_test_atlas(void) { return g_nt_ui_atlas; }
-uint32_t nt_ui_test_white_region(void) { return g_nt_ui_white_region; }
-nt_material_t nt_ui_test_sprite_material(void) { return g_nt_ui_sprite_material; }
-nt_material_t nt_ui_test_text_material(void) { return g_nt_ui_text_material; }
-
-/* Plan 04 probe: clear all walker globals so death-tests can re-setUp from
- * scratch. Setter validation prevents writing back invalid values, so a
- * reset has to go through this probe. */
-void nt_ui_test_reset_walker_globals(void) {
-    g_nt_ui_atlas = (nt_resource_t){0};
-    g_nt_ui_white_region = 0u;
-    g_nt_ui_sprite_material = (nt_material_t){0};
-    g_nt_ui_text_material = (nt_material_t){0};
-    g_nt_ui_custom_fn = NULL;
-    g_nt_ui_custom_user = NULL;
-    s_last_walk_draw_call_delta = 0u;
-    s_last_walk_element_count = 0u;
+/* Walker setter introspection: verifies the per-context setters wrote what
+ * was passed in. "Setter not called before walk" death-tests simply create
+ * a fresh context (all fields zero-initialised) and walk -- no reset probe. */
+nt_resource_t nt_ui_test_atlas(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL);
+    return ctx->atlas;
+}
+uint32_t nt_ui_test_white_region(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL);
+    return ctx->white_region;
+}
+nt_material_t nt_ui_test_sprite_material(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL);
+    return ctx->sprite_material;
+}
+nt_material_t nt_ui_test_text_material(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL);
+    return ctx->text_material;
 }
 
 /* CLAY-04 / D-52-16 verification probes. ctx->clay is a Clay_Context whose

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -135,6 +135,7 @@ void nt_ui_destroy_context(nt_ui_context_t *ctx) {
 // #region font_registry
 void nt_ui_set_font(nt_ui_context_t *ctx, uint16_t font_id, nt_font_t font) {
     NT_ASSERT(ctx != NULL && "nt_ui_set_font: ctx must be non-NULL");
+    NT_ASSERT(!ctx->in_frame && "nt_ui_set_font: must be called outside begin/end (mid-frame mutation would split layout vs walker view)");
     NT_ASSERT(font_id < NT_UI_MAX_FONTS && "nt_ui_set_font: font_id out of range (raise NT_UI_MAX_FONTS)");
     ctx->fonts[font_id] = font;
 }
@@ -236,24 +237,24 @@ static void emit_border(const nt_ui_context_t *ctx, const Clay_RenderCommand *c)
      * left/right edge geometry below would emit a negative-height rect.
      * Fail early on that contract violation rather than feeding garbage to
      * the sprite renderer. */
-    const float _top = (float)b->width.top;
-    const float _bot = (float)b->width.bottom;
-    const float _lft = (float)b->width.left;
-    const float _rgt = (float)b->width.right;
-    NT_ASSERT(_top + _bot <= bb.height && "nt_ui BORDER: top+bottom widths exceed bbox.height");
-    NT_ASSERT(_lft + _rgt <= bb.width && "nt_ui BORDER: left+right widths exceed bbox.width");
+    const float top = (float)b->width.top;
+    const float bot = (float)b->width.bottom;
+    const float lft = (float)b->width.left;
+    const float rgt = (float)b->width.right;
+    NT_ASSERT(top + bot <= bb.height && "nt_ui BORDER: top+bottom widths exceed bbox.height");
+    NT_ASSERT(lft + rgt <= bb.width && "nt_ui BORDER: left+right widths exceed bbox.width");
 
     if (b->width.top) {
-        emit_screen_rect(atlas, wr, bb.x, bb.y, bb.width, _top, col);
+        emit_screen_rect(atlas, wr, bb.x, bb.y, bb.width, top, col);
     }
     if (b->width.bottom) {
-        emit_screen_rect(atlas, wr, bb.x, bb.y + bb.height - _bot, bb.width, _bot, col);
+        emit_screen_rect(atlas, wr, bb.x, bb.y + bb.height - bot, bb.width, bot, col);
     }
     if (b->width.left) {
-        emit_screen_rect(atlas, wr, bb.x, bb.y + _top, _lft, bb.height - _top - _bot, col);
+        emit_screen_rect(atlas, wr, bb.x, bb.y + top, lft, bb.height - top - bot, col);
     }
     if (b->width.right) {
-        emit_screen_rect(atlas, wr, bb.x + bb.width - _rgt, bb.y + _top, _rgt, bb.height - _top - _bot, col);
+        emit_screen_rect(atlas, wr, bb.x + bb.width - rgt, bb.y + top, rgt, bb.height - top - bot, col);
     }
 }
 // #endregion
@@ -524,11 +525,13 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
      * this guard, a create -> walk skipping begin/end would be a silent
      * no-op. */
     NT_ASSERT(ctx->frozen_cmds.internalArray != NULL && "nt_ui_walk: frozen_cmds not populated (call nt_ui_end before walk)");
-    /* Viewport must be finite and non-negative -- the cast to int below
-     * would otherwise turn NaN / +-inf into garbage GL state. isfinite()
-     * rejects both NaN and infinity; raw `>= 0.0F` lets +inf through. */
+    /* Viewport must be finite and strictly positive in width/height --
+     * GL accepts zero dimensions (no draws) but downstream scissor math
+     * `vh - y - hp` underflows to negative when vh == 0, which is GL
+     * undefined. Origin x/y may be zero. */
     NT_ASSERT(isfinite(target->viewport[0]) && isfinite(target->viewport[1]) && isfinite(target->viewport[2]) && isfinite(target->viewport[3]) && "nt_ui_walk: target->viewport must be finite");
-    NT_ASSERT(target->viewport[0] >= 0.0F && target->viewport[1] >= 0.0F && target->viewport[2] >= 0.0F && target->viewport[3] >= 0.0F && "nt_ui_walk: target->viewport must be non-negative");
+    NT_ASSERT(target->viewport[0] >= 0.0F && target->viewport[1] >= 0.0F && "nt_ui_walk: target->viewport origin (x,y) must be non-negative");
+    NT_ASSERT(target->viewport[2] > 0.0F && target->viewport[3] > 0.0F && "nt_ui_walk: target->viewport (w,h) must be > 0 (zero-size walk is not a supported no-op)");
     NT_ASSERT(ctx->atlas.id != 0 && "nt_ui_set_atlas_white_region(ctx,...) required before nt_ui_walk");
     NT_ASSERT(nt_resource_is_ready(ctx->atlas) && "nt_ui_walk: ctx atlas must be READY");
     NT_ASSERT(ctx->sprite_material.id != 0 && "nt_ui_set_sprite_material(ctx,...) required before nt_ui_walk");
@@ -626,6 +629,7 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_ui_set_atlas_white_region(nt_ui_context_t *ctx, nt_resource_t atlas, uint32_t white_region_idx) {
     NT_ASSERT(ctx != NULL && "nt_ui_set_atlas_white_region: ctx must be non-NULL");
+    NT_ASSERT(!ctx->in_frame && "nt_ui_set_atlas_white_region: must be called outside begin/end");
     NT_ASSERT(atlas.id != 0 && "nt_ui_set_atlas_white_region: invalid atlas handle");
     NT_ASSERT(nt_resource_is_ready(atlas) && "nt_ui_set_atlas_white_region: atlas must be READY");
     const nt_texture_region_t *r = nt_atlas_get_region(atlas, white_region_idx);
@@ -640,18 +644,21 @@ void nt_ui_set_atlas_white_region(nt_ui_context_t *ctx, nt_resource_t atlas, uin
 
 void nt_ui_set_sprite_material(nt_ui_context_t *ctx, nt_material_t sprite_material) {
     NT_ASSERT(ctx != NULL && "nt_ui_set_sprite_material: ctx must be non-NULL");
+    NT_ASSERT(!ctx->in_frame && "nt_ui_set_sprite_material: must be called outside begin/end");
     NT_ASSERT(sprite_material.id != 0 && "nt_ui_set_sprite_material: invalid material handle");
     ctx->sprite_material = sprite_material;
 }
 
 void nt_ui_set_text_material(nt_ui_context_t *ctx, nt_material_t text_material) {
     NT_ASSERT(ctx != NULL && "nt_ui_set_text_material: ctx must be non-NULL");
+    NT_ASSERT(!ctx->in_frame && "nt_ui_set_text_material: must be called outside begin/end");
     NT_ASSERT(text_material.id != 0 && "nt_ui_set_text_material: invalid material handle");
     ctx->text_material = text_material;
 }
 
 void nt_ui_set_custom_handler(nt_ui_context_t *ctx, nt_ui_custom_handler_t fn, void *userdata) {
     NT_ASSERT(ctx != NULL && "nt_ui_set_custom_handler: ctx must be non-NULL");
+    NT_ASSERT(!ctx->in_frame && "nt_ui_set_custom_handler: must be called outside begin/end");
     /* NULL fn is allowed -- legitimate "reserved space" pattern. */
     ctx->custom_fn = fn;
     ctx->custom_user = userdata;

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -145,11 +145,13 @@ void nt_ui_set_font(nt_ui_context_t *ctx, uint16_t font_id, nt_font_t font) {
 void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, const nt_pointer_t *mouse) {
     NT_ASSERT(ctx != NULL && "nt_ui_begin: ctx must be non-NULL");
     NT_ASSERT(mouse != NULL && "nt_ui_begin: mouse must be non-NULL");
-    /* Layout dimensions go straight into Clay; NaN / -inf / negative would
-     * silently corrupt layout calculations downstream. Match the boundary
-     * check nt_ui_walk applies to target->viewport. */
-    NT_ASSERT(screen_w >= 0.0F && screen_w == screen_w && "nt_ui_begin: screen_w must be finite and non-negative");
-    NT_ASSERT(screen_h >= 0.0F && screen_h == screen_h && "nt_ui_begin: screen_h must be finite and non-negative");
+    /* Layout dimensions go straight into Clay; NaN / +-inf / negative
+     * would silently corrupt layout calculations downstream. isfinite()
+     * rejects both NaN and infinity in one call -- the older `x == x`
+     * idiom only catches NaN. Match the boundary check nt_ui_walk
+     * applies to target->viewport. */
+    NT_ASSERT(isfinite(screen_w) && screen_w >= 0.0F && "nt_ui_begin: screen_w must be finite and non-negative");
+    NT_ASSERT(isfinite(screen_h) && screen_h >= 0.0F && "nt_ui_begin: screen_h must be finite and non-negative");
     NT_ASSERT(g_nt_ui_inframe_ctx == NULL && "nt_ui_begin: another ctx is mid-frame");
     NT_ASSERT(!ctx->in_frame && "nt_ui_begin: ctx already in_frame");
 
@@ -526,8 +528,10 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
      * this guard, a create -> walk skipping begin/end would be a silent
      * no-op. */
     NT_ASSERT(ctx->frozen_cmds.internalArray != NULL && "nt_ui_walk: frozen_cmds not populated (call nt_ui_end before walk)");
-    /* Viewport must be non-negative -- the cast to int below would
-     * otherwise turn NaN / -inf into garbage GL state. */
+    /* Viewport must be finite and non-negative -- the cast to int below
+     * would otherwise turn NaN / +-inf into garbage GL state. isfinite()
+     * rejects both NaN and infinity; raw `>= 0.0F` lets +inf through. */
+    NT_ASSERT(isfinite(target->viewport[0]) && isfinite(target->viewport[1]) && isfinite(target->viewport[2]) && isfinite(target->viewport[3]) && "nt_ui_walk: target->viewport must be finite");
     NT_ASSERT(target->viewport[0] >= 0.0F && target->viewport[1] >= 0.0F && target->viewport[2] >= 0.0F && target->viewport[3] >= 0.0F && "nt_ui_walk: target->viewport must be non-negative");
     /* projection is reserved -- caller MUST keep ALL 16 floats zero. The
      * walker does not consume the field; if a later phase grows the walker

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -34,37 +34,15 @@ static nt_ui_context_t *g_nt_ui_inframe_ctx = NULL;
 // #endregion
 
 // #region clay_error_handler
-/* Unknown defaults to fatal so a Clay version bump can't silently demote
- * a new invariant violation. */
-static bool nt_ui_clay_error_is_recoverable(Clay_ErrorType type) {
-    switch (type) {
-    case CLAY_ERROR_TYPE_DUPLICATE_ID:
-    case CLAY_ERROR_TYPE_FLOATING_CONTAINER_PARENT_NOT_FOUND:
-    case CLAY_ERROR_TYPE_PERCENTAGE_OVER_1:
-        return true;
-    case CLAY_ERROR_TYPE_TEXT_MEASUREMENT_FUNCTION_NOT_PROVIDED:
-    case CLAY_ERROR_TYPE_ARENA_CAPACITY_EXCEEDED:
-    case CLAY_ERROR_TYPE_ELEMENTS_CAPACITY_EXCEEDED:
-    case CLAY_ERROR_TYPE_TEXT_MEASUREMENT_CAPACITY_EXCEEDED:
-    case CLAY_ERROR_TYPE_INTERNAL_ERROR:
-        return false;
-    }
-    return false;
-}
-
+/* All Clay errors are fatal -- assert compiles out in NT_ASSERT_OFF production. */
 static void nt_ui_clay_error_cb(Clay_ErrorData err) {
-    /* errorText is .length + .chars (NOT NUL-terminated). */
+    /* errorText is .length + .chars, NOT NUL-terminated. */
     const int len = err.errorText.length;
     const char *const chars = (err.errorText.chars != NULL && len > 0) ? err.errorText.chars : "(no text)";
     const int safe_len = (err.errorText.chars != NULL && len > 0) ? len : 9;
     const int type = (int)err.errorType;
-
-    if (nt_ui_clay_error_is_recoverable(err.errorType)) {
-        NT_LOG_WARN("clay error type=%d: %.*s", type, safe_len, chars);
-        return;
-    }
-    NT_LOG_ERROR("clay fatal error type=%d: %.*s", type, safe_len, chars);
-    NT_ASSERT(false && "nt_ui: Clay reported a fatal invariant violation (see preceding log line)");
+    NT_LOG_ERROR("clay error type=%d: %.*s", type, safe_len, chars);
+    NT_ASSERT(false && "nt_ui: Clay reported a contract violation (see preceding log line)");
 }
 // #endregion
 
@@ -91,13 +69,11 @@ static Clay_Dimensions nt_ui_measure_text_cb(Clay_StringSlice text, Clay_TextEle
 // #endregion
 
 // #region module_init
-/* Per-quarter-arc segment count. Bound prevents WASM stack / staging overflow. */
 #define NT_UI_CORNER_SEGMENTS 6
 _Static_assert(NT_UI_CORNER_SEGMENTS >= 2 && NT_UI_CORNER_SEGMENTS <= 32, "NT_UI_CORNER_SEGMENTS must be in [2, 32]");
 #define NT_UI_PI_F 3.14159265358979323846F
 
-/* Precomputed cos/sin per arc segment per quadrant (0=BR, 1=BL, 2=TL, 3=TR).
- * Replaces per-frame cosf/sinf in rounded RECT/BORDER. */
+/* Quadrant index: 0=BR, 1=BL, 2=TL, 3=TR (a_start = q * π/2). */
 typedef struct {
     float cos;
     float sin;
@@ -116,16 +92,16 @@ static void nt_ui_init_arc_lut(void) {
     }
 }
 
-/* Direct global write bypasses Clay_SetMeasureTextFunction which requires an
- * active Clay context. Legal because CLAY_IMPLEMENTATION lives in this TU.
- * Also resets in-frame tracker for death-test recovery. */
+/* Clay__MeasureText doubles as the "module initialized" flag. */
 void nt_ui_module_init(void) {
+    NT_ASSERT(Clay__MeasureText == NULL && "nt_ui_module_init: already initialized; call nt_ui_module_shutdown first");
     Clay__MeasureText = nt_ui_measure_text_cb;
     g_nt_ui_inframe_ctx = NULL;
     Clay_SetCurrentContext(NULL);
     nt_ui_init_arc_lut();
 }
 void nt_ui_module_shutdown(void) {
+    NT_ASSERT(Clay__MeasureText != NULL && "nt_ui_module_shutdown: not initialized");
     Clay__MeasureText = NULL;
     g_nt_ui_inframe_ctx = NULL;
     Clay_SetCurrentContext(NULL);
@@ -143,10 +119,8 @@ size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc) {
     NT_ASSERT(desc->max_elements <= UINT16_MAX && "nt_ui_min_arena_size: desc->max_elements exceeds uint16 sorted-index range");
     NT_ASSERT(desc->max_scissor_depth > 0U && "nt_ui_min_arena_size: desc->max_scissor_depth must be > 0");
     NT_ASSERT(desc->max_scissor_depth <= 256U && "nt_ui_min_arena_size: desc->max_scissor_depth > 256 (likely uninit garbage; walker stack VLA would be huge)");
-    /* Pure-query contract: Clay_SetMaxElementCount(N) writes globals (no
-     * current ctx) AND sets defaultMaxMeasureTextWordCacheCount = N*2
-     * (clay.h:4332). Restore via the SAME public call so BOTH side-effect
-     * globals are brought back together. */
+    /* Clay_SetMaxElementCount(N) also writes defaultMaxMeasureTextWordCacheCount
+     * = N*2 (clay.h:4332); restore via the same call so both come back. */
     Clay_Context *saved_ctx = Clay_GetCurrentContext();
     const int32_t saved_default = Clay__defaultMaxElementCount;
     Clay_SetCurrentContext(NULL);
@@ -169,19 +143,15 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_u
     memset(ctx, 0, sizeof(*ctx));
 
     const size_t ctx_size = nt_ui_ctx_size_aligned();
-    /* Layout: [ctx struct][Clay arena]. Each block is sized
-     * to keep the next block's start at NT_UI_ARENA_ALIGN-aligned offset. */
+    /* Layout: [ctx struct][Clay arena], both NT_UI_ARENA_ALIGN aligned. */
     ctx->max_elements = desc->max_elements;
     ctx->max_scissor_depth = desc->max_scissor_depth;
     void *clay_mem = (char *)arena + ctx_size;
     const size_t clay_size = arena_size - ctx_size;
 
-    /* Stage desc->max_elements into Clay's globals so Clay_Initialize inherits
-     * it. Restore via Clay_SetMaxElementCount so the paired global
-     * defaultMaxMeasureTextWordCacheCount=N*2 comes back too (clay.h:4332).
-     * Clay_Initialize sets current=new_ctx, so re-null current before the
-     * restoring call -- Clay_SetMaxElementCount writes per-ctx when current
-     * is non-null and writes globals only when current is null. */
+    /* Stage max_elements into Clay's globals so Clay_Initialize inherits it;
+     * re-null current before restore -- Clay_SetMaxElementCount writes
+     * per-ctx when current is non-NULL. */
     Clay_Context *saved_ctx = Clay_GetCurrentContext();
     const int32_t saved_default = Clay__defaultMaxElementCount;
     Clay_SetCurrentContext(NULL);
@@ -237,8 +207,7 @@ void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, const nt_
 
     Clay_SetLayoutDimensions((Clay_Dimensions){.width = screen_w, .height = screen_h});
 
-    /* Left-button only; Clay v0.14 does not consume right/middle/wheel.
-     * Caller picks which pointer to feed -- typically pointers[0]. */
+    /* Left-button only; Clay v0.14 has no right/middle/wheel. */
     Clay_SetPointerState((Clay_Vector2){.x = mouse->x, .y = mouse->y}, mouse->buttons[NT_BUTTON_LEFT].is_down);
 
     Clay_BeginLayout();
@@ -252,9 +221,7 @@ void nt_ui_end(nt_ui_context_t *ctx) {
     ctx->frozen_cmds = Clay_EndLayout();
     ctx->in_frame = false;
     g_nt_ui_inframe_ctx = NULL;
-    /* Symmetric with begin's Clay_SetCurrentContext(ctx->clay): a stray
-     * CLAY_* call between end and the next begin now NULL-derefs in Clay
-     * instead of silently corrupting the just-frozen layout. */
+    /* Stray CLAY_* between end and next begin NULL-derefs instead of corrupting. */
     Clay_SetCurrentContext(NULL);
 }
 // #endregion
@@ -282,7 +249,6 @@ static inline uint32_t nt_color_pack_clay(Clay_Color c) {
 // #endregion
 
 // #region helper_emit_screen_rect
-/* mat4(scale w,h; translate x,y) on the 1x1 white-region unit square. */
 static inline void emit_screen_rect(nt_resource_t atlas, uint32_t region_index, float x, float y, float w, float h, uint32_t color_packed) {
     const float m[16] = {
         w, 0.0F, 0.0F, 0.0F, 0.0F, h, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, x, y, 0.0F, 1.0F,
@@ -292,8 +258,7 @@ static inline void emit_screen_rect(nt_resource_t atlas, uint32_t region_index, 
 // #endregion
 
 // #region helper_clamp_radii_css3
-/* CSS3 border-radius §5.5 proportional clamp: negative -> 0, then if any
- * adjacent-pair sum exceeds the side, scale all four by the smallest factor. */
+/* CSS3 border-radius §5.5: scale all four by smallest factor so adjacent sums fit. */
 static inline void clamp_radii_css3(float w, float h, float *tl, float *tr, float *bl, float *br) {
     *tl = (*tl > 0.0F) ? *tl : 0.0F;
     *tr = (*tr > 0.0F) ? *tr : 0.0F;
@@ -322,7 +287,6 @@ static inline void clamp_radii_css3(float w, float h, float *tl, float *tr, floa
 // #endregion
 
 // #region helper_emit_rounded_rect
-/* Triangle fan from rect center: 1 vert per zero corner, SEG+1 per rounded. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void emit_rounded_rect(nt_resource_t atlas, uint32_t region_index, float x, float y, float w, float h, Clay_CornerRadius cr, uint32_t color_packed) {
     float tl = cr.topLeft;
@@ -333,13 +297,11 @@ static void emit_rounded_rect(nt_resource_t atlas, uint32_t region_index, float 
     const float half_w = w * 0.5F;
     const float half_h = h * 0.5F;
 
-    /* All-square fast path stays on emit_screen_rect (1 quad, 4 verts). */
     if (tl == 0.0F && tr == 0.0F && bl == 0.0F && br == 0.0F) {
         emit_screen_rect(atlas, region_index, x, y, w, h, color_packed);
         return;
     }
 
-    /* Worst case: center + 4 * (segments+1) boundary verts. */
     float positions[1 + (4 * (NT_UI_CORNER_SEGMENTS + 1))][2];
     uint16_t indices[4 * (NT_UI_CORNER_SEGMENTS + 1) * 3];
 
@@ -347,7 +309,7 @@ static void emit_rounded_rect(nt_resource_t atlas, uint32_t region_index, float 
     positions[0][1] = y + half_h;
     uint32_t vi = 1;
 
-    /* Per-corner LUT row: TL=2, TR=3, BR=0, BL=1 (q*π/2 start angle). */
+    /* LUT row per corner: TL=2, TR=3, BR=0, BL=1. */
     if (tl == 0.0F) {
         positions[vi][0] = x;
         positions[vi][1] = y;
@@ -401,7 +363,7 @@ static void emit_rounded_rect(nt_resource_t atlas, uint32_t region_index, float 
         }
     }
 
-    /* Triangle fan: (center=0, i, i+1) for i in [1..vi-1], wrap last to 1. */
+    /* Triangle fan (center=0, i, i+1), wrap last to 1. */
     uint32_t ii = 0;
     for (uint32_t i = 1; i < vi; i++) {
         const uint16_t next = (uint16_t)((i + 1 < vi) ? (i + 1) : 1);
@@ -438,8 +400,6 @@ static void emit_square_border(nt_resource_t atlas, uint32_t region_index, Clay_
     }
 }
 
-/* radius==0 -> single sharp pair (outer at corner, inner offset by widths).
- * Otherwise emit SEG+1 (outer,inner) pairs along the quadrant's arc. */
 static uint32_t emit_corner_strip_pairs(float (*pos)[2], uint32_t vi, float radius, float cx, float cy, float w_perp_x, float w_perp_y, float sharp_x, float sharp_y, float sign_x, float sign_y,
                                         uint32_t quadrant) {
     if (radius == 0.0F) {
@@ -451,7 +411,7 @@ static uint32_t emit_corner_strip_pairs(float (*pos)[2], uint32_t vi, float radi
         vi++;
         return vi;
     }
-    /* width > radius -> inner curve clamps to 0 on that axis (CSS parity). */
+    /* width > radius -> inner curve collapses to 0 on that axis (CSS parity). */
     const float irx = (radius > w_perp_x) ? (radius - w_perp_x) : 0.0F;
     const float iry = (radius > w_perp_y) ? (radius - w_perp_y) : 0.0F;
     for (uint32_t s = 0; s <= NT_UI_CORNER_SEGMENTS; s++) {
@@ -467,10 +427,9 @@ static uint32_t emit_corner_strip_pairs(float (*pos)[2], uint32_t vi, float radi
     return vi;
 }
 
-/* Outer rounded-rect ring with inner inset by per-side widths (CSS/Godot
- * parity: zero-width side → zero-area strip, width>radius → corner-filled). */
+/* Caller (emit_border) clamps radii and guarantees at least one is non-zero. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-static void emit_rounded_border(nt_resource_t atlas, uint32_t region_index, Clay_BoundingBox bb, Clay_BorderWidth widths, Clay_CornerRadius cr_in, uint32_t color_packed) {
+static void emit_rounded_border(nt_resource_t atlas, uint32_t region_index, Clay_BoundingBox bb, Clay_BorderWidth widths, float tl, float tr, float bl, float br, uint32_t color_packed) {
     const float x = bb.x;
     const float y = bb.y;
     const float w = bb.width;
@@ -479,19 +438,6 @@ static void emit_rounded_border(nt_resource_t atlas, uint32_t region_index, Clay
     const float bot = (float)widths.bottom;
     const float lft = (float)widths.left;
     const float rgt = (float)widths.right;
-    NT_ASSERT(top + bot <= h && "nt_ui BORDER: top+bottom widths exceed bbox.height");
-    NT_ASSERT(lft + rgt <= w && "nt_ui BORDER: left+right widths exceed bbox.width");
-
-    float tl = cr_in.topLeft;
-    float tr = cr_in.topRight;
-    float bl = cr_in.bottomLeft;
-    float br = cr_in.bottomRight;
-    clamp_radii_css3(w, h, &tl, &tr, &bl, &br);
-
-    if (tl == 0.0F && tr == 0.0F && bl == 0.0F && br == 0.0F) {
-        emit_square_border(atlas, region_index, bb, widths, color_packed);
-        return;
-    }
 
     float positions[4 * (NT_UI_CORNER_SEGMENTS + 1) * 2][2];
     uint32_t vi = 0;
@@ -500,7 +446,7 @@ static void emit_rounded_border(nt_resource_t atlas, uint32_t region_index, Clay
     vi = emit_corner_strip_pairs(positions, vi, br, x + w - br, y + h - br, rgt, bot, x + w, y + h, -1.0F, -1.0F, 0U);
     vi = emit_corner_strip_pairs(positions, vi, bl, x + bl, y + h - bl, lft, bot, x, y + h, 1.0F, -1.0F, 1U);
 
-    /* Triangle strip with wrap: pair k at (2k, 2k+1), connect to pair k+1. */
+    /* Triangle strip with wrap: pair k at (outer=2k, inner=2k+1). */
     const uint32_t pair_count = vi / 2;
     uint16_t indices[4 * (NT_UI_CORNER_SEGMENTS + 1) * 6];
     uint32_t ii = 0;
@@ -526,21 +472,35 @@ static void emit_rounded_border(nt_resource_t atlas, uint32_t region_index, Clay
 
 static void emit_border(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
     const Clay_BorderRenderData *b = &c->renderData.border;
+    const Clay_BoundingBox bb = c->boundingBox;
+    const float top = (float)b->width.top;
+    const float bot = (float)b->width.bottom;
+    const float lft = (float)b->width.left;
+    const float rgt = (float)b->width.right;
+    NT_ASSERT(top + bot <= bb.height && "nt_ui BORDER: top+bottom widths exceed bbox.height");
+    NT_ASSERT(lft + rgt <= bb.width && "nt_ui BORDER: left+right widths exceed bbox.width");
+
     const uint32_t col = nt_color_pack_clay(b->color);
-    emit_rounded_border(ctx->atlas, ctx->white_region, c->boundingBox, b->width, b->cornerRadius, col);
+    float tl = b->cornerRadius.topLeft;
+    float tr = b->cornerRadius.topRight;
+    float bl = b->cornerRadius.bottomLeft;
+    float br = b->cornerRadius.bottomRight;
+    clamp_radii_css3(bb.width, bb.height, &tl, &tr, &bl, &br);
+
+    if (tl == 0.0F && tr == 0.0F && bl == 0.0F && br == 0.0F) {
+        emit_square_border(ctx->atlas, ctx->white_region, bb, b->width, col);
+        return;
+    }
+    emit_rounded_border(ctx->atlas, ctx->white_region, bb, b->width, tl, tr, bl, br, col);
 }
 // #endregion
 
 // #region helper_emit_image
-/* IMAGE uses payload atlas, not ctx->atlas. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void emit_image(const Clay_RenderCommand *c) {
     const nt_ui_image_payload_t *p = (const nt_ui_image_payload_t *)c->renderData.image.imageData;
     NT_ASSERT(p != NULL && "nt_ui IMAGE: imageData must point to nt_ui_image_payload_t");
-    NT_ASSERT(p->atlas.id != 0 && "nt_ui IMAGE payload: invalid atlas handle (zero id)");
-    /* IMAGE corner radius is not supported -- bake rounded edges into the
-     * atlas instead. Polygon atlas regions would already escape any
-     * bbox-aligned corner clip. */
+    NT_ASSERT(p->atlas.id != 0 && "nt_ui IMAGE payload: invalid atlas handle");
     const Clay_CornerRadius cr = c->renderData.image.cornerRadius;
     NT_ASSERT(cr.topLeft == 0.0F && cr.topRight == 0.0F && cr.bottomLeft == 0.0F && cr.bottomRight == 0.0F && "nt_ui IMAGE: cornerRadius unsupported; pre-bake into atlas");
     if (!nt_resource_is_ready(p->atlas)) {
@@ -561,7 +521,7 @@ static void emit_image(const Clay_RenderCommand *c) {
     const float ipu = nt_atlas_get_inverse_pixels_per_unit(p->atlas);
     const float src_w = (float)r->source_w * ipu;
     const float src_h = (float)r->source_h * ipu;
-    /* Div-by-zero guard for tombstoned regions that slipped vertex_count gate. */
+    /* Div-by-zero guard for degenerate regions. */
     const float sx = (src_w > 0.0F) ? (bb.width / src_w) : bb.width;
     const float sy = (src_h > 0.0F) ? (bb.height / src_h) : bb.height;
 
@@ -576,7 +536,7 @@ static void rebind_sprite_after_flush(const nt_ui_context_t *ctx);
 
 // #region helper_emit_text
 static void emit_text(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
-    /* Different pipeline: drain sprite staging first, rebind at the tail. */
+    /* Drain sprite staging first; text uses a different pipeline. */
     nt_sprite_renderer_flush();
 
     const Clay_TextRenderData *t = &c->renderData.text;
@@ -587,11 +547,10 @@ static void emit_text(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
     nt_text_renderer_set_font(font);
     nt_text_renderer_set_material(ctx->text_material);
 
-    /* Translation-only; size is the scale arg to draw_n. */
     const float m[16] = {
         1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, c->boundingBox.x, c->boundingBox.y, 0.0F, 1.0F,
     };
-    /* text_renderer expects 0..1; Clay stores 0..255. */
+    /* text_renderer wants 0..1; Clay stores 0..255. */
     const float color[4] = {
         t->textColor.r / 255.0F,
         t->textColor.g / 255.0F,
@@ -611,17 +570,15 @@ typedef struct {
     int h;
 } sscissor_rect_t;
 
-/* sprite_flush closed the cmd; reopen for the next emit. */
 static void rebind_sprite_after_flush(const nt_ui_context_t *ctx) { nt_sprite_renderer_set_material(ctx->sprite_material); }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, sscissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
     NT_ASSERT((uint32_t)*depth < ctx->max_scissor_depth && "scissor stack overflow; raise desc->max_scissor_depth or restructure nested clip");
 
-    /* Unclipped axis falls back to viewport extent; floor/ceil avoid a 1px
-     * truncation bite at the right/bottom edge on subpixel-aligned UI. */
+    /* Unclipped axis falls back to viewport; floor/ceil avoid 1px right/bottom bite. */
     const Clay_ClipRenderData *clip = &c->renderData.clip;
-    NT_ASSERT((clip->horizontal || clip->vertical) && "nt_ui SCISSOR_START with both axes unclipped is a no-op; check Clay clip config");
+    NT_ASSERT((clip->horizontal || clip->vertical) && "nt_ui SCISSOR_START with both axes unclipped is a no-op");
     const int vx = (int)target->viewport[0];
     const int vy = (int)target->viewport[1];
     const int vw = (int)target->viewport[2];
@@ -660,14 +617,13 @@ static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c
         hp = (b2 > y2) ? (b2 - y2) : 0;
     }
 
-    /* Flush BEFORE the scissor switch so staging keeps its prior clip. */
+    /* Flush BEFORE scissor switch so staging keeps prior clip. */
     nt_sprite_renderer_flush();
     nt_text_renderer_flush();
 
     stack[(*depth)++] = (sscissor_rect_t){.x = x, .y = y, .w = wp, .h = hp};
 
-    /* Clay bbox is target-local; shift by viewport.{x,y} and Y-flip against
-     * viewport.h (NOT framebuffer h) so split-screen panes clip correctly. */
+    /* Y-flip against viewport.h (NOT framebuffer h) for split-screen panes. */
     nt_gfx_set_scissor(vx + x, vy + vh - y - hp, wp, hp);
     nt_gfx_set_scissor_enabled(true);
 
@@ -693,7 +649,7 @@ static void scissor_pop(const nt_ui_context_t *ctx, sscissor_rect_t *stack, int 
 // #endregion
 
 // #region helper_emit_custom
-/* Handler may bind its own pipeline; flush both before, rebind sprite after. */
+/* Handler may bind its own pipeline; flush both, rebind sprite on return. */
 static void emit_custom(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
     nt_sprite_renderer_flush();
     nt_text_renderer_flush();
@@ -705,7 +661,7 @@ static void emit_custom(const nt_ui_context_t *ctx, const Clay_RenderCommand *c)
 // #endregion
 
 // #region walk
-/* SCISSOR/CUSTOM/NONE are hard barriers -- never reordered by layer sort. */
+/* SCISSOR/CUSTOM/NONE = hard barriers; never reordered. */
 static bool is_segmentable(Clay_RenderCommandType cmd_type) {
     switch (cmd_type) {
     case CLAY_RENDER_COMMAND_TYPE_RECTANGLE:
@@ -719,8 +675,8 @@ static bool is_segmentable(Clay_RenderCommandType cmd_type) {
 }
 
 static void dispatch_command(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, sscissor_rect_t *scissor_stack, int *depth, const nt_ui_target_t *target) {
-    /* Sprite cmds drain pending text first (mirror of emit_text's sprite_flush)
-     * so declaration order survives text→sprite transitions. No-op if empty. */
+    /* Sprite cmds drain pending text first -- preserves declaration order
+     * across text→sprite transitions. No-op on empty staging. */
     switch (c->commandType) {
     case CLAY_RENDER_COMMAND_TYPE_NONE:
         return;
@@ -764,13 +720,12 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(target->viewport[0] >= 0.0F && target->viewport[1] >= 0.0F && "nt_ui_walk: target->viewport origin must be non-negative");
     NT_ASSERT(target->viewport[2] >= 0.0F && target->viewport[3] >= 0.0F && "nt_ui_walk: target->viewport (w,h) must be non-negative");
 
-    /* Drain prior staging BEFORE the zero-viewport early return so leaked
-     * geometry can't survive a minimized frame. Both no-op on empty. */
+    /* Drain BEFORE zero-viewport early return so leaked staging doesn't
+     * survive a minimized frame. No-op on empty. */
     nt_sprite_renderer_flush();
     nt_text_renderer_flush();
 
-    /* Zero viewport (minimized tab, orientation change): silent no-op,
-     * reset per-walk stats so callers don't read stale values. */
+    /* Zero viewport (minimized tab, orientation change): silent no-op. */
     if (target->viewport[2] == 0.0F || target->viewport[3] == 0.0F) {
         ctx->last_walk_draw_call_delta = 0;
         ctx->last_walk_command_count = 0;
@@ -784,27 +739,22 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(ctx->sprite_material.id != 0 && "nt_ui_set_sprite_material(ctx,...) required before nt_ui_walk");
     NT_ASSERT(ctx->text_material.id != 0 && "nt_ui_set_text_material(ctx,...) required before nt_ui_walk");
 
-    /* VLA per-walk -- multi-walk on same ctx doesn't share scissor state. */
+    /* Per-walk VLA so multi-walk on same ctx doesn't share scissor state. */
     sscissor_rect_t scissor_stack[ctx->max_scissor_depth];
     int depth = 0;
 
-    /* Snapshot AFTER entry flushes so the per-walk delta excludes the
-     * caller's drained geometry. */
+    /* AFTER entry flush so per-walk delta excludes caller's drained geometry. */
     const uint32_t calls_at_entry = nt_gfx_get_frame_draw_calls();
 
     nt_gfx_set_viewport((int)target->viewport[0], (int)target->viewport[1], (int)target->viewport[2], (int)target->viewport[3]);
     nt_gfx_set_scissor_enabled(false);
 
-    /* Sprite material bound up-front; text binds lazily in emit_text. */
+    /* Sprite material up-front; text binds lazily inside emit_text. */
     nt_sprite_renderer_set_material(ctx->sprite_material);
 
-    /* Per segment: bitmask of active layers in 8 uint32s (256 bits), then
-     * one pass per set bit dispatching matching cmds in declaration order.
-     * O(L_active × N) per segment. Counting sort (O(N)) was prototyped but
-     * shelved -- real UIs hold ~5-6 active layers per segment, the bitmask
-     * costs 32 B stack vs ~2 KB for counting, and sequential rescans cache
-     * better than scatter writes at small L_active. Revisit if a profile
-     * shows L_active > 16 in practice. */
+    /* Bitmask layer dispatch: O(L_active × N). Counting sort was prototyped
+     * but shelved -- real UIs use ~5-6 layers, bitmask is 32 B stack vs
+     * ~2 KB. Revisit if a profile shows L_active > 16. */
     const Clay_RenderCommandArray *arr = &ctx->frozen_cmds;
 #ifdef NT_TEST_ACCESS
     uint32_t unlayered_count = 0U;
@@ -867,7 +817,7 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(depth == 0 && "unbalanced scissor stack at walk exit");
     nt_gfx_set_scissor_enabled(false);
 
-    /* Underflow guard: CUSTOM handler that resets gfx counters would wrap. */
+    /* Guard against CUSTOM handler resetting gfx counter -> unsigned wrap. */
     const uint32_t calls_after = nt_gfx_get_frame_draw_calls();
     NT_ASSERT(calls_after >= calls_at_entry && "nt_ui_walk: frame draw-call counter went backwards");
     ctx->last_walk_draw_call_delta = calls_after - calls_at_entry;
@@ -887,10 +837,9 @@ void nt_ui_set_atlas_white_region(nt_ui_context_t *ctx, nt_resource_t atlas, uin
     NT_ASSERT(nt_resource_is_ready(atlas) && "nt_ui_set_atlas_white_region: atlas must be READY");
     const nt_texture_region_t *r = nt_atlas_get_region(atlas, white_region_idx);
     NT_ASSERT(r != NULL && r->vertex_count > 0U && "nt_ui_set_atlas_white_region: white region missing / tombstoned");
-    /* emit_screen_rect's mat4(w,h) assumes cached_pos {0,1}x{0,1} -- requires
-     * 1x1 source AND PPU=1 (non-1 PPU shrinks every UI rect by 1/PPU). */
+    /* mat4(w,h) needs cached_pos {0,1}x{0,1}: 1x1 source AND PPU=1. */
     NT_ASSERT(r->source_w == 1 && r->source_h == 1 && "nt_ui_set_atlas_white_region: white region must be 1x1 source");
-    NT_ASSERT(nt_atlas_get_inverse_pixels_per_unit(atlas) == 1.0F && "nt_ui_set_atlas_white_region: atlas must have PPU=1; use a dedicated UI atlas");
+    NT_ASSERT(nt_atlas_get_inverse_pixels_per_unit(atlas) == 1.0F && "nt_ui_set_atlas_white_region: atlas must have PPU=1");
     ctx->atlas = atlas;
     ctx->white_region = white_region_idx;
 }
@@ -912,7 +861,7 @@ void nt_ui_set_text_material(nt_ui_context_t *ctx, nt_material_t text_material) 
 void nt_ui_set_custom_handler(nt_ui_context_t *ctx, nt_ui_custom_handler_t fn, void *userdata) {
     NT_ASSERT(ctx != NULL && "nt_ui_set_custom_handler: ctx must be non-NULL");
     NT_ASSERT(!ctx->in_frame && "nt_ui_set_custom_handler: must be called outside begin/end");
-    /* NULL fn is legal (reserved-slot pattern). */
+    /* NULL fn legal: reserved-slot pattern. */
     ctx->custom_fn = fn;
     ctx->custom_user = userdata;
 }

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -142,15 +142,16 @@ size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc) {
     NT_ASSERT(desc->max_elements > 0U && "nt_ui_min_arena_size: desc->max_elements must be > 0");
     NT_ASSERT(desc->max_elements <= UINT16_MAX && "nt_ui_min_arena_size: desc->max_elements exceeds uint16 sorted-index range");
     NT_ASSERT(desc->max_scissor_depth > 0U && "nt_ui_min_arena_size: desc->max_scissor_depth must be > 0");
-    /* Pure-query contract: stage max_elements through Clay's global default
-     * (Clay_SetMaxElementCount writes there with no current ctx), then
-     * restore both saved ctx and saved global. */
+    /* Pure-query contract: Clay_SetMaxElementCount(N) writes globals (no
+     * current ctx) AND sets defaultMaxMeasureTextWordCacheCount = N*2
+     * (clay.h:4332). Restore via the SAME public call so BOTH side-effect
+     * globals are brought back together. */
     Clay_Context *saved_ctx = Clay_GetCurrentContext();
     const int32_t saved_default = Clay__defaultMaxElementCount;
     Clay_SetCurrentContext(NULL);
     Clay_SetMaxElementCount((int32_t)desc->max_elements);
     const size_t clay_bytes = (size_t)Clay_MinMemorySize();
-    Clay__defaultMaxElementCount = saved_default;
+    Clay_SetMaxElementCount(saved_default);
     Clay_SetCurrentContext(saved_ctx);
     return nt_ui_ctx_size_aligned() + clay_bytes;
 }
@@ -174,11 +175,12 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_u
     void *clay_mem = (char *)arena + ctx_size;
     const size_t clay_size = arena_size - ctx_size;
 
-    /* Stage desc->max_elements into Clay's global default so Clay_Initialize
-     * inherits it for this new context. Snapshot BOTH current ctx and the
-     * Clay__defaultMaxElementCount global, then restore both -- otherwise
-     * the temporary mutation persists across create_context calls and
-     * leaks our internals into any Clay consumer outside nt_ui. */
+    /* Stage desc->max_elements into Clay's globals so Clay_Initialize inherits
+     * it. Restore via Clay_SetMaxElementCount so the paired global
+     * defaultMaxMeasureTextWordCacheCount=N*2 comes back too (clay.h:4332).
+     * Clay_Initialize sets current=new_ctx, so re-null current before the
+     * restoring call -- Clay_SetMaxElementCount writes per-ctx when current
+     * is non-null and writes globals only when current is null. */
     Clay_Context *saved_ctx = Clay_GetCurrentContext();
     const int32_t saved_default = Clay__defaultMaxElementCount;
     Clay_SetCurrentContext(NULL);
@@ -188,9 +190,8 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_u
     ctx->clay_arena = Clay_CreateArenaWithCapacityAndMemory(clay_size, clay_mem);
     ctx->clay = Clay_Initialize(ctx->clay_arena, (Clay_Dimensions){.width = 1.0F, .height = 1.0F}, (Clay_ErrorHandler){.errorHandlerFunction = nt_ui_clay_error_cb, .userData = ctx});
 
-    /* nt_ui_begin owns active-ctx selection -- restore both so create
-     * doesn't accidentally leave the new ctx current. */
-    Clay__defaultMaxElementCount = saved_default;
+    Clay_SetCurrentContext(NULL);
+    Clay_SetMaxElementCount(saved_default);
     Clay_SetCurrentContext(saved_ctx);
 
     return ctx;
@@ -948,6 +949,7 @@ nt_material_t nt_ui_test_text_material(const nt_ui_context_t *ctx) {
 }
 
 int32_t nt_ui_test_clay_default_max_element_count(void) { return Clay__defaultMaxElementCount; }
+int32_t nt_ui_test_clay_default_max_measure_text_word_cache_count(void) { return Clay__defaultMaxMeasureTextWordCacheCount; }
 
 uint32_t nt_ui_test_last_walk_unlayered_count(const nt_ui_context_t *ctx) {
     NT_ASSERT(ctx != NULL);

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -31,6 +31,7 @@
 
 _Static_assert(CLAY_PINNED_MAJOR == 0 && CLAY_PINNED_MINOR == 14, "Clay v0.14 required -- deps/clay/VERSION disagrees with the engine pin");
 
+#include <math.h>
 #include <stddef.h>
 #include <stdint.h>
 #include <string.h>
@@ -378,10 +379,15 @@ static void rebind_sprite_after_flush(void) { nt_sprite_renderer_set_material(g_
 static void scissor_push(const Clay_RenderCommand *c, sscissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
     NT_ASSERT(*depth < NT_UI_WALKER_MAX_SCISSOR_DEPTH && "scissor stack overflow");
 
-    int x = (int)c->boundingBox.x;
-    int y = (int)c->boundingBox.y;
-    int wp = (int)c->boundingBox.width;
-    int hp = (int)c->boundingBox.height;
+    /* Conservative integer rectangle: floor the min corner, ceil the max
+     * corner. (int)truncate would clip subpixel-aligned UI by 1px at the
+     * right/bottom edge. */
+    const float bx = c->boundingBox.x;
+    const float by = c->boundingBox.y;
+    int x = (int)floorf(bx);
+    int y = (int)floorf(by);
+    int wp = (int)ceilf(bx + c->boundingBox.width) - x;
+    int hp = (int)ceilf(by + c->boundingBox.height) - y;
 
     /* Nested scissor -> intersect with top (D-52-17). REPLACE would let an
      * inner widget paint outside its parent's clip, e.g. scroll-content

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -71,7 +71,7 @@ static Clay_Dimensions nt_ui_measure_text_cb(Clay_StringSlice text, Clay_TextEle
 
 // #region module_init
 #define NT_UI_CORNER_SEGMENTS 6
-_Static_assert(NT_UI_CORNER_SEGMENTS >= 2 && NT_UI_CORNER_SEGMENTS <= 32, "NT_UI_CORNER_SEGMENTS must be in [2, 32]");
+_Static_assert(NT_UI_CORNER_SEGMENTS >= 2 && NT_UI_CORNER_SEGMENTS <= 16, "NT_UI_CORNER_SEGMENTS must be in [2, 16]");
 #define NT_UI_PI_F 3.14159265358979323846F
 
 /* Quadrant index: 0=BR, 1=BL, 2=TL, 3=TR (a_start = q * π/2). */
@@ -542,13 +542,10 @@ static void emit_image(const Clay_RenderCommand *c) {
 }
 // #endregion
 
-static void rebind_sprite_after_flush(const nt_ui_context_t *ctx);
-
 // #region helper_emit_text
+/* Pure text emit: no sprite renderer knowledge. dispatch_command handles
+ * the sprite_flush before and the lazy sprite rebind after. */
 static void emit_text(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
-    /* Drain sprite staging first; text uses a different pipeline. */
-    nt_sprite_renderer_flush();
-
     const Clay_TextRenderData *t = &c->renderData.text;
     NT_ASSERT((uint32_t)t->fontId < NT_UI_MAX_FONTS && "nt_ui TEXT: fontId >= NT_UI_MAX_FONTS");
     nt_font_t font = ctx->fonts[t->fontId];
@@ -568,7 +565,6 @@ static void emit_text(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
         t->textColor.a / 255.0F,
     };
     nt_text_renderer_draw_n(t->stringContents.chars, (size_t)t->stringContents.length, m, (float)t->fontSize, color, (float)t->letterSpacing);
-    rebind_sprite_after_flush(ctx);
 }
 // #endregion
 
@@ -583,7 +579,8 @@ typedef struct {
 static void rebind_sprite_after_flush(const nt_ui_context_t *ctx) { nt_sprite_renderer_set_material(ctx->sprite_material); }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, scissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
+static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, scissor_rect_t *stack, int *depth, const nt_ui_target_t *target, bool *sprite_pipeline_dirty) {
+    (void)ctx;
     NT_ASSERT((uint32_t)*depth < ctx->max_scissor_depth && "scissor stack overflow; raise desc->max_scissor_depth or restructure nested clip");
 
     /* Unclipped axis falls back to viewport; floor/ceil avoid 1px right/bottom bite. */
@@ -630,20 +627,20 @@ static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c
     /* Flush BEFORE scissor switch so staging keeps prior clip. */
     nt_sprite_renderer_flush();
     nt_text_renderer_flush();
+    *sprite_pipeline_dirty = true;
 
     stack[(*depth)++] = (scissor_rect_t){.x = x, .y = y, .w = wp, .h = hp};
 
     /* Y-flip against viewport.h (NOT framebuffer h) for split-screen panes. */
     nt_gfx_set_scissor(vx + x, vy + vh - y - hp, wp, hp);
     nt_gfx_set_scissor_enabled(true);
-
-    rebind_sprite_after_flush(ctx);
 }
 
-static void scissor_pop(const nt_ui_context_t *ctx, scissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
+static void scissor_pop(scissor_rect_t *stack, int *depth, const nt_ui_target_t *target, bool *sprite_pipeline_dirty) {
     NT_ASSERT(*depth > 0 && "scissor underflow");
     nt_sprite_renderer_flush();
     nt_text_renderer_flush();
+    *sprite_pipeline_dirty = true;
     (*depth)--;
     if (*depth == 0) {
         nt_gfx_set_scissor_enabled(false);
@@ -654,19 +651,19 @@ static void scissor_pop(const nt_ui_context_t *ctx, scissor_rect_t *stack, int *
         const int vh = (int)target->viewport[3];
         nt_gfx_set_scissor(vx + r.x, vy + vh - r.y - r.h, r.w, r.h);
     }
-    rebind_sprite_after_flush(ctx);
 }
 // #endregion
 
 // #region helper_emit_custom
-/* Handler may bind its own pipeline; flush both, rebind sprite on return. */
-static void emit_custom(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
+/* Handler may bind its own pipeline; flush both. Sprite rebind is lazy
+ * (deferred to first sprite-backed emit after). */
+static void emit_custom(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, bool *sprite_pipeline_dirty) {
     nt_sprite_renderer_flush();
     nt_text_renderer_flush();
+    *sprite_pipeline_dirty = true;
     if (ctx->custom_fn != NULL) {
         ctx->custom_fn((const void *)c, ctx->custom_user);
     }
-    rebind_sprite_after_flush(ctx);
 }
 // #endregion
 
@@ -684,38 +681,49 @@ static bool is_segmentable(Clay_RenderCommandType cmd_type) {
     }
 }
 
-static void dispatch_command(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, scissor_rect_t *scissor_stack, int *depth, const nt_ui_target_t *target) {
-    /* Sprite cmds drain pending text first -- preserves declaration order
-     * across text→sprite transitions. No-op on empty staging. */
+/* Sprite-backed dispatch: drain pending text, lazy-rebind sprite cmd if a
+ * prior text/scissor/custom closed it. */
+static inline void prep_sprite_dispatch(const nt_ui_context_t *ctx, bool *sprite_pipeline_dirty) {
+    nt_text_renderer_flush();
+    if (*sprite_pipeline_dirty) {
+        rebind_sprite_after_flush(ctx);
+        *sprite_pipeline_dirty = false;
+    }
+}
+
+static void dispatch_command(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, scissor_rect_t *scissor_stack, int *depth, const nt_ui_target_t *target, bool *sprite_pipeline_dirty) {
     switch (c->commandType) {
     case CLAY_RENDER_COMMAND_TYPE_NONE:
         return;
     case CLAY_RENDER_COMMAND_TYPE_RECTANGLE: {
-        nt_text_renderer_flush();
+        prep_sprite_dispatch(ctx, sprite_pipeline_dirty);
         const Clay_RectangleRenderData *r = &c->renderData.rectangle;
         const uint32_t col = nt_color_pack_clay(r->backgroundColor);
         emit_rounded_rect(ctx->atlas, ctx->white_region, c->boundingBox.x, c->boundingBox.y, c->boundingBox.width, c->boundingBox.height, r->cornerRadius, col);
         return;
     }
     case CLAY_RENDER_COMMAND_TYPE_BORDER:
-        nt_text_renderer_flush();
+        prep_sprite_dispatch(ctx, sprite_pipeline_dirty);
         emit_border(ctx, c);
         return;
     case CLAY_RENDER_COMMAND_TYPE_TEXT:
+        /* Drain sprite before switching to text pipeline; mark for lazy rebind. */
+        nt_sprite_renderer_flush();
+        *sprite_pipeline_dirty = true;
         emit_text(ctx, c);
         return;
     case CLAY_RENDER_COMMAND_TYPE_IMAGE:
-        nt_text_renderer_flush();
+        prep_sprite_dispatch(ctx, sprite_pipeline_dirty);
         emit_image(c);
         return;
     case CLAY_RENDER_COMMAND_TYPE_SCISSOR_START:
-        scissor_push(ctx, c, scissor_stack, depth, target);
+        scissor_push(ctx, c, scissor_stack, depth, target, sprite_pipeline_dirty);
         return;
     case CLAY_RENDER_COMMAND_TYPE_SCISSOR_END:
-        scissor_pop(ctx, scissor_stack, depth, target);
+        scissor_pop(scissor_stack, depth, target, sprite_pipeline_dirty);
         return;
     case CLAY_RENDER_COMMAND_TYPE_CUSTOM:
-        emit_custom(ctx, c);
+        emit_custom(ctx, c, sprite_pipeline_dirty);
         return;
     }
 }
@@ -761,9 +769,11 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     /* Sprite material up-front; text binds lazily inside emit_text. */
     nt_sprite_renderer_set_material(ctx->sprite_material);
 
-    /* Bitmask layer dispatch: O(L_active × N). Counting sort was prototyped
-     * but shelved -- real UIs use ~5-6 layers, bitmask is 32 B stack vs
-     * ~2 KB. Revisit if a profile shows L_active > 16. */
+    /* Sprite cmd open after set_material above; clean → no rebind needed. */
+    bool sprite_pipeline_dirty = false;
+
+    /* Bitmask layer dispatch + ctz: O(L_active × N) per segment, only set
+     * bits visited (32 B stack vs ~2 KB for counting sort). */
     const Clay_RenderCommandArray *arr = &ctx->frozen_cmds;
 #ifdef NT_TEST_ACCESS
     uint32_t unlayered_count = 0U;
@@ -772,7 +782,7 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     while (i < arr->length) {
         const Clay_RenderCommand *c = &arr->internalArray[i];
         if (!is_segmentable(c->commandType)) {
-            dispatch_command(ctx, c, scissor_stack, &depth, target);
+            dispatch_command(ctx, c, scissor_stack, &depth, target, &sprite_pipeline_dirty);
             ++i;
             continue;
         }
@@ -800,20 +810,18 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
 #endif
         }
 
+        /* Iterate set bits via ctz instead of 256-bit linear scan. */
         for (uint32_t word_idx = 0U; word_idx < 8U; ++word_idx) {
-            const uint32_t mask = active_layers[word_idx];
-            if (mask == 0U) {
-                continue;
-            }
-            for (uint32_t bit_idx = 0U; bit_idx < 32U; ++bit_idx) {
-                if ((mask & (1U << bit_idx)) != 0U) {
-                    const uint8_t current_layer = (uint8_t)((word_idx << 5U) | bit_idx);
-                    for (int32_t j = i; j < seg_end; ++j) {
-                        const Clay_RenderCommand *cc = &arr->internalArray[j];
-                        const uint8_t layer = cc->userData ? ((const nt_ui_element_data_t *)cc->userData)->layer : 0U;
-                        if (layer == current_layer) {
-                            dispatch_command(ctx, cc, scissor_stack, &depth, target);
-                        }
+            uint32_t mask = active_layers[word_idx];
+            while (mask != 0U) {
+                const uint32_t bit_idx = (uint32_t)__builtin_ctz(mask);
+                mask &= mask - 1U;
+                const uint8_t current_layer = (uint8_t)((word_idx << 5U) | bit_idx);
+                for (int32_t j = i; j < seg_end; ++j) {
+                    const Clay_RenderCommand *cc = &arr->internalArray[j];
+                    const uint8_t layer = cc->userData ? ((const nt_ui_element_data_t *)cc->userData)->layer : 0U;
+                    if (layer == current_layer) {
+                        dispatch_command(ctx, cc, scissor_stack, &depth, target, &sprite_pipeline_dirty);
                     }
                 }
             }
@@ -845,7 +853,7 @@ void nt_ui_set_atlas_white_region(nt_ui_context_t *ctx, nt_resource_t atlas, uin
     NT_ASSERT(atlas.id != 0 && "nt_ui_set_atlas_white_region: invalid atlas handle");
     NT_ASSERT(nt_resource_is_ready(atlas) && "nt_ui_set_atlas_white_region: atlas must be READY");
     const nt_texture_region_t *r = nt_atlas_get_region(atlas, white_region_idx);
-    NT_ASSERT(r != NULL && r->vertex_count > 0U && "nt_ui_set_atlas_white_region: white region missing / tombstoned");
+    NT_ASSERT(r->vertex_count > 0U && "nt_ui_set_atlas_white_region: white region tombstoned");
     /* mat4(w,h) needs cached_pos {0,1}x{0,1}: 1x1 source AND PPU=1. */
     NT_ASSERT(r->source_w == 1 && r->source_h == 1 && "nt_ui_set_atlas_white_region: white region must be 1x1 source");
     NT_ASSERT(nt_atlas_get_inverse_pixels_per_unit(atlas) == 1.0F && "nt_ui_set_atlas_white_region: atlas must have PPU=1");

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -5,6 +5,7 @@
 #include "material/nt_material.h"
 #include "renderers/nt_sprite_renderer.h"
 #include "renderers/nt_text_renderer.h"
+#include "stats/nt_stats.h"
 
 /*
  * Clay v0.14 implementation TU.
@@ -531,9 +532,16 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(depth == 0 && "unbalanced scissor stack at walk exit");
     nt_gfx_set_scissor_enabled(false);
 
-    /* Stats (D-52-20 / WALK-09). Plan 05 routes these through nt_stats. */
-    s_last_walk_draw_call_delta = nt_gfx_get_frame_draw_calls() - calls_at_entry;
+    /* Stats (D-52-20 / WALK-09). Plan 04 captures the per-walk deltas
+     * into BSS for test probes; Plan 05 routes them through nt_stats so
+     * the overlay surfaces walker overhead alongside FPS/CPU/GPU/Draws.
+     * Counter names are conventional strings; nt_stats default capacity
+     * (16 slots) is plenty for these two. */
+    const uint32_t delta = nt_gfx_get_frame_draw_calls() - calls_at_entry;
+    s_last_walk_draw_call_delta = delta;
     s_last_walk_element_count = (uint32_t)arr->length;
+    nt_stats_count("ui_draw_calls", (uint64_t)delta);
+    nt_stats_count("ui_element_count", (uint64_t)arr->length);
 }
 // #endregion
 

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -207,13 +207,314 @@ void nt_ui_end(nt_ui_context_t *ctx) {
 }
 // #endregion
 
-// #region walk_stub
-/* Walker body lives in Plan 04. Phase 52 ships entry-guard asserts only. */
+// #region helpers_color_pack
+/* Clay packs RGBA as 0..255 floats (clay.h:481). Walker emits as 0xAABBGGRR
+ * uint32 (sprite-renderer vertex format -- nt_sprite_vertex_t.color[4]).
+ *
+ * Saturate before casting because Clay does not clamp -- a theme that wrote
+ * 256.0f or -1.0f would otherwise wrap around in the uint8 cast. */
+static inline uint32_t nt_color_pack_clay(Clay_Color c) {
+    int ri = (int)c.r;
+    int gi = (int)c.g;
+    int bi = (int)c.b;
+    int ai = (int)c.a;
+    uint32_t r = (uint32_t)(ri > 255 ? 255 : (ri < 0 ? 0 : ri));
+    uint32_t g = (uint32_t)(gi > 255 ? 255 : (gi < 0 ? 0 : gi));
+    uint32_t b = (uint32_t)(bi > 255 ? 255 : (bi < 0 ? 0 : bi));
+    uint32_t a = (uint32_t)(ai > 255 ? 255 : (ai < 0 ? 0 : ai));
+    return r | (g << 8) | (b << 16) | (a << 24); /* 0xAABBGGRR */
+}
+// #endregion
+
+// #region helper_emit_screen_rect
+/* D-52-03: 2D-ortho mat4 (scale x,y by w,h; translate to x,y) onto the sprite
+ * renderer. Origin {0,0} and flip 0 -- the rect already covers (x,y..x+w,y+h)
+ * directly because cached_pos for a 1x1 white region is (0,0)..(1,1) in
+ * source space, and the scale m[0]=w / m[5]=h folds that into the target rect. */
+static inline void emit_screen_rect(nt_resource_t atlas, uint32_t region_index, float x, float y, float w, float h, uint32_t color_packed) {
+    /* Column-major layout: m[0..3]=col0, m[4..7]=col1, m[8..11]=col2, m[12..15]=col3. */
+    const float m[16] = {
+        w,    0.0f, 0.0f, 0.0f, /* col0: scale x */
+        0.0f, h,    0.0f, 0.0f, /* col1: scale y */
+        0.0f, 0.0f, 1.0f, 0.0f, /* col2 */
+        x,    y,    0.0f, 1.0f  /* col3: translate */
+    };
+    nt_sprite_renderer_emit_region(atlas, region_index, m, 0.0f, 0.0f, color_packed, 0u);
+}
+// #endregion
+
+// #region helper_emit_border
+/* WALK-04 / D-52-03: BORDER -> up to 4 thin RECT quads via emit_screen_rect.
+ * Top/bottom run the full width; left/right are inset by top/bottom heights
+ * to avoid double-blending corners (matches 52-RESEARCH.md §BORDER emit). */
+static void emit_border(const Clay_RenderCommand *c) {
+    const Clay_BorderRenderData *b = &c->renderData.border;
+    const Clay_BoundingBox bb = c->boundingBox;
+    const uint32_t col = nt_color_pack_clay(b->color);
+
+    if (b->width.top) {
+        emit_screen_rect(g_nt_ui_atlas, g_nt_ui_white_region, bb.x, bb.y, bb.width, (float)b->width.top, col);
+    }
+    if (b->width.bottom) {
+        emit_screen_rect(g_nt_ui_atlas, g_nt_ui_white_region, bb.x, bb.y + bb.height - (float)b->width.bottom, bb.width, (float)b->width.bottom, col);
+    }
+    if (b->width.left) {
+        emit_screen_rect(g_nt_ui_atlas, g_nt_ui_white_region, bb.x, bb.y + (float)b->width.top, (float)b->width.left, bb.height - (float)b->width.top - (float)b->width.bottom, col);
+    }
+    if (b->width.right) {
+        emit_screen_rect(g_nt_ui_atlas, g_nt_ui_white_region, bb.x + bb.width - (float)b->width.right, bb.y + (float)b->width.top, (float)b->width.right,
+                         bb.height - (float)b->width.top - (float)b->width.bottom, col);
+    }
+}
+// #endregion
+
+// #region helper_emit_image
+/* D-52-07 + D-52-08: IMAGE -> read nt_ui_image_payload_t* from imageData,
+ * emit one region at bbox. slice9 fields are reserved-but-inactive in
+ * Phase 52 -- warn-once and fall through to a plain quad emit.
+ *
+ * IMPORTANT: image uses the PAYLOAD's atlas, not g_nt_ui_atlas. Different
+ * atlas pages auto-flush via the sprite renderer's
+ * ensure_current_cmd_page_texture path. */
+static void emit_image(const Clay_RenderCommand *c) {
+    const nt_ui_image_payload_t *p = (const nt_ui_image_payload_t *)c->renderData.image.imageData;
+    if (p == NULL) {
+        return; /* tolerate missing payload — Clay does not enforce */
+    }
+
+    const bool slice9 = (p->slice9_lrtb[0] | p->slice9_lrtb[1] | p->slice9_lrtb[2] | p->slice9_lrtb[3]) != 0u;
+    if (slice9) {
+        static bool s_slice9_warned = false;
+        if (!s_slice9_warned) {
+            NT_LOG_WARN("nt_ui slice9 payload set in Phase 52 — Phase 54 required; emitting plain quad");
+            s_slice9_warned = true;
+        }
+        /* fall through -- emit as plain quad */
+    }
+
+    const Clay_BoundingBox bb = c->boundingBox;
+
+    /* Clay's default backgroundColor for IMAGE is {0,0,0,0} == untinted
+     * (clay.h:481 comment). Map that to 0xFFFFFFFF so the sprite shader's
+     * per-vertex tint is a no-op. */
+    Clay_Color tint = c->renderData.image.backgroundColor;
+    const uint32_t col = (tint.r == 0.0f && tint.g == 0.0f && tint.b == 0.0f && tint.a == 0.0f) ? 0xFFFFFFFFu : nt_color_pack_clay(tint);
+
+    /* Resolve region via the payload's atlas. Tombstones / out-of-range
+     * silently no-op via the sprite renderer's emit_region_resolved. */
+    const nt_texture_region_t *r = nt_atlas_get_region(p->atlas, p->region_index);
+    if (r == NULL || r->vertex_count == 0u) {
+        return;
+    }
+    const float ipu = nt_atlas_get_inverse_pixels_per_unit(p->atlas);
+    const float src_w = (float)r->source_w * ipu;
+    const float src_h = (float)r->source_h * ipu;
+    /* Guard against degenerate source dim (avoid div-by-zero on tombstoned
+     * regions that slipped through the vertex_count gate). */
+    const float sx = (src_w > 0.0f) ? (bb.width / src_w) : bb.width;
+    const float sy = (src_h > 0.0f) ? (bb.height / src_h) : bb.height;
+
+    const float m[16] = {
+        sx, 0.0f, 0.0f, 0.0f, 0.0f, sy, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, bb.x, bb.y, 0.0f, 1.0f,
+    };
+    nt_sprite_renderer_emit_region(p->atlas, p->region_index, m, 0.0f, 0.0f, col, p->flip_bits);
+}
+// #endregion
+
+// #region helper_emit_text
+/* D-52-18: TEXT command emit. Flushes sprite renderer first (different
+ * material/pipeline boundary), then binds the text font + text material
+ * and forwards to nt_text_renderer_draw_n (Phase 51 length-aware API). */
+static void emit_text(nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
+    /* State boundary: sprite material/pipeline must flush before text
+     * binds its own pipeline. Auto-flush on font/material change happens
+     * inside the text renderer, but the sprite renderer's own staging
+     * needs to drain here. */
+    nt_sprite_renderer_flush();
+
+    const Clay_TextRenderData *t = &c->renderData.text;
+    if ((uint32_t)t->fontId >= NT_UI_MAX_FONTS) {
+        return;
+    }
+    nt_font_t font = ctx->fonts[t->fontId];
+    if (!nt_font_valid(font)) {
+        return;
+    }
+
+    nt_text_renderer_set_font(font);
+    nt_text_renderer_set_material(g_nt_ui_text_material);
+
+    /* Translation-only model mat4 -- font size is the scale argument
+     * to draw_n, not folded into the model. */
+    const float m[16] = {
+        1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f, c->boundingBox.x, c->boundingBox.y, 0.0f, 1.0f,
+    };
+    /* Text renderer color contract: float[4] in 0..1 range (engine/renderers
+     * /nt_text_renderer.c writes it straight into vertex color via memcpy at
+     * line 281). Clay stores 0..255 floats -- divide. */
+    const float color[4] = {
+        t->textColor.r / 255.0f,
+        t->textColor.g / 255.0f,
+        t->textColor.b / 255.0f,
+        t->textColor.a / 255.0f,
+    };
+    nt_text_renderer_draw_n(t->stringContents.chars, (size_t)t->stringContents.length, m, (float)t->fontSize, color);
+}
+// #endregion
+
+// #region helper_scissor_stack
+typedef struct {
+    int x;
+    int y;
+    int w;
+    int h;
+} sscissor_rect_t;
+
+static void scissor_push(const Clay_RenderCommand *c, sscissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
+    NT_ASSERT(*depth < NT_UI_WALKER_MAX_SCISSOR_DEPTH && "scissor stack overflow");
+
+    int x = (int)c->boundingBox.x;
+    int y = (int)c->boundingBox.y;
+    int wp = (int)c->boundingBox.width;
+    int hp = (int)c->boundingBox.height;
+
+    /* Nested scissor -> intersect with top (D-52-17). REPLACE would let an
+     * inner widget paint outside its parent's clip, e.g. scroll-content
+     * leaking past a modal backdrop. */
+    if (*depth > 0) {
+        sscissor_rect_t t = stack[*depth - 1];
+        int x2 = (x > t.x) ? x : t.x;
+        int y2 = (y > t.y) ? y : t.y;
+        int r2 = ((x + wp) < (t.x + t.w)) ? (x + wp) : (t.x + t.w);
+        int b2 = ((y + hp) < (t.y + t.h)) ? (y + hp) : (t.y + t.h);
+        x = x2;
+        y = y2;
+        wp = (r2 > x2) ? (r2 - x2) : 0;
+        hp = (b2 > y2) ? (b2 - y2) : 0;
+    }
+
+    /* FLUSH both renderers BEFORE changing GL scissor state. Pending
+     * staging written under the prior scissor would otherwise be drawn
+     * under the new one. */
+    nt_sprite_renderer_flush();
+    nt_text_renderer_flush();
+
+    stack[(*depth)++] = (sscissor_rect_t){.x = x, .y = y, .w = wp, .h = hp};
+
+    /* Y-flip top-left -> GL bottom-left (PP-03 / D-51-04). */
+    const int fb_h = (int)target->viewport[3];
+    nt_gfx_set_scissor(x, fb_h - y - hp, wp, hp);
+    nt_gfx_set_scissor_enabled(true);
+}
+
+static void scissor_pop(sscissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
+    NT_ASSERT(*depth > 0 && "scissor underflow");
+    nt_sprite_renderer_flush();
+    nt_text_renderer_flush();
+    (*depth)--;
+    if (*depth == 0) {
+        nt_gfx_set_scissor_enabled(false);
+    } else {
+        sscissor_rect_t r = stack[*depth - 1];
+        const int fb_h = (int)target->viewport[3];
+        nt_gfx_set_scissor(r.x, fb_h - r.y - r.h, r.w, r.h);
+    }
+}
+// #endregion
+
+// #region helper_emit_custom
+/* WALK-05 / D-52-09: CUSTOM -> flush both renderers then invoke the
+ * registered handler (NULL handler == silent skip). The handler is
+ * responsible for its own pipeline binds; the walker re-binds the sprite
+ * material via the existing cmd-state preservation in set_material on the
+ * next RECT/BORDER/IMAGE, so we don't need to re-set here. */
+static void emit_custom(const Clay_RenderCommand *c) {
+    nt_sprite_renderer_flush();
+    nt_text_renderer_flush();
+    if (g_nt_ui_custom_fn != NULL) {
+        g_nt_ui_custom_fn((const void *)c, g_nt_ui_custom_user);
+    }
+}
+// #endregion
+
+// #region walk
+/* D-52-05 / Revision Issue 2: depth test/write are pipeline-baked.
+ * UI materials must use pipelines with depth_test=false, depth_write=false.
+ * Walker takes no per-frame depth action — nt_gfx has no such API
+ * (verified against engine/graphics/nt_gfx.h at plan-write time). */
 void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(ctx != NULL && "nt_ui_walk: ctx must be non-NULL");
     NT_ASSERT(target != NULL && "nt_ui_walk: target must be non-NULL");
     NT_ASSERT(!ctx->in_frame && "nt_ui_walk: ctx is mid-frame (call nt_ui_end first)");
-    /* Plan 04 fills: viewport setup, frozen_cmds iteration, dispatch. */
+    NT_ASSERT(g_nt_ui_atlas.id != 0 && "nt_ui_set_atlas_white_region required before nt_ui_walk");
+    NT_ASSERT(nt_resource_is_ready(g_nt_ui_atlas) && "nt_ui_walk: UI atlas must be READY");
+    /* Revision Issue 1: sprite + text materials are separate; assert BOTH. */
+    NT_ASSERT(g_nt_ui_sprite_material.id != 0 && "nt_ui_set_sprite_material required before nt_ui_walk");
+    NT_ASSERT(g_nt_ui_text_material.id != 0 && "nt_ui_set_text_material required before nt_ui_walk");
+
+    /* Walker-local scissor stack -- D-52-17 (on C stack, NOT in ctx, so
+     * multiple walks against the same ctx don't share state). */
+    sscissor_rect_t scissor_stack[NT_UI_WALKER_MAX_SCISSOR_DEPTH];
+    int depth = 0;
+
+    /* Snapshot draw-call counter for the delta (Plan 05 will route to
+     * nt_stats_count; Plan 04 captures into static module state). */
+    const uint32_t calls_at_entry = nt_gfx_get_frame_draw_calls();
+
+    /* Apply viewport from target (UI-07). Bottom-left GL convention. */
+    nt_gfx_set_viewport((int)target->viewport[0], (int)target->viewport[1], (int)target->viewport[2], (int)target->viewport[3]);
+
+    /* Defensive scissor disable at entry (CP-04 prevention). */
+    nt_gfx_set_scissor_enabled(false);
+
+    /* Revision Issue 1: bind SPRITE material for RECT/BORDER/IMAGE emits.
+     * TEXT material binds lazily inside emit_text just before draw_n
+     * (auto-flush handles the boundary). */
+    nt_sprite_renderer_set_material(g_nt_ui_sprite_material);
+
+    /* Iterate Clay's frozen command array -- already zIndex-ascending sorted. */
+    const Clay_RenderCommandArray *arr = &ctx->frozen_cmds;
+    for (int32_t i = 0; i < arr->length; ++i) {
+        const Clay_RenderCommand *c = &arr->internalArray[i];
+        switch (c->commandType) {
+        case CLAY_RENDER_COMMAND_TYPE_NONE:
+            break; /* silent skip — Clay sentinel */
+        case CLAY_RENDER_COMMAND_TYPE_RECTANGLE: {
+            const Clay_RectangleRenderData *r = &c->renderData.rectangle;
+            const uint32_t col = nt_color_pack_clay(r->backgroundColor);
+            emit_screen_rect(g_nt_ui_atlas, g_nt_ui_white_region, c->boundingBox.x, c->boundingBox.y, c->boundingBox.width, c->boundingBox.height, col);
+            break;
+        }
+        case CLAY_RENDER_COMMAND_TYPE_BORDER:
+            emit_border(c);
+            break;
+        case CLAY_RENDER_COMMAND_TYPE_TEXT:
+            emit_text(ctx, c);
+            break;
+        case CLAY_RENDER_COMMAND_TYPE_IMAGE:
+            emit_image(c);
+            break;
+        case CLAY_RENDER_COMMAND_TYPE_SCISSOR_START:
+            scissor_push(c, scissor_stack, &depth, target);
+            break;
+        case CLAY_RENDER_COMMAND_TYPE_SCISSOR_END:
+            scissor_pop(scissor_stack, &depth, target);
+            break;
+        case CLAY_RENDER_COMMAND_TYPE_CUSTOM:
+            emit_custom(c);
+            break;
+        }
+    }
+
+    /* Final flushes + invariant check (WALK-06 + CP-04). */
+    nt_sprite_renderer_flush();
+    nt_text_renderer_flush();
+    NT_ASSERT(depth == 0 && "unbalanced scissor stack at walk exit");
+    nt_gfx_set_scissor_enabled(false);
+
+    /* Stats (D-52-20 / WALK-09). Plan 05 routes these through nt_stats. */
+    s_last_walk_draw_call_delta = nt_gfx_get_frame_draw_calls() - calls_at_entry;
+    s_last_walk_element_count = (uint32_t)arr->length;
 }
 // #endregion
 

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -314,21 +314,13 @@ static void emit_text(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
 
     const Clay_TextRenderData *t = &c->renderData.text;
     if ((uint32_t)t->fontId >= NT_UI_MAX_FONTS) {
-        static bool warned = false;
-        if (!warned) {
-            NT_LOG_WARN("nt_ui TEXT: fontId %u >= NT_UI_MAX_FONTS=%u; skipping (further occurrences silenced)", (unsigned)t->fontId, (unsigned)NT_UI_MAX_FONTS);
-            warned = true;
-        }
+        NT_LOG_WARN_ONCE("nt_ui TEXT: fontId %u >= NT_UI_MAX_FONTS=%u; skipping (further occurrences silenced)", (unsigned)t->fontId, (unsigned)NT_UI_MAX_FONTS);
         rebind_sprite_after_flush(ctx);
         return;
     }
     nt_font_t font = ctx->fonts[t->fontId];
     if (!nt_font_valid(font)) {
-        static bool warned_invalid = false;
-        if (!warned_invalid) {
-            NT_LOG_WARN("nt_ui TEXT: fontId %u resolves to an invalid font handle; skipping (further occurrences silenced)", (unsigned)t->fontId);
-            warned_invalid = true;
-        }
+        NT_LOG_WARN_ONCE("nt_ui TEXT: fontId %u resolves to an invalid font handle; skipping (further occurrences silenced)", (unsigned)t->fontId);
         rebind_sprite_after_flush(ctx);
         return;
     }

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -216,5 +216,22 @@ nt_ui_context_t *nt_ui_test_inframe_ctx(void) { return g_nt_ui_inframe_ctx; }
 /* Plan 05 fills the body. */
 uint32_t nt_ui_test_last_walk_draw_call_delta(void) { return 0u; }
 uint32_t nt_ui_test_last_walk_element_count(void) { return 0u; }
+
+/* CLAY-04 / D-52-16 verification probes. ctx->clay is a Clay_Context whose
+ * struct definition is only visible to this TU (CLAY_IMPLEMENTATION above);
+ * tests cannot read pointerInfo directly. These getters bridge that gap. */
+float nt_ui_test_clay_pointer_x(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_test_clay_pointer_x: ctx must be non-NULL");
+    return ctx->clay->pointerInfo.position.x;
+}
+float nt_ui_test_clay_pointer_y(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_test_clay_pointer_y: ctx must be non-NULL");
+    return ctx->clay->pointerInfo.position.y;
+}
+int nt_ui_test_clay_pointer_down(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_test_clay_pointer_down: ctx must be non-NULL");
+    const Clay_PointerDataInteractionState s = ctx->clay->pointerInfo.state;
+    return (s == CLAY_POINTER_DATA_PRESSED || s == CLAY_POINTER_DATA_PRESSED_THIS_FRAME) ? 1 : 0;
+}
 #endif /* NT_UI_TEST_ACCESS */
 // #endregion

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -102,8 +102,7 @@ static Clay_Dimensions nt_ui_measure_text_cb(Clay_StringSlice text, Clay_TextEle
 static size_t nt_ui_ctx_size_aligned(void) { return (sizeof(struct nt_ui_context) + 63U) & ~(size_t)63U; }
 
 size_t nt_ui_min_arena_size(void) {
-    /* Idempotent: ensures Clay_MinMemorySize() reflects our element-count
-     * default no matter whether caller queries before create_context. */
+    /* Lock element-count default before Clay_MinMemorySize reads it. */
     Clay_SetMaxElementCount(NT_UI_DEFAULT_MAX_ELEMENT_COUNT);
     return nt_ui_ctx_size_aligned() + (size_t)Clay_MinMemorySize();
 }
@@ -121,8 +120,6 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size) {
     const size_t clay_size = arena_size - ctx_size;
 
     ctx->in_frame = false;
-    /* nt_ui_min_arena_size() already locked Clay's element-count default
-     * via Clay_SetMaxElementCount; Clay_Initialize picks it up below. */
     ctx->clay_arena = Clay_CreateArenaWithCapacityAndMemory(clay_size, clay_mem);
     ctx->clay = Clay_Initialize(ctx->clay_arena, (Clay_Dimensions){.width = 1.0F, .height = 1.0F}, (Clay_ErrorHandler){.errorHandlerFunction = nt_ui_clay_error_cb, .userData = ctx});
 
@@ -504,18 +501,11 @@ static void dispatch_command(nt_ui_context_t *ctx, const Clay_RenderCommand *c, 
     }
 }
 
-/* Depth test/write must be baked into the UI material's pipeline
- * (depth_test=false, depth_write=false). nt_gfx has no per-frame depth
- * API, so the walker can't enforce this -- it's a caller contract. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(ctx != NULL && "nt_ui_walk: ctx must be non-NULL");
     NT_ASSERT(target != NULL && "nt_ui_walk: target must be non-NULL");
     NT_ASSERT(!ctx->in_frame && "nt_ui_walk: ctx is mid-frame (call nt_ui_end first)");
-    /* frozen_cmds.internalArray is zero-init'd until nt_ui_end populates
-     * it (Clay returns a valid pointer even for an empty layout). Without
-     * this guard, a create -> walk skipping begin/end would be a silent
-     * no-op. */
     NT_ASSERT(ctx->frozen_cmds.internalArray != NULL && "nt_ui_walk: frozen_cmds not populated (call nt_ui_end before walk)");
     /* w/h > 0: scissor math `vh - y - hp` underflows negative when
      * vh==0 (GL undefined). Origin x/y may be zero. */
@@ -549,15 +539,7 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
      * lazily inside emit_text just before draw_n. */
     nt_sprite_renderer_set_material(ctx->sprite_material);
 
-    /* Clay's frozen array is zIndex-ascending sorted. Walker contract:
-     * within a maximal run of same-zIndex, barrier-free commands
-     * (a "segment"), reorderable types (RECT/BORDER/IMAGE/TEXT) emit in
-     * two passes -- sprite-bound first, text second -- so interleaved
-     * RECT/TEXT in the same layer don't fragment renderer batches. Hard
-     * barriers (SCISSOR_START/END, CUSTOM) always emit in original order
-     * and never enter a segment. Game code that relies on strict painter
-     * order within same-z must put overlapping elements on different
-     * zIndex layers. */
+    /* Segment-aware dispatch -- see nt_ui_walk header doc for contract. */
     const Clay_RenderCommandArray *arr = &ctx->frozen_cmds;
     int32_t i = 0;
     while (i < arr->length) {
@@ -576,18 +558,12 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
             }
             ++seg_end;
         }
-        /* Pass 1: sprite-bound (RECT/BORDER/IMAGE). All share the same
-         * ctx->sprite_material; sprite_renderer auto-flushes on atlas
-         * page change (RECT/BORDER use ctx->atlas, IMAGE uses payload). */
         for (int32_t j = i; j < seg_end; ++j) {
             const Clay_RenderCommand *cc = &arr->internalArray[j];
             if (cc->commandType != CLAY_RENDER_COMMAND_TYPE_TEXT) {
                 dispatch_command(ctx, cc, scissor_stack, &depth, target);
             }
         }
-        /* Pass 2: TEXT. emit_text's prologue flushes sprite_renderer at
-         * the first text in the segment, so painter order across the
-         * sprite->text transition is preserved. */
         for (int32_t j = i; j < seg_end; ++j) {
             const Clay_RenderCommand *cc = &arr->internalArray[j];
             if (cc->commandType == CLAY_RENDER_COMMAND_TYPE_TEXT) {
@@ -612,10 +588,6 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
 // #endregion
 
 // #region setters
-/* Atlas setter asserts the white region resolves with vertex_count > 0
- * so a mis-baked atlas surfaces here, not one frame later in the walker.
- * Material setters only check .id != 0 -- pipeline readiness is checked
- * later when the renderer's set_material actually consumes the handle. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_ui_set_atlas_white_region(nt_ui_context_t *ctx, nt_resource_t atlas, uint32_t white_region_idx) {
     NT_ASSERT(ctx != NULL && "nt_ui_set_atlas_white_region: ctx must be non-NULL");
@@ -624,9 +596,7 @@ void nt_ui_set_atlas_white_region(nt_ui_context_t *ctx, nt_resource_t atlas, uin
     NT_ASSERT(nt_resource_is_ready(atlas) && "nt_ui_set_atlas_white_region: atlas must be READY");
     const nt_texture_region_t *r = nt_atlas_get_region(atlas, white_region_idx);
     NT_ASSERT(r != NULL && r->vertex_count > 0U && "nt_ui_set_atlas_white_region: white region missing / tombstoned (mis-baked atlas)");
-    /* emit_screen_rect assumes a unit-square white region so that its
-     * mat4(scale=w,h; translate=x,y) maps cached_pos {0,1}x{0,1} directly
-     * onto the target rect. A non-unit region would mis-scale RECT/BORDER. */
+    /* emit_screen_rect scales by mat4(w,h) on cached_pos {0,1}x{0,1}. */
     NT_ASSERT(r->source_w == 1 && r->source_h == 1 && "nt_ui_set_atlas_white_region: white region must be 1x1 source");
     ctx->atlas = atlas;
     ctx->white_region = white_region_idx;

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -101,7 +101,12 @@ static Clay_Dimensions nt_ui_measure_text_cb(Clay_StringSlice text, Clay_TextEle
 /* ctx struct rounded up to cache-line so Clay's arena starts aligned. */
 static size_t nt_ui_ctx_size_aligned(void) { return (sizeof(struct nt_ui_context) + 63U) & ~(size_t)63U; }
 
-size_t nt_ui_min_arena_size(void) { return nt_ui_ctx_size_aligned() + (size_t)Clay_MinMemorySize(); }
+size_t nt_ui_min_arena_size(void) {
+    /* Idempotent: ensures Clay_MinMemorySize() reflects our element-count
+     * default no matter whether caller queries before create_context. */
+    Clay_SetMaxElementCount(NT_UI_DEFAULT_MAX_ELEMENT_COUNT);
+    return nt_ui_ctx_size_aligned() + (size_t)Clay_MinMemorySize();
+}
 
 nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size) {
     NT_ASSERT(arena != NULL && "nt_ui_create_context: arena must be non-NULL");
@@ -116,6 +121,8 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size) {
     const size_t clay_size = arena_size - ctx_size;
 
     ctx->in_frame = false;
+    /* nt_ui_min_arena_size() already locked Clay's element-count default
+     * via Clay_SetMaxElementCount; Clay_Initialize picks it up below. */
     ctx->clay_arena = Clay_CreateArenaWithCapacityAndMemory(clay_size, clay_mem);
     ctx->clay = Clay_Initialize(ctx->clay_arena, (Clay_Dimensions){.width = 1.0F, .height = 1.0F}, (Clay_ErrorHandler){.errorHandlerFunction = nt_ui_clay_error_cb, .userData = ctx});
 

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -7,23 +7,17 @@
 #include "renderers/nt_sprite_renderer.h"
 #include "renderers/nt_text_renderer.h"
 
-/*
- * Exactly one TU in the build defines CLAY_IMPLEMENTATION -- this one.
- *
- * Clay version is pinned via deps/clay/VERSION; CMake parses major.minor
- * and passes CLAY_PINNED_MAJOR / CLAY_PINNED_MINOR. The _Static_assert
- * below catches dev-time drift where deps/clay/VERSION is hand-edited
- * without re-vendoring (Clay itself has no CLAY_VERSION_* macros).
- */
+/* This is the single CLAY_IMPLEMENTATION TU. CMake parses deps/clay/VERSION
+ * into CLAY_PINNED_*; the assert below catches version drift. */
 
 #if !defined(CLAY_PINNED_MAJOR) || !defined(CLAY_PINNED_MINOR)
-#error "nt_ui: CLAY_PINNED_MAJOR / CLAY_PINNED_MINOR must be defined by CMake (engine/ui/CMakeLists.txt parses deps/clay/VERSION)"
+#error "nt_ui: CLAY_PINNED_MAJOR / CLAY_PINNED_MINOR must be defined by CMake"
 #endif
 
 #define CLAY_IMPLEMENTATION
 #include "clay.h"
 
-_Static_assert(CLAY_PINNED_MAJOR == 0 && CLAY_PINNED_MINOR == 14, "Clay v0.14 required -- deps/clay/VERSION disagrees with the engine pin");
+_Static_assert(CLAY_PINNED_MAJOR == 0 && CLAY_PINNED_MINOR == 14, "Clay v0.14 required");
 
 #include <math.h>
 #include <stddef.h>
@@ -35,17 +29,12 @@ _Static_assert(CLAY_PINNED_MAJOR == 0 && CLAY_PINNED_MINOR == 14, "Clay v0.14 re
 #include "ui/nt_ui_internal.h"
 
 // #region module_state
-/* Only one ctx may be in-frame at a time; nt_ui_begin asserts NULL on
- * entry and assigns, nt_ui_end clears. All other walker state lives in
- * nt_ui_context_t -- this is the single piece of module-level state. */
+/* Only one ctx may be in-frame at a time; nt_ui_begin asserts NULL on entry. */
 static nt_ui_context_t *g_nt_ui_inframe_ctx = NULL;
 // #endregion
 
 // #region clay_error_handler
-/* Recoverable: Clay safely no-ops the error and the rest of the UI still
- * renders correctly. Fatal: capacity overflow silently truncates the UI,
- * missing measure callback or internal Clay errors mean broken state.
- * Unknown defaults to fatal so a Clay version bump can't silently demote
+/* Unknown defaults to fatal so a Clay version bump can't silently demote
  * a new invariant violation. */
 static bool nt_ui_clay_error_is_recoverable(Clay_ErrorType type) {
     switch (type) {
@@ -63,8 +52,8 @@ static bool nt_ui_clay_error_is_recoverable(Clay_ErrorType type) {
     return false;
 }
 
-/* errorText is a Clay_String with .length + .chars -- not NUL-terminated. */
 static void nt_ui_clay_error_cb(Clay_ErrorData err) {
+    /* errorText is .length + .chars (NOT NUL-terminated). */
     const int len = err.errorText.length;
     const char *const chars = (err.errorText.chars != NULL && len > 0) ? err.errorText.chars : "(no text)";
     const int safe_len = (err.errorText.chars != NULL && len > 0) ? len : 9;
@@ -92,13 +81,8 @@ static Clay_Dimensions nt_ui_measure_text_cb(Clay_StringSlice text, Clay_TextEle
     NT_ASSERT(nt_font_valid(font) && "nt_ui measure_cb: font slot empty; call nt_ui_set_font before declaring TEXT with this fontId");
     const float ls = (float)config->letterSpacing;
     nt_text_size_t s = nt_font_measure_n(font, text.chars, (size_t)text.length, (float)config->fontSize, ls);
-    /* Clay convention: callback returns word width WITH one trailing
-     * letterSpacing slot, then Clay subtracts a single trailing slot at
-     * end-of-line (clay.h Clay__MeasureTextCached line 1677). Our
-     * nt_font_measure_n returns the CSS-style (N-1) gap width, so add one
-     * trailing slot here when the measurement produced any width. Without
-     * this, Clay's bbox is short by exactly one letterSpacing relative to
-     * the rendered text. */
+    /* Clay's MeasureTextCached subtracts one trailing letterSpacing per line
+     * (clay.h:1677); add it back so bbox matches the renderer's (N-1)*ls width. */
     if (s.width > 0.0F && ls != 0.0F) {
         s.width += ls;
     }
@@ -107,20 +91,13 @@ static Clay_Dimensions nt_ui_measure_text_cb(Clay_StringSlice text, Clay_TextEle
 // #endregion
 
 // #region module_init
-/* Per-quarter-arc segment count (rounded RECT/BORDER). Defined here so the
- * LUT below sizes correctly. Helpers below use the same #define. */
+/* Per-quarter-arc segment count. Bound prevents WASM stack / staging overflow. */
 #define NT_UI_CORNER_SEGMENTS 6
-_Static_assert(NT_UI_CORNER_SEGMENTS >= 2 && NT_UI_CORNER_SEGMENTS <= 32, "NT_UI_CORNER_SEGMENTS must be in [2, 32]: lower degenerate, higher wastes stack and staging");
+_Static_assert(NT_UI_CORNER_SEGMENTS >= 2 && NT_UI_CORNER_SEGMENTS <= 32, "NT_UI_CORNER_SEGMENTS must be in [2, 32]");
 #define NT_UI_PI_F 3.14159265358979323846F
 
-/* Precomputed (cos, sin) per arc segment per corner quadrant.
- * Quadrant index encodes the starting angle (a_start = q * π/2):
- *   q=0 -> BR (angle 0 → π/2)
- *   q=1 -> BL (π/2 → π)
- *   q=2 -> TL (π → 3π/2)
- *   q=3 -> TR (3π/2 → 2π)
- * Populated once at module init; .rodata-sized 4 * (SEG+1) * 8 = 224 B for SEG=6.
- * Replaces 28-56 cosf/sinf calls per rounded element on the walker hot path. */
+/* Precomputed cos/sin per arc segment per quadrant (0=BR, 1=BL, 2=TL, 3=TR).
+ * Replaces per-frame cosf/sinf in rounded RECT/BORDER. */
 typedef struct {
     float cos;
     float sin;
@@ -139,12 +116,9 @@ static void nt_ui_init_arc_lut(void) {
     }
 }
 
-/* Wire measure callback into Clay's global function pointer. Bypasses
- * Clay_SetMeasureTextFunction (which requires an active Clay context) by
- * writing directly to the global -- legal because CLAY_IMPLEMENTATION
- * places Clay's internals in this TU. Also clears the module-global
- * in-frame ctx tracker (death-test longjmp through nt_ui_end leaves it
- * stale; module init/shutdown is the natural reset point). */
+/* Direct global write bypasses Clay_SetMeasureTextFunction which requires an
+ * active Clay context. Legal because CLAY_IMPLEMENTATION lives in this TU.
+ * Also resets in-frame tracker for death-test recovery. */
 void nt_ui_module_init(void) {
     Clay__MeasureText = nt_ui_measure_text_cb;
     g_nt_ui_inframe_ctx = NULL;
@@ -159,7 +133,7 @@ void nt_ui_module_shutdown(void) {
 // #endregion
 
 // #region create_destroy
-/* ctx struct rounded up to cache-line so Clay's arena starts aligned. */
+/* Cache-line aligned so Clay's arena starts on a clean boundary. */
 static size_t nt_ui_ctx_size_aligned(void) { return (sizeof(struct nt_ui_context) + 63U) & ~(size_t)63U; }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
@@ -168,13 +142,9 @@ size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc) {
     NT_ASSERT(desc->max_elements > 0U && "nt_ui_min_arena_size: desc->max_elements must be > 0");
     NT_ASSERT(desc->max_elements <= UINT16_MAX && "nt_ui_min_arena_size: desc->max_elements exceeds uint16 sorted-index range");
     NT_ASSERT(desc->max_scissor_depth > 0U && "nt_ui_min_arena_size: desc->max_scissor_depth must be > 0");
-    /* Clay_SetMaxElementCount writes to GLOBAL Clay__defaultMaxElementCount
-     * when no current context exists, or to current context otherwise. We
-     * want to size against desc->max_elements WITHOUT mutating any active
-     * ctx AND without leaving Clay's global default at our temporary value
-     * (pure-query contract). Snapshot current ctx + global default, set,
-     * query, restore both. Direct read of Clay__defaultMaxElementCount is
-     * legal because CLAY_IMPLEMENTATION is in this TU. */
+    /* Pure-query contract: stage max_elements through Clay's global default
+     * (Clay_SetMaxElementCount writes there with no current ctx), then
+     * restore both saved ctx and saved global. */
     Clay_Context *saved_ctx = Clay_GetCurrentContext();
     const int32_t saved_default = Clay__defaultMaxElementCount;
     Clay_SetCurrentContext(NULL);
@@ -218,10 +188,8 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_u
     ctx->clay_arena = Clay_CreateArenaWithCapacityAndMemory(clay_size, clay_mem);
     ctx->clay = Clay_Initialize(ctx->clay_arena, (Clay_Dimensions){.width = 1.0F, .height = 1.0F}, (Clay_ErrorHandler){.errorHandlerFunction = nt_ui_clay_error_cb, .userData = ctx});
 
-    /* Restore both pre-create state. Clay_Initialize sets current to the
-     * new ctx; without restore the caller would inherit our new ctx as
-     * active without ever calling nt_ui_begin -- breaks the contract that
-     * nt_ui_begin owns active-ctx selection. */
+    /* nt_ui_begin owns active-ctx selection -- restore both so create
+     * doesn't accidentally leave the new ctx current. */
     Clay__defaultMaxElementCount = saved_default;
     Clay_SetCurrentContext(saved_ctx);
 
@@ -231,10 +199,7 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_u
 void nt_ui_destroy_context(nt_ui_context_t *ctx) {
     NT_ASSERT(ctx != NULL && "nt_ui_destroy_context: ctx must be non-NULL");
     NT_ASSERT(!ctx->in_frame && "nt_ui_destroy_context: ctx is mid-frame (call nt_ui_end first)");
-    /* nt_ui_begin sets Clay's global current_ptr to ctx->clay; that pointer
-     * lives inside ctx's arena and becomes dangling after memset below.
-     * Null Clay's current if it points at us so subsequent Clay API calls
-     * either short-circuit (Clay_MinMemorySize) or assert cleanly. */
+    /* Clay's current_ptr would dangle into the freshly memset arena. */
     if (Clay_GetCurrentContext() == ctx->clay) {
         Clay_SetCurrentContext(NULL);
     }
@@ -245,8 +210,8 @@ void nt_ui_destroy_context(nt_ui_context_t *ctx) {
 // #region font_registry
 void nt_ui_set_font(nt_ui_context_t *ctx, uint16_t font_id, nt_font_t font) {
     NT_ASSERT(ctx != NULL && "nt_ui_set_font: ctx must be non-NULL");
-    NT_ASSERT(!ctx->in_frame && "nt_ui_set_font: must be called outside begin/end (mid-frame mutation would split layout vs walker view)");
-    NT_ASSERT(font_id < NT_UI_MAX_FONTS && "nt_ui_set_font: font_id out of range (raise NT_UI_MAX_FONTS)");
+    NT_ASSERT(!ctx->in_frame && "nt_ui_set_font: must be called outside begin/end");
+    NT_ASSERT(font_id < NT_UI_MAX_FONTS && "nt_ui_set_font: font_id >= NT_UI_MAX_FONTS");
     ctx->fonts[font_id] = font;
 }
 // #endregion
@@ -256,14 +221,13 @@ void nt_ui_set_font(nt_ui_context_t *ctx, uint16_t font_id, nt_font_t font) {
 void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, const nt_pointer_t *mouse) {
     NT_ASSERT(ctx != NULL && "nt_ui_begin: ctx must be non-NULL");
     NT_ASSERT(mouse != NULL && "nt_ui_begin: mouse must be non-NULL");
-    /* isfinite() rejects NaN + +-inf; raw `>= 0.0F` lets +inf through. */
+    /* isfinite() rejects NaN + +-inf which `>= 0.0F` alone lets through. */
     NT_ASSERT(isfinite(screen_w) && screen_w >= 0.0F && "nt_ui_begin: screen_w must be finite and non-negative");
     NT_ASSERT(isfinite(screen_h) && screen_h >= 0.0F && "nt_ui_begin: screen_h must be finite and non-negative");
     NT_ASSERT(g_nt_ui_inframe_ctx == NULL && "nt_ui_begin: another ctx is mid-frame");
     NT_ASSERT(!ctx->in_frame && "nt_ui_begin: ctx already in_frame");
 
-    /* MUST be first: switches Clay's current-context global so every
-     * subsequent Clay call below operates on ctx->clay. */
+    /* MUST be first so subsequent Clay calls operate on ctx->clay. */
     Clay_SetCurrentContext(ctx->clay);
 
     ctx->in_frame = true;
@@ -290,9 +254,8 @@ void nt_ui_end(nt_ui_context_t *ctx) {
 // #endregion
 
 // #region helpers_color_pack
-/* Clay stores RGBA as 0..255 floats with no clamping; sprite vertex
- * format is 0xAABBGGRR uint32. Saturate so a theme that wrote 256 or -1
- * doesn't wrap around the uint8 cast. */
+/* Clay's RGBA floats are unclamped; saturate then round-to-nearest so slow
+ * fades don't step on integer boundaries. Upper clamp ensures v+0.5F < 256. */
 static inline uint8_t clamp_u8(float v) {
     if (v <= 0.0F) {
         return 0U;
@@ -300,8 +263,6 @@ static inline uint8_t clamp_u8(float v) {
     if (v >= 255.0F) {
         return 255U;
     }
-    /* Round-to-nearest (not truncation) so slow fades don't step on
-     * integer boundaries. The clamp above ensures v + 0.5F < 256. */
     return (uint8_t)(v + 0.5F);
 }
 
@@ -315,38 +276,25 @@ static inline uint32_t nt_color_pack_clay(Clay_Color c) {
 // #endregion
 
 // #region helper_emit_screen_rect
-/* Builds a column-major 2D-ortho mat4 (scale by w,h; translate to x,y)
- * directly onto the renderer. cached_pos for a 1x1 white region is the
- * unit square in source space, so m[0]=w / m[5]=h folds straight into
- * the target rect with no per-corner work. */
+/* mat4(scale w,h; translate x,y) on the 1x1 white-region unit square. */
 static inline void emit_screen_rect(nt_resource_t atlas, uint32_t region_index, float x, float y, float w, float h, uint32_t color_packed) {
     const float m[16] = {
-        w,    0.0F, 0.0F, 0.0F, /* col0: scale x */
-        0.0F, h,    0.0F, 0.0F, /* col1: scale y */
-        0.0F, 0.0F, 1.0F, 0.0F, /* col2 */
-        x,    y,    0.0F, 1.0F, /* col3: translate */
+        w, 0.0F, 0.0F, 0.0F, 0.0F, h, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, x, y, 0.0F, 1.0F,
     };
     nt_sprite_renderer_emit_region(atlas, region_index, m, 0.0F, 0.0F, color_packed, 0U);
 }
 // #endregion
 
 // #region helper_emit_rounded_rect
-/* NT_UI_CORNER_SEGMENTS, NT_UI_PI_F and s_arc_lut declared above in module_init. */
-
-/* Triangle fan from rect center to the boundary. Each corner contributes
- * either 1 vertex (radius 0) or NT_UI_CORNER_SEGMENTS+1 arc vertices.
- * Boundary order is screen-CW starting at TL arc entry on the left edge. */
+/* Triangle fan from rect center: 1 vert per zero corner, SEG+1 per rounded. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void emit_rounded_rect(nt_resource_t atlas, uint32_t region_index, float x, float y, float w, float h, Clay_CornerRadius cr, uint32_t color_packed) {
-    /* Negative input -> 0. */
     float tl = (cr.topLeft > 0.0F) ? cr.topLeft : 0.0F;
     float tr = (cr.topRight > 0.0F) ? cr.topRight : 0.0F;
     float bl = (cr.bottomLeft > 0.0F) ? cr.bottomLeft : 0.0F;
     float br = (cr.bottomRight > 0.0F) ? cr.bottomRight : 0.0F;
-    /* CSS3 border-radius §5.5 proportional clamp: when the sum of two
-     * radii along a side exceeds the side length, scale ALL four radii
-     * by the smallest factor needed. Preserves the user's intended
-     * proportions and matches browser/Godot/Skia behaviour. */
+    /* CSS3 border-radius §5.5 proportional clamp -- when adjacent-pair sums
+     * exceed the side, scale ALL radii by the smallest needed factor. */
     float factor = 1.0F;
     if (tl + tr > w) {
         factor = fminf(factor, w / (tl + tr));
@@ -383,7 +331,7 @@ static void emit_rounded_rect(nt_resource_t atlas, uint32_t region_index, float 
     positions[0][1] = y + half_h;
     uint32_t vi = 1;
 
-    /* TL arc: quadrant 2 (π → 1.5π) -- sweeps west to north of corner center. */
+    /* Per-corner LUT row: TL=2, TR=3, BR=0, BL=1 (q*π/2 start angle). */
     if (tl == 0.0F) {
         positions[vi][0] = x;
         positions[vi][1] = y;
@@ -397,7 +345,6 @@ static void emit_rounded_rect(nt_resource_t atlas, uint32_t region_index, float 
             vi++;
         }
     }
-    /* TR arc: quadrant 3 (1.5π → 2π). */
     if (tr == 0.0F) {
         positions[vi][0] = x + w;
         positions[vi][1] = y;
@@ -411,7 +358,6 @@ static void emit_rounded_rect(nt_resource_t atlas, uint32_t region_index, float 
             vi++;
         }
     }
-    /* BR arc: quadrant 0 (0 → 0.5π). */
     if (br == 0.0F) {
         positions[vi][0] = x + w;
         positions[vi][1] = y + h;
@@ -425,7 +371,6 @@ static void emit_rounded_rect(nt_resource_t atlas, uint32_t region_index, float 
             vi++;
         }
     }
-    /* BL arc: quadrant 1 (0.5π → π). */
     if (bl == 0.0F) {
         positions[vi][0] = x;
         positions[vi][1] = y + h;
@@ -457,8 +402,7 @@ static void emit_rounded_rect(nt_resource_t atlas, uint32_t region_index, float 
 // #endregion
 
 // #region helper_emit_border
-/* Square-corner fast path: up to 4 thin RECT quads. Top/bottom run the
- * full width; left/right are inset by top/bottom so corners don't blend. */
+/* Top/bottom run full width; left/right inset to avoid corner overlap. */
 static void emit_square_border(nt_resource_t atlas, uint32_t region_index, Clay_BoundingBox bb, Clay_BorderWidth widths, uint32_t col) {
     const float top = (float)widths.top;
     const float bot = (float)widths.bottom;
@@ -478,11 +422,8 @@ static void emit_square_border(nt_resource_t atlas, uint32_t region_index, Clay_
     }
 }
 
-/* Append one corner's (outer,inner) vertex pair(s) into the strip array.
- * quadrant picks the LUT row: 2=TL (π → 1.5π), 3=TR (1.5π → 2π),
- * 0=BR (0 → 0.5π), 1=BL (0.5π → π). radius==0 collapses to a single
- * sharp pair at (sharp_x, sharp_y) (outer) and
- * (sharp_x + sx*wx, sharp_y + sy*wy) (inner). */
+/* radius==0 -> single sharp pair (outer at corner, inner offset by widths).
+ * Otherwise emit SEG+1 (outer,inner) pairs along the quadrant's arc. */
 static uint32_t emit_corner_strip_pairs(float (*pos)[2], uint32_t vi, float radius, float cx, float cy, float w_perp_x, float w_perp_y, float sharp_x, float sharp_y, float sign_x, float sign_y,
                                         uint32_t quadrant) {
     if (radius == 0.0F) {
@@ -494,9 +435,7 @@ static uint32_t emit_corner_strip_pairs(float (*pos)[2], uint32_t vi, float radi
         vi++;
         return vi;
     }
-    /* Clamp inner radii to 0 -- when border width exceeds the corner radius,
-     * the inner curve degenerates to a flat segment through the corner
-     * center on that axis. Matches CSS/Godot/Skia behaviour. */
+    /* width > radius -> inner curve clamps to 0 on that axis (CSS parity). */
     const float irx = (radius > w_perp_x) ? (radius - w_perp_x) : 0.0F;
     const float iry = (radius > w_perp_y) ? (radius - w_perp_y) : 0.0F;
     for (uint32_t s = 0; s <= NT_UI_CORNER_SEGMENTS; s++) {
@@ -512,11 +451,8 @@ static uint32_t emit_corner_strip_pairs(float (*pos)[2], uint32_t vi, float radi
     return vi;
 }
 
-/* Tessellated ring between the outer rounded-rect boundary and the inner
- * boundary (inset by per-side widths). Inner radius on each axis clamps
- * to max(0, radius - adjacent_width); a zero-width side produces a
- * zero-area strip segment (visually skipped). Matches CSS/Godot/Skia.
- * Top+bottom widths must still fit bbox height (and left+right the width). */
+/* Outer rounded-rect ring with inner inset by per-side widths (CSS/Godot
+ * parity: zero-width side → zero-area strip, width>radius → corner-filled). */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void emit_rounded_border(nt_resource_t atlas, uint32_t region_index, Clay_BoundingBox bb, Clay_BorderWidth widths, Clay_CornerRadius cr_in, uint32_t color_packed) {
     const float x = bb.x;
@@ -534,7 +470,7 @@ static void emit_rounded_border(nt_resource_t atlas, uint32_t region_index, Clay
     float tr = (cr_in.topRight > 0.0F) ? cr_in.topRight : 0.0F;
     float bl = (cr_in.bottomLeft > 0.0F) ? cr_in.bottomLeft : 0.0F;
     float br = (cr_in.bottomRight > 0.0F) ? cr_in.bottomRight : 0.0F;
-    /* CSS3 border-radius §5.5 proportional clamp -- see emit_rounded_rect. */
+    /* Same CSS3 §5.5 proportional clamp as emit_rounded_rect. */
     float factor = 1.0F;
     if (tl + tr > w) {
         factor = fminf(factor, w / (tl + tr));
@@ -560,22 +496,14 @@ static void emit_rounded_border(nt_resource_t atlas, uint32_t region_index, Clay
         return;
     }
 
-    /* Rounded path supports partial borders: a zero side width collapses
-     * its strip to zero-area triangles (no visible stroke). A side width
-     * larger than the corner radius clamps the inner curve to 0 on that
-     * axis (corner becomes "filled" inside). CSS/Godot/Skia parity. */
-
-    /* Worst case: 4 * (SEG+1) pairs * 2 verts = 56 for SEG=6. */
     float positions[4 * (NT_UI_CORNER_SEGMENTS + 1) * 2][2];
     uint32_t vi = 0;
-
-    /* Quadrant: 2=TL (π → 1.5π), 3=TR (1.5π → 2π), 0=BR (0 → 0.5π), 1=BL (0.5π → π). */
     vi = emit_corner_strip_pairs(positions, vi, tl, x + tl, y + tl, lft, top, x, y, 1.0F, 1.0F, 2U);
     vi = emit_corner_strip_pairs(positions, vi, tr, x + w - tr, y + tr, rgt, top, x + w, y, -1.0F, 1.0F, 3U);
     vi = emit_corner_strip_pairs(positions, vi, br, x + w - br, y + h - br, rgt, bot, x + w, y + h, -1.0F, -1.0F, 0U);
     vi = emit_corner_strip_pairs(positions, vi, bl, x + bl, y + h - bl, lft, bot, x, y + h, 1.0F, -1.0F, 1U);
 
-    /* Triangle strip with wrap. Each pair k: outer at 2k, inner at 2k+1. */
+    /* Triangle strip with wrap: pair k at (2k, 2k+1), connect to pair k+1. */
     const uint32_t pair_count = vi / 2;
     uint16_t indices[4 * (NT_UI_CORNER_SEGMENTS + 1) * 6];
     uint32_t ii = 0;
@@ -618,15 +546,13 @@ static void emit_image(const Clay_RenderCommand *c) {
      * bbox-aligned corner clip. */
     const Clay_CornerRadius cr = c->renderData.image.cornerRadius;
     NT_ASSERT(cr.topLeft == 0.0F && cr.topRight == 0.0F && cr.bottomLeft == 0.0F && cr.bottomRight == 0.0F && "nt_ui IMAGE: cornerRadius unsupported; pre-bake into atlas");
-    /* Async-loading atlas: skip this frame. */
     if (!nt_resource_is_ready(p->atlas)) {
-        return;
+        return; /* async-loading atlas */
     }
 
     const Clay_BoundingBox bb = c->boundingBox;
 
-    /* Clay defaults backgroundColor to {0,0,0,0} = "untinted", not "draw
-     * nothing". Alpha-only check would clobber legitimate transparent tints. */
+    /* Clay {0,0,0,0} backgroundColor means "untinted", not transparent. */
     Clay_Color tint = c->renderData.image.backgroundColor;
     const bool default_untinted = (tint.r == 0.0F && tint.g == 0.0F && tint.b == 0.0F && tint.a == 0.0F);
     const uint32_t col = default_untinted ? 0xFFFFFFFFU : nt_color_pack_clay(tint);
@@ -638,8 +564,7 @@ static void emit_image(const Clay_RenderCommand *c) {
     const float ipu = nt_atlas_get_inverse_pixels_per_unit(p->atlas);
     const float src_w = (float)r->source_w * ipu;
     const float src_h = (float)r->source_h * ipu;
-    /* Guard against degenerate src dim (tombstoned region slipping the
-     * vertex_count gate) -- div-by-zero protection. */
+    /* Div-by-zero guard for tombstoned regions that slipped vertex_count gate. */
     const float sx = (src_w > 0.0F) ? (bb.width / src_w) : bb.width;
     const float sy = (src_h > 0.0F) ? (bb.height / src_h) : bb.height;
 
@@ -654,24 +579,22 @@ static void rebind_sprite_after_flush(const nt_ui_context_t *ctx);
 
 // #region helper_emit_text
 static void emit_text(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
-    /* Sprite cmd is open at entry; text uses a different pipeline. Drain
-     * sprite staging first; rebind at the tail so subsequent RECT/BORDER
-     * /IMAGE has a live cmd. */
+    /* Different pipeline: drain sprite staging first, rebind at the tail. */
     nt_sprite_renderer_flush();
 
     const Clay_TextRenderData *t = &c->renderData.text;
-    NT_ASSERT((uint32_t)t->fontId < NT_UI_MAX_FONTS && "nt_ui TEXT: fontId out of range; check CLAY_TEXT_CONFIG vs NT_UI_MAX_FONTS");
+    NT_ASSERT((uint32_t)t->fontId < NT_UI_MAX_FONTS && "nt_ui TEXT: fontId >= NT_UI_MAX_FONTS");
     nt_font_t font = ctx->fonts[t->fontId];
-    NT_ASSERT(nt_font_valid(font) && "nt_ui TEXT: font slot empty; call nt_ui_set_font(ctx, fontId, font) before declaring TEXT with this fontId");
+    NT_ASSERT(nt_font_valid(font) && "nt_ui TEXT: font slot empty; call nt_ui_set_font first");
 
     nt_text_renderer_set_font(font);
     nt_text_renderer_set_material(ctx->text_material);
 
-    /* Translation-only model -- font size is the scale arg to draw_n. */
+    /* Translation-only; size is the scale arg to draw_n. */
     const float m[16] = {
         1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, c->boundingBox.x, c->boundingBox.y, 0.0F, 1.0F,
     };
-    /* nt_text_renderer expects color in 0..1; Clay stores 0..255. */
+    /* text_renderer expects 0..1; Clay stores 0..255. */
     const float color[4] = {
         t->textColor.r / 255.0F,
         t->textColor.g / 255.0F,
@@ -691,21 +614,14 @@ typedef struct {
     int h;
 } sscissor_rect_t;
 
-/* nt_sprite_renderer_flush closes the current cmd; the next emit would
- * otherwise trip "no open cmd". Same-handle re-open is cheap (caches
- * pipeline + mat_info). */
+/* sprite_flush closed the cmd; reopen for the next emit. */
 static void rebind_sprite_after_flush(const nt_ui_context_t *ctx) { nt_sprite_renderer_set_material(ctx->sprite_material); }
 
 static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, sscissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
     NT_ASSERT((uint32_t)*depth < ctx->max_scissor_depth && "scissor stack overflow; raise desc->max_scissor_depth or restructure nested clip");
 
-    /* clip.horizontal / .vertical flag the axes that should be clipped.
-     * On an unclipped axis we use the target viewport extent so the GL
-     * scissor still has well-defined bounds; the nested-intersect step
-     * below will narrow it to the parent on that axis if there is one.
-     *
-     * floor min / ceil max on the clipped axis: a (int)truncate would
-     * clip subpixel-aligned UI by 1px at the right/bottom edge. */
+    /* Unclipped axis falls back to viewport extent; floor/ceil avoid a 1px
+     * truncation bite at the right/bottom edge on subpixel-aligned UI. */
     const Clay_ClipRenderData *clip = &c->renderData.clip;
     const int vx = (int)target->viewport[0];
     const int vy = (int)target->viewport[1];
@@ -732,9 +648,7 @@ static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c
         hp = vh;
     }
 
-    /* Nested scissor intersects with stack top -- REPLACE semantics would
-     * let an inner widget paint outside its parent's clip (e.g. scroll
-     * content leaking past a modal backdrop). */
+    /* Intersect with parent so inner widgets can't escape outer clip. */
     if (*depth > 0) {
         sscissor_rect_t t = stack[*depth - 1];
         int x2 = (x > t.x) ? x : t.x;
@@ -747,17 +661,14 @@ static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c
         hp = (b2 > y2) ? (b2 - y2) : 0;
     }
 
-    /* MUST flush before changing GL scissor state -- pending staging
-     * written under the prior scissor would otherwise be drawn under
-     * the new one. */
+    /* Flush BEFORE the scissor switch so staging keeps its prior clip. */
     nt_sprite_renderer_flush();
     nt_text_renderer_flush();
 
     stack[(*depth)++] = (sscissor_rect_t){.x = x, .y = y, .w = wp, .h = hp};
 
-    /* Clay's bbox is target-local; shift by viewport.{x,y} and Y-flip
-     * against viewport.h, NOT raw framebuffer height. Without the offset,
-     * split-screen panes and sub-FBO targets clip the wrong pixels. */
+    /* Clay bbox is target-local; shift by viewport.{x,y} and Y-flip against
+     * viewport.h (NOT framebuffer h) so split-screen panes clip correctly. */
     nt_gfx_set_scissor(vx + x, vy + vh - y - hp, wp, hp);
     nt_gfx_set_scissor_enabled(true);
 
@@ -783,9 +694,7 @@ static void scissor_pop(const nt_ui_context_t *ctx, sscissor_rect_t *stack, int 
 // #endregion
 
 // #region helper_emit_custom
-/* Flush both renderers so the handler sees clean state; it may bind its
- * own pipeline. On return, re-bind sprite so the next RECT/BORDER/IMAGE
- * has a live cmd. */
+/* Handler may bind its own pipeline; flush both before, rebind sprite after. */
 static void emit_custom(const nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
     nt_sprite_renderer_flush();
     nt_text_renderer_flush();
@@ -797,9 +706,7 @@ static void emit_custom(const nt_ui_context_t *ctx, const Clay_RenderCommand *c)
 // #endregion
 
 // #region walk
-/* True iff the command participates in same-zIndex batch reordering.
- * SCISSOR_START/END, CUSTOM, and NONE are hard barriers / no-ops -- they
- * always emit in original sequence and never go through the bucket pass. */
+/* SCISSOR/CUSTOM/NONE are hard barriers -- never reordered by layer sort. */
 static bool is_segmentable(Clay_RenderCommandType cmd_type) {
     switch (cmd_type) {
     case CLAY_RENDER_COMMAND_TYPE_RECTANGLE:
@@ -813,12 +720,8 @@ static bool is_segmentable(Clay_RenderCommandType cmd_type) {
 }
 
 static void dispatch_command(nt_ui_context_t *ctx, const Clay_RenderCommand *c, sscissor_rect_t *scissor_stack, int *depth, const nt_ui_target_t *target) {
-    /* emit_text drains pending sprite at its top; mirror that here so a
-     * sprite-backed command after a TEXT sees an empty text staging. Without
-     * this, text staging persists until walker exit (flushes sprite then
-     * text in that order) and a sprite-after-text declared between two TEXTs
-     * would render UNDER the text, violating declaration-order semantics.
-     * Empty-staging text_flush is a cheap no-op (early-returns on glyph_count==0). */
+    /* Sprite cmds drain pending text first (mirror of emit_text's sprite_flush)
+     * so declaration order survives text→sprite transitions. No-op if empty. */
     switch (c->commandType) {
     case CLAY_RENDER_COMMAND_TYPE_NONE:
         return;
@@ -858,23 +761,17 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(target != NULL && "nt_ui_walk: target must be non-NULL");
     NT_ASSERT(!ctx->in_frame && "nt_ui_walk: ctx is mid-frame (call nt_ui_end first)");
     NT_ASSERT(ctx->frozen_cmds.internalArray != NULL && "nt_ui_walk: frozen_cmds not populated (call nt_ui_end before walk)");
-    /* w/h > 0: scissor math `vh - y - hp` underflows negative when
-     * vh==0 (GL undefined). Origin x/y may be zero. */
     NT_ASSERT(isfinite(target->viewport[0]) && isfinite(target->viewport[1]) && isfinite(target->viewport[2]) && isfinite(target->viewport[3]) && "nt_ui_walk: target->viewport must be finite");
-    NT_ASSERT(target->viewport[0] >= 0.0F && target->viewport[1] >= 0.0F && "nt_ui_walk: target->viewport origin (x,y) must be non-negative");
+    NT_ASSERT(target->viewport[0] >= 0.0F && target->viewport[1] >= 0.0F && "nt_ui_walk: target->viewport origin must be non-negative");
     NT_ASSERT(target->viewport[2] >= 0.0F && target->viewport[3] >= 0.0F && "nt_ui_walk: target->viewport (w,h) must be non-negative");
 
-    /* Drain caller-side pending geometry unconditionally -- BEFORE the
-     * zero-viewport early-return so leaked staging from a prior scene
-     * can't survive a minimized frame and render later under unrelated
-     * GL state. Both flushes early-out on empty staging. */
+    /* Drain prior staging BEFORE the zero-viewport early return so leaked
+     * geometry can't survive a minimized frame. Both no-op on empty. */
     nt_sprite_renderer_flush();
     nt_text_renderer_flush();
 
-    /* Zero-size viewport is a legitimate runtime state (minimized browser
-     * tab, mobile orientation transition). Silent no-op rather than assert,
-     * but reset per-walk stats so callers don't read stale values from the
-     * previous non-empty walk. */
+    /* Zero viewport (minimized tab, orientation change): silent no-op,
+     * reset per-walk stats so callers don't read stale values. */
     if (target->viewport[2] == 0.0F || target->viewport[3] == 0.0F) {
         ctx->last_walk_draw_call_delta = 0;
         ctx->last_walk_element_count = 0;
@@ -888,29 +785,22 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(ctx->sprite_material.id != 0 && "nt_ui_set_sprite_material(ctx,...) required before nt_ui_walk");
     NT_ASSERT(ctx->text_material.id != 0 && "nt_ui_set_text_material(ctx,...) required before nt_ui_walk");
 
-    /* On C stack, NOT in ctx, so multi-walk against the same ctx doesn't
-     * share state. VLA sized per ctx (max_scissor_depth from create desc). */
+    /* VLA per-walk -- multi-walk on same ctx doesn't share scissor state. */
     sscissor_rect_t scissor_stack[ctx->max_scissor_depth];
     int depth = 0;
 
-    /* Snapshot AFTER the entry flushes so the per-walk delta excludes the
+    /* Snapshot AFTER entry flushes so the per-walk delta excludes the
      * caller's drained geometry. */
     const uint32_t calls_at_entry = nt_gfx_get_frame_draw_calls();
 
     nt_gfx_set_viewport((int)target->viewport[0], (int)target->viewport[1], (int)target->viewport[2], (int)target->viewport[3]);
     nt_gfx_set_scissor_enabled(false);
 
-    /* Sprite material bound up-front (most commands need it); text binds
-     * lazily inside emit_text just before draw_n. */
+    /* Sprite material bound up-front; text binds lazily in emit_text. */
     nt_sprite_renderer_set_material(ctx->sprite_material);
 
-    /* Segment-aware dispatch -- see nt_ui_walk header doc for contract.
-     * Within a segment (same z, no SCISSOR/CUSTOM barrier crossed):
-     *   Bitmask Multipass layer dispatch (stable, zero persistent memory).
-     *   1) Scan segment commands (N), record active layers in active_layers[8] bitmask.
-     *   2) For each set layer bit in the mask, scan the segment (N) sequentially
-     *      and dispatch matching commands.
-     *   O(N + 8 + L_active * N) total per segment. Memory: 32 bytes on stack, 0 in arena. */
+    /* Per segment: bitmask of active layers in 8 uint32s (256 bits), then
+     * one pass per set bit dispatching matching cmds in declaration order. */
     const Clay_RenderCommandArray *arr = &ctx->frozen_cmds;
 #ifdef NT_TEST_ACCESS
     uint32_t unlayered_count = 0U;
@@ -973,10 +863,9 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(depth == 0 && "unbalanced scissor stack at walk exit");
     nt_gfx_set_scissor_enabled(false);
 
-    /* Guard underflow if a CUSTOM handler reset frame stats mid-walk --
-     * unsigned wrap would produce a spurious huge delta. */
+    /* Underflow guard: CUSTOM handler that resets gfx counters would wrap. */
     const uint32_t calls_after = nt_gfx_get_frame_draw_calls();
-    NT_ASSERT(calls_after >= calls_at_entry && "nt_ui_walk: frame draw-call counter went backwards (CUSTOM handler reset stats?)");
+    NT_ASSERT(calls_after >= calls_at_entry && "nt_ui_walk: frame draw-call counter went backwards");
     ctx->last_walk_draw_call_delta = calls_after - calls_at_entry;
     ctx->last_walk_element_count = (uint32_t)arr->length;
 #ifdef NT_TEST_ACCESS
@@ -993,15 +882,11 @@ void nt_ui_set_atlas_white_region(nt_ui_context_t *ctx, nt_resource_t atlas, uin
     NT_ASSERT(atlas.id != 0 && "nt_ui_set_atlas_white_region: invalid atlas handle");
     NT_ASSERT(nt_resource_is_ready(atlas) && "nt_ui_set_atlas_white_region: atlas must be READY");
     const nt_texture_region_t *r = nt_atlas_get_region(atlas, white_region_idx);
-    NT_ASSERT(r != NULL && r->vertex_count > 0U && "nt_ui_set_atlas_white_region: white region missing / tombstoned (mis-baked atlas)");
-    /* emit_screen_rect scales by mat4(w,h) on cached_pos {0,1}x{0,1}. */
+    NT_ASSERT(r != NULL && r->vertex_count > 0U && "nt_ui_set_atlas_white_region: white region missing / tombstoned");
+    /* emit_screen_rect's mat4(w,h) assumes cached_pos {0,1}x{0,1} -- requires
+     * 1x1 source AND PPU=1 (non-1 PPU shrinks every UI rect by 1/PPU). */
     NT_ASSERT(r->source_w == 1 && r->source_h == 1 && "nt_ui_set_atlas_white_region: white region must be 1x1 source");
-    /* cached_pos for the white quad is local_pos * ipu; emit_screen_rect
-     * expects ipu==1 so its mat4(w,h) scale lands at exactly w x h world
-     * units. A non-1 PPU atlas (e.g. shared game-sprite atlas with PPU=100)
-     * would shrink every UI rect by that factor -- use a dedicated UI atlas
-     * with default PPU. */
-    NT_ASSERT(nt_atlas_get_inverse_pixels_per_unit(atlas) == 1.0F && "nt_ui_set_atlas_white_region: atlas must have PPU=1 (no PPU metadata); use a dedicated UI atlas");
+    NT_ASSERT(nt_atlas_get_inverse_pixels_per_unit(atlas) == 1.0F && "nt_ui_set_atlas_white_region: atlas must have PPU=1; use a dedicated UI atlas");
     ctx->atlas = atlas;
     ctx->white_region = white_region_idx;
 }
@@ -1023,7 +908,7 @@ void nt_ui_set_text_material(nt_ui_context_t *ctx, nt_material_t text_material) 
 void nt_ui_set_custom_handler(nt_ui_context_t *ctx, nt_ui_custom_handler_t fn, void *userdata) {
     NT_ASSERT(ctx != NULL && "nt_ui_set_custom_handler: ctx must be non-NULL");
     NT_ASSERT(!ctx->in_frame && "nt_ui_set_custom_handler: must be called outside begin/end");
-    /* NULL fn is allowed -- legitimate "reserved space" pattern. */
+    /* NULL fn is legal (reserved-slot pattern). */
     ctx->custom_fn = fn;
     ctx->custom_user = userdata;
 }

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -267,10 +267,6 @@ static void emit_image(const Clay_RenderCommand *c) {
     const nt_ui_image_payload_t *p = (const nt_ui_image_payload_t *)c->renderData.image.imageData;
     NT_ASSERT(p != NULL && "nt_ui IMAGE: imageData must point to nt_ui_image_payload_t");
     NT_ASSERT(p->atlas.id != 0 && "nt_ui IMAGE payload: invalid atlas handle (zero id)");
-    /* Reserved field -- caller writing into it indicates a feature
-     * expectation we don't yet meet. Assert until slice9 emit lands. */
-    NT_ASSERT(p->slice9_lrtb[0] == 0 && p->slice9_lrtb[1] == 0 && p->slice9_lrtb[2] == 0 && p->slice9_lrtb[3] == 0 && "nt_ui IMAGE payload: slice9_lrtb is reserved");
-
     /* Async-loading atlas is a legitimate runtime state -- skip this
      * frame, next frame will draw. */
     if (!nt_resource_is_ready(p->atlas)) {
@@ -533,18 +529,6 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
      * rejects both NaN and infinity; raw `>= 0.0F` lets +inf through. */
     NT_ASSERT(isfinite(target->viewport[0]) && isfinite(target->viewport[1]) && isfinite(target->viewport[2]) && isfinite(target->viewport[3]) && "nt_ui_walk: target->viewport must be finite");
     NT_ASSERT(target->viewport[0] >= 0.0F && target->viewport[1] >= 0.0F && target->viewport[2] >= 0.0F && target->viewport[3] >= 0.0F && "nt_ui_walk: target->viewport must be non-negative");
-    /* projection is reserved -- caller MUST keep ALL 16 floats zero. The
-     * walker does not consume the field; if a later phase grows the walker
-     * to upload Globals UBO from it, callers who wrote non-zero off-diagonal
-     * values expecting "old" behaviour would silently get the wrong matrix. */
-    bool _projection_all_zero = true;
-    for (int _pi = 0; _pi < 16; ++_pi) {
-        if (target->projection[_pi] != 0.0F) {
-            _projection_all_zero = false;
-            break;
-        }
-    }
-    NT_ASSERT(_projection_all_zero && "nt_ui_walk: target->projection is reserved -- must be all-zero (caller owns Globals UBO)");
     NT_ASSERT(ctx->atlas.id != 0 && "nt_ui_set_atlas_white_region(ctx,...) required before nt_ui_walk");
     NT_ASSERT(nt_resource_is_ready(ctx->atlas) && "nt_ui_walk: ctx atlas must be READY");
     NT_ASSERT(ctx->sprite_material.id != 0 && "nt_ui_set_sprite_material(ctx,...) required before nt_ui_walk");

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -52,21 +52,26 @@ static nt_ui_context_t *g_nt_ui_inframe_ctx = NULL;
 // #endregion
 
 // #region clay_error_handler
-/* Returns true if a Clay error code is a recoverable caller-author bug
- * (Clay safely no-ops it). Everything else is treated as a fatal invariant
- * violation -- arena too small, missing measure callback, internal Clay
- * bug, or an unknown type from a future Clay version. Defaulting unknown
- * to fatal prevents a Clay upgrade from silently demoting new invariants. */
+/* Returns true if a Clay error code is a recoverable visual bug (Clay
+ * safely no-ops it; the UI still renders, just with the buggy element
+ * missing or mis-styled). Everything else -- including capacity overflows
+ * that SILENTLY TRUNCATE the UI -- is a fatal invariant violation.
+ * Defaulting unknown to fatal prevents a future Clay version from silently
+ * demoting new invariants. */
 static bool nt_ui_clay_error_is_recoverable(Clay_ErrorType type) {
     switch (type) {
-    case CLAY_ERROR_TYPE_ELEMENTS_CAPACITY_EXCEEDED:
-    case CLAY_ERROR_TYPE_TEXT_MEASUREMENT_CAPACITY_EXCEEDED:
     case CLAY_ERROR_TYPE_DUPLICATE_ID:
     case CLAY_ERROR_TYPE_FLOATING_CONTAINER_PARENT_NOT_FOUND:
     case CLAY_ERROR_TYPE_PERCENTAGE_OVER_1:
         return true;
     case CLAY_ERROR_TYPE_TEXT_MEASUREMENT_FUNCTION_NOT_PROVIDED:
     case CLAY_ERROR_TYPE_ARENA_CAPACITY_EXCEEDED:
+    /* Capacity exceeded silently truncates the UI -- caller declared
+     * more than Clay's internal arrays could hold. That's a sizing bug
+     * the developer must fix (raise Clay's limits or simplify the UI),
+     * not a runtime condition to tolerate. */
+    case CLAY_ERROR_TYPE_ELEMENTS_CAPACITY_EXCEEDED:
+    case CLAY_ERROR_TYPE_TEXT_MEASUREMENT_CAPACITY_EXCEEDED:
     case CLAY_ERROR_TYPE_INTERNAL_ERROR:
         return false;
     }

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -192,6 +192,7 @@ void nt_ui_set_font(nt_ui_context_t *ctx, uint16_t font_id, nt_font_t font) {
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, const nt_pointer_t *mouse) {
     NT_ASSERT(ctx != NULL && "nt_ui_begin: ctx must be non-NULL");
+    NT_ASSERT(Clay__MeasureText == nt_ui_measure_text_cb && "nt_ui_begin: nt_ui_module_init() must be called before begin");
     NT_ASSERT(mouse != NULL && "nt_ui_begin: mouse must be non-NULL");
     /* isfinite() rejects NaN + +-inf which `>= 0.0F` alone lets through. */
     NT_ASSERT(isfinite(screen_w) && screen_w >= 0.0F && "nt_ui_begin: screen_w must be finite and non-negative");

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -288,10 +288,16 @@ static void emit_image(const Clay_RenderCommand *c) {
     }
 
     /* Payload's atlas is independent of the walker's white-region atlas.
-     * Validate it here so the failure points at the IMAGE call site, not
-     * deep inside nt_atlas_get_region or the sprite renderer's emit. */
-    NT_ASSERT(p->atlas.id != 0 && "nt_ui IMAGE payload: invalid atlas handle");
-    NT_ASSERT(nt_resource_is_ready(p->atlas) && "nt_ui IMAGE payload: atlas not READY");
+     *
+     * id == 0 is a caller bug -- never a legitimate runtime state -- so
+     * assert. nt_resource_is_ready == false IS a legitimate state when an
+     * image atlas is still loading asynchronously; the IMAGE element just
+     * draws nothing this frame and the UI continues. AGENTS.md "runtime
+     * is a safety net" applies. */
+    NT_ASSERT(p->atlas.id != 0 && "nt_ui IMAGE payload: invalid atlas handle (zero id)");
+    if (!nt_resource_is_ready(p->atlas)) {
+        return; /* atlas still loading -- silent no-op, render next frame */
+    }
 
     const Clay_BoundingBox bb = c->boundingBox;
 

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -519,9 +519,9 @@ static void emit_image(const Clay_RenderCommand *c) {
     const float ipu = nt_atlas_get_inverse_pixels_per_unit(p->atlas);
     const float src_w = (float)r->source_w * ipu;
     const float src_h = (float)r->source_h * ipu;
-    /* Div-by-zero guard for degenerate regions. */
-    const float sx = (src_w > 0.0F) ? (bb.width / src_w) : bb.width;
-    const float sy = (src_h > 0.0F) ? (bb.height / src_h) : bb.height;
+    NT_ASSERT(src_w > 0.0F && src_h > 0.0F && "nt_ui IMAGE: atlas region has zero source dimensions (broken atlas data)");
+    const float sx = bb.width / src_w;
+    const float sy = bb.height / src_h;
 
     const float m[16] = {
         sx, 0.0F, 0.0F, 0.0F, 0.0F, sy, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, bb.x, bb.y, 0.0F, 1.0F,

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -119,7 +119,7 @@ size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc) {
     NT_ASSERT(desc->max_elements > 0U && "nt_ui_min_arena_size: desc->max_elements must be > 0");
     NT_ASSERT(desc->max_elements <= UINT16_MAX && "nt_ui_min_arena_size: desc->max_elements exceeds uint16 sorted-index range");
     NT_ASSERT(desc->max_scissor_depth > 0U && "nt_ui_min_arena_size: desc->max_scissor_depth must be > 0");
-    NT_ASSERT(desc->max_scissor_depth <= 256U && "nt_ui_min_arena_size: desc->max_scissor_depth > 256 (likely uninit garbage; walker stack VLA would be huge)");
+    NT_ASSERT(desc->max_scissor_depth <= NT_UI_WALKER_SCISSOR_DEPTH_CAP && "nt_ui_min_arena_size: desc->max_scissor_depth > cap");
     /* Clay_SetMaxElementCount(N) also writes defaultMaxMeasureTextWordCacheCount
      * = N*2 (clay.h:4332); restore via the same call so both come back. */
     Clay_Context *saved_ctx = Clay_GetCurrentContext();
@@ -578,12 +578,12 @@ typedef struct {
     int y;
     int w;
     int h;
-} sscissor_rect_t;
+} scissor_rect_t;
 
 static void rebind_sprite_after_flush(const nt_ui_context_t *ctx) { nt_sprite_renderer_set_material(ctx->sprite_material); }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, sscissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
+static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, scissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
     NT_ASSERT((uint32_t)*depth < ctx->max_scissor_depth && "scissor stack overflow; raise desc->max_scissor_depth or restructure nested clip");
 
     /* Unclipped axis falls back to viewport; floor/ceil avoid 1px right/bottom bite. */
@@ -616,7 +616,7 @@ static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c
 
     /* Intersect with parent so inner widgets can't escape outer clip. */
     if (*depth > 0) {
-        sscissor_rect_t t = stack[*depth - 1];
+        scissor_rect_t t = stack[*depth - 1];
         int x2 = (x > t.x) ? x : t.x;
         int y2 = (y > t.y) ? y : t.y;
         int r2 = ((x + wp) < (t.x + t.w)) ? (x + wp) : (t.x + t.w);
@@ -631,7 +631,7 @@ static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c
     nt_sprite_renderer_flush();
     nt_text_renderer_flush();
 
-    stack[(*depth)++] = (sscissor_rect_t){.x = x, .y = y, .w = wp, .h = hp};
+    stack[(*depth)++] = (scissor_rect_t){.x = x, .y = y, .w = wp, .h = hp};
 
     /* Y-flip against viewport.h (NOT framebuffer h) for split-screen panes. */
     nt_gfx_set_scissor(vx + x, vy + vh - y - hp, wp, hp);
@@ -640,7 +640,7 @@ static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c
     rebind_sprite_after_flush(ctx);
 }
 
-static void scissor_pop(const nt_ui_context_t *ctx, sscissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
+static void scissor_pop(const nt_ui_context_t *ctx, scissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
     NT_ASSERT(*depth > 0 && "scissor underflow");
     nt_sprite_renderer_flush();
     nt_text_renderer_flush();
@@ -648,7 +648,7 @@ static void scissor_pop(const nt_ui_context_t *ctx, sscissor_rect_t *stack, int 
     if (*depth == 0) {
         nt_gfx_set_scissor_enabled(false);
     } else {
-        sscissor_rect_t r = stack[*depth - 1];
+        scissor_rect_t r = stack[*depth - 1];
         const int vx = (int)target->viewport[0];
         const int vy = (int)target->viewport[1];
         const int vh = (int)target->viewport[3];
@@ -684,7 +684,7 @@ static bool is_segmentable(Clay_RenderCommandType cmd_type) {
     }
 }
 
-static void dispatch_command(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, sscissor_rect_t *scissor_stack, int *depth, const nt_ui_target_t *target) {
+static void dispatch_command(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, scissor_rect_t *scissor_stack, int *depth, const nt_ui_target_t *target) {
     /* Sprite cmds drain pending text first -- preserves declaration order
      * across text→sprite transitions. No-op on empty staging. */
     switch (c->commandType) {
@@ -749,8 +749,7 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(ctx->sprite_material.id != 0 && "nt_ui_set_sprite_material(ctx,...) required before nt_ui_walk");
     NT_ASSERT(ctx->text_material.id != 0 && "nt_ui_set_text_material(ctx,...) required before nt_ui_walk");
 
-    /* Per-walk VLA so multi-walk on same ctx doesn't share scissor state. */
-    sscissor_rect_t scissor_stack[ctx->max_scissor_depth];
+    scissor_rect_t scissor_stack[NT_UI_WALKER_SCISSOR_DEPTH_CAP];
     int depth = 0;
 
     /* AFTER entry flush so per-walk delta excludes caller's drained geometry. */

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -497,6 +497,11 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     /* Viewport must be non-negative -- the cast to int below would
      * otherwise turn NaN / -inf into garbage GL state. */
     NT_ASSERT(target->viewport[0] >= 0.0F && target->viewport[1] >= 0.0F && target->viewport[2] >= 0.0F && target->viewport[3] >= 0.0F && "nt_ui_walk: target->viewport must be non-negative");
+    /* projection is reserved -- caller MUST keep it all-zero. The walker
+     * does not consume it; if Phase 5x grows the walker to upload Globals
+     * UBO from this field, callers writing into it expecting "old"
+     * behaviour would silently get the wrong projection. */
+    NT_ASSERT(target->projection[0] == 0.0F && target->projection[5] == 0.0F && target->projection[10] == 0.0F && target->projection[15] == 0.0F && "nt_ui_walk: target->projection is reserved -- must be all-zero (caller owns Globals UBO)");
     NT_ASSERT(ctx->atlas.id != 0 && "nt_ui_set_atlas_white_region(ctx,...) required before nt_ui_walk");
     NT_ASSERT(nt_resource_is_ready(ctx->atlas) && "nt_ui_walk: ctx atlas must be READY");
     NT_ASSERT(ctx->sprite_material.id != 0 && "nt_ui_set_sprite_material(ctx,...) required before nt_ui_walk");

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -146,11 +146,7 @@ void nt_ui_set_font(nt_ui_context_t *ctx, uint16_t font_id, nt_font_t font) {
 void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, const nt_pointer_t *mouse) {
     NT_ASSERT(ctx != NULL && "nt_ui_begin: ctx must be non-NULL");
     NT_ASSERT(mouse != NULL && "nt_ui_begin: mouse must be non-NULL");
-    /* Layout dimensions go straight into Clay; NaN / +-inf / negative
-     * would silently corrupt layout calculations downstream. isfinite()
-     * rejects both NaN and infinity in one call -- the older `x == x`
-     * idiom only catches NaN. Match the boundary check nt_ui_walk
-     * applies to target->viewport. */
+    /* isfinite() rejects NaN + +-inf; raw `>= 0.0F` lets +inf through. */
     NT_ASSERT(isfinite(screen_w) && screen_w >= 0.0F && "nt_ui_begin: screen_w must be finite and non-negative");
     NT_ASSERT(isfinite(screen_h) && screen_h >= 0.0F && "nt_ui_begin: screen_h must be finite and non-negative");
     NT_ASSERT(g_nt_ui_inframe_ctx == NULL && "nt_ui_begin: another ctx is mid-frame");
@@ -232,11 +228,8 @@ static void emit_border(const nt_ui_context_t *ctx, const Clay_RenderCommand *c)
     const nt_resource_t atlas = ctx->atlas;
     const uint32_t wr = ctx->white_region;
 
-    /* Clay's BorderWidth fields are uint16_t and unvalidated -- caller could
-     * set top+bottom > bbox.height (or left+right > bbox.width) and the
-     * left/right edge geometry below would emit a negative-height rect.
-     * Fail early on that contract violation rather than feeding garbage to
-     * the sprite renderer. */
+    /* Clay borders are uint16_t -- top+bot > bb.height (or lft+rgt >
+     * bb.width) would emit a negative-size rect downstream. */
     const float top = (float)b->width.top;
     const float bot = (float)b->width.bottom;
     const float lft = (float)b->width.left;
@@ -525,10 +518,8 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
      * this guard, a create -> walk skipping begin/end would be a silent
      * no-op. */
     NT_ASSERT(ctx->frozen_cmds.internalArray != NULL && "nt_ui_walk: frozen_cmds not populated (call nt_ui_end before walk)");
-    /* Viewport must be finite and strictly positive in width/height --
-     * GL accepts zero dimensions (no draws) but downstream scissor math
-     * `vh - y - hp` underflows to negative when vh == 0, which is GL
-     * undefined. Origin x/y may be zero. */
+    /* w/h > 0: scissor math `vh - y - hp` underflows negative when
+     * vh==0 (GL undefined). Origin x/y may be zero. */
     NT_ASSERT(isfinite(target->viewport[0]) && isfinite(target->viewport[1]) && isfinite(target->viewport[2]) && isfinite(target->viewport[3]) && "nt_ui_walk: target->viewport must be finite");
     NT_ASSERT(target->viewport[0] >= 0.0F && target->viewport[1] >= 0.0F && "nt_ui_walk: target->viewport origin (x,y) must be non-negative");
     NT_ASSERT(target->viewport[2] > 0.0F && target->viewport[3] > 0.0F && "nt_ui_walk: target->viewport (w,h) must be > 0 (zero-size walk is not a supported no-op)");

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -26,6 +26,7 @@ _Static_assert(CLAY_PINNED_MAJOR == 0 && CLAY_PINNED_MINOR == 14, "Clay v0.14 re
 
 #include "core/nt_align.h"
 #include "core/nt_assert.h"
+#include "core/nt_clamp.h"
 #include "log/nt_log.h"
 #include "memory/nt_mem_scratch.h"
 #include "ui/nt_ui_internal.h"
@@ -226,23 +227,12 @@ void nt_ui_end(nt_ui_context_t *ctx) {
 // #endregion
 
 // #region helpers_color_pack
-/* Clay's RGBA floats are unclamped; saturate then round-to-nearest so slow
- * fades don't step on integer boundaries. Upper clamp ensures v+0.5F < 256. */
-static inline uint8_t clamp_u8(float v) {
-    if (v <= 0.0F) {
-        return 0U;
-    }
-    if (v >= 255.0F) {
-        return 255U;
-    }
-    return (uint8_t)(v + 0.5F);
-}
-
+/* Clay's RGBA floats are 0..255 unclamped; saturate via nt_clamp_f_to_u8. */
 static inline uint32_t nt_color_pack_clay(Clay_Color c) {
-    uint32_t r = clamp_u8(c.r);
-    uint32_t g = clamp_u8(c.g);
-    uint32_t b = clamp_u8(c.b);
-    uint32_t a = clamp_u8(c.a);
+    uint32_t r = nt_clamp_f_to_u8(c.r);
+    uint32_t g = nt_clamp_f_to_u8(c.g);
+    uint32_t b = nt_clamp_f_to_u8(c.b);
+    uint32_t a = nt_clamp_f_to_u8(c.a);
     return r | (g << 8) | (b << 16) | (a << 24);
 }
 // #endregion

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -23,3 +23,178 @@
 #include "clay.h"
 
 _Static_assert(CLAY_PINNED_MAJOR == 0 && CLAY_PINNED_MINOR == 14, "Clay v0.14 required -- deps/clay/VERSION disagrees with the engine pin");
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "core/nt_assert.h"
+#include "log/nt_log.h"
+#include "ui/nt_ui_internal.h"
+
+// #region module_state
+/* g_nt_ui_inframe_ctx -- module-level pointer enforcing the multi-context
+ * invariant (D-52-12). Exactly one ctx may be in-frame at a time; nt_ui_begin
+ * asserts this is NULL on entry and assigns ctx; nt_ui_end clears it. */
+static nt_ui_context_t *g_nt_ui_inframe_ctx = NULL;
+
+/* g_nt_ui_measure_wired -- Clay_SetMeasureTextFunction is a global hook.
+ * We wire it lazily on first create_context. Plan 03 fills the body. */
+static bool g_nt_ui_measure_wired = false;
+// #endregion
+
+// #region clay_error_handler
+/* Forward a Clay error to NT_LOG_WARN. errorText is a Clay_String with
+ * .length + .chars (not necessarily NUL-terminated). */
+static void nt_ui_clay_error_cb(Clay_ErrorData err) {
+    int len = err.errorText.length;
+    const char *chars = err.errorText.chars;
+    if (chars == NULL || len <= 0) {
+        NT_LOG_WARN("clay error type=%d (no text)", (int)err.errorType);
+        return;
+    }
+    NT_LOG_WARN("clay error type=%d: %.*s", (int)err.errorType, len, chars);
+}
+// #endregion
+
+// #region measure_cb_stub
+/* Clay measure callback stub. Plan 03 fills the body (look up font by
+ * config->fontId in g_nt_ui_inframe_ctx->fonts and call nt_font_measure_n). */
+static Clay_Dimensions nt_ui_measure_text_cb(Clay_StringSlice text, Clay_TextElementConfig *config, void *user_data) {
+    (void)text;
+    (void)config;
+    (void)user_data;
+    return (Clay_Dimensions){.width = 0.0f, .height = 0.0f};
+}
+// #endregion
+
+// #region create_destroy
+/* Pattern 2 from 52-RESEARCH.md: caller-owned arena, ctx struct lives in
+ * the first ~256 bytes (cache-line aligned), Clay arena takes the rest. */
+static size_t nt_ui_ctx_size_aligned(void) { return (sizeof(struct nt_ui_context) + 63u) & ~(size_t)63u; }
+
+size_t nt_ui_min_arena_size(void) { return nt_ui_ctx_size_aligned() + (size_t)Clay_MinMemorySize(); }
+
+nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size) {
+    NT_ASSERT(arena != NULL && "nt_ui_create_context: arena must be non-NULL");
+    NT_ASSERT(((uintptr_t)arena & 7u) == 0u && "nt_ui_create_context: arena must be 8-byte aligned");
+    NT_ASSERT(arena_size >= nt_ui_min_arena_size() && "nt_ui_create_context: arena_size < nt_ui_min_arena_size()");
+
+    nt_ui_context_t *ctx = (nt_ui_context_t *)arena;
+    memset(ctx, 0, sizeof(*ctx));
+
+    const size_t ctx_size = nt_ui_ctx_size_aligned();
+    void *clay_mem = (char *)arena + ctx_size;
+    const size_t clay_size = arena_size - ctx_size;
+
+    ctx->arena_base = arena;
+    ctx->arena_size = arena_size;
+    ctx->in_frame = false;
+    ctx->clay_arena = Clay_CreateArenaWithCapacityAndMemory(clay_size, clay_mem);
+    ctx->clay = Clay_Initialize(ctx->clay_arena, (Clay_Dimensions){.width = 1.0f, .height = 1.0f}, (Clay_ErrorHandler){.errorHandlerFunction = nt_ui_clay_error_cb, .userData = ctx});
+
+    /* Clay_SetMeasureTextFunction is a global hook -- wire it once. Plan 03
+     * fills the callback body with font-registry lookup + nt_font_measure_n. */
+    if (!g_nt_ui_measure_wired) {
+        Clay_SetMeasureTextFunction(nt_ui_measure_text_cb, NULL);
+        g_nt_ui_measure_wired = true;
+    }
+
+    return ctx;
+}
+
+void nt_ui_destroy_context(nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_destroy_context: ctx must be non-NULL");
+    NT_ASSERT(!ctx->in_frame && "nt_ui_destroy_context: ctx is mid-frame (call nt_ui_end first)");
+
+    /* If this context is the in-frame ctx for any reason, clear the global
+     * (defensive -- assert above should prevent this). */
+    if (g_nt_ui_inframe_ctx == ctx) {
+        g_nt_ui_inframe_ctx = NULL;
+    }
+
+    /* Caller owns the arena memory -- only zero the ctx struct portion. */
+    memset(ctx, 0, sizeof(*ctx));
+}
+// #endregion
+
+// #region font_registry
+void nt_ui_set_font(nt_ui_context_t *ctx, uint16_t font_id, nt_font_t font) {
+    NT_ASSERT(ctx != NULL && "nt_ui_set_font: ctx must be non-NULL");
+    NT_ASSERT(font_id < NT_UI_MAX_FONTS && "nt_ui_set_font: font_id out of range (raise NT_UI_MAX_FONTS)");
+    ctx->fonts[font_id] = font;
+}
+// #endregion
+
+// #region begin_end
+void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, const nt_pointer_t *mouse) {
+    NT_ASSERT(ctx != NULL && "nt_ui_begin: ctx must be non-NULL");
+    NT_ASSERT(mouse != NULL && "nt_ui_begin: mouse must be non-NULL");
+    NT_ASSERT(g_nt_ui_inframe_ctx == NULL && "nt_ui_begin: another ctx is mid-frame (D-52-12 violation)");
+    NT_ASSERT(!ctx->in_frame && "nt_ui_begin: ctx already in_frame (CP-03 footgun)");
+
+    /* FIRST executable: switch Clay's global current-context pointer to
+     * this ctx's Clay context (UI-04 / CP-03 prevention). Every Clay call
+     * below operates on ctx->clay. */
+    Clay_SetCurrentContext(ctx->clay);
+
+    ctx->in_frame = true;
+    g_nt_ui_inframe_ctx = ctx;
+
+    Clay_SetLayoutDimensions((Clay_Dimensions){.width = screen_w, .height = screen_h});
+
+    /* Pointer-state wiring is Plan 03 territory (D-52-16). */
+    (void)mouse;
+
+    Clay_BeginLayout();
+}
+
+void nt_ui_end(nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_end: ctx must be non-NULL");
+    NT_ASSERT(ctx->in_frame && "nt_ui_end: ctx is not in_frame (begin was not called)");
+    NT_ASSERT(ctx == g_nt_ui_inframe_ctx && "nt_ui_end: ctx mismatch with module in-frame ctx");
+
+    ctx->frozen_cmds = Clay_EndLayout();
+    ctx->in_frame = false;
+    g_nt_ui_inframe_ctx = NULL;
+}
+// #endregion
+
+// #region walk_stub
+/* Walker body lives in Plan 04. Phase 52 ships entry-guard asserts only. */
+void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
+    NT_ASSERT(ctx != NULL && "nt_ui_walk: ctx must be non-NULL");
+    NT_ASSERT(target != NULL && "nt_ui_walk: target must be non-NULL");
+    NT_ASSERT(!ctx->in_frame && "nt_ui_walk: ctx is mid-frame (call nt_ui_end first)");
+    /* Plan 04 fills: viewport setup, frozen_cmds iteration, dispatch. */
+}
+// #endregion
+
+// #region setters_stub
+/* Setter bodies land in Plan 04 next to the walker code that consumes
+ * them. Phase 52 declares them in the public header (Revision Issue 1
+ * locks symmetric sprite + text material setters). */
+void nt_ui_set_atlas_white_region(nt_resource_t atlas, uint32_t white_region_idx) {
+    (void)atlas;
+    (void)white_region_idx;
+}
+
+void nt_ui_set_sprite_material(nt_material_t sprite_material) { (void)sprite_material; }
+
+void nt_ui_set_text_material(nt_material_t text_material) { (void)text_material; }
+
+void nt_ui_set_custom_handler(nt_ui_custom_handler_t fn, void *userdata) {
+    (void)fn;
+    (void)userdata;
+}
+// #endregion
+
+// #region test_access
+#ifdef NT_UI_TEST_ACCESS
+nt_ui_context_t *nt_ui_test_inframe_ctx(void) { return g_nt_ui_inframe_ctx; }
+
+/* Plan 05 fills the body. */
+uint32_t nt_ui_test_last_walk_draw_call_delta(void) { return 0u; }
+uint32_t nt_ui_test_last_walk_element_count(void) { return 0u; }
+#endif /* NT_UI_TEST_ACCESS */
+// #endregion

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -321,6 +321,9 @@ static void emit_image(const Clay_RenderCommand *c) {
 }
 // #endregion
 
+/* Forward declaration -- defined alongside the scissor stack helpers. */
+static void rebind_sprite_after_flush(void);
+
 // #region helper_emit_text
 /* D-52-18: TEXT command emit. Flushes sprite renderer first (different
  * material/pipeline boundary), then binds the text font + text material
@@ -329,15 +332,18 @@ static void emit_text(nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
     /* State boundary: sprite material/pipeline must flush before text
      * binds its own pipeline. Auto-flush on font/material change happens
      * inside the text renderer, but the sprite renderer's own staging
-     * needs to drain here. */
+     * needs to drain here. The matching sprite-rebind happens at the
+     * tail so the next RECT/BORDER/IMAGE has a live cmd. */
     nt_sprite_renderer_flush();
 
     const Clay_TextRenderData *t = &c->renderData.text;
     if ((uint32_t)t->fontId >= NT_UI_MAX_FONTS) {
+        rebind_sprite_after_flush();
         return;
     }
     nt_font_t font = ctx->fonts[t->fontId];
     if (!nt_font_valid(font)) {
+        rebind_sprite_after_flush();
         return;
     }
 
@@ -359,6 +365,7 @@ static void emit_text(nt_ui_context_t *ctx, const Clay_RenderCommand *c) {
         t->textColor.a / 255.0f,
     };
     nt_text_renderer_draw_n(t->stringContents.chars, (size_t)t->stringContents.length, m, (float)t->fontSize, color);
+    rebind_sprite_after_flush();
 }
 // #endregion
 
@@ -369,6 +376,13 @@ typedef struct {
     int w;
     int h;
 } sscissor_rect_t;
+
+/* Re-bind the sprite material after a flush. nt_sprite_renderer_flush closes
+ * the current cmd (cmd_count -> 0), so the next nt_sprite_renderer_emit_region
+ * would trip "call nt_sprite_renderer_set_material first" without this. The
+ * sprite renderer's set_material is cheap when cmd_count == 0 with same
+ * handle: it just re-opens the cmd from the cached pipeline + mat_info. */
+static void rebind_sprite_after_flush(void) { nt_sprite_renderer_set_material(g_nt_ui_sprite_material); }
 
 static void scissor_push(const Clay_RenderCommand *c, sscissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
     NT_ASSERT(*depth < NT_UI_WALKER_MAX_SCISSOR_DEPTH && "scissor stack overflow");
@@ -405,6 +419,9 @@ static void scissor_push(const Clay_RenderCommand *c, sscissor_rect_t *stack, in
     const int fb_h = (int)target->viewport[3];
     nt_gfx_set_scissor(x, fb_h - y - hp, wp, hp);
     nt_gfx_set_scissor_enabled(true);
+
+    /* Re-open sprite cmd so the next RECT/BORDER/IMAGE can emit. */
+    rebind_sprite_after_flush();
 }
 
 static void scissor_pop(sscissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
@@ -419,21 +436,23 @@ static void scissor_pop(sscissor_rect_t *stack, int *depth, const nt_ui_target_t
         const int fb_h = (int)target->viewport[3];
         nt_gfx_set_scissor(r.x, fb_h - r.y - r.h, r.w, r.h);
     }
+    /* Re-open sprite cmd so the next RECT/BORDER/IMAGE can emit. */
+    rebind_sprite_after_flush();
 }
 // #endregion
 
 // #region helper_emit_custom
 /* WALK-05 / D-52-09: CUSTOM -> flush both renderers then invoke the
- * registered handler (NULL handler == silent skip). The handler is
- * responsible for its own pipeline binds; the walker re-binds the sprite
- * material via the existing cmd-state preservation in set_material on the
- * next RECT/BORDER/IMAGE, so we don't need to re-set here. */
+ * registered handler (NULL handler == silent skip). The handler may bind
+ * its own pipeline; on return, we re-bind the sprite material so the next
+ * RECT/BORDER/IMAGE has a live cmd. */
 static void emit_custom(const Clay_RenderCommand *c) {
     nt_sprite_renderer_flush();
     nt_text_renderer_flush();
     if (g_nt_ui_custom_fn != NULL) {
         g_nt_ui_custom_fn((const void *)c, g_nt_ui_custom_user);
     }
+    rebind_sprite_after_flush();
 }
 // #endregion
 

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -336,27 +336,36 @@ static inline void emit_screen_rect(nt_resource_t atlas, uint32_t region_index, 
  * Boundary order is screen-CW starting at TL arc entry on the left edge. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void emit_rounded_rect(nt_resource_t atlas, uint32_t region_index, float x, float y, float w, float h, Clay_CornerRadius cr, uint32_t color_packed) {
-    /* Clamp radii so opposite corners can't overlap. Negative input is
-     * treated as zero. */
-    const float half_w = w * 0.5F;
-    const float half_h = h * 0.5F;
-    const float clamp = (half_w < half_h) ? half_w : half_h;
+    /* Negative input -> 0. */
     float tl = (cr.topLeft > 0.0F) ? cr.topLeft : 0.0F;
     float tr = (cr.topRight > 0.0F) ? cr.topRight : 0.0F;
     float bl = (cr.bottomLeft > 0.0F) ? cr.bottomLeft : 0.0F;
     float br = (cr.bottomRight > 0.0F) ? cr.bottomRight : 0.0F;
-    if (tl > clamp) {
-        tl = clamp;
+    /* CSS3 border-radius §5.5 proportional clamp: when the sum of two
+     * radii along a side exceeds the side length, scale ALL four radii
+     * by the smallest factor needed. Preserves the user's intended
+     * proportions and matches browser/Godot/Skia behaviour. */
+    float factor = 1.0F;
+    if (tl + tr > w) {
+        factor = fminf(factor, w / (tl + tr));
     }
-    if (tr > clamp) {
-        tr = clamp;
+    if (bl + br > w) {
+        factor = fminf(factor, w / (bl + br));
     }
-    if (bl > clamp) {
-        bl = clamp;
+    if (tl + bl > h) {
+        factor = fminf(factor, h / (tl + bl));
     }
-    if (br > clamp) {
-        br = clamp;
+    if (tr + br > h) {
+        factor = fminf(factor, h / (tr + br));
     }
+    if (factor < 1.0F) {
+        tl *= factor;
+        tr *= factor;
+        bl *= factor;
+        br *= factor;
+    }
+    const float half_w = w * 0.5F;
+    const float half_h = h * 0.5F;
 
     /* All-square fast path stays on emit_screen_rect (1 quad, 4 verts). */
     if (tl == 0.0F && tr == 0.0F && bl == 0.0F && br == 0.0F) {
@@ -519,24 +528,29 @@ static void emit_rounded_border(nt_resource_t atlas, uint32_t region_index, Clay
     NT_ASSERT(top + bot <= h && "nt_ui BORDER: top+bottom widths exceed bbox.height");
     NT_ASSERT(lft + rgt <= w && "nt_ui BORDER: left+right widths exceed bbox.width");
 
-    const float half_w = w * 0.5F;
-    const float half_h = h * 0.5F;
-    const float clamp_r = (half_w < half_h) ? half_w : half_h;
     float tl = (cr_in.topLeft > 0.0F) ? cr_in.topLeft : 0.0F;
     float tr = (cr_in.topRight > 0.0F) ? cr_in.topRight : 0.0F;
     float bl = (cr_in.bottomLeft > 0.0F) ? cr_in.bottomLeft : 0.0F;
     float br = (cr_in.bottomRight > 0.0F) ? cr_in.bottomRight : 0.0F;
-    if (tl > clamp_r) {
-        tl = clamp_r;
+    /* CSS3 border-radius §5.5 proportional clamp -- see emit_rounded_rect. */
+    float factor = 1.0F;
+    if (tl + tr > w) {
+        factor = fminf(factor, w / (tl + tr));
     }
-    if (tr > clamp_r) {
-        tr = clamp_r;
+    if (bl + br > w) {
+        factor = fminf(factor, w / (bl + br));
     }
-    if (bl > clamp_r) {
-        bl = clamp_r;
+    if (tl + bl > h) {
+        factor = fminf(factor, h / (tl + bl));
     }
-    if (br > clamp_r) {
-        br = clamp_r;
+    if (tr + br > h) {
+        factor = fminf(factor, h / (tr + br));
+    }
+    if (factor < 1.0F) {
+        tl *= factor;
+        tr *= factor;
+        bl *= factor;
+        br *= factor;
     }
 
     if (tl == 0.0F && tr == 0.0F && bl == 0.0F && br == 0.0F) {

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -26,6 +26,7 @@ _Static_assert(CLAY_PINNED_MAJOR == 0 && CLAY_PINNED_MINOR == 14, "Clay v0.14 re
 
 #include "core/nt_assert.h"
 #include "log/nt_log.h"
+#include "memory/nt_mem_scratch.h"
 #include "ui/nt_ui_internal.h"
 
 // #region module_state
@@ -245,6 +246,15 @@ static inline uint32_t nt_color_pack_clay(Clay_Color c) {
     uint32_t b = clamp_u8(c.b);
     uint32_t a = clamp_u8(c.a);
     return r | (g << 8) | (b << 16) | (a << 24);
+}
+// #endregion
+
+// #region element_data_alloc
+void *nt_ui_make_element_data(nt_ui_layer_t layer, void *user_data) {
+    nt_ui_element_data_t *d = NT_MEM_SCRATCH_ALLOC(nt_ui_element_data_t);
+    d->layer = layer;
+    d->user_data = user_data;
+    return d;
 }
 // #endregion
 

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -45,10 +45,6 @@ _Static_assert(CLAY_PINNED_MAJOR == 0 && CLAY_PINNED_MINOR == 14, "Clay v0.14 re
  * asserts this is NULL on entry and assigns ctx; nt_ui_end clears it. */
 static nt_ui_context_t *g_nt_ui_inframe_ctx = NULL;
 
-/* g_nt_ui_measure_wired -- Clay_SetMeasureTextFunction is a global hook.
- * We wire it lazily on first create_context. Plan 03 fills the body. */
-static bool g_nt_ui_measure_wired = false;
-
 /* Plan 04 / Revision Issue 1: walker globals set by nt_ui_set_* APIs.
  *
  * Sprite and text materials are SEPARATE globals -- they map to different
@@ -138,12 +134,9 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size) {
     ctx->clay_arena = Clay_CreateArenaWithCapacityAndMemory(clay_size, clay_mem);
     ctx->clay = Clay_Initialize(ctx->clay_arena, (Clay_Dimensions){.width = 1.0f, .height = 1.0f}, (Clay_ErrorHandler){.errorHandlerFunction = nt_ui_clay_error_cb, .userData = ctx});
 
-    /* Clay_SetMeasureTextFunction is a global hook -- wire it once. The
-     * callback (nt_ui_measure_text_cb above) handles font lookup + measure. */
-    if (!g_nt_ui_measure_wired) {
-        Clay_SetMeasureTextFunction(nt_ui_measure_text_cb, NULL);
-        g_nt_ui_measure_wired = true;
-    }
+    /* Clay_SetMeasureTextFunction is idempotent -- always wire (cheap pointer
+     * assignment in Clay v0.14). Avoids any lazy-init state of our own. */
+    Clay_SetMeasureTextFunction(nt_ui_measure_text_cb, NULL);
 
     return ctx;
 }
@@ -151,12 +144,6 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size) {
 void nt_ui_destroy_context(nt_ui_context_t *ctx) {
     NT_ASSERT(ctx != NULL && "nt_ui_destroy_context: ctx must be non-NULL");
     NT_ASSERT(!ctx->in_frame && "nt_ui_destroy_context: ctx is mid-frame (call nt_ui_end first)");
-
-    /* If this context is the in-frame ctx for any reason, clear the global
-     * (defensive -- assert above should prevent this). */
-    if (g_nt_ui_inframe_ctx == ctx) {
-        g_nt_ui_inframe_ctx = NULL;
-    }
 
     /* Caller owns the arena memory -- only zero the ctx struct portion. */
     memset(ctx, 0, sizeof(*ctx));
@@ -211,18 +198,23 @@ void nt_ui_end(nt_ui_context_t *ctx) {
 // #region helpers_color_pack
 /* Clay packs RGBA as 0..255 floats (clay.h:481). Walker emits as 0xAABBGGRR
  * uint32 (sprite-renderer vertex format -- nt_sprite_vertex_t.color[4]).
- *
- * Saturate before casting because Clay does not clamp -- a theme that wrote
- * 256.0f or -1.0f would otherwise wrap around in the uint8 cast. */
+ * Saturate at uint8 because Clay does not clamp -- a theme that wrote
+ * 256.0f or -1.0f would otherwise wrap around. */
+static inline uint8_t clamp_u8(float v) {
+    if (v <= 0.0f) {
+        return 0u;
+    }
+    if (v >= 255.0f) {
+        return 255u;
+    }
+    return (uint8_t)v;
+}
+
 static inline uint32_t nt_color_pack_clay(Clay_Color c) {
-    int ri = (int)c.r;
-    int gi = (int)c.g;
-    int bi = (int)c.b;
-    int ai = (int)c.a;
-    uint32_t r = (uint32_t)(ri > 255 ? 255 : (ri < 0 ? 0 : ri));
-    uint32_t g = (uint32_t)(gi > 255 ? 255 : (gi < 0 ? 0 : gi));
-    uint32_t b = (uint32_t)(bi > 255 ? 255 : (bi < 0 ? 0 : bi));
-    uint32_t a = (uint32_t)(ai > 255 ? 255 : (ai < 0 ? 0 : ai));
+    uint32_t r = clamp_u8(c.r);
+    uint32_t g = clamp_u8(c.g);
+    uint32_t b = clamp_u8(c.b);
+    uint32_t a = clamp_u8(c.a);
     return r | (g << 8) | (b << 16) | (a << 24); /* 0xAABBGGRR */
 }
 // #endregion

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -169,10 +169,12 @@ static size_t nt_ui_sorted_size_aligned(uint32_t max_elements) {
     return (bytes + (NT_UI_ARENA_ALIGN - 1U)) & ~(size_t)(NT_UI_ARENA_ALIGN - 1U);
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc) {
     NT_ASSERT(desc != NULL && "nt_ui_min_arena_size: desc must be non-NULL");
     NT_ASSERT(desc->max_elements > 0U && "nt_ui_min_arena_size: desc->max_elements must be > 0");
     NT_ASSERT(desc->max_elements <= UINT16_MAX && "nt_ui_min_arena_size: desc->max_elements exceeds uint16 sorted-index range");
+    NT_ASSERT(desc->max_scissor_depth > 0U && "nt_ui_min_arena_size: desc->max_scissor_depth must be > 0");
     /* Clay_SetMaxElementCount writes to GLOBAL Clay__defaultMaxElementCount
      * when no current context exists, or to current context otherwise. We
      * want to size against desc-> max_elements WITHOUT mutating any active
@@ -202,6 +204,7 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_u
      * to keep the next block's start at NT_UI_ARENA_ALIGN-aligned offset. */
     ctx->sorted = (uint16_t *)((char *)arena + ctx_size);
     ctx->max_elements = desc->max_elements;
+    ctx->max_scissor_depth = desc->max_scissor_depth;
     void *clay_mem = (char *)arena + ctx_size + sorted_size;
     const size_t clay_size = arena_size - ctx_size - sorted_size;
 
@@ -678,7 +681,7 @@ typedef struct {
 static void rebind_sprite_after_flush(const nt_ui_context_t *ctx) { nt_sprite_renderer_set_material(ctx->sprite_material); }
 
 static void scissor_push(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, sscissor_rect_t *stack, int *depth, const nt_ui_target_t *target) {
-    NT_ASSERT(*depth < NT_UI_WALKER_MAX_SCISSOR_DEPTH && "scissor stack overflow");
+    NT_ASSERT((uint32_t)*depth < ctx->max_scissor_depth && "scissor stack overflow; raise desc->max_scissor_depth or restructure nested clip");
 
     /* clip.horizontal / .vertical flag the axes that should be clipped.
      * On an unclipped axis we use the target viewport extent so the GL
@@ -853,8 +856,8 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(ctx->text_material.id != 0 && "nt_ui_set_text_material(ctx,...) required before nt_ui_walk");
 
     /* On C stack, NOT in ctx, so multi-walk against the same ctx doesn't
-     * share state. */
-    sscissor_rect_t scissor_stack[NT_UI_WALKER_MAX_SCISSOR_DEPTH];
+     * share state. VLA sized per ctx (max_scissor_depth from create desc). */
+    sscissor_rect_t scissor_stack[ctx->max_scissor_depth];
     int depth = 0;
 
     /* Drain caller-side pending geometry BEFORE mutating GL state, so

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -162,13 +162,6 @@ void nt_ui_module_shutdown(void) {
 /* ctx struct rounded up to cache-line so Clay's arena starts aligned. */
 static size_t nt_ui_ctx_size_aligned(void) { return (sizeof(struct nt_ui_context) + 63U) & ~(size_t)63U; }
 
-/* Counting-sort scratch buffer in the arena: uint16_t per cmd, aligned up
- * to NT_UI_ARENA_ALIGN so the Clay arena that follows stays aligned. */
-static size_t nt_ui_sorted_size_aligned(uint32_t max_elements) {
-    const size_t bytes = (size_t)max_elements * sizeof(uint16_t);
-    return (bytes + (NT_UI_ARENA_ALIGN - 1U)) & ~(size_t)(NT_UI_ARENA_ALIGN - 1U);
-}
-
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc) {
     NT_ASSERT(desc != NULL && "nt_ui_min_arena_size: desc must be non-NULL");
@@ -184,7 +177,7 @@ size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc) {
     Clay_SetMaxElementCount((int32_t)desc->max_elements);
     const size_t clay_bytes = (size_t)Clay_MinMemorySize();
     Clay_SetCurrentContext(saved);
-    return nt_ui_ctx_size_aligned() + nt_ui_sorted_size_aligned(desc->max_elements) + clay_bytes;
+    return nt_ui_ctx_size_aligned() + clay_bytes;
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
@@ -199,14 +192,12 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_u
     memset(ctx, 0, sizeof(*ctx));
 
     const size_t ctx_size = nt_ui_ctx_size_aligned();
-    const size_t sorted_size = nt_ui_sorted_size_aligned(desc->max_elements);
-    /* Layout: [ctx struct][sorted buffer][Clay arena]. Each block is sized
+    /* Layout: [ctx struct][Clay arena]. Each block is sized
      * to keep the next block's start at NT_UI_ARENA_ALIGN-aligned offset. */
-    ctx->sorted = (uint16_t *)((char *)arena + ctx_size);
     ctx->max_elements = desc->max_elements;
     ctx->max_scissor_depth = desc->max_scissor_depth;
-    void *clay_mem = (char *)arena + ctx_size + sorted_size;
-    const size_t clay_size = arena_size - ctx_size - sorted_size;
+    void *clay_mem = (char *)arena + ctx_size;
+    const size_t clay_size = arena_size - ctx_size;
 
     /* Stage desc->max_elements into Clay's global default so Clay_Initialize
      * inherits it for this new context. Save/restore current ctx so this
@@ -300,7 +291,9 @@ static inline uint8_t clamp_u8(float v) {
     if (v >= 255.0F) {
         return 255U;
     }
-    return (uint8_t)v;
+    /* Round-to-nearest (not truncation) so slow fades don't step on
+     * integer boundaries. The clamp above ensures v + 0.5F < 256. */
+    return (uint8_t)(v + 0.5F);
 }
 
 static inline uint32_t nt_color_pack_clay(Clay_Color c) {
@@ -893,14 +886,11 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
 
     /* Segment-aware dispatch -- see nt_ui_walk header doc for contract.
      * Within a segment (same z, no SCISSOR/CUSTOM barrier crossed):
-     *   counting sort by layer (stable). 4 passes over N segment commands:
-     *     1) count[layer]++ per cmd
-     *     2) prefix-sum count[] into offset[]
-     *     3) place cmd index into ctx->sorted[offset[layer]++]
-     *     4) iterate ctx->sorted[] in order, dispatch
-     * O(N + 256) total per segment, ~6N ops dominant. count[256] and
-     * offset[256] live on this stack (2 KB); ctx->sorted lives in the
-     * per-ctx arena sized for ctx->max_elements. */
+     *   Bitmask Multipass layer dispatch (stable, zero persistent memory).
+     *   1) Scan segment commands (N), record active layers in active_layers[8] bitmask.
+     *   2) For each set layer bit in the mask, scan the segment (N) sequentially
+     *      and dispatch matching commands.
+     *   O(N + 8 + L_active * N) total per segment. Memory: 32 bytes on stack, 0 in arena. */
     const Clay_RenderCommandArray *arr = &ctx->frozen_cmds;
 #ifdef NT_TEST_ACCESS
     uint32_t unlayered_count = 0U;
@@ -925,30 +915,35 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
         const int32_t seg_n = seg_end - i;
         NT_ASSERT((uint32_t)seg_n <= ctx->max_elements && "nt_ui_walk: segment size exceeds ctx->max_elements; raise desc->max_elements or split via SCISSOR");
 
-        uint32_t count[256] = {0};
+        uint32_t active_layers[8] = {0U};
         for (int32_t j = i; j < seg_end; ++j) {
             const Clay_RenderCommand *cc = &arr->internalArray[j];
             const uint8_t layer = cc->userData ? ((const nt_ui_element_data_t *)cc->userData)->layer : 0U;
-            count[layer]++;
+            active_layers[layer >> 5U] |= (1U << (layer & 31U));
 #ifdef NT_TEST_ACCESS
             if (cc->userData == NULL) {
                 ++unlayered_count;
             }
 #endif
         }
-        uint32_t offset[256];
-        uint32_t total = 0U;
-        for (uint32_t l = 0U; l < 256U; ++l) {
-            offset[l] = total;
-            total += count[l];
-        }
-        for (int32_t j = i; j < seg_end; ++j) {
-            const Clay_RenderCommand *cc = &arr->internalArray[j];
-            const uint8_t layer = cc->userData ? ((const nt_ui_element_data_t *)cc->userData)->layer : 0U;
-            ctx->sorted[offset[layer]++] = (uint16_t)j;
-        }
-        for (uint32_t k = 0U; k < total; ++k) {
-            dispatch_command(ctx, &arr->internalArray[ctx->sorted[k]], scissor_stack, &depth, target);
+
+        for (uint32_t word_idx = 0U; word_idx < 8U; ++word_idx) {
+            const uint32_t mask = active_layers[word_idx];
+            if (mask == 0U) {
+                continue;
+            }
+            for (uint32_t bit_idx = 0U; bit_idx < 32U; ++bit_idx) {
+                if ((mask & (1U << bit_idx)) != 0U) {
+                    const uint8_t current_layer = (uint8_t)((word_idx << 5U) | bit_idx);
+                    for (int32_t j = i; j < seg_end; ++j) {
+                        const Clay_RenderCommand *cc = &arr->internalArray[j];
+                        const uint8_t layer = cc->userData ? ((const nt_ui_element_data_t *)cc->userData)->layer : 0U;
+                        if (layer == current_layer) {
+                            dispatch_command(ctx, cc, scissor_stack, &depth, target);
+                        }
+                    }
+                }
+            }
         }
         i = seg_end;
     }
@@ -981,6 +976,12 @@ void nt_ui_set_atlas_white_region(nt_ui_context_t *ctx, nt_resource_t atlas, uin
     NT_ASSERT(r != NULL && r->vertex_count > 0U && "nt_ui_set_atlas_white_region: white region missing / tombstoned (mis-baked atlas)");
     /* emit_screen_rect scales by mat4(w,h) on cached_pos {0,1}x{0,1}. */
     NT_ASSERT(r->source_w == 1 && r->source_h == 1 && "nt_ui_set_atlas_white_region: white region must be 1x1 source");
+    /* cached_pos for the white quad is local_pos * ipu; emit_screen_rect
+     * expects ipu==1 so its mat4(w,h) scale lands at exactly w x h world
+     * units. A non-1 PPU atlas (e.g. shared game-sprite atlas with PPU=100)
+     * would shrink every UI rect by that factor -- use a dedicated UI atlas
+     * with default PPU. */
+    NT_ASSERT(nt_atlas_get_inverse_pixels_per_unit(atlas) == 1.0F && "nt_ui_set_atlas_white_region: atlas must have PPU=1 (no PPU metadata); use a dedicated UI atlas");
     ctx->atlas = atlas;
     ctx->white_region = white_region_idx;
 }

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -257,26 +257,21 @@ static void emit_border(const nt_ui_context_t *ctx, const Clay_RenderCommand *c)
 // #endregion
 
 // #region helper_emit_image
-/* IMAGE uses the PAYLOAD's atlas, not ctx->atlas (the latter is for
- * RECT/BORDER's white region). Different atlas pages auto-flush via the
- * sprite renderer's ensure_current_cmd_page_texture path. */
+/* IMAGE uses payload atlas, not ctx->atlas. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void emit_image(const Clay_RenderCommand *c) {
     const nt_ui_image_payload_t *p = (const nt_ui_image_payload_t *)c->renderData.image.imageData;
     NT_ASSERT(p != NULL && "nt_ui IMAGE: imageData must point to nt_ui_image_payload_t");
     NT_ASSERT(p->atlas.id != 0 && "nt_ui IMAGE payload: invalid atlas handle (zero id)");
-    /* Async-loading atlas is a legitimate runtime state -- skip this
-     * frame, next frame will draw. */
+    /* Async-loading atlas: skip this frame. */
     if (!nt_resource_is_ready(p->atlas)) {
         return;
     }
 
     const Clay_BoundingBox bb = c->boundingBox;
 
-    /* Clay's IMAGE default backgroundColor is {0,0,0,0}. Caller intent is
-     * "untinted" (the default-constructed Clay struct), not "draw nothing".
-     * Distinguishing on alpha==0 alone keeps legitimate transparent tints
-     * (e.g. {0,0,0,128} half-alpha black) working as expected. */
+    /* Clay defaults backgroundColor to {0,0,0,0} = "untinted", not "draw
+     * nothing". Alpha-only check would clobber legitimate transparent tints. */
     Clay_Color tint = c->renderData.image.backgroundColor;
     const bool default_untinted = (tint.r == 0.0F && tint.g == 0.0F && tint.b == 0.0F && tint.a == 0.0F);
     const uint32_t col = default_untinted ? 0xFFFFFFFFU : nt_color_pack_clay(tint);

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -1,5 +1,11 @@
 #include "ui/nt_ui.h"
 
+#include "atlas/nt_atlas.h"
+#include "graphics/nt_gfx.h"
+#include "material/nt_material.h"
+#include "renderers/nt_sprite_renderer.h"
+#include "renderers/nt_text_renderer.h"
+
 /*
  * Clay v0.14 implementation TU.
  *
@@ -41,6 +47,27 @@ static nt_ui_context_t *g_nt_ui_inframe_ctx = NULL;
 /* g_nt_ui_measure_wired -- Clay_SetMeasureTextFunction is a global hook.
  * We wire it lazily on first create_context. Plan 03 fills the body. */
 static bool g_nt_ui_measure_wired = false;
+
+/* Plan 04 / Revision Issue 1: walker globals set by nt_ui_set_* APIs.
+ *
+ * Sprite and text materials are SEPARATE globals -- they map to different
+ * nt_material_t handles (different shaders / pipelines), so a single shared
+ * slot would force a flush+rebind on every TEXT command. Walker asserts
+ * BOTH are valid at entry.
+ *
+ * g_nt_ui_atlas + g_nt_ui_white_region drive RECT/BORDER emit (and IMAGE's
+ * fallback when the payload has no atlas of its own -- D-52-06). */
+static nt_resource_t g_nt_ui_atlas;
+static uint32_t g_nt_ui_white_region;
+static nt_material_t g_nt_ui_sprite_material;
+static nt_material_t g_nt_ui_text_material;
+static nt_ui_custom_handler_t g_nt_ui_custom_fn;
+static void *g_nt_ui_custom_user;
+
+/* Walker stats (D-52-20 / WALK-09). Plan 05 wires them into nt_stats; Plan
+ * 04 captures the values into BSS so the test probes can read them. */
+static uint32_t s_last_walk_draw_call_delta;
+static uint32_t s_last_walk_element_count;
 // #endregion
 
 // #region clay_error_handler
@@ -190,22 +217,42 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
 }
 // #endregion
 
-// #region setters_stub
-/* Setter bodies land in Plan 04 next to the walker code that consumes
- * them. Phase 52 declares them in the public header (Revision Issue 1
- * locks symmetric sprite + text material setters). */
+// #region setters
+/* Walker entry asserts these were set; setters validate at call time so the
+ * developer sees the bad input at the call site, not at first walk.
+ *
+ * Atlas setter: requires non-zero, READY (Drift 5 -- nt_resource_is_ready),
+ * AND the named region resolves with vertex_count > 0 (Q4 -- catches a
+ * mis-baked atlas one frame earlier than the walker would).
+ *
+ * Material setters: only check .id != 0 -- Phase 52 doesn't synchronously
+ * resolve material pipelines (nt_material_step happens elsewhere); the
+ * sprite/text renderers' own set_material asserts material.ready when
+ * actually consumed inside the walker. */
 void nt_ui_set_atlas_white_region(nt_resource_t atlas, uint32_t white_region_idx) {
-    (void)atlas;
-    (void)white_region_idx;
+    NT_ASSERT(atlas.id != 0 && "nt_ui_set_atlas_white_region: invalid atlas handle");
+    NT_ASSERT(nt_resource_is_ready(atlas) && "nt_ui_set_atlas_white_region: atlas must be READY");
+    const nt_texture_region_t *r = nt_atlas_get_region(atlas, white_region_idx);
+    NT_ASSERT(r != NULL && r->vertex_count > 0u && "nt_ui_set_atlas_white_region: white region missing / tombstoned (mis-baked atlas)");
+    g_nt_ui_atlas = atlas;
+    g_nt_ui_white_region = white_region_idx;
 }
 
-void nt_ui_set_sprite_material(nt_material_t sprite_material) { (void)sprite_material; }
+void nt_ui_set_sprite_material(nt_material_t sprite_material) {
+    NT_ASSERT(sprite_material.id != 0 && "nt_ui_set_sprite_material: invalid material handle");
+    g_nt_ui_sprite_material = sprite_material;
+}
 
-void nt_ui_set_text_material(nt_material_t text_material) { (void)text_material; }
+void nt_ui_set_text_material(nt_material_t text_material) {
+    NT_ASSERT(text_material.id != 0 && "nt_ui_set_text_material: invalid material handle");
+    g_nt_ui_text_material = text_material;
+}
 
 void nt_ui_set_custom_handler(nt_ui_custom_handler_t fn, void *userdata) {
-    (void)fn;
-    (void)userdata;
+    /* NULL fn is allowed -- D-52-09 says CUSTOM with no handler is a
+     * silent skip (legitimate "reserved space" pattern). */
+    g_nt_ui_custom_fn = fn;
+    g_nt_ui_custom_user = userdata;
 }
 // #endregion
 
@@ -213,9 +260,31 @@ void nt_ui_set_custom_handler(nt_ui_custom_handler_t fn, void *userdata) {
 #ifdef NT_UI_TEST_ACCESS
 nt_ui_context_t *nt_ui_test_inframe_ctx(void) { return g_nt_ui_inframe_ctx; }
 
-/* Plan 05 fills the body. */
-uint32_t nt_ui_test_last_walk_draw_call_delta(void) { return 0u; }
-uint32_t nt_ui_test_last_walk_element_count(void) { return 0u; }
+/* Plan 04 captures the per-walk deltas; Plan 05 will route them to nt_stats. */
+uint32_t nt_ui_test_last_walk_draw_call_delta(void) { return s_last_walk_draw_call_delta; }
+uint32_t nt_ui_test_last_walk_element_count(void) { return s_last_walk_element_count; }
+
+/* Plan 04 probes: walker setter state introspection. Tests need these to
+ * verify (a) reset semantics for walk_without_* death tests and (b) that
+ * setters actually wrote what was passed in. */
+nt_resource_t nt_ui_test_atlas(void) { return g_nt_ui_atlas; }
+uint32_t nt_ui_test_white_region(void) { return g_nt_ui_white_region; }
+nt_material_t nt_ui_test_sprite_material(void) { return g_nt_ui_sprite_material; }
+nt_material_t nt_ui_test_text_material(void) { return g_nt_ui_text_material; }
+
+/* Plan 04 probe: clear all walker globals so death-tests can re-setUp from
+ * scratch. Setter validation prevents writing back invalid values, so a
+ * reset has to go through this probe. */
+void nt_ui_test_reset_walker_globals(void) {
+    g_nt_ui_atlas = (nt_resource_t){0};
+    g_nt_ui_white_region = 0u;
+    g_nt_ui_sprite_material = (nt_material_t){0};
+    g_nt_ui_text_material = (nt_material_t){0};
+    g_nt_ui_custom_fn = NULL;
+    g_nt_ui_custom_user = NULL;
+    s_last_walk_draw_call_delta = 0u;
+    s_last_walk_element_count = 0u;
+}
 
 /* CLAY-04 / D-52-16 verification probes. ctx->clay is a Clay_Context whose
  * struct definition is only visible to this TU (CLAY_IMPLEMENTATION above);

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -603,7 +603,7 @@ uint32_t nt_ui_get_last_walk_element_count(const nt_ui_context_t *ctx) {
 // #endregion
 
 // #region test_access
-#ifdef NT_UI_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
 nt_ui_context_t *nt_ui_test_inframe_ctx(void) { return g_nt_ui_inframe_ctx; }
 
 nt_resource_t nt_ui_test_atlas(const nt_ui_context_t *ctx) {

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -24,6 +24,7 @@ _Static_assert(CLAY_PINNED_MAJOR == 0 && CLAY_PINNED_MINOR == 14, "Clay v0.14 re
 #include <stdint.h>
 #include <string.h>
 
+#include "core/nt_align.h"
 #include "core/nt_assert.h"
 #include "log/nt_log.h"
 #include "memory/nt_mem_scratch.h"
@@ -111,7 +112,7 @@ void nt_ui_module_shutdown(void) {
 
 // #region create_destroy
 /* Cache-line aligned so Clay's arena starts on a clean boundary. */
-static size_t nt_ui_ctx_size_aligned(void) { return (sizeof(struct nt_ui_context) + 63U) & ~(size_t)63U; }
+static size_t nt_ui_ctx_size_aligned(void) { return NT_ALIGN_UP(sizeof(struct nt_ui_context), (size_t)64U); }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc) {

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -131,7 +131,21 @@ void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, const nt_
 void nt_ui_end(nt_ui_context_t *ctx);
 
 /* Read-only on ctx; safe to call N times against different targets in
- * the same frame. */
+ * the same frame.
+ *
+ * Render order contract:
+ * -- Different zIndex layers are drawn in strict ascending z order
+ *    (preserving Clay's sort).
+ * -- Within a single zIndex layer, the walker reorders compatible
+ *    commands for renderer batching: all sprite-bound commands
+ *    (RECT/BORDER/IMAGE) emit first, then all TEXT. Sprite emission
+ *    order within the batch follows the original index, so two
+ *    overlapping sprites on the same z still paint in declaration
+ *    order. Code that needs strict painter order between overlapping
+ *    elements MUST place them on different zIndex layers.
+ * -- SCISSOR_START / SCISSOR_END / CUSTOM are hard barriers: commands
+ *    on either side are never reordered across them. Clip scope and
+ *    custom-callback state are preserved exactly. */
 void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
 
 /* Per-walk metrics captured into ctx at every nt_ui_walk exit. Apps that

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -90,15 +90,14 @@ typedef struct {
  * Caller fills + assigns pointer to Clay_ImageElementConfig.imageData.
  * Lifetime: must live until the matching nt_ui_walk call returns.
  *
- * D-52-08: slice9_lrtb bytes are reserved in Phase 52 but inactive --
- * the walker emits as plain quad when any field is non-zero (with a
- * once-per-region warning). Phase 54 fills the slice9 emit path.
+ * D-52-08: slice9_lrtb bytes are RESERVED in Phase 52 -- silently ignored
+ * by the walker (plain-quad emit). Phase 54 will fill the slice9 emit path.
  */
 typedef struct {
     nt_resource_t atlas;
     uint32_t region_index;
     uint8_t flip_bits;
-    uint8_t slice9_lrtb[4]; /* {left, right, top, bottom} -- Phase 54 */
+    uint8_t slice9_lrtb[4]; /* {left, right, top, bottom} -- reserved, Phase 54 */
 } nt_ui_image_payload_t;
 
 /* ---- CUSTOM-command handler (D-52-09, Option A) ----

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -136,13 +136,19 @@ void nt_ui_end(nt_ui_context_t *ctx);
  * Render order contract:
  * -- Different zIndex layers are drawn in strict ascending z order
  *    (preserving Clay's sort).
- * -- Within a single zIndex layer, the walker reorders compatible
- *    commands for renderer batching: all sprite-bound commands
- *    (RECT/BORDER/IMAGE) emit first, then all TEXT. Sprite emission
- *    order within the batch follows the original index, so two
- *    overlapping sprites on the same z still paint in declaration
- *    order. Code that needs strict painter order between overlapping
- *    elements MUST place them on different zIndex layers.
+ * -- Within a single zIndex layer, the walker partitions commands into
+ *    two groups and emits sprite-bound first (RECTANGLE / BORDER /
+ *    IMAGE), TEXT second. Inside each group, commands keep their
+ *    original Clay index order -- so two overlapping sprites at the
+ *    same z still paint in declaration order. Code that needs strict
+ *    painter order between an overlapping sprite and a text MUST place
+ *    them on different zIndex layers.
+ * -- Within the sprite group, the walker does NOT yet bucket-sort by
+ *    atlas, so interleaved IMAGEs that reference different atlas pages
+ *    will still fragment the sprite batch on the page transitions.
+ *    Within the TEXT group, the walker does NOT yet bucket by font.
+ *    These additional sorts are valid extensions of the contract
+ *    above (within-z reorderable) and may land in a later phase.
  * -- SCISSOR_START / SCISSOR_END / CUSTOM are hard barriers: commands
  *    on either side are never reordered across them. Clip scope and
  *    custom-callback state are preserved exactly. */

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -69,8 +69,13 @@ typedef struct {
     uint8_t _reserved[3];
 } nt_ui_element_data_t;
 
-#define NT_UI_DATA_LAYER(layer_value) ((void *)&(const nt_ui_element_data_t){.layer = (layer_value)})
-#define NT_UI_DATA_FULL(layer_value, user_ptr) ((void *)&(const nt_ui_element_data_t){.layer = (layer_value), .user_data = (user_ptr)})
+/* Macros allocate from nt_mem_scratch (frame arena) so the pointer stays valid
+ * across helper-function returns until the next nt_mem_scratch_reset. Game
+ * MUST init scratch before any CLAY({...}) declaration. */
+void *nt_ui_make_element_data(nt_ui_layer_t layer, void *user_data);
+
+#define NT_UI_DATA_LAYER(layer_value) nt_ui_make_element_data((layer_value), NULL)
+#define NT_UI_DATA_FULL(layer_value, user_ptr) nt_ui_make_element_data((layer_value), (user_ptr))
 
 /* All four setters required per-context before first walk. */
 void nt_ui_set_atlas_white_region(nt_ui_context_t *ctx, nt_resource_t atlas, uint32_t white_region_idx);

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -24,7 +24,7 @@
 #endif
 
 /* Fixed stack-array size (no VLA -- MSVC C compat). */
-#define NT_UI_WALKER_SCISSOR_DEPTH_CAP 256
+#define NT_UI_WALKER_SCISSOR_DEPTH_CAP 64
 
 /* Clay places its Clay_Context at the arena head via raw cast. */
 #define NT_UI_ARENA_ALIGN _Alignof(max_align_t)
@@ -32,7 +32,6 @@
 #ifndef NT_UI_DEFAULT_MAX_ELEMENT_COUNT
 #define NT_UI_DEFAULT_MAX_ELEMENT_COUNT 1024
 #endif
-#define NT_UI_DEFAULT_ARENA_SIZE (1U * 1024U * 1024U)
 
 /* Bare uint8_t[N] has 1-byte alignment -- create_context would assert. */
 #define NT_UI_DECLARE_ARENA(name, size) alignas(NT_UI_ARENA_ALIGN) uint8_t name[(size)]
@@ -121,6 +120,7 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
 
 /* Window delta over the walk; includes CUSTOM-handler draws. */
 uint32_t nt_ui_get_last_walk_draw_calls(const nt_ui_context_t *ctx);
+/* Total Clay commands incl. SCISSOR/CUSTOM/NONE (non-drawing barriers). */
 uint32_t nt_ui_get_last_walk_command_count(const nt_ui_context_t *ctx);
 
 // #region test_access

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -127,28 +127,13 @@ void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, const nt_
 /* Freezes Clay's command array into ctx for subsequent walk(s). */
 void nt_ui_end(nt_ui_context_t *ctx);
 
-/* Read-only on ctx; safe to call N times against different targets in
- * the same frame.
- *
- * Render order contract:
- * -- Different zIndex layers are drawn in strict ascending z order
- *    (preserving Clay's sort).
- * -- Within a single zIndex layer, the walker partitions commands into
- *    two groups and emits sprite-bound first (RECTANGLE / BORDER /
- *    IMAGE), TEXT second. Inside each group, commands keep their
- *    original Clay index order -- so two overlapping sprites at the
- *    same z still paint in declaration order. Code that needs strict
- *    painter order between an overlapping sprite and a text MUST place
- *    them on different zIndex layers.
- * -- Within the sprite group, the walker does NOT yet bucket-sort by
- *    atlas, so interleaved IMAGEs that reference different atlas pages
- *    will still fragment the sprite batch on the page transitions.
- *    Within the TEXT group, the walker does NOT yet bucket by font.
- *    These additional sorts are valid extensions of the contract
- *    above (within-z reorderable) and may land in a later phase.
- * -- SCISSOR_START / SCISSOR_END / CUSTOM are hard barriers: commands
- *    on either side are never reordered across them. Clip scope and
- *    custom-callback state are preserved exactly. */
+/* Read-only on ctx; safe to call N times against different targets per
+ * frame. Render order:
+ *  - Different zIndex: strict ascending z.
+ *  - Same z: sprite-bound (RECT/BORDER/IMAGE) emitted before TEXT;
+ *    declaration order kept within each group. Overlapping sprite+text
+ *    needing strict painter order MUST use different z.
+ *  - SCISSOR_START/END and CUSTOM are hard barriers -- never reordered. */
 void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
 
 /* Per-walk metrics captured into ctx at every nt_ui_walk exit. Apps that
@@ -158,14 +143,9 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
  *     nt_stats_count("ui_draw_calls",    nt_ui_get_last_walk_draw_calls(ctx));
  *     nt_stats_count("ui_element_count", nt_ui_get_last_walk_element_count(ctx));
  *
- * draw_calls is a WINDOW measurement: the GL draw-call counter delta
- * between walk entry and exit. It counts every physical
- * glDrawElements made during the walk, which includes any draws a
- * CUSTOM-command handler emits (the handler's draws are part of the
- * UI's cost, not separable from batching efficiency). Use this as
- * "what did this walk cost the GPU?". If you need UI-only draws
- * (excluding CUSTOM handler output), snapshot sprite/text renderer
- * stats yourself around nt_ui_walk. */
+ * draw_calls is a WINDOW measurement: GL draw-call delta between walk
+ * entry and exit. Includes any draws a CUSTOM handler emits. For
+ * UI-only counts, snapshot sprite/text renderer stats around the walk. */
 uint32_t nt_ui_get_last_walk_draw_calls(const nt_ui_context_t *ctx);
 uint32_t nt_ui_get_last_walk_element_count(const nt_ui_context_t *ctx);
 

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -113,7 +113,7 @@ typedef struct nt_ui_context nt_ui_context_t;
 typedef struct {
     uint32_t fbo;         /* 0 = default framebuffer; non-zero reserved */
     float viewport[4];    /* {x, y, width, height} */
-    float projection[16]; /* row-major; all-zero = caller owns Globals UBO */
+    float projection[16]; /* column-major (cglm); all-zero = caller owns Globals UBO */
 } nt_ui_target_t;
 
 /* ---- Image payload (D-52-07) ----

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -174,7 +174,8 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
 /* Module-level in-frame pointer (D-52-12). NULL when no context is mid-frame. */
 nt_ui_context_t *nt_ui_test_inframe_ctx(void);
 
-/* Plan 05 will populate these. Phase 52 returns 0u placeholders. */
+/* Plan 04 captures into static module state at walk exit; Plan 05 will
+ * additionally route these through nt_stats_count. */
 uint32_t nt_ui_test_last_walk_draw_call_delta(void);
 uint32_t nt_ui_test_last_walk_element_count(void);
 
@@ -187,6 +188,16 @@ float nt_ui_test_clay_pointer_x(const nt_ui_context_t *ctx);
 float nt_ui_test_clay_pointer_y(const nt_ui_context_t *ctx);
 /* 0 = released-family, 1 = pressed-family. */
 int nt_ui_test_clay_pointer_down(const nt_ui_context_t *ctx);
+
+/* Plan 04: walker-setter introspection + reset.
+ * Tests use these to verify what the setters wrote and to reset the
+ * module-level globals for death-tests that need a "no setter called"
+ * pre-state (e.g. walk_without_atlas_asserts). */
+nt_resource_t nt_ui_test_atlas(void);
+uint32_t nt_ui_test_white_region(void);
+nt_material_t nt_ui_test_sprite_material(void);
+nt_material_t nt_ui_test_text_material(void);
+void nt_ui_test_reset_walker_globals(void);
 #endif /* NT_UI_TEST_ACCESS */
 
 #endif /* NT_UI_H */

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -1,36 +1,14 @@
 #ifndef NT_UI_H
 #define NT_UI_H
 
-/*
- * nt_ui -- Immediate-mode UI built on Clay v0.14.
+/* Immediate-mode UI bridge over Clay v0.14.
  *
- * Engine init sequence required before nt_ui_walk:
- *   nt_gfx_init(...);
- *   nt_resource_init(...);
- *   nt_atlas_init();
- *   nt_font_init(...);
- *   nt_material_init(...);
- *   nt_sprite_renderer_init(...);
- *   nt_text_renderer_init();
+ * Lifecycle: nt_ui_module_init -> nt_ui_create_context -> per-ctx setters
+ * (font, atlas/white-region, sprite/text material). Per frame: begin /
+ * Clay declarations / end / walk (N targets per frame OK).
  *
- * Per-context setup (once at boot):
- *   nt_ui_create_desc_t desc = nt_ui_create_desc_defaults();
- *   ctx = nt_ui_create_context(arena, sizeof arena, &desc);
- *   nt_ui_set_font(ctx, 0, font);
- *   nt_ui_set_atlas_white_region(ctx, atlas, white_region_idx);
- *   nt_ui_set_sprite_material(ctx, sprite_material);
- *   nt_ui_set_text_material(ctx, text_material);
- *
- * Per frame:
- *   nt_ui_begin(ctx, screen_w, screen_h, &mouse);
- *   // ... Clay declarations ...
- *   nt_ui_end(ctx);
- *   nt_ui_walk(ctx, &target);  // may be called N times against different targets
- *
- * Multi-context invariant: only one context may be in-frame at a time.
- * The caller owns the Globals UBO -- the walker writes only viewport
- * and scissor state.
- */
+ * Only one ctx may be in-frame at a time. Caller owns the Globals UBO;
+ * walker writes viewport and scissor only. */
 
 #include <stdalign.h>
 #include <stdbool.h>
@@ -54,97 +32,71 @@
 /* Clay places its Clay_Context at the arena head via raw cast. */
 #define NT_UI_ARENA_ALIGN _Alignof(max_align_t)
 
-/* Override at compile time + raise arena if your layout has more elements. */
 #ifndef NT_UI_DEFAULT_MAX_ELEMENT_COUNT
 #define NT_UI_DEFAULT_MAX_ELEMENT_COUNT 1024
 #endif
 #define NT_UI_DEFAULT_ARENA_SIZE (1U * 1024U * 1024U)
 
-/* Bare uint8_t[N] has 1-byte alignment and trips the create_context assert. */
+/* Bare uint8_t[N] has 1-byte alignment -- create_context would assert. */
 #define NT_UI_DECLARE_ARENA(name, size) alignas(NT_UI_ARENA_ALIGN) uint8_t name[(size)]
 
 typedef struct nt_ui_context nt_ui_context_t;
 
-/* Caller owns framebuffer binding -- bind your FBO before nt_ui_walk
- * if rendering to texture. Walker only touches viewport and scissor. */
+/* Caller owns framebuffer binding; walker writes only viewport + scissor. */
 typedef struct {
     float viewport[4]; /* {x, y, w, h} in framebuffer pixels */
 } nt_ui_target_t;
 
-/* Pointed to by Clay_ImageElementConfig.imageData. Lifetime must extend
- * through the matching nt_ui_walk. IMAGE elements assert cornerRadius
- * is all-zero -- pre-bake rounded edges into the atlas region. */
+/* Pointed to by Clay_ImageElementConfig.imageData; lifetime must extend
+ * through the matching nt_ui_walk. cornerRadius must be 0 (pre-bake into atlas). */
 typedef struct {
     nt_resource_t atlas;
     uint32_t region_index;
     uint8_t flip_bits;
 } nt_ui_image_payload_t;
 
-/* clay_cmd is an opaque const Clay_RenderCommand * (cast back if needed).
- * Keeping it opaque lets clay.h stay private to the nt_ui TU. */
+/* clay_cmd is opaque const Clay_RenderCommand * (cast back inside handler). */
 typedef void (*nt_ui_custom_handler_t)(const void *clay_cmd, void *userdata);
 
-/* ---- Layer-based painter order ----
- * Walker sorts RECT/BORDER/IMAGE/TEXT commands within a segment (between
- * SCISSOR/CUSTOM barriers) by layer ascending, then by declaration order
- * within a layer. Lower layer renders first.
+/* Layer-based painter order. Attach to Clay_ElementDeclaration.userData or
+ * Clay_TextElementConfig.userData. Lower layer draws first; within a layer
+ * declaration order is preserved. NULL userData -> layer 0.
  *
- * Attach via Clay_ElementDeclaration.userData (or
- * Clay_TextElementConfig.userData for TEXT). Pointer must outlive the
- * matching nt_ui_walk -- use file-scope static const or a compound literal
- * inside the function that calls walk (not in a deeper block scope).
+ * Pointer must outlive nt_ui_walk -- use file-scope static const or a
+ * compound literal in the function that calls walk:
+ *   CLAY({ .userData = NT_UI_DATA(LAYER_BG), ... })
  *
- * NULL userData -> layer 0 (default). Use NT_UI_DATA(N) for an inline
- * compound literal:
- *
- *   CLAY({ .backgroundColor = c, .userData = NT_UI_DATA(LAYER_BG) }) {
- *       CLAY_TEXT(s, CLAY_TEXT_CONFIG({ .userData = NT_UI_DATA(LAYER_FG) }));
- *   }
- *
- * For game-specific layer names, define your own enum:
- *   enum { LAYER_BG = 0, LAYER_HUD = 1, LAYER_OVERLAY = 2 };
- *
- * Note: layer sort applies ONLY to segmentable commands. SCISSOR_START/END
- * and CUSTOM are hard barriers -- their position in the command stream is
- * never reordered. */
+ * Layer sort applies to RECT/BORDER/IMAGE/TEXT only. SCISSOR/CUSTOM are
+ * hard barriers and never reordered. */
 typedef uint8_t nt_ui_layer_t;
 typedef struct {
     nt_ui_layer_t layer;  /* 0..255; lower draws first */
-    uint8_t _reserved[3]; /* padding for future per-element fields */
+    uint8_t _reserved[3]; /* future per-element fields */
 } nt_ui_element_data_t;
-_Static_assert(sizeof(nt_ui_element_data_t) == 4, "nt_ui_element_data_t must be 4 bytes (stable ABI)");
+_Static_assert(sizeof(nt_ui_element_data_t) == 4, "nt_ui_element_data_t stable ABI");
 
 #define NT_UI_DATA(layer_value) ((void *)&(const nt_ui_element_data_t){.layer = (layer_value)})
 
-/* All four setters below must be called per-context before its first walk.
- * Per-context (not module-global) so multi-context UIs can carry separate
- * atlases and themes without state swaps between walks. */
+/* All four setters must be called per-context before first walk. */
 
-/* Atlas + white-region used for RECT and BORDER. IMAGE uses the payload
- * atlas independently. */
+/* Atlas + white-region for RECT/BORDER. IMAGE uses its own payload atlas. */
 void nt_ui_set_atlas_white_region(nt_ui_context_t *ctx, nt_resource_t atlas, uint32_t white_region_idx);
 
-/* Sprite material drives RECT/BORDER/IMAGE; text material drives TEXT.
- * They cannot share a slot -- different shaders, different pipelines. */
+/* Sprite for RECT/BORDER/IMAGE; text for TEXT -- different pipelines. */
 void nt_ui_set_sprite_material(nt_ui_context_t *ctx, nt_material_t sprite_material);
 void nt_ui_set_text_material(nt_ui_context_t *ctx, nt_material_t text_material);
 
 /* NULL fn silently skips CUSTOM commands. */
 void nt_ui_set_custom_handler(nt_ui_context_t *ctx, nt_ui_custom_handler_t fn, void *userdata);
 
-/* ---- Module init ----
- * Wires nt_ui's measure callback into Clay's global function pointer.
- * MUST be called once before any nt_ui_create_context. Idempotent.
- * Pair with nt_ui_module_shutdown for symmetry; not required for correctness. */
+/* Wires Clay's measure callback. MUST be called once before any
+ * nt_ui_create_context. Idempotent. */
 void nt_ui_module_init(void);
 void nt_ui_module_shutdown(void);
 
-/* Per-context Clay capacity. Use nt_ui_create_desc_defaults() for a sane
- * starting point and adjust fields explicitly when the layout grows beyond
- * default limits. */
 typedef struct {
-    uint32_t max_elements;      /* Max layout elements Clay can hold in this ctx. */
-    uint32_t max_scissor_depth; /* Max nested SCISSOR_START/END depth during walk. */
+    uint32_t max_elements;      /* Clay layout-element cap. */
+    uint32_t max_scissor_depth; /* Walker scissor-stack VLA size. */
 } nt_ui_create_desc_t;
 
 static inline nt_ui_create_desc_t nt_ui_create_desc_defaults(void) {
@@ -154,43 +106,32 @@ static inline nt_ui_create_desc_t nt_ui_create_desc_defaults(void) {
     };
 }
 
-/* Pure query: bytes required to host one nt_ui_context for the given desc.
- * Saves/restores Clay's current-context so concurrent contexts are not
- * mutated. Asserts desc != NULL. */
+/* Pure query: byte count required for one ctx with this desc. */
 size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc);
 
-/* Arena is caller-owned; ctx lives in the first ~256 bytes. Asserts
- * arena != NULL, size >= nt_ui_min_arena_size(desc), NT_UI_ARENA_ALIGN-aligned,
- * desc != NULL. */
+/* Arena is caller-owned; ctx lives in the first ~256 bytes. */
 nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_ui_create_desc_t *desc);
 
 /* Tears down ctx state; caller still owns the arena memory. */
 void nt_ui_destroy_context(nt_ui_context_t *ctx);
 
-/* Clay's fontId indexes this per-ctx table when the measure callback fires. */
 void nt_ui_set_font(nt_ui_context_t *ctx, uint16_t font_id, nt_font_t font);
 
-/* First call inside switches Clay's current-context to this ctx so
- * subsequent CLAY({...}) macros operate on it. */
+/* Switches Clay's current-context to this ctx for the CLAY({...}) macros. */
 void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, const nt_pointer_t *mouse);
 
 /* Freezes Clay's command array into ctx for subsequent walk(s). */
 void nt_ui_end(nt_ui_context_t *ctx);
 
-/* Read-only on ctx; safe to call N times against different targets per
- * frame. Render order:
- *  - Different zIndex (Clay floating only): strict ascending z.
- *  - Same z, different layer (nt_ui_element_data_t): ascending layer.
+/* Read-only on ctx; safe to call N times against different targets per frame.
+ * Render order:
+ *  - Different zIndex (Clay floating only): ascending z.
+ *  - Same z, different layer: ascending layer.
  *  - Same z, same layer: declaration order.
- *  - SCISSOR_START/END and CUSTOM are hard barriers -- never reordered.
- *
- * For tight batching, group elements sharing a material into the same
- * layer (sprites vs text on different layers naturally minimizes material
- * switches). Layer sort runs over segments bounded by barriers above. */
+ *  - SCISSOR/CUSTOM are hard barriers (never reordered). */
 void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
 
-/* draw_calls is a window delta over the walk -- includes CUSTOM-handler
- * draws. Snapshot sprite/text renderer stats yourself for UI-only counts. */
+/* Window delta over the walk; includes CUSTOM-handler draws. */
 uint32_t nt_ui_get_last_walk_draw_calls(const nt_ui_context_t *ctx);
 uint32_t nt_ui_get_last_walk_element_count(const nt_ui_context_t *ctx);
 
@@ -198,8 +139,7 @@ uint32_t nt_ui_get_last_walk_element_count(const nt_ui_context_t *ctx);
 #ifdef NT_TEST_ACCESS
 nt_ui_context_t *nt_ui_test_inframe_ctx(void);
 
-/* Clay_Context isn't visible outside the nt_ui TU, so tests need these
- * to read ctx->clay->pointerInfo. */
+/* Clay_Context lives in the impl TU only; expose ctx->clay->pointerInfo. */
 float nt_ui_test_clay_pointer_x(const nt_ui_context_t *ctx);
 float nt_ui_test_clay_pointer_y(const nt_ui_context_t *ctx);
 int nt_ui_test_clay_pointer_down(const nt_ui_context_t *ctx); /* 0 released, 1 pressed */
@@ -209,15 +149,10 @@ uint32_t nt_ui_test_white_region(const nt_ui_context_t *ctx);
 nt_material_t nt_ui_test_sprite_material(const nt_ui_context_t *ctx);
 nt_material_t nt_ui_test_text_material(const nt_ui_context_t *ctx);
 
-/* Diagnostic: count of segmentable commands in last walk whose userData
- * was NULL (i.e. fell back to layer 0 implicitly). Useful to detect
- * "forgot to set layer on critical element" during development. */
+/* Count of segmentable cmds in last walk with NULL userData (layer 0 fallback). */
 uint32_t nt_ui_test_last_walk_unlayered_count(const nt_ui_context_t *ctx);
 
-/* Exposes Clay's global Clay__defaultMaxElementCount for save/restore
- * regression tests. Clay symbol is internal to the implementation TU
- * (CLAY_IMPLEMENTATION lives in nt_ui.c), so external tests can't read
- * it directly. */
+/* Clay__defaultMaxElementCount is impl-internal; expose for regression tests. */
 int32_t nt_ui_test_clay_default_max_element_count(void);
 #endif
 // #endregion

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -4,6 +4,23 @@
 /*
  * nt_ui -- Immediate-mode UI module built atop Clay v0.14.
  *
+ * Engine dependencies. nt_ui_walk transitively calls into nt_gfx (viewport
+ * + scissor), nt_sprite_renderer + nt_text_renderer (geometry emit), and
+ * nt_stats (per-walk ui_draw_calls / ui_element_count counters). All of
+ * these must be init'd by the application BEFORE any nt_ui_walk:
+ *
+ *     nt_gfx_init(...);
+ *     nt_resource_init(...);
+ *     nt_atlas_init();
+ *     nt_font_init(...);
+ *     nt_material_init(...);
+ *     nt_sprite_renderer_init(...);
+ *     nt_text_renderer_init();
+ *     nt_stats_init(NULL);       // walker pushes counters every walk
+ *
+ * The walker doesn't init these itself -- the application drives the
+ * full engine lifecycle and is responsible for the order.
+ *
  * Frame lifecycle (Phase 52):
  *
  *   1) Once at boot, per context:
@@ -171,7 +188,10 @@ void nt_ui_end(nt_ui_context_t *ctx);
 /* Render phase -- iterates frozen commands and dispatches to renderers.
  * Read-only on ctx; can be called multiple times per frame against
  * different targets (split-screen / screenshot FBO).
- * Phase 52: body lands in Plan 04. */
+ *
+ * Engine dependencies: requires nt_gfx, nt_sprite_renderer,
+ * nt_text_renderer, and nt_stats to be init'd. See the file-level
+ * comment for the full init sequence. */
 void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
 
 /* ---- Test access (compiled only when NT_UI_TEST_ACCESS is defined) ---- */

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -6,12 +6,12 @@
  *
  * Frame lifecycle (Phase 52):
  *
- *   1) Once at boot:
+ *   1) Once at boot, per context:
  *        ctx = nt_ui_create_context(arena, sizeof arena);
  *        nt_ui_set_font(ctx, 0, font);
- *        nt_ui_set_atlas_white_region(atlas, white_region_idx);
- *        nt_ui_set_sprite_material(sprite_material);
- *        nt_ui_set_text_material(text_material);
+ *        nt_ui_set_atlas_white_region(ctx, atlas, white_region_idx);
+ *        nt_ui_set_sprite_material(ctx, sprite_material);
+ *        nt_ui_set_text_material(ctx, text_material);
  *
  *   2) Per frame, declaration phase (Phase 1):
  *        nt_pointer_t mouse = g_nt_input.pointers[0];
@@ -107,23 +107,30 @@ typedef struct {
  */
 typedef void (*nt_ui_custom_handler_t)(const void *clay_cmd, void *userdata);
 
-/* ---- Global setters (implementations in Plan 04) ---- */
+/* ---- Per-context setters (atlas / materials / custom handler) ----
+ *
+ * Walker state is owned by each context, NOT by globals. This makes the
+ * "one ctx, many walks against different targets" pattern (split-screen,
+ * screenshot FBO, minimap UI) trivially correct: separate contexts can
+ * carry separate atlases and themes without swapping state between walks.
+ *
+ * All four setters must be called for each context before its first walk;
+ * nt_ui_walk asserts every field is set at entry. */
 
-/* White-region & atlas setter -- one call between init and first walk.
- * Walker asserts atlas is valid + ready before each walk. */
-void nt_ui_set_atlas_white_region(nt_resource_t atlas, uint32_t white_region_idx);
+/* White-region & atlas binding. Walker emits RECT and BORDER through this
+ * atlas+region. IMAGE uses the payload's atlas independently. */
+void nt_ui_set_atlas_white_region(nt_ui_context_t *ctx, nt_resource_t atlas, uint32_t white_region_idx);
 
 /* Material setters -- symmetric pair (Revision Issue 1, D-52-19).
  * Sprite material drives RECT/BORDER/IMAGE; text material drives TEXT.
- * Both must be set before first nt_ui_walk (walker asserts at entry).
- * Phase 53 theme sets both atomically; Phase 52 setters are the bootstrap.
+ * Phase 53 theme will set both atomically; Phase 52 setters are the bootstrap.
  * Single-material reuse was rejected because sprite and text use different
  * nt_material_t (different shaders) and cannot share a pipeline slot. */
-void nt_ui_set_sprite_material(nt_material_t sprite_material);
-void nt_ui_set_text_material(nt_material_t text_material);
+void nt_ui_set_sprite_material(nt_ui_context_t *ctx, nt_material_t sprite_material);
+void nt_ui_set_text_material(nt_ui_context_t *ctx, nt_material_t text_material);
 
-/* CUSTOM handler -- global, NULL = silent skip. */
-void nt_ui_set_custom_handler(nt_ui_custom_handler_t fn, void *userdata);
+/* CUSTOM handler -- per-context, NULL fn = silent skip. */
+void nt_ui_set_custom_handler(nt_ui_context_t *ctx, nt_ui_custom_handler_t fn, void *userdata);
 
 /* ---- Lifecycle (D-52-10) ---- */
 
@@ -173,10 +180,10 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
 /* Module-level in-frame pointer (D-52-12). NULL when no context is mid-frame. */
 nt_ui_context_t *nt_ui_test_inframe_ctx(void);
 
-/* Plan 04 captures into static module state at walk exit; Plan 05 will
- * additionally route these through nt_stats_count. */
-uint32_t nt_ui_test_last_walk_draw_call_delta(void);
-uint32_t nt_ui_test_last_walk_element_count(void);
+/* Walker captures per-walk deltas into the ctx itself; tests read them back
+ * via these probes. Plan 05 also routes them through nt_stats_count. */
+uint32_t nt_ui_test_last_walk_draw_call_delta(const nt_ui_context_t *ctx);
+uint32_t nt_ui_test_last_walk_element_count(const nt_ui_context_t *ctx);
 
 /* Plan 03: snapshot of the Clay-side pointer state for the given ctx,
  * intended for CLAY-04 / D-52-16 verification. Returns the values that
@@ -188,15 +195,14 @@ float nt_ui_test_clay_pointer_y(const nt_ui_context_t *ctx);
 /* 0 = released-family, 1 = pressed-family. */
 int nt_ui_test_clay_pointer_down(const nt_ui_context_t *ctx);
 
-/* Plan 04: walker-setter introspection + reset.
- * Tests use these to verify what the setters wrote and to reset the
- * module-level globals for death-tests that need a "no setter called"
- * pre-state (e.g. walk_without_atlas_asserts). */
-nt_resource_t nt_ui_test_atlas(void);
-uint32_t nt_ui_test_white_region(void);
-nt_material_t nt_ui_test_sprite_material(void);
-nt_material_t nt_ui_test_text_material(void);
-void nt_ui_test_reset_walker_globals(void);
+/* Walker-setter introspection. Tests use these to verify what the per-context
+ * setters wrote. Death-tests for "setter not called before walk" simply use
+ * a freshly-created context (all walker fields zero-initialised); no reset
+ * probe is needed. */
+nt_resource_t nt_ui_test_atlas(const nt_ui_context_t *ctx);
+uint32_t nt_ui_test_white_region(const nt_ui_context_t *ctx);
+nt_material_t nt_ui_test_sprite_material(const nt_ui_context_t *ctx);
+nt_material_t nt_ui_test_text_material(const nt_ui_context_t *ctx);
 #endif /* NT_UI_TEST_ACCESS */
 
 #endif /* NT_UI_H */

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -2,57 +2,33 @@
 #define NT_UI_H
 
 /*
- * nt_ui -- Immediate-mode UI module built atop Clay v0.14.
+ * nt_ui -- Immediate-mode UI built on Clay v0.14.
  *
- * Engine dependencies. nt_ui_walk transitively calls into nt_gfx (viewport
- * + scissor) and nt_sprite_renderer + nt_text_renderer (geometry emit).
- * All of these must be init'd by the application BEFORE any nt_ui_walk:
+ * Engine init sequence required before nt_ui_walk:
+ *   nt_gfx_init(...);
+ *   nt_resource_init(...);
+ *   nt_atlas_init();
+ *   nt_font_init(...);
+ *   nt_material_init(...);
+ *   nt_sprite_renderer_init(...);
+ *   nt_text_renderer_init();
  *
- *     nt_gfx_init(...);
- *     nt_resource_init(...);
- *     nt_atlas_init();
- *     nt_font_init(...);
- *     nt_material_init(...);
- *     nt_sprite_renderer_init(...);
- *     nt_text_renderer_init();
+ * Per-context setup (once at boot):
+ *   ctx = nt_ui_create_context(arena, sizeof arena);
+ *   nt_ui_set_font(ctx, 0, font);
+ *   nt_ui_set_atlas_white_region(ctx, atlas, white_region_idx);
+ *   nt_ui_set_sprite_material(ctx, sprite_material);
+ *   nt_ui_set_text_material(ctx, text_material);
  *
- * The walker doesn't init these itself -- the application drives the
- * full engine lifecycle and is responsible for the order.
+ * Per frame:
+ *   nt_ui_begin(ctx, screen_w, screen_h, &mouse);
+ *   // ... Clay declarations ...
+ *   nt_ui_end(ctx);
+ *   nt_ui_walk(ctx, &target);  // may be called N times against different targets
  *
- * nt_stats is NOT a dependency. Walker exposes per-walk metrics via the
- * getter functions below (nt_ui_get_last_walk_draw_calls etc.); the
- * application chooses whether to publish them to nt_stats for the debug
- * overlay or to consume them privately for telemetry.
- *
- * Frame lifecycle (Phase 52):
- *
- *   1) Once at boot, per context:
- *        ctx = nt_ui_create_context(arena, sizeof arena);
- *        nt_ui_set_font(ctx, 0, font);
- *        nt_ui_set_atlas_white_region(ctx, atlas, white_region_idx);
- *        nt_ui_set_sprite_material(ctx, sprite_material);
- *        nt_ui_set_text_material(ctx, text_material);
- *
- *   2) Per frame, declaration phase (Phase 1):
- *        nt_pointer_t mouse = g_nt_input.pointers[0];
- *        nt_ui_begin(ctx, screen_w, screen_h, &mouse);
- *        // ... Clay declarations (CLAY({...}) { ... }) ...
- *        nt_ui_end(ctx);
- *
- *   3) Per frame, render phase (Phase 2) -- can be called N times against
- *      different targets (split-screen, screenshot FBO):
- *        nt_ui_target_t target = {.viewport = {0, 0, screen_w, screen_h}};
- *        nt_ui_walk(ctx, &target);
- *
- *   4) On shutdown:
- *        nt_ui_destroy_context(ctx);  // does NOT free arena bytes
- *
- * Multi-context invariant (D-52-12 / UI-08): only one context may be
- * in-frame at a time. nt_ui_begin asserts on stray nested begin.
- *
- * Globals UBO ownership (Drift 6): the caller owns the Globals UBO. The
- * walker only writes viewport + scissor state -- it does NOT update
- * Globals. See nt_ui_target_t for details.
+ * Multi-context invariant: only one context may be in-frame at a time.
+ * The caller owns the Globals UBO -- the walker writes only viewport
+ * and scissor state.
  */
 
 #include <stdalign.h>
@@ -66,8 +42,6 @@
 #include "material/nt_material.h"
 #include "resource/nt_resource.h"
 
-/* ---- Compile-time limits ---- */
-
 #ifndef NT_UI_MAX_FONTS
 #define NT_UI_MAX_FONTS 8
 #endif
@@ -76,195 +50,104 @@
 #define NT_UI_WALKER_MAX_SCISSOR_DEPTH 8
 #endif
 
-/* Required arena alignment. Clay places its Clay_Context struct at the
- * head of the arena via raw pointer cast and that struct holds fields
- * whose strictest alignment is max_align_t (16 bytes on x86_64). A raw
- * `static uint8_t arena[N]` declaration has only 1-byte alignment in C,
- * so callers MUST use the alignas decoration shown below. */
+/* Clay places its Clay_Context at the head of the arena via raw cast;
+ * the strictest field there needs max_align_t. A bare `static uint8_t
+ * arena[N]` has 1-byte alignment in C, so callers MUST use alignas. */
 #define NT_UI_ARENA_ALIGN _Alignof(max_align_t)
 
-/* Default arena size suitable for ~50k Clay elements + 8 fonts + scroll/
- * modal stacks. Recommended caller pattern:
- *
- *     alignas(NT_UI_ARENA_ALIGN) static uint8_t g_ui_arena[NT_UI_DEFAULT_ARENA_SIZE];
- *
- * `static uint64_t arena[N/8]` gives 8-byte alignment which is NOT enough.
- * The cleanest stack-friendly alternative is a uint64_t array sized to fit
- * plus a cast through a max-aligned union; tests use this pattern. */
+/* Recommended caller pattern:
+ *     alignas(NT_UI_ARENA_ALIGN) static uint8_t g_ui_arena[NT_UI_DEFAULT_ARENA_SIZE]; */
 #define NT_UI_DEFAULT_ARENA_SIZE (8U * 1024U * 1024U)
-
-/* ---- Opaque context handle ---- */
 
 typedef struct nt_ui_context nt_ui_context_t;
 
-/* ---- Render target ---- */
-
-/* nt_ui_target_t -- where the walker emits pixels.
- *
- * Phase 52 ships viewport-only support. fbo and projection slots are
- * reserved for future render-to-texture (v1.10+).
- *
- * Drift 6 (Globals UBO ownership): ALL-ZERO projection sentinel means
- * walker does NOT update Globals UBO -- caller must have uploaded a
- * screen-space ortho matching viewport BEFORE nt_ui_walk. Reference
- * examples/bunnymark/main.c lines 353-364 (build nt_frame_uniforms_t)
- * and line 506 (nt_gfx_register_global_block("Globals", 0)) for the
- * canonical caller pattern.
- *
- * viewport layout: {x, y, width, height} in framebuffer pixels.
- */
+/* All-zero projection signals "caller owns Globals UBO" -- walker skips
+ * the upload and uses whatever ortho the caller wrote before walk. fbo
+ * and projection are reserved for future render-to-texture. */
 typedef struct {
     uint32_t fbo;         /* 0 = default framebuffer; non-zero reserved */
-    float viewport[4];    /* {x, y, width, height} */
+    float viewport[4];    /* {x, y, w, h} in framebuffer pixels */
     float projection[16]; /* column-major (cglm); all-zero = caller owns Globals UBO */
 } nt_ui_target_t;
 
-/* ---- Image payload (D-52-07) ----
- *
- * Caller fills + assigns pointer to Clay_ImageElementConfig.imageData.
- * Lifetime: must live until the matching nt_ui_walk call returns.
- *
- * D-52-08: slice9_lrtb bytes are RESERVED in Phase 52 -- silently ignored
- * by the walker (plain-quad emit). Phase 54 will fill the slice9 emit path.
- */
+/* Pointed to by Clay_ImageElementConfig.imageData. Lifetime must extend
+ * through the matching nt_ui_walk. slice9_lrtb is reserved (currently
+ * ignored, walker emits a plain quad). */
 typedef struct {
     nt_resource_t atlas;
     uint32_t region_index;
     uint8_t flip_bits;
-    uint8_t slice9_lrtb[4]; /* {left, right, top, bottom} -- reserved, Phase 54 */
+    uint8_t slice9_lrtb[4]; /* reserved */
 } nt_ui_image_payload_t;
 
-/* ---- CUSTOM-command handler (D-52-09, Option A) ----
- *
- * clay_cmd is opaque (const Clay_RenderCommand *) -- caller casts back
- * if needed. Option A keeps clay.h private to the nt_ui TU.
- */
+/* clay_cmd is an opaque const Clay_RenderCommand * (cast back if needed).
+ * Keeping it opaque lets clay.h stay private to the nt_ui TU. */
 typedef void (*nt_ui_custom_handler_t)(const void *clay_cmd, void *userdata);
 
-/* ---- Per-context setters (atlas / materials / custom handler) ----
- *
- * Walker state is owned by each context, NOT by globals. This makes the
- * "one ctx, many walks against different targets" pattern (split-screen,
- * screenshot FBO, minimap UI) trivially correct: separate contexts can
- * carry separate atlases and themes without swapping state between walks.
- *
- * All four setters must be called for each context before its first walk;
- * nt_ui_walk asserts every field is set at entry. */
+/* All four setters below must be called per-context before its first walk.
+ * Per-context (not module-global) so multi-context UIs can carry separate
+ * atlases and themes without state swaps between walks. */
 
-/* White-region & atlas binding. Walker emits RECT and BORDER through this
- * atlas+region. IMAGE uses the payload's atlas independently. */
+/* Atlas + white-region used for RECT and BORDER. IMAGE uses the payload
+ * atlas independently. */
 void nt_ui_set_atlas_white_region(nt_ui_context_t *ctx, nt_resource_t atlas, uint32_t white_region_idx);
 
-/* Material setters -- symmetric pair (Revision Issue 1, D-52-19).
- * Sprite material drives RECT/BORDER/IMAGE; text material drives TEXT.
- * Phase 53 theme will set both atomically; Phase 52 setters are the bootstrap.
- * Single-material reuse was rejected because sprite and text use different
- * nt_material_t (different shaders) and cannot share a pipeline slot. */
+/* Sprite material drives RECT/BORDER/IMAGE; text material drives TEXT.
+ * They cannot share a slot -- different shaders, different pipelines. */
 void nt_ui_set_sprite_material(nt_ui_context_t *ctx, nt_material_t sprite_material);
 void nt_ui_set_text_material(nt_ui_context_t *ctx, nt_material_t text_material);
 
-/* CUSTOM handler -- per-context, NULL fn = silent skip. */
+/* NULL fn silently skips CUSTOM commands. */
 void nt_ui_set_custom_handler(nt_ui_context_t *ctx, nt_ui_custom_handler_t fn, void *userdata);
 
-/* ---- Lifecycle (D-52-10) ---- */
-
-/* Returns the minimum arena size required by nt_ui_create_context.
- * Includes sizeof(nt_ui_context_t) + Clay_MinMemorySize() + alignment slack. */
 size_t nt_ui_min_arena_size(void);
 
-/* Creates a UI context in caller-provided arena memory.
- * Asserts: arena != NULL, arena_size >= nt_ui_min_arena_size(),
- *          ((uintptr_t)arena & 7u) == 0u (8-byte alignment).
- * Returns a pointer into the first ~256 bytes of arena. */
+/* Arena is caller-owned; ctx lives in the first ~256 bytes. Asserts
+ * arena != NULL, size >= nt_ui_min_arena_size(), NT_UI_ARENA_ALIGN-aligned. */
 nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size);
 
-/* Tears down a context. Does NOT touch arena memory -- caller owns it. */
+/* Tears down ctx state; caller still owns the arena memory. */
 void nt_ui_destroy_context(nt_ui_context_t *ctx);
 
-/* ---- Per-context font registry (D-52-15) ---- */
-
-/* Registers a font handle at the given font_id slot. Clay's fontId field
- * indexes into this table when the measure callback fires. Phase 53 theme
- * will own a canonical font table -- Phase 52 setter is the bootstrap. */
+/* Clay's fontId indexes this per-ctx table when the measure callback fires. */
 void nt_ui_set_font(nt_ui_context_t *ctx, uint16_t font_id, nt_font_t font);
 
-/* ---- Per-frame lifecycle ---- */
-
-/* Begin declaration phase.
- * - FIRST action: Clay_SetCurrentContext(ctx->clay) (UI-04 / CP-03 prevention)
- * - Sets ctx->in_frame, g_inframe_ctx
- * - Asserts !ctx->in_frame, g_inframe_ctx == NULL (D-52-12 multi-context invariant)
- * - Forwards pointer state to Clay (Phase 52: pointer body wired in Plan 03)
- * - Calls Clay_BeginLayout */
+/* First call inside switches Clay's current-context to this ctx so
+ * subsequent CLAY({...}) macros operate on it. */
 void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, const nt_pointer_t *mouse);
 
-/* End declaration phase. Calls Clay_EndLayout and freezes commands into ctx.
- * Asserts ctx->in_frame and ctx == g_inframe_ctx. */
+/* Freezes Clay's command array into ctx for subsequent walk(s). */
 void nt_ui_end(nt_ui_context_t *ctx);
 
-/* Render phase -- iterates frozen commands and dispatches to renderers.
- * Read-only on ctx; can be called multiple times per frame against
- * different targets (split-screen / screenshot FBO).
- *
- * Engine dependencies: requires nt_gfx, nt_sprite_renderer, and
- * nt_text_renderer to be init'd. See the file-level comment for the
- * full init sequence. */
+/* Read-only on ctx; safe to call N times against different targets in
+ * the same frame. */
 void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
 
-/* ---- Per-walk metrics (D-52-20 / WALK-09) ----
- *
- * Walker captures these into the ctx at the end of every nt_ui_walk.
- * They're per-context so split-screen / multi-walk setups can read each
- * pane's cost independently. Read-only on ctx; valid until the next
- * nt_ui_walk against the same ctx overwrites them.
- *
- * The walker DOES NOT push these to nt_stats automatically -- nt_ui
- * doesn't depend on nt_stats (observability is opt-in). Apps that want
- * the values in the debug overlay forward them themselves:
+/* Per-walk metrics captured into ctx at every nt_ui_walk exit. Apps that
+ * want them in the debug overlay forward themselves:
  *
  *     nt_ui_walk(ctx, &target);
  *     nt_stats_count("ui_draw_calls",    nt_ui_get_last_walk_draw_calls(ctx));
  *     nt_stats_count("ui_element_count", nt_ui_get_last_walk_element_count(ctx));
  *
- * Per-context names ("ui_draw_calls_hud" vs "ui_draw_calls_minimap") are
- * the app's call.
- */
-
-/* GPU draw calls issued by the most recent nt_ui_walk against `ctx`.
- * Counts physical glDrawElements (one per renderer flush), not Clay
- * command count -- so it reflects batching efficiency. Returns 0 if no
- * walk has been performed against this ctx yet. */
+ * draw_calls counts physical glDrawElements (one per renderer flush) --
+ * the metric reflects batching efficiency, not Clay command count. */
 uint32_t nt_ui_get_last_walk_draw_calls(const nt_ui_context_t *ctx);
-
-/* Number of Clay render commands the most recent nt_ui_walk dispatched
- * against `ctx` (== frozen_cmds.length at walk time). Returns 0 if no
- * walk has been performed against this ctx yet. */
 uint32_t nt_ui_get_last_walk_element_count(const nt_ui_context_t *ctx);
 
-/* ---- Test access (compiled only when NT_UI_TEST_ACCESS is defined) ---- */
-
 #ifdef NT_UI_TEST_ACCESS
-/* Module-level in-frame pointer (D-52-12). NULL when no context is mid-frame. */
 nt_ui_context_t *nt_ui_test_inframe_ctx(void);
 
-/* Plan 03: snapshot of the Clay-side pointer state for the given ctx,
- * intended for CLAY-04 / D-52-16 verification. Returns the values that
- * the most recent Clay_SetPointerState call (inside nt_ui_begin) wrote
- * to ctx->clay->pointerInfo. The struct stays Clay-opaque in the public
- * header -- the getters surface only the scalar fields tests need. */
+/* Clay_Context isn't visible outside the nt_ui TU, so tests need these
+ * to read ctx->clay->pointerInfo. */
 float nt_ui_test_clay_pointer_x(const nt_ui_context_t *ctx);
 float nt_ui_test_clay_pointer_y(const nt_ui_context_t *ctx);
-/* 0 = released-family, 1 = pressed-family. */
-int nt_ui_test_clay_pointer_down(const nt_ui_context_t *ctx);
+int nt_ui_test_clay_pointer_down(const nt_ui_context_t *ctx); /* 0 released, 1 pressed */
 
-/* Walker-setter introspection. Tests use these to verify what the per-context
- * setters wrote. Death-tests for "setter not called before walk" simply use
- * a freshly-created context (all walker fields zero-initialised); no reset
- * probe is needed. */
 nt_resource_t nt_ui_test_atlas(const nt_ui_context_t *ctx);
 uint32_t nt_ui_test_white_region(const nt_ui_context_t *ctx);
 nt_material_t nt_ui_test_sprite_material(const nt_ui_context_t *ctx);
 nt_material_t nt_ui_test_text_material(const nt_ui_context_t *ctx);
-#endif /* NT_UI_TEST_ACCESS */
+#endif
 
 #endif /* NT_UI_H */

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -213,6 +213,12 @@ nt_material_t nt_ui_test_text_material(const nt_ui_context_t *ctx);
  * was NULL (i.e. fell back to layer 0 implicitly). Useful to detect
  * "forgot to set layer on critical element" during development. */
 uint32_t nt_ui_test_last_walk_unlayered_count(const nt_ui_context_t *ctx);
+
+/* Exposes Clay's global Clay__defaultMaxElementCount for save/restore
+ * regression tests. Clay symbol is internal to the implementation TU
+ * (CLAY_IMPLEMENTATION lives in nt_ui.c), so external tests can't read
+ * it directly. */
+int32_t nt_ui_test_clay_default_max_element_count(void);
 #endif
 // #endregion
 

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -50,31 +50,16 @@
 #define NT_UI_WALKER_MAX_SCISSOR_DEPTH 8
 #endif
 
-/* Clay places its Clay_Context at the head of the arena via raw cast;
- * the strictest field there needs max_align_t. A bare `static uint8_t
- * arena[N]` has 1-byte alignment in C, so callers MUST use alignas. */
+/* Clay places its Clay_Context at the arena head via raw cast. */
 #define NT_UI_ARENA_ALIGN _Alignof(max_align_t)
 
-/* Clay sizes its internal arena by maxElementCount; default 8192 wants
- * ~8 MiB. Most game UIs use 100-1000 elements -- 1024 default keeps min
- * arena ~700 KiB. Override at compile time + raise arena if your layout
- * has more elements. nt_ui_create_context asserts on under-size. */
+/* Override at compile time + raise arena if your layout has more elements. */
 #ifndef NT_UI_DEFAULT_MAX_ELEMENT_COUNT
 #define NT_UI_DEFAULT_MAX_ELEMENT_COUNT 1024
 #endif
 #define NT_UI_DEFAULT_ARENA_SIZE (1U * 1024U * 1024U)
 
-/* Declares a correctly-aligned arena. The bare alternative
- *
- *     static uint8_t arena[NT_UI_DEFAULT_ARENA_SIZE];
- *
- * has only 1-byte alignment per the C spec and trips the runtime
- * assert in nt_ui_create_context. This macro produces a definition
- * compatible with file-scope, function-static, and (compilers that
- * accept _Alignas on auto) block-scope. Usage:
- *
- *     NT_UI_DECLARE_ARENA(g_ui_arena, NT_UI_DEFAULT_ARENA_SIZE);
- *     ctx = nt_ui_create_context(g_ui_arena, sizeof g_ui_arena); */
+/* Bare uint8_t[N] has 1-byte alignment and trips the create_context assert. */
 #define NT_UI_DECLARE_ARENA(name, size) alignas(NT_UI_ARENA_ALIGN) uint8_t name[(size)]
 
 typedef struct nt_ui_context nt_ui_context_t;
@@ -143,16 +128,8 @@ void nt_ui_end(nt_ui_context_t *ctx);
  *  - SCISSOR_START/END and CUSTOM are hard barriers -- never reordered. */
 void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
 
-/* Per-walk metrics captured into ctx at every nt_ui_walk exit. Apps that
- * want them in the debug overlay forward themselves:
- *
- *     nt_ui_walk(ctx, &target);
- *     nt_stats_count("ui_draw_calls",    nt_ui_get_last_walk_draw_calls(ctx));
- *     nt_stats_count("ui_element_count", nt_ui_get_last_walk_element_count(ctx));
- *
- * draw_calls is a WINDOW measurement: GL draw-call delta between walk
- * entry and exit. Includes any draws a CUSTOM handler emits. For
- * UI-only counts, snapshot sprite/text renderer stats around the walk. */
+/* draw_calls is a window delta over the walk -- includes CUSTOM-handler
+ * draws. Snapshot sprite/text renderer stats yourself for UI-only counts. */
 uint32_t nt_ui_get_last_walk_draw_calls(const nt_ui_context_t *ctx);
 uint32_t nt_ui_get_last_walk_element_count(const nt_ui_context_t *ctx);
 

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -177,6 +177,16 @@ nt_ui_context_t *nt_ui_test_inframe_ctx(void);
 /* Plan 05 will populate these. Phase 52 returns 0u placeholders. */
 uint32_t nt_ui_test_last_walk_draw_call_delta(void);
 uint32_t nt_ui_test_last_walk_element_count(void);
+
+/* Plan 03: snapshot of the Clay-side pointer state for the given ctx,
+ * intended for CLAY-04 / D-52-16 verification. Returns the values that
+ * the most recent Clay_SetPointerState call (inside nt_ui_begin) wrote
+ * to ctx->clay->pointerInfo. The struct stays Clay-opaque in the public
+ * header -- the getters surface only the scalar fields tests need. */
+float nt_ui_test_clay_pointer_x(const nt_ui_context_t *ctx);
+float nt_ui_test_clay_pointer_y(const nt_ui_context_t *ctx);
+/* 0 = released-family, 1 = pressed-family. */
+int nt_ui_test_clay_pointer_down(const nt_ui_context_t *ctx);
 #endif /* NT_UI_TEST_ACCESS */
 
 #endif /* NT_UI_H */

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -55,9 +55,20 @@
  * arena[N]` has 1-byte alignment in C, so callers MUST use alignas. */
 #define NT_UI_ARENA_ALIGN _Alignof(max_align_t)
 
-/* Recommended caller pattern:
- *     alignas(NT_UI_ARENA_ALIGN) static uint8_t g_ui_arena[NT_UI_DEFAULT_ARENA_SIZE]; */
 #define NT_UI_DEFAULT_ARENA_SIZE (8U * 1024U * 1024U)
+
+/* Declares a correctly-aligned arena. The bare alternative
+ *
+ *     static uint8_t arena[NT_UI_DEFAULT_ARENA_SIZE];
+ *
+ * has only 1-byte alignment per the C spec and trips the runtime
+ * assert in nt_ui_create_context. This macro produces a definition
+ * compatible with file-scope, function-static, and (compilers that
+ * accept _Alignas on auto) block-scope. Usage:
+ *
+ *     NT_UI_DECLARE_ARENA(g_ui_arena, NT_UI_DEFAULT_ARENA_SIZE);
+ *     ctx = nt_ui_create_context(g_ui_arena, sizeof g_ui_arena); */
+#define NT_UI_DECLARE_ARENA(name, size) alignas(NT_UI_ARENA_ALIGN) uint8_t name[(size)]
 
 typedef struct nt_ui_context nt_ui_context_t;
 

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -14,7 +14,8 @@
  *   nt_text_renderer_init();
  *
  * Per-context setup (once at boot):
- *   ctx = nt_ui_create_context(arena, sizeof arena);
+ *   nt_ui_create_desc_t desc = nt_ui_create_desc_defaults();
+ *   ctx = nt_ui_create_context(arena, sizeof arena, &desc);
  *   nt_ui_set_font(ctx, 0, font);
  *   nt_ui_set_atlas_white_region(ctx, atlas, white_region_idx);
  *   nt_ui_set_sprite_material(ctx, sprite_material);
@@ -64,16 +65,15 @@
 
 typedef struct nt_ui_context nt_ui_context_t;
 
-/* All-zero projection signals "caller owns Globals UBO" -- walker skips
- * the upload and uses whatever ortho the caller wrote before walk. fbo
- * and projection are reserved for future render-to-texture. */
+/* Caller owns framebuffer binding -- bind your FBO before nt_ui_walk
+ * if rendering to texture. Walker only touches viewport and scissor. */
 typedef struct {
-    uint32_t fbo;      /* 0 = default framebuffer; non-zero reserved */
     float viewport[4]; /* {x, y, w, h} in framebuffer pixels */
 } nt_ui_target_t;
 
 /* Pointed to by Clay_ImageElementConfig.imageData. Lifetime must extend
- * through the matching nt_ui_walk. */
+ * through the matching nt_ui_walk. IMAGE elements assert cornerRadius
+ * is all-zero -- pre-bake rounded edges into the atlas region. */
 typedef struct {
     nt_resource_t atlas;
     uint32_t region_index;
@@ -83,6 +83,38 @@ typedef struct {
 /* clay_cmd is an opaque const Clay_RenderCommand * (cast back if needed).
  * Keeping it opaque lets clay.h stay private to the nt_ui TU. */
 typedef void (*nt_ui_custom_handler_t)(const void *clay_cmd, void *userdata);
+
+/* ---- Layer-based painter order ----
+ * Walker sorts RECT/BORDER/IMAGE/TEXT commands within a segment (between
+ * SCISSOR/CUSTOM barriers) by layer ascending, then by declaration order
+ * within a layer. Lower layer renders first.
+ *
+ * Attach via Clay_ElementDeclaration.userData (or
+ * Clay_TextElementConfig.userData for TEXT). Pointer must outlive the
+ * matching nt_ui_walk -- use file-scope static const or a compound literal
+ * inside the function that calls walk (not in a deeper block scope).
+ *
+ * NULL userData -> layer 0 (default). Use NT_UI_DATA(N) for an inline
+ * compound literal:
+ *
+ *   CLAY({ .backgroundColor = c, .userData = NT_UI_DATA(LAYER_BG) }) {
+ *       CLAY_TEXT(s, CLAY_TEXT_CONFIG({ .userData = NT_UI_DATA(LAYER_FG) }));
+ *   }
+ *
+ * For game-specific layer names, define your own enum:
+ *   enum { LAYER_BG = 0, LAYER_HUD = 1, LAYER_OVERLAY = 2 };
+ *
+ * Note: layer sort applies ONLY to segmentable commands. SCISSOR_START/END
+ * and CUSTOM are hard barriers -- their position in the command stream is
+ * never reordered. */
+typedef uint8_t nt_ui_layer_t;
+typedef struct {
+    nt_ui_layer_t layer;  /* 0..255; lower draws first */
+    uint8_t _reserved[3]; /* padding for future per-element fields */
+} nt_ui_element_data_t;
+_Static_assert(sizeof(nt_ui_element_data_t) == 4, "nt_ui_element_data_t must be 4 bytes (stable ABI)");
+
+#define NT_UI_DATA(layer_value) ((void *)&(const nt_ui_element_data_t){.layer = (layer_value)})
 
 /* All four setters below must be called per-context before its first walk.
  * Per-context (not module-global) so multi-context UIs can carry separate
@@ -100,11 +132,35 @@ void nt_ui_set_text_material(nt_ui_context_t *ctx, nt_material_t text_material);
 /* NULL fn silently skips CUSTOM commands. */
 void nt_ui_set_custom_handler(nt_ui_context_t *ctx, nt_ui_custom_handler_t fn, void *userdata);
 
-size_t nt_ui_min_arena_size(void);
+/* ---- Module init ----
+ * Wires nt_ui's measure callback into Clay's global function pointer.
+ * MUST be called once before any nt_ui_create_context. Idempotent.
+ * Pair with nt_ui_module_shutdown for symmetry; not required for correctness. */
+void nt_ui_module_init(void);
+void nt_ui_module_shutdown(void);
+
+/* Per-context Clay capacity. Use nt_ui_create_desc_defaults() for a sane
+ * starting point and adjust fields explicitly when the layout grows beyond
+ * default limits. */
+typedef struct {
+    uint32_t max_elements; /* Max layout elements Clay can hold in this ctx. */
+} nt_ui_create_desc_t;
+
+static inline nt_ui_create_desc_t nt_ui_create_desc_defaults(void) {
+    return (nt_ui_create_desc_t){
+        .max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT,
+    };
+}
+
+/* Pure query: bytes required to host one nt_ui_context for the given desc.
+ * Saves/restores Clay's current-context so concurrent contexts are not
+ * mutated. Asserts desc != NULL. */
+size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc);
 
 /* Arena is caller-owned; ctx lives in the first ~256 bytes. Asserts
- * arena != NULL, size >= nt_ui_min_arena_size(), NT_UI_ARENA_ALIGN-aligned. */
-nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size);
+ * arena != NULL, size >= nt_ui_min_arena_size(desc), NT_UI_ARENA_ALIGN-aligned,
+ * desc != NULL. */
+nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_ui_create_desc_t *desc);
 
 /* Tears down ctx state; caller still owns the arena memory. */
 void nt_ui_destroy_context(nt_ui_context_t *ctx);
@@ -121,11 +177,14 @@ void nt_ui_end(nt_ui_context_t *ctx);
 
 /* Read-only on ctx; safe to call N times against different targets per
  * frame. Render order:
- *  - Different zIndex: strict ascending z.
- *  - Same z: sprite-bound (RECT/BORDER/IMAGE) emitted before TEXT;
- *    declaration order kept within each group. Overlapping sprite+text
- *    needing strict painter order MUST use different z.
- *  - SCISSOR_START/END and CUSTOM are hard barriers -- never reordered. */
+ *  - Different zIndex (Clay floating only): strict ascending z.
+ *  - Same z, different layer (nt_ui_element_data_t): ascending layer.
+ *  - Same z, same layer: declaration order.
+ *  - SCISSOR_START/END and CUSTOM are hard barriers -- never reordered.
+ *
+ * For tight batching, group elements sharing a material into the same
+ * layer (sprites vs text on different layers naturally minimizes material
+ * switches). Layer sort runs over segments bounded by barriers above. */
 void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
 
 /* draw_calls is a window delta over the walk -- includes CUSTOM-handler
@@ -147,6 +206,11 @@ nt_resource_t nt_ui_test_atlas(const nt_ui_context_t *ctx);
 uint32_t nt_ui_test_white_region(const nt_ui_context_t *ctx);
 nt_material_t nt_ui_test_sprite_material(const nt_ui_context_t *ctx);
 nt_material_t nt_ui_test_text_material(const nt_ui_context_t *ctx);
+
+/* Diagnostic: count of segmentable commands in last walk whose userData
+ * was NULL (i.e. fell back to layer 0 implicitly). Useful to detect
+ * "forgot to set layer on critical element" during development. */
+uint32_t nt_ui_test_last_walk_unlayered_count(const nt_ui_context_t *ctx);
 #endif
 // #endregion
 

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -74,7 +74,7 @@
 
 /* Default arena size suitable for ~50k Clay elements + 8 fonts + scroll/
  * modal stacks. Caller pattern: static uint8_t g_ui_arena[NT_UI_DEFAULT_ARENA_SIZE]. */
-#define NT_UI_DEFAULT_ARENA_SIZE (8u * 1024u * 1024u)
+#define NT_UI_DEFAULT_ARENA_SIZE (8U * 1024U * 1024U)
 
 /* ---- Opaque context handle ---- */
 

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -4,8 +4,179 @@
 /*
  * nt_ui -- Immediate-mode UI module built atop Clay v0.14.
  *
- * Currently a skeleton TU compiling Clay (CLAY_IMPLEMENTATION +
- * version-pin assert). Public API to follow.
+ * Frame lifecycle (Phase 52):
+ *
+ *   1) Once at boot:
+ *        ctx = nt_ui_create_context(arena, sizeof arena);
+ *        nt_ui_set_font(ctx, 0, font);
+ *        nt_ui_set_atlas_white_region(atlas, white_region_idx);
+ *        nt_ui_set_sprite_material(sprite_material);
+ *        nt_ui_set_text_material(text_material);
+ *
+ *   2) Per frame, declaration phase (Phase 1):
+ *        nt_pointer_t mouse = g_nt_input.pointers[0];
+ *        nt_ui_begin(ctx, screen_w, screen_h, &mouse);
+ *        // ... Clay declarations (CLAY({...}) { ... }) ...
+ *        nt_ui_end(ctx);
+ *
+ *   3) Per frame, render phase (Phase 2) -- can be called N times against
+ *      different targets (split-screen, screenshot FBO):
+ *        nt_ui_target_t target = {.viewport = {0, 0, screen_w, screen_h}};
+ *        nt_ui_walk(ctx, &target);
+ *
+ *   4) On shutdown:
+ *        nt_ui_destroy_context(ctx);  // does NOT free arena bytes
+ *
+ * Multi-context invariant (D-52-12 / UI-08): only one context may be
+ * in-frame at a time. nt_ui_begin asserts on stray nested begin.
+ *
+ * Globals UBO ownership (Drift 6): the caller owns the Globals UBO. The
+ * walker only writes viewport + scissor state -- it does NOT update
+ * Globals. See nt_ui_target_t for details.
  */
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "core/nt_types.h"
+#include "font/nt_font.h"
+#include "input/nt_input.h"
+#include "material/nt_material.h"
+#include "resource/nt_resource.h"
+
+/* ---- Compile-time limits ---- */
+
+#ifndef NT_UI_MAX_FONTS
+#define NT_UI_MAX_FONTS 8
+#endif
+
+#ifndef NT_UI_WALKER_MAX_SCISSOR_DEPTH
+#define NT_UI_WALKER_MAX_SCISSOR_DEPTH 8
+#endif
+
+/* Default arena size suitable for ~50k Clay elements + 8 fonts + scroll/
+ * modal stacks. Caller pattern: static uint8_t g_ui_arena[NT_UI_DEFAULT_ARENA_SIZE]. */
+#define NT_UI_DEFAULT_ARENA_SIZE (8u * 1024u * 1024u)
+
+/* ---- Opaque context handle ---- */
+
+typedef struct nt_ui_context nt_ui_context_t;
+
+/* ---- Render target ---- */
+
+/* nt_ui_target_t -- where the walker emits pixels.
+ *
+ * Phase 52 ships viewport-only support. fbo and projection slots are
+ * reserved for future render-to-texture (v1.10+).
+ *
+ * Drift 6 (Globals UBO ownership): ALL-ZERO projection sentinel means
+ * walker does NOT update Globals UBO -- caller must have uploaded a
+ * screen-space ortho matching viewport BEFORE nt_ui_walk. Reference
+ * examples/bunnymark/main.c lines 353-364 (build nt_frame_uniforms_t)
+ * and line 506 (nt_gfx_register_global_block("Globals", 0)) for the
+ * canonical caller pattern.
+ *
+ * viewport layout: {x, y, width, height} in framebuffer pixels.
+ */
+typedef struct {
+    uint32_t fbo;         /* 0 = default framebuffer; non-zero reserved */
+    float viewport[4];    /* {x, y, width, height} */
+    float projection[16]; /* row-major; all-zero = caller owns Globals UBO */
+} nt_ui_target_t;
+
+/* ---- Image payload (D-52-07) ----
+ *
+ * Caller fills + assigns pointer to Clay_ImageElementConfig.imageData.
+ * Lifetime: must live until the matching nt_ui_walk call returns.
+ *
+ * D-52-08: slice9_lrtb bytes are reserved in Phase 52 but inactive --
+ * the walker emits as plain quad when any field is non-zero (with a
+ * once-per-region warning). Phase 54 fills the slice9 emit path.
+ */
+typedef struct {
+    nt_resource_t atlas;
+    uint32_t region_index;
+    uint8_t flip_bits;
+    uint8_t slice9_lrtb[4]; /* {left, right, top, bottom} -- Phase 54 */
+} nt_ui_image_payload_t;
+
+/* ---- CUSTOM-command handler (D-52-09, Option A) ----
+ *
+ * clay_cmd is opaque (const Clay_RenderCommand *) -- caller casts back
+ * if needed. Option A keeps clay.h private to the nt_ui TU.
+ */
+typedef void (*nt_ui_custom_handler_t)(const void *clay_cmd, void *userdata);
+
+/* ---- Global setters (implementations in Plan 04) ---- */
+
+/* White-region & atlas setter -- one call between init and first walk.
+ * Walker asserts atlas is valid + ready before each walk. */
+void nt_ui_set_atlas_white_region(nt_resource_t atlas, uint32_t white_region_idx);
+
+/* Material setters -- symmetric pair (Revision Issue 1, D-52-19).
+ * Sprite material drives RECT/BORDER/IMAGE; text material drives TEXT.
+ * Both must be set before first nt_ui_walk (walker asserts at entry).
+ * Phase 53 theme sets both atomically; Phase 52 setters are the bootstrap.
+ * Single-material reuse was rejected because sprite and text use different
+ * nt_material_t (different shaders) and cannot share a pipeline slot. */
+void nt_ui_set_sprite_material(nt_material_t sprite_material);
+void nt_ui_set_text_material(nt_material_t text_material);
+
+/* CUSTOM handler -- global, NULL = silent skip. */
+void nt_ui_set_custom_handler(nt_ui_custom_handler_t fn, void *userdata);
+
+/* ---- Lifecycle (D-52-10) ---- */
+
+/* Returns the minimum arena size required by nt_ui_create_context.
+ * Includes sizeof(nt_ui_context_t) + Clay_MinMemorySize() + alignment slack. */
+size_t nt_ui_min_arena_size(void);
+
+/* Creates a UI context in caller-provided arena memory.
+ * Asserts: arena != NULL, arena_size >= nt_ui_min_arena_size(),
+ *          ((uintptr_t)arena & 7u) == 0u (8-byte alignment).
+ * Returns a pointer into the first ~256 bytes of arena. */
+nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size);
+
+/* Tears down a context. Does NOT touch arena memory -- caller owns it. */
+void nt_ui_destroy_context(nt_ui_context_t *ctx);
+
+/* ---- Per-context font registry (D-52-15) ---- */
+
+/* Registers a font handle at the given font_id slot. Clay's fontId field
+ * indexes into this table when the measure callback fires. Phase 53 theme
+ * will own a canonical font table -- Phase 52 setter is the bootstrap. */
+void nt_ui_set_font(nt_ui_context_t *ctx, uint16_t font_id, nt_font_t font);
+
+/* ---- Per-frame lifecycle ---- */
+
+/* Begin declaration phase.
+ * - FIRST action: Clay_SetCurrentContext(ctx->clay) (UI-04 / CP-03 prevention)
+ * - Sets ctx->in_frame, g_inframe_ctx
+ * - Asserts !ctx->in_frame, g_inframe_ctx == NULL (D-52-12 multi-context invariant)
+ * - Forwards pointer state to Clay (Phase 52: pointer body wired in Plan 03)
+ * - Calls Clay_BeginLayout */
+void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, const nt_pointer_t *mouse);
+
+/* End declaration phase. Calls Clay_EndLayout and freezes commands into ctx.
+ * Asserts ctx->in_frame and ctx == g_inframe_ctx. */
+void nt_ui_end(nt_ui_context_t *ctx);
+
+/* Render phase -- iterates frozen commands and dispatches to renderers.
+ * Read-only on ctx; can be called multiple times per frame against
+ * different targets (split-screen / screenshot FBO).
+ * Phase 52: body lands in Plan 04. */
+void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
+
+/* ---- Test access (compiled only when NT_UI_TEST_ACCESS is defined) ---- */
+
+#ifdef NT_UI_TEST_ACCESS
+/* Module-level in-frame pointer (D-52-12). NULL when no context is mid-frame. */
+nt_ui_context_t *nt_ui_test_inframe_ctx(void);
+
+/* Plan 05 will populate these. Phase 52 returns 0u placeholders. */
+uint32_t nt_ui_test_last_walk_draw_call_delta(void);
+uint32_t nt_ui_test_last_walk_element_count(void);
+#endif /* NT_UI_TEST_ACCESS */
 
 #endif /* NT_UI_H */

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -152,8 +152,9 @@ nt_material_t nt_ui_test_text_material(const nt_ui_context_t *ctx);
 /* Count of segmentable cmds in last walk with NULL userData (layer 0 fallback). */
 uint32_t nt_ui_test_last_walk_unlayered_count(const nt_ui_context_t *ctx);
 
-/* Clay__defaultMaxElementCount is impl-internal; expose for regression tests. */
+/* Clay globals are impl-internal; expose for regression tests. */
 int32_t nt_ui_test_clay_default_max_element_count(void);
+int32_t nt_ui_test_clay_default_max_measure_text_word_cache_count(void);
 #endif
 // #endregion
 

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -55,7 +55,14 @@
  * arena[N]` has 1-byte alignment in C, so callers MUST use alignas. */
 #define NT_UI_ARENA_ALIGN _Alignof(max_align_t)
 
-#define NT_UI_DEFAULT_ARENA_SIZE (8U * 1024U * 1024U)
+/* Clay sizes its internal arena by maxElementCount; default 8192 wants
+ * ~8 MiB. Most game UIs use 100-1000 elements -- 1024 default keeps min
+ * arena ~700 KiB. Override at compile time + raise arena if your layout
+ * has more elements. nt_ui_create_context asserts on under-size. */
+#ifndef NT_UI_DEFAULT_MAX_ELEMENT_COUNT
+#define NT_UI_DEFAULT_MAX_ELEMENT_COUNT 1024
+#endif
+#define NT_UI_DEFAULT_ARENA_SIZE (1U * 1024U * 1024U)
 
 /* Declares a correctly-aligned arena. The bare alternative
  *

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -52,6 +52,7 @@
  * Globals. See nt_ui_target_t for details.
  */
 
+#include <stdalign.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -72,8 +73,21 @@
 #define NT_UI_WALKER_MAX_SCISSOR_DEPTH 8
 #endif
 
+/* Required arena alignment. Clay places its Clay_Context struct at the
+ * head of the arena via raw pointer cast and that struct holds fields
+ * whose strictest alignment is max_align_t (16 bytes on x86_64). A raw
+ * `static uint8_t arena[N]` declaration has only 1-byte alignment in C,
+ * so callers MUST use the alignas decoration shown below. */
+#define NT_UI_ARENA_ALIGN _Alignof(max_align_t)
+
 /* Default arena size suitable for ~50k Clay elements + 8 fonts + scroll/
- * modal stacks. Caller pattern: static uint8_t g_ui_arena[NT_UI_DEFAULT_ARENA_SIZE]. */
+ * modal stacks. Recommended caller pattern:
+ *
+ *     alignas(NT_UI_ARENA_ALIGN) static uint8_t g_ui_arena[NT_UI_DEFAULT_ARENA_SIZE];
+ *
+ * `static uint64_t arena[N/8]` gives 8-byte alignment which is NOT enough.
+ * The cleanest stack-friendly alternative is a uint64_t array sized to fit
+ * plus a cast through a max-aligned union; tests use this pattern. */
 #define NT_UI_DEFAULT_ARENA_SIZE (8U * 1024U * 1024U)
 
 /* ---- Opaque context handle ---- */

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -143,12 +143,14 @@ void nt_ui_module_shutdown(void);
  * starting point and adjust fields explicitly when the layout grows beyond
  * default limits. */
 typedef struct {
-    uint32_t max_elements; /* Max layout elements Clay can hold in this ctx. */
+    uint32_t max_elements;      /* Max layout elements Clay can hold in this ctx. */
+    uint32_t max_scissor_depth; /* Max nested SCISSOR_START/END depth during walk. */
 } nt_ui_create_desc_t;
 
 static inline nt_ui_create_desc_t nt_ui_create_desc_defaults(void) {
     return (nt_ui_create_desc_t){
         .max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT,
+        .max_scissor_depth = NT_UI_WALKER_MAX_SCISSOR_DEPTH,
     };
 }
 

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -158,8 +158,14 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
  *     nt_stats_count("ui_draw_calls",    nt_ui_get_last_walk_draw_calls(ctx));
  *     nt_stats_count("ui_element_count", nt_ui_get_last_walk_element_count(ctx));
  *
- * draw_calls counts physical glDrawElements (one per renderer flush) --
- * the metric reflects batching efficiency, not Clay command count. */
+ * draw_calls is a WINDOW measurement: the GL draw-call counter delta
+ * between walk entry and exit. It counts every physical
+ * glDrawElements made during the walk, which includes any draws a
+ * CUSTOM-command handler emits (the handler's draws are part of the
+ * UI's cost, not separable from batching efficiency). Use this as
+ * "what did this walk cost the GPU?". If you need UI-only draws
+ * (excluding CUSTOM handler output), snapshot sprite/text renderer
+ * stats yourself around nt_ui_walk. */
 uint32_t nt_ui_get_last_walk_draw_calls(const nt_ui_context_t *ctx);
 uint32_t nt_ui_get_last_walk_element_count(const nt_ui_context_t *ctx);
 

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -19,11 +19,8 @@
 #define NT_UI_MAX_FONTS 8
 #endif
 
-#ifndef NT_UI_WALKER_MAX_SCISSOR_DEPTH
-#define NT_UI_WALKER_MAX_SCISSOR_DEPTH 8
-#endif
-
-/* Fixed stack-array size (no VLA -- MSVC C compat). */
+/* Walker's scissor stack capacity. Asserts on overflow. Real UIs nest 1-4
+ * levels; cap is 16x that headroom. */
 #define NT_UI_WALKER_SCISSOR_DEPTH_CAP 64
 
 /* Clay places its Clay_Context at the arena head via raw cast. */
@@ -93,14 +90,12 @@ void nt_ui_module_init(void);
 void nt_ui_module_shutdown(void);
 
 typedef struct {
-    uint32_t max_elements;      /* Clay layout-element cap. */
-    uint32_t max_scissor_depth; /* Walker scissor-stack VLA size. */
+    uint32_t max_elements; /* Clay layout-element cap. */
 } nt_ui_create_desc_t;
 
 static inline nt_ui_create_desc_t nt_ui_create_desc_defaults(void) {
     return (nt_ui_create_desc_t){
         .max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT,
-        .max_scissor_depth = NT_UI_WALKER_MAX_SCISSOR_DEPTH,
     };
 }
 
@@ -130,11 +125,6 @@ nt_ui_context_t *nt_ui_test_inframe_ctx(void);
 float nt_ui_test_clay_pointer_x(const nt_ui_context_t *ctx);
 float nt_ui_test_clay_pointer_y(const nt_ui_context_t *ctx);
 int nt_ui_test_clay_pointer_down(const nt_ui_context_t *ctx); /* 0 released, 1 pressed */
-
-nt_resource_t nt_ui_test_atlas(const nt_ui_context_t *ctx);
-uint32_t nt_ui_test_white_region(const nt_ui_context_t *ctx);
-nt_material_t nt_ui_test_sprite_material(const nt_ui_context_t *ctx);
-nt_material_t nt_ui_test_text_material(const nt_ui_context_t *ctx);
 
 /* Count of segmentable cmds with NULL userData (= implicit layer-0 fallback). */
 uint32_t nt_ui_test_last_walk_unlayered_count(const nt_ui_context_t *ctx);

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -1,14 +1,8 @@
 #ifndef NT_UI_H
 #define NT_UI_H
 
-/* Immediate-mode UI bridge over Clay v0.14.
- *
- * Lifecycle: nt_ui_module_init -> nt_ui_create_context -> per-ctx setters
- * (font, atlas/white-region, sprite/text material). Per frame: begin /
- * Clay declarations / end / walk (N targets per frame OK).
- *
- * Only one ctx may be in-frame at a time. Caller owns the Globals UBO;
- * walker writes viewport and scissor only. */
+/* Immediate-mode UI bridge over Clay v0.14. Only one ctx may be in-frame at
+ * a time; caller owns the Globals UBO -- walker writes viewport + scissor. */
 
 #include <stdalign.h>
 #include <stdbool.h>
@@ -60,39 +54,31 @@ _Static_assert(sizeof(nt_ui_image_payload_t) == 12, "nt_ui_image_payload_t stabl
 /* clay_cmd is opaque const Clay_RenderCommand * (cast back inside handler). */
 typedef void (*nt_ui_custom_handler_t)(const void *clay_cmd, void *userdata);
 
-/* Layer-based painter order. Attach to Clay_ElementDeclaration.userData or
- * Clay_TextElementConfig.userData. Lower layer draws first; within a layer
- * declaration order is preserved. NULL userData -> layer 0.
+/* Attached via Clay's userData slot. Engine owns the wire format -- ANY
+ * non-NULL userData MUST be nt_ui_element_data_t* (walker casts blindly).
+ * Game pointers go into the user_data field, not directly into Clay's slot.
  *
- * Pointer must outlive nt_ui_walk -- use file-scope static const or a
- * compound literal in the function that calls walk:
- *   CLAY({ .userData = NT_UI_DATA(LAYER_BG), ... })
+ * Layer sort applies to RECT/BORDER/IMAGE/TEXT; SCISSOR/CUSTOM are barriers.
  *
- * Layer sort applies to RECT/BORDER/IMAGE/TEXT only. SCISSOR/CUSTOM are
- * hard barriers and never reordered. */
+ *   CLAY({ .userData = NT_UI_DATA_LAYER(LAYER_BG), ... })
+ *   CLAY({ .userData = NT_UI_DATA_FULL(LAYER_HUD, &my_button), ... }) */
 typedef uint8_t nt_ui_layer_t;
 typedef struct {
-    nt_ui_layer_t layer;  /* 0..255; lower draws first */
-    uint8_t _reserved[3]; /* future per-element fields */
+    void *user_data;
+    nt_ui_layer_t layer; /* 0..255; lower draws first */
+    uint8_t _reserved[3];
 } nt_ui_element_data_t;
-_Static_assert(sizeof(nt_ui_element_data_t) == 4, "nt_ui_element_data_t stable ABI");
 
-#define NT_UI_DATA(layer_value) ((void *)&(const nt_ui_element_data_t){.layer = (layer_value)})
+#define NT_UI_DATA_LAYER(layer_value) ((void *)&(const nt_ui_element_data_t){.layer = (layer_value)})
+#define NT_UI_DATA_FULL(layer_value, user_ptr) ((void *)&(const nt_ui_element_data_t){.layer = (layer_value), .user_data = (user_ptr)})
 
-/* All four setters must be called per-context before first walk. */
-
-/* Atlas + white-region for RECT/BORDER. IMAGE uses its own payload atlas. */
+/* All four setters required per-context before first walk. */
 void nt_ui_set_atlas_white_region(nt_ui_context_t *ctx, nt_resource_t atlas, uint32_t white_region_idx);
-
-/* Sprite for RECT/BORDER/IMAGE; text for TEXT -- different pipelines. */
 void nt_ui_set_sprite_material(nt_ui_context_t *ctx, nt_material_t sprite_material);
 void nt_ui_set_text_material(nt_ui_context_t *ctx, nt_material_t text_material);
-
 /* NULL fn silently skips CUSTOM commands. */
 void nt_ui_set_custom_handler(nt_ui_context_t *ctx, nt_ui_custom_handler_t fn, void *userdata);
 
-/* Wires Clay's measure callback. MUST be called once before any
- * nt_ui_create_context. Idempotent. */
 void nt_ui_module_init(void);
 void nt_ui_module_shutdown(void);
 
@@ -108,30 +94,18 @@ static inline nt_ui_create_desc_t nt_ui_create_desc_defaults(void) {
     };
 }
 
-/* Pure query: byte count required for one ctx with this desc. */
 size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc);
-
-/* Arena is caller-owned; ctx lives in the first ~256 bytes. */
 nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_ui_create_desc_t *desc);
-
-/* Tears down ctx state; caller still owns the arena memory. */
 void nt_ui_destroy_context(nt_ui_context_t *ctx);
 
 void nt_ui_set_font(nt_ui_context_t *ctx, uint16_t font_id, nt_font_t font);
 
-/* Switches Clay's current-context to this ctx for the CLAY({...}) macros. */
 void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, const nt_pointer_t *mouse);
-
-/* Freezes Clay's command array into ctx for subsequent walk(s). */
 void nt_ui_end(nt_ui_context_t *ctx);
 
-/* Does not mutate frozen_cmds or bindings; per-walk stats reflect the most
- * recent call. Safe to call N times against different targets per frame.
- * Render order:
- *  - Different zIndex (Clay floating only): ascending z.
- *  - Same z, different layer: ascending layer.
- *  - Same z, same layer: declaration order.
- *  - SCISSOR/CUSTOM are hard barriers (never reordered). */
+/* Read-only on frozen_cmds + bindings; per-walk stats reflect the latest call.
+ * Order: zIndex asc, then layer asc, then declaration. SCISSOR/CUSTOM are
+ * hard barriers and never reordered. */
 void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
 
 /* Window delta over the walk; includes CUSTOM-handler draws. */
@@ -142,7 +116,6 @@ uint32_t nt_ui_get_last_walk_command_count(const nt_ui_context_t *ctx);
 #ifdef NT_TEST_ACCESS
 nt_ui_context_t *nt_ui_test_inframe_ctx(void);
 
-/* Clay_Context lives in the impl TU only; expose ctx->clay->pointerInfo. */
 float nt_ui_test_clay_pointer_x(const nt_ui_context_t *ctx);
 float nt_ui_test_clay_pointer_y(const nt_ui_context_t *ctx);
 int nt_ui_test_clay_pointer_down(const nt_ui_context_t *ctx); /* 0 released, 1 pressed */
@@ -152,10 +125,9 @@ uint32_t nt_ui_test_white_region(const nt_ui_context_t *ctx);
 nt_material_t nt_ui_test_sprite_material(const nt_ui_context_t *ctx);
 nt_material_t nt_ui_test_text_material(const nt_ui_context_t *ctx);
 
-/* Count of segmentable cmds in last walk with NULL userData (layer 0 fallback). */
+/* Count of segmentable cmds with NULL userData (= implicit layer-0 fallback). */
 uint32_t nt_ui_test_last_walk_unlayered_count(const nt_ui_context_t *ctx);
 
-/* Clay globals are impl-internal; expose for regression tests. */
 int32_t nt_ui_test_clay_default_max_element_count(void);
 int32_t nt_ui_test_clay_default_max_measure_text_word_cache_count(void);
 #endif

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -23,6 +23,9 @@
 #define NT_UI_WALKER_MAX_SCISSOR_DEPTH 8
 #endif
 
+/* Fixed stack-array size (no VLA -- MSVC C compat). */
+#define NT_UI_WALKER_SCISSOR_DEPTH_CAP 256
+
 /* Clay places its Clay_Context at the arena head via raw cast. */
 #define NT_UI_ARENA_ALIGN _Alignof(max_align_t)
 
@@ -51,7 +54,10 @@ typedef struct {
 } nt_ui_image_payload_t;
 _Static_assert(sizeof(nt_ui_image_payload_t) == 12, "nt_ui_image_payload_t stable ABI");
 
-/* clay_cmd is opaque const Clay_RenderCommand * (cast back inside handler). */
+/* clay_cmd is opaque const Clay_RenderCommand * (cast back inside handler).
+ * Handler owns the GL state it touches: if you change viewport or scissor,
+ * restore them before returning. Walker only rebinds the sprite material
+ * (its own flush invariant) -- everything else is the handler's mess. */
 typedef void (*nt_ui_custom_handler_t)(const void *clay_cmd, void *userdata);
 
 /* Attached via Clay's userData slot. Engine owns the wire format -- ANY

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -76,19 +76,16 @@ typedef struct nt_ui_context nt_ui_context_t;
  * the upload and uses whatever ortho the caller wrote before walk. fbo
  * and projection are reserved for future render-to-texture. */
 typedef struct {
-    uint32_t fbo;         /* 0 = default framebuffer; non-zero reserved */
-    float viewport[4];    /* {x, y, w, h} in framebuffer pixels */
-    float projection[16]; /* column-major (cglm); all-zero = caller owns Globals UBO */
+    uint32_t fbo;      /* 0 = default framebuffer; non-zero reserved */
+    float viewport[4]; /* {x, y, w, h} in framebuffer pixels */
 } nt_ui_target_t;
 
 /* Pointed to by Clay_ImageElementConfig.imageData. Lifetime must extend
- * through the matching nt_ui_walk. slice9_lrtb is reserved (currently
- * ignored, walker emits a plain quad). */
+ * through the matching nt_ui_walk. */
 typedef struct {
     nt_resource_t atlas;
     uint32_t region_index;
     uint8_t flip_bits;
-    uint8_t slice9_lrtb[4]; /* reserved */
 } nt_ui_image_payload_t;
 
 /* clay_cmd is an opaque const Clay_RenderCommand * (cast back if needed).

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -53,7 +53,9 @@ typedef struct {
     nt_resource_t atlas;
     uint32_t region_index;
     uint8_t flip_bits;
+    uint8_t _reserved[3];
 } nt_ui_image_payload_t;
+_Static_assert(sizeof(nt_ui_image_payload_t) == 12, "nt_ui_image_payload_t stable ABI");
 
 /* clay_cmd is opaque const Clay_RenderCommand * (cast back inside handler). */
 typedef void (*nt_ui_custom_handler_t)(const void *clay_cmd, void *userdata);
@@ -123,7 +125,8 @@ void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, const nt_
 /* Freezes Clay's command array into ctx for subsequent walk(s). */
 void nt_ui_end(nt_ui_context_t *ctx);
 
-/* Read-only on ctx; safe to call N times against different targets per frame.
+/* Does not mutate frozen_cmds or bindings; per-walk stats reflect the most
+ * recent call. Safe to call N times against different targets per frame.
  * Render order:
  *  - Different zIndex (Clay floating only): ascending z.
  *  - Same z, different layer: ascending layer.
@@ -133,7 +136,7 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
 
 /* Window delta over the walk; includes CUSTOM-handler draws. */
 uint32_t nt_ui_get_last_walk_draw_calls(const nt_ui_context_t *ctx);
-uint32_t nt_ui_get_last_walk_element_count(const nt_ui_context_t *ctx);
+uint32_t nt_ui_get_last_walk_command_count(const nt_ui_context_t *ctx);
 
 // #region test_access
 #ifdef NT_TEST_ACCESS

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -146,7 +146,8 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
 uint32_t nt_ui_get_last_walk_draw_calls(const nt_ui_context_t *ctx);
 uint32_t nt_ui_get_last_walk_element_count(const nt_ui_context_t *ctx);
 
-#ifdef NT_UI_TEST_ACCESS
+// #region test_access
+#ifdef NT_TEST_ACCESS
 nt_ui_context_t *nt_ui_test_inframe_ctx(void);
 
 /* Clay_Context isn't visible outside the nt_ui TU, so tests need these
@@ -160,5 +161,6 @@ uint32_t nt_ui_test_white_region(const nt_ui_context_t *ctx);
 nt_material_t nt_ui_test_sprite_material(const nt_ui_context_t *ctx);
 nt_material_t nt_ui_test_text_material(const nt_ui_context_t *ctx);
 #endif
+// #endregion
 
 #endif /* NT_UI_H */

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -5,9 +5,8 @@
  * nt_ui -- Immediate-mode UI module built atop Clay v0.14.
  *
  * Engine dependencies. nt_ui_walk transitively calls into nt_gfx (viewport
- * + scissor), nt_sprite_renderer + nt_text_renderer (geometry emit), and
- * nt_stats (per-walk ui_draw_calls / ui_element_count counters). All of
- * these must be init'd by the application BEFORE any nt_ui_walk:
+ * + scissor) and nt_sprite_renderer + nt_text_renderer (geometry emit).
+ * All of these must be init'd by the application BEFORE any nt_ui_walk:
  *
  *     nt_gfx_init(...);
  *     nt_resource_init(...);
@@ -16,10 +15,14 @@
  *     nt_material_init(...);
  *     nt_sprite_renderer_init(...);
  *     nt_text_renderer_init();
- *     nt_stats_init(NULL);       // walker pushes counters every walk
  *
  * The walker doesn't init these itself -- the application drives the
  * full engine lifecycle and is responsible for the order.
+ *
+ * nt_stats is NOT a dependency. Walker exposes per-walk metrics via the
+ * getter functions below (nt_ui_get_last_walk_draw_calls etc.); the
+ * application chooses whether to publish them to nt_stats for the debug
+ * overlay or to consume them privately for telemetry.
  *
  * Frame lifecycle (Phase 52):
  *
@@ -203,21 +206,46 @@ void nt_ui_end(nt_ui_context_t *ctx);
  * Read-only on ctx; can be called multiple times per frame against
  * different targets (split-screen / screenshot FBO).
  *
- * Engine dependencies: requires nt_gfx, nt_sprite_renderer,
- * nt_text_renderer, and nt_stats to be init'd. See the file-level
- * comment for the full init sequence. */
+ * Engine dependencies: requires nt_gfx, nt_sprite_renderer, and
+ * nt_text_renderer to be init'd. See the file-level comment for the
+ * full init sequence. */
 void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
+
+/* ---- Per-walk metrics (D-52-20 / WALK-09) ----
+ *
+ * Walker captures these into the ctx at the end of every nt_ui_walk.
+ * They're per-context so split-screen / multi-walk setups can read each
+ * pane's cost independently. Read-only on ctx; valid until the next
+ * nt_ui_walk against the same ctx overwrites them.
+ *
+ * The walker DOES NOT push these to nt_stats automatically -- nt_ui
+ * doesn't depend on nt_stats (observability is opt-in). Apps that want
+ * the values in the debug overlay forward them themselves:
+ *
+ *     nt_ui_walk(ctx, &target);
+ *     nt_stats_count("ui_draw_calls",    nt_ui_get_last_walk_draw_calls(ctx));
+ *     nt_stats_count("ui_element_count", nt_ui_get_last_walk_element_count(ctx));
+ *
+ * Per-context names ("ui_draw_calls_hud" vs "ui_draw_calls_minimap") are
+ * the app's call.
+ */
+
+/* GPU draw calls issued by the most recent nt_ui_walk against `ctx`.
+ * Counts physical glDrawElements (one per renderer flush), not Clay
+ * command count -- so it reflects batching efficiency. Returns 0 if no
+ * walk has been performed against this ctx yet. */
+uint32_t nt_ui_get_last_walk_draw_calls(const nt_ui_context_t *ctx);
+
+/* Number of Clay render commands the most recent nt_ui_walk dispatched
+ * against `ctx` (== frozen_cmds.length at walk time). Returns 0 if no
+ * walk has been performed against this ctx yet. */
+uint32_t nt_ui_get_last_walk_element_count(const nt_ui_context_t *ctx);
 
 /* ---- Test access (compiled only when NT_UI_TEST_ACCESS is defined) ---- */
 
 #ifdef NT_UI_TEST_ACCESS
 /* Module-level in-frame pointer (D-52-12). NULL when no context is mid-frame. */
 nt_ui_context_t *nt_ui_test_inframe_ctx(void);
-
-/* Walker captures per-walk deltas into the ctx itself; tests read them back
- * via these probes. Plan 05 also routes them through nt_stats_count. */
-uint32_t nt_ui_test_last_walk_draw_call_delta(const nt_ui_context_t *ctx);
-uint32_t nt_ui_test_last_walk_element_count(const nt_ui_context_t *ctx);
 
 /* Plan 03: snapshot of the Clay-side pointer state for the given ctx,
  * intended for CLAY-04 / D-52-16 verification. Returns the values that

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -1,0 +1,35 @@
+#ifndef NT_UI_INTERNAL_H
+#define NT_UI_INTERNAL_H
+
+/*
+ * nt_ui internal definitions.
+ *
+ * This header exposes struct nt_ui_context to TU code that needs the
+ * concrete layout (nt_ui.c itself, and tests compiled with
+ * NT_UI_TEST_ACCESS). The public header (engine/ui/nt_ui.h) only
+ * forward-declares the type as opaque.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "clay.h"
+#include "font/nt_font.h"
+#include "ui/nt_ui.h"
+
+/* Concrete context layout (D-52-10 / D-52-15).
+ *
+ * Lives in the first ~256 bytes of the caller-provided arena. Hot fields
+ * (clay, frozen_cmds, in_frame) come first for cache locality. The
+ * remainder of the arena is owned by Clay (via Clay_Initialize). */
+struct nt_ui_context {
+    Clay_Context *clay;                  /* returned by Clay_Initialize */
+    Clay_RenderCommandArray frozen_cmds; /* set by nt_ui_end, read by walk */
+    bool in_frame;                       /* between begin and end */
+    nt_font_t fonts[NT_UI_MAX_FONTS];    /* per-ctx font registry (D-52-15) */
+    Clay_Arena clay_arena;               /* opaque arena descriptor */
+    void *arena_base;                    /* caller's arena pointer */
+    size_t arena_size;                   /* caller's arena size */
+};
+
+#endif /* NT_UI_INTERNAL_H */

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -1,10 +1,7 @@
 #ifndef NT_UI_INTERNAL_H
 #define NT_UI_INTERNAL_H
 
-/*
- * Concrete struct nt_ui_context layout. The public header forward-declares
- * the type as opaque; only nt_ui.c and NT_TEST_ACCESS test TUs see this.
- */
+/* Concrete layout of opaque nt_ui_context_t. */
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -13,10 +10,7 @@
 #include "font/nt_font.h"
 #include "ui/nt_ui.h"
 
-/* Lives in the first ~256 bytes of the caller-owned arena (Clay owns the
- * rest). Hot fields first for cache locality. All walker state is per-ctx
- * -- no module globals -- so multi-context UIs are correct without state
- * swaps between walks. */
+/* Lives at arena head; hot fields first. Per-ctx -- no module globals. */
 struct nt_ui_context {
     Clay_Context *clay;
     Clay_RenderCommandArray frozen_cmds; /* set by end, read by walk */

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -31,10 +31,6 @@ struct nt_ui_context {
     uint32_t test_last_walk_unlayered_count;
 #endif
 
-    /* Layer-sort scratch buffer (uint16 indices into frozen_cmds). Lives
-     * in the same caller-owned arena right after the ctx struct, sized to
-     * fit one whole segment worst case (== max_elements). */
-    uint16_t *sorted;
     uint32_t max_elements;
     /* Walker allocates a VLA of this depth for its scissor stack. */
     uint32_t max_scissor_depth;

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -3,7 +3,7 @@
 
 /*
  * Concrete struct nt_ui_context layout. The public header forward-declares
- * the type as opaque; only nt_ui.c and NT_UI_TEST_ACCESS test TUs see this.
+ * the type as opaque; only nt_ui.c and NT_TEST_ACCESS test TUs see this.
  */
 
 #include <stdbool.h>

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -27,6 +27,9 @@ struct nt_ui_context {
     /* Per-walk metrics. Walker writes; nt_ui_get_last_walk_* reads. */
     uint32_t last_walk_draw_call_delta;
     uint32_t last_walk_element_count;
+#ifdef NT_TEST_ACCESS
+    uint32_t test_last_walk_unlayered_count;
+#endif
 
     nt_font_t fonts[NT_UI_MAX_FONTS];
 

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -37,8 +37,6 @@ struct nt_ui_context {
     nt_font_t fonts[NT_UI_MAX_FONTS];
 
     Clay_Arena clay_arena;
-    void *arena_base;
-    size_t arena_size;
 };
 
 #endif /* NT_UI_INTERNAL_H */

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -26,7 +26,7 @@ struct nt_ui_context {
 
     /* Per-walk metrics. Walker writes; nt_ui_get_last_walk_* reads. */
     uint32_t last_walk_draw_call_delta;
-    uint32_t last_walk_element_count;
+    uint32_t last_walk_command_count;
 #ifdef NT_TEST_ACCESS
     uint32_t test_last_walk_unlayered_count;
 #endif

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -36,6 +36,8 @@ struct nt_ui_context {
      * fit one whole segment worst case (== max_elements). */
     uint16_t *sorted;
     uint32_t max_elements;
+    /* Walker allocates a VLA of this depth for its scissor stack. */
+    uint32_t max_scissor_depth;
 
     nt_font_t fonts[NT_UI_MAX_FONTS];
 

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -21,15 +21,37 @@
  *
  * Lives in the first ~256 bytes of the caller-provided arena. Hot fields
  * (clay, frozen_cmds, in_frame) come first for cache locality. The
- * remainder of the arena is owned by Clay (via Clay_Initialize). */
+ * remainder of the arena is owned by Clay (via Clay_Initialize).
+ *
+ * All walker state (atlas, materials, custom handler, walker stats) is
+ * per-context -- no module globals. This makes "one ctx, many walks
+ * against different targets" trivially correct and lets Phase 53 themes
+ * own their state cleanly. */
 struct nt_ui_context {
+    /* --- Hot frame fields --- */
     Clay_Context *clay;                  /* returned by Clay_Initialize */
     Clay_RenderCommandArray frozen_cmds; /* set by nt_ui_end, read by walk */
     bool in_frame;                       /* between begin and end */
-    nt_font_t fonts[NT_UI_MAX_FONTS];    /* per-ctx font registry (D-52-15) */
-    Clay_Arena clay_arena;               /* opaque arena descriptor */
-    void *arena_base;                    /* caller's arena pointer */
-    size_t arena_size;                   /* caller's arena size */
+
+    /* --- Walker bindings (set by nt_ui_set_*; walker asserts non-zero) --- */
+    nt_resource_t atlas;
+    uint32_t white_region;
+    nt_material_t sprite_material;
+    nt_material_t text_material;
+    nt_ui_custom_handler_t custom_fn;
+    void *custom_user;
+
+    /* --- Per-walk stats (D-52-20 / WALK-09); also routed to nt_stats. --- */
+    uint32_t last_walk_draw_call_delta;
+    uint32_t last_walk_element_count;
+
+    /* --- Per-ctx font registry (D-52-15) --- */
+    nt_font_t fonts[NT_UI_MAX_FONTS];
+
+    /* --- Arena bookkeeping --- */
+    Clay_Arena clay_arena; /* opaque arena descriptor */
+    void *arena_base;      /* caller's arena pointer */
+    size_t arena_size;     /* caller's arena size */
 };
 
 #endif /* NT_UI_INTERNAL_H */

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -31,6 +31,12 @@ struct nt_ui_context {
     uint32_t test_last_walk_unlayered_count;
 #endif
 
+    /* Layer-sort scratch buffer (uint16 indices into frozen_cmds). Lives
+     * in the same caller-owned arena right after the ctx struct, sized to
+     * fit one whole segment worst case (== max_elements). */
+    uint16_t *sorted;
+    uint32_t max_elements;
+
     nt_font_t fonts[NT_UI_MAX_FONTS];
 
     Clay_Arena clay_arena;

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -32,8 +32,6 @@ struct nt_ui_context {
 #endif
 
     uint32_t max_elements;
-    /* Walker allocates a VLA of this depth for its scissor stack. */
-    uint32_t max_scissor_depth;
 
     nt_font_t fonts[NT_UI_MAX_FONTS];
 

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -2,12 +2,8 @@
 #define NT_UI_INTERNAL_H
 
 /*
- * nt_ui internal definitions.
- *
- * This header exposes struct nt_ui_context to TU code that needs the
- * concrete layout (nt_ui.c itself, and tests compiled with
- * NT_UI_TEST_ACCESS). The public header (engine/ui/nt_ui.h) only
- * forward-declares the type as opaque.
+ * Concrete struct nt_ui_context layout. The public header forward-declares
+ * the type as opaque; only nt_ui.c and NT_UI_TEST_ACCESS test TUs see this.
  */
 
 #include <stdbool.h>
@@ -17,23 +13,16 @@
 #include "font/nt_font.h"
 #include "ui/nt_ui.h"
 
-/* Concrete context layout (D-52-10 / D-52-15).
- *
- * Lives in the first ~256 bytes of the caller-provided arena. Hot fields
- * (clay, frozen_cmds, in_frame) come first for cache locality. The
- * remainder of the arena is owned by Clay (via Clay_Initialize).
- *
- * All walker state (atlas, materials, custom handler, walker stats) is
- * per-context -- no module globals. This makes "one ctx, many walks
- * against different targets" trivially correct and lets Phase 53 themes
- * own their state cleanly. */
+/* Lives in the first ~256 bytes of the caller-owned arena (Clay owns the
+ * rest). Hot fields first for cache locality. All walker state is per-ctx
+ * -- no module globals -- so multi-context UIs are correct without state
+ * swaps between walks. */
 struct nt_ui_context {
-    /* --- Hot frame fields --- */
-    Clay_Context *clay;                  /* returned by Clay_Initialize */
-    Clay_RenderCommandArray frozen_cmds; /* set by nt_ui_end, read by walk */
-    bool in_frame;                       /* between begin and end */
+    Clay_Context *clay;
+    Clay_RenderCommandArray frozen_cmds; /* set by end, read by walk */
+    bool in_frame;
 
-    /* --- Walker bindings (set by nt_ui_set_*; walker asserts non-zero) --- */
+    /* Walker bindings -- nt_ui_walk asserts each is non-zero at entry. */
     nt_resource_t atlas;
     uint32_t white_region;
     nt_material_t sprite_material;
@@ -41,17 +30,15 @@ struct nt_ui_context {
     nt_ui_custom_handler_t custom_fn;
     void *custom_user;
 
-    /* --- Per-walk stats (D-52-20 / WALK-09); also routed to nt_stats. --- */
+    /* Per-walk metrics. Walker writes; nt_ui_get_last_walk_* reads. */
     uint32_t last_walk_draw_call_delta;
     uint32_t last_walk_element_count;
 
-    /* --- Per-ctx font registry (D-52-15) --- */
     nt_font_t fonts[NT_UI_MAX_FONTS];
 
-    /* --- Arena bookkeeping --- */
-    Clay_Arena clay_arena; /* opaque arena descriptor */
-    void *arena_base;      /* caller's arena pointer */
-    size_t arena_size;     /* caller's arena size */
+    Clay_Arena clay_arena;
+    void *arena_base;
+    size_t arena_size;
 };
 
 #endif /* NT_UI_INTERNAL_H */

--- a/examples/bunnymark/main.c
+++ b/examples/bunnymark/main.c
@@ -450,7 +450,7 @@ static void frame(void) {
         }
         nt_text_renderer_set_material(s_text_material);
         nt_text_renderer_set_font(s_overlay_font);
-        nt_text_renderer_draw(overlay, (const float *)overlay_model, overlay_size, white, 0.0F);
+        nt_text_renderer_draw(overlay, (const float *)overlay_model, overlay_size, white, 0.0F, 0.0F);
         nt_text_renderer_flush();
     }
     // #endregion

--- a/examples/bunnymark/main.c
+++ b/examples/bunnymark/main.c
@@ -450,7 +450,7 @@ static void frame(void) {
         }
         nt_text_renderer_set_material(s_text_material);
         nt_text_renderer_set_font(s_overlay_font);
-        nt_text_renderer_draw(overlay, (const float *)overlay_model, overlay_size, white);
+        nt_text_renderer_draw(overlay, (const float *)overlay_model, overlay_size, white, 0.0F);
         nt_text_renderer_flush();
     }
     // #endregion

--- a/examples/text/main.c
+++ b/examples/text/main.c
@@ -158,7 +158,7 @@ static void draw_text_scene(void) {
         float white[4] = {1.0F, 1.0F, 1.0F, 1.0F};
         glm_mat4_identity(model);
         glm_translate(model, (vec3){-5.0F, 3.0F, 0.0F});
-        nt_text_renderer_draw(TEXT_EN, (const float *)model, 2.0F, white, 0.0F);
+        nt_text_renderer_draw(TEXT_EN, (const float *)model, 2.0F, white, 0.0F, 0.0F);
     }
 
     /* Medium Russian text at Y=1.0, light blue */
@@ -166,7 +166,7 @@ static void draw_text_scene(void) {
         float blue[4] = {0.6F, 0.8F, 1.0F, 1.0F};
         glm_mat4_identity(model);
         glm_translate(model, (vec3){-5.0F, 1.0F, 0.0F});
-        nt_text_renderer_draw(TEXT_RU, (const float *)model, 1.5F, blue, 0.0F);
+        nt_text_renderer_draw(TEXT_RU, (const float *)model, 1.5F, blue, 0.0F, 0.0F);
     }
 
     /* Chinese text at Y=-1.0, light green */
@@ -174,7 +174,7 @@ static void draw_text_scene(void) {
         float green[4] = {0.6F, 1.0F, 0.6F, 1.0F};
         glm_mat4_identity(model);
         glm_translate(model, (vec3){-3.0F, -1.0F, 0.0F});
-        nt_text_renderer_draw(TEXT_CN, (const float *)model, 1.5F, green, 0.0F);
+        nt_text_renderer_draw(TEXT_CN, (const float *)model, 1.5F, green, 0.0F, 0.0F);
     }
 
     /* Korean text at Y=-3.0, light yellow */
@@ -182,7 +182,7 @@ static void draw_text_scene(void) {
         float yellow[4] = {1.0F, 1.0F, 0.6F, 1.0F};
         glm_mat4_identity(model);
         glm_translate(model, (vec3){-4.0F, -3.0F, 0.0F});
-        nt_text_renderer_draw(TEXT_KR, (const float *)model, 1.5F, yellow, 0.0F);
+        nt_text_renderer_draw(TEXT_KR, (const float *)model, 1.5F, yellow, 0.0F, 0.0F);
     }
 
     /* Small size reference at bottom */
@@ -191,19 +191,19 @@ static void draw_text_scene(void) {
 
         glm_mat4_identity(model);
         glm_translate(model, (vec3){-8.0F, -5.5F, 0.0F});
-        nt_text_renderer_draw(TEXT_EN, (const float *)model, 0.5F, gray, 0.0F);
+        nt_text_renderer_draw(TEXT_EN, (const float *)model, 0.5F, gray, 0.0F, 0.0F);
 
         glm_mat4_identity(model);
         glm_translate(model, (vec3){-2.0F, -5.5F, 0.0F});
-        nt_text_renderer_draw(TEXT_RU, (const float *)model, 0.5F, gray, 0.0F);
+        nt_text_renderer_draw(TEXT_RU, (const float *)model, 0.5F, gray, 0.0F, 0.0F);
 
         glm_mat4_identity(model);
         glm_translate(model, (vec3){4.0F, -5.5F, 0.0F});
-        nt_text_renderer_draw(TEXT_CN, (const float *)model, 0.5F, gray, 0.0F);
+        nt_text_renderer_draw(TEXT_CN, (const float *)model, 0.5F, gray, 0.0F, 0.0F);
 
         glm_mat4_identity(model);
         glm_translate(model, (vec3){8.0F, -5.5F, 0.0F});
-        nt_text_renderer_draw(TEXT_KR, (const float *)model, 0.5F, gray, 0.0F);
+        nt_text_renderer_draw(TEXT_KR, (const float *)model, 0.5F, gray, 0.0F, 0.0F);
     }
 }
 

--- a/examples/text/main.c
+++ b/examples/text/main.c
@@ -158,7 +158,7 @@ static void draw_text_scene(void) {
         float white[4] = {1.0F, 1.0F, 1.0F, 1.0F};
         glm_mat4_identity(model);
         glm_translate(model, (vec3){-5.0F, 3.0F, 0.0F});
-        nt_text_renderer_draw(TEXT_EN, (const float *)model, 2.0F, white);
+        nt_text_renderer_draw(TEXT_EN, (const float *)model, 2.0F, white, 0.0F);
     }
 
     /* Medium Russian text at Y=1.0, light blue */
@@ -166,7 +166,7 @@ static void draw_text_scene(void) {
         float blue[4] = {0.6F, 0.8F, 1.0F, 1.0F};
         glm_mat4_identity(model);
         glm_translate(model, (vec3){-5.0F, 1.0F, 0.0F});
-        nt_text_renderer_draw(TEXT_RU, (const float *)model, 1.5F, blue);
+        nt_text_renderer_draw(TEXT_RU, (const float *)model, 1.5F, blue, 0.0F);
     }
 
     /* Chinese text at Y=-1.0, light green */
@@ -174,7 +174,7 @@ static void draw_text_scene(void) {
         float green[4] = {0.6F, 1.0F, 0.6F, 1.0F};
         glm_mat4_identity(model);
         glm_translate(model, (vec3){-3.0F, -1.0F, 0.0F});
-        nt_text_renderer_draw(TEXT_CN, (const float *)model, 1.5F, green);
+        nt_text_renderer_draw(TEXT_CN, (const float *)model, 1.5F, green, 0.0F);
     }
 
     /* Korean text at Y=-3.0, light yellow */
@@ -182,7 +182,7 @@ static void draw_text_scene(void) {
         float yellow[4] = {1.0F, 1.0F, 0.6F, 1.0F};
         glm_mat4_identity(model);
         glm_translate(model, (vec3){-4.0F, -3.0F, 0.0F});
-        nt_text_renderer_draw(TEXT_KR, (const float *)model, 1.5F, yellow);
+        nt_text_renderer_draw(TEXT_KR, (const float *)model, 1.5F, yellow, 0.0F);
     }
 
     /* Small size reference at bottom */
@@ -191,19 +191,19 @@ static void draw_text_scene(void) {
 
         glm_mat4_identity(model);
         glm_translate(model, (vec3){-8.0F, -5.5F, 0.0F});
-        nt_text_renderer_draw(TEXT_EN, (const float *)model, 0.5F, gray);
+        nt_text_renderer_draw(TEXT_EN, (const float *)model, 0.5F, gray, 0.0F);
 
         glm_mat4_identity(model);
         glm_translate(model, (vec3){-2.0F, -5.5F, 0.0F});
-        nt_text_renderer_draw(TEXT_RU, (const float *)model, 0.5F, gray);
+        nt_text_renderer_draw(TEXT_RU, (const float *)model, 0.5F, gray, 0.0F);
 
         glm_mat4_identity(model);
         glm_translate(model, (vec3){4.0F, -5.5F, 0.0F});
-        nt_text_renderer_draw(TEXT_CN, (const float *)model, 0.5F, gray);
+        nt_text_renderer_draw(TEXT_CN, (const float *)model, 0.5F, gray, 0.0F);
 
         glm_mat4_identity(model);
         glm_translate(model, (vec3){8.0F, -5.5F, 0.0F});
-        nt_text_renderer_draw(TEXT_KR, (const float *)model, 0.5F, gray);
+        nt_text_renderer_draw(TEXT_KR, (const float *)model, 0.5F, gray, 0.0F);
     }
 }
 

--- a/scripts/tidy.sh
+++ b/scripts/tidy.sh
@@ -29,21 +29,23 @@ SYSTEM_DEPS=(
     "$ROOT_DIR/deps/stb"
 )
 
-EXTRA_ARGS=""
+EXTRA_ARGS=()
 for dep in "${SYSTEM_DEPS[@]}"; do
-    EXTRA_ARGS+=" --extra-arg=-isystem$dep"
+    EXTRA_ARGS+=("--extra-arg=-isystem$dep")
 done
 
 # Always invoke clang-tidy directly. The LLVM run-clang-tidy Python wrapper
 # silently swallows diagnostics on Windows + LLVM 19, causing the script to
 # report PASS while real errors exist. Direct per-file invocation surfaces
 # errors reliably; parallelism via xargs -P keeps wall time comparable.
+# EXTRA_ARGS is an array (not a string) so dep paths with spaces stay intact
+# through xargs splitting.
 TIDY_OUTPUT=$(mktemp)
 TIDY_RC=0
 
 PARALLEL_JOBS="${TIDY_JOBS:-$(nproc 2>/dev/null || echo 4)}"
 
-echo "$SOURCES" | tr ' ' '\n' | xargs -n 1 -P "$PARALLEL_JOBS" clang-tidy -p "$BUILD_DIR" $EXTRA_ARGS > "$TIDY_OUTPUT" 2>&1 || TIDY_RC=$?
+echo "$SOURCES" | tr ' ' '\n' | xargs -n 1 -P "$PARALLEL_JOBS" -I {} clang-tidy -p "$BUILD_DIR" "${EXTRA_ARGS[@]}" {} > "$TIDY_OUTPUT" 2>&1 || TIDY_RC=$?
 
 # Filter: show only errors from project files, not vendored deps
 PROJECT_ERRORS=$(grep "error:" "$TIDY_OUTPUT" | grep -v "deps/" || true)

--- a/scripts/tidy.sh
+++ b/scripts/tidy.sh
@@ -3,6 +3,11 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+# Match compile_commands.json's path style (Windows C:/... when on Git Bash);
+# clang treats /c/... and C:/... as distinct, breaking -isystem suppression.
+if command -v cygpath > /dev/null 2>&1; then
+    ROOT_DIR="$(cygpath -m "$ROOT_DIR")"
+fi
 BUILD_DIR="${1:-build/_cmake/native-debug}"
 
 if [ ! -f "$BUILD_DIR/compile_commands.json" ]; then
@@ -27,6 +32,13 @@ SYSTEM_DEPS=(
     "$ROOT_DIR/deps/cgltf"
     "$ROOT_DIR/deps/mikktspace"
     "$ROOT_DIR/deps/stb"
+    "$ROOT_DIR/deps/clay"
+    "$ROOT_DIR/deps/clipper2/CPP"
+    "$ROOT_DIR/deps/glfw/include"
+    "$ROOT_DIR/deps/miniz"
+    "$ROOT_DIR/deps/tinycthread"
+    "$ROOT_DIR/deps/basisu/transcoder"
+    "$ROOT_DIR/deps/basisu/encoder"
 )
 
 EXTRA_ARGS=()
@@ -56,6 +68,19 @@ if [ -n "$PROJECT_ERRORS" ]; then
     echo "clang-tidy: FAILED — errors in project files"
     rm -f "$TIDY_OUTPUT"
     exit 1
+fi
+
+# xargs returns 123 when a subcommand exited 1-125: clang-tidy did run
+# but treated deps warnings-as-errors (HeaderFilterRegex can't catch every
+# deps path that goes through engine/.. relative includes). PROJECT_ERRORS
+# above already covers real project issues. Other codes (127 = not found,
+# 124 = killed, etc.) mean tidy itself failed -- surface them.
+if [ "$TIDY_RC" -ne 0 ] && [ "$TIDY_RC" -ne 123 ]; then
+    echo "clang-tidy: invocation failed with exit $TIDY_RC"
+    echo "--- full output ---"
+    cat "$TIDY_OUTPUT"
+    rm -f "$TIDY_OUTPUT"
+    exit "$TIDY_RC"
 fi
 
 # Count suppressed deps warnings for info

--- a/scripts/tidy.sh
+++ b/scripts/tidy.sh
@@ -30,21 +30,20 @@ SYSTEM_DEPS=(
 )
 
 EXTRA_ARGS=""
-RCT_ARGS=""
 for dep in "${SYSTEM_DEPS[@]}"; do
     EXTRA_ARGS+=" --extra-arg=-isystem$dep"
-    RCT_ARGS+=" -extra-arg=-isystem$dep"
 done
 
-# Capture output, filter deps noise, then check for project errors
+# Always invoke clang-tidy directly. The LLVM run-clang-tidy Python wrapper
+# silently swallows diagnostics on Windows + LLVM 19, causing the script to
+# report PASS while real errors exist. Direct per-file invocation surfaces
+# errors reliably; parallelism via xargs -P keeps wall time comparable.
 TIDY_OUTPUT=$(mktemp)
 TIDY_RC=0
 
-if command -v run-clang-tidy &>/dev/null && command -v python3 &>/dev/null; then
-    echo "$SOURCES" | xargs run-clang-tidy -p "$BUILD_DIR" $RCT_ARGS > "$TIDY_OUTPUT" 2>&1 || TIDY_RC=$?
-else
-    echo "$SOURCES" | xargs clang-tidy -p "$BUILD_DIR" $EXTRA_ARGS > "$TIDY_OUTPUT" 2>&1 || TIDY_RC=$?
-fi
+PARALLEL_JOBS="${TIDY_JOBS:-$(nproc 2>/dev/null || echo 4)}"
+
+echo "$SOURCES" | tr ' ' '\n' | xargs -n 1 -P "$PARALLEL_JOBS" clang-tidy -p "$BUILD_DIR" $EXTRA_ARGS > "$TIDY_OUTPUT" 2>&1 || TIDY_RC=$?
 
 # Filter: show only errors from project files, not vendored deps
 PROJECT_ERRORS=$(grep "error:" "$TIDY_OUTPUT" | grep -v "deps/" || true)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -413,6 +413,7 @@ if(NOT EMSCRIPTEN)
         test_nt_ui_walker_custom
         test_nt_ui_walker_flush
         test_nt_ui_walker_readonly
+        test_nt_ui_walker_batching
     )
 
     foreach(_t IN LISTS _nt_ui_test_names)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -441,6 +441,273 @@ if(NOT EMSCRIPTEN)
     )
     add_test(NAME test_stats COMMAND test_stats)
 
+    # --- Phase 52: nt_ui module + walker MVP tests ---
+    # All tests use stub gfx backend + Phase 51 NT_GFX_TEST_ACCESS probes.
+    # nt_ui tests additionally use NT_UI_TEST_ACCESS for in-frame/walk probes.
+    # Death-tests use the shared NT_TEST_EXPECT_ASSERT macro (Revision Issue 3).
+
+    # Shared helper sources compiled into each binary.
+    # - ui_atlas: produces minimal_ui_atlas via NT_ATLAS_TEST_ACCESS (Revision Issue 4)
+    # - nt_assert_trap: NT_TEST_EXPECT_ASSERT death-test helper (Revision Issue 3)
+    set(_nt_ui_test_helper_sources
+        unit/test_helpers/ui_atlas.c
+        unit/test_helpers/nt_assert_trap.c
+    )
+
+    # Helpers need `tests/unit/` on the include path so
+    # `#include "test_helpers/ui_atlas.h"` resolves.
+    set(_nt_ui_test_helper_includes
+        "${CMAKE_CURRENT_SOURCE_DIR}/unit"
+    )
+
+    # Force nt_atlas to expose NT_ATLAS_TEST_ACCESS symbols
+    # (nt_atlas_test_drive_resolve, nt_atlas_test_drive_cleanup) so the
+    # ui_atlas helper can link.
+    target_compile_definitions(nt_atlas PRIVATE NT_ATLAS_TEST_ACCESS)
+
+    # --- test_nt_sprite_renderer_emit_region -- D-52-01/02 + Drift 4 ---
+    add_executable(test_nt_sprite_renderer_emit_region
+        unit/test_nt_sprite_renderer_emit_region.c
+        ${_nt_ui_test_helper_sources}
+    )
+    target_include_directories(test_nt_sprite_renderer_emit_region PRIVATE ${_nt_ui_test_helper_includes})
+    target_link_libraries(test_nt_sprite_renderer_emit_region PRIVATE
+        nt_sprite_renderer nt_text_renderer nt_font nt_material
+        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
+    )
+    target_compile_definitions(test_nt_sprite_renderer_emit_region PRIVATE
+        NT_GFX_TEST_ACCESS NT_SPRITE_RENDERER_TEST_ACCESS NT_ATLAS_TEST_ACCESS
+        _CRT_SECURE_NO_WARNINGS)
+    target_compile_definitions(nt_gfx_stub PRIVATE NT_GFX_TEST_ACCESS)
+    target_compile_options(test_nt_sprite_renderer_emit_region PRIVATE -U_DLL)
+    nt_set_warning_flags(test_nt_sprite_renderer_emit_region)
+    nt_set_sanitizer_flags(test_nt_sprite_renderer_emit_region)
+    set_target_properties(test_nt_sprite_renderer_emit_region PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
+    add_test(NAME test_nt_sprite_renderer_emit_region COMMAND test_nt_sprite_renderer_emit_region)
+
+    # --- test_nt_ui_lifecycle -- UI-01, UI-02 ---
+    add_executable(test_nt_ui_lifecycle
+        unit/test_nt_ui_lifecycle.c
+        ${_nt_ui_test_helper_sources}
+    )
+    target_include_directories(test_nt_ui_lifecycle PRIVATE ${_nt_ui_test_helper_includes})
+    target_link_libraries(test_nt_ui_lifecycle PRIVATE
+        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
+        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
+    )
+    target_compile_definitions(test_nt_ui_lifecycle PRIVATE
+        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
+        _CRT_SECURE_NO_WARNINGS)
+    target_compile_options(test_nt_ui_lifecycle PRIVATE -U_DLL)
+    nt_set_warning_flags(test_nt_ui_lifecycle)
+    nt_set_sanitizer_flags(test_nt_ui_lifecycle)
+    set_target_properties(test_nt_ui_lifecycle PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
+    add_test(NAME test_nt_ui_lifecycle COMMAND test_nt_ui_lifecycle)
+
+    # --- test_nt_ui_multictx -- UI-03 ---
+    add_executable(test_nt_ui_multictx
+        unit/test_nt_ui_multictx.c
+        ${_nt_ui_test_helper_sources}
+    )
+    target_include_directories(test_nt_ui_multictx PRIVATE ${_nt_ui_test_helper_includes})
+    target_link_libraries(test_nt_ui_multictx PRIVATE
+        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
+        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
+    )
+    target_compile_definitions(test_nt_ui_multictx PRIVATE
+        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
+        _CRT_SECURE_NO_WARNINGS)
+    target_compile_options(test_nt_ui_multictx PRIVATE -U_DLL)
+    nt_set_warning_flags(test_nt_ui_multictx)
+    nt_set_sanitizer_flags(test_nt_ui_multictx)
+    set_target_properties(test_nt_ui_multictx PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
+    add_test(NAME test_nt_ui_multictx COMMAND test_nt_ui_multictx)
+
+    # --- test_nt_ui_begin_end -- UI-04, UI-05, UI-08 ---
+    add_executable(test_nt_ui_begin_end
+        unit/test_nt_ui_begin_end.c
+        ${_nt_ui_test_helper_sources}
+    )
+    target_include_directories(test_nt_ui_begin_end PRIVATE ${_nt_ui_test_helper_includes})
+    target_link_libraries(test_nt_ui_begin_end PRIVATE
+        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
+        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
+    )
+    target_compile_definitions(test_nt_ui_begin_end PRIVATE
+        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
+        _CRT_SECURE_NO_WARNINGS)
+    target_compile_options(test_nt_ui_begin_end PRIVATE -U_DLL)
+    nt_set_warning_flags(test_nt_ui_begin_end)
+    nt_set_sanitizer_flags(test_nt_ui_begin_end)
+    set_target_properties(test_nt_ui_begin_end PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
+    add_test(NAME test_nt_ui_begin_end COMMAND test_nt_ui_begin_end)
+
+    # --- test_nt_ui_measure_cb -- CLAY-03 ---
+    add_executable(test_nt_ui_measure_cb
+        unit/test_nt_ui_measure_cb.c
+        ${_nt_ui_test_helper_sources}
+    )
+    target_include_directories(test_nt_ui_measure_cb PRIVATE ${_nt_ui_test_helper_includes})
+    target_link_libraries(test_nt_ui_measure_cb PRIVATE
+        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
+        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
+    )
+    target_compile_definitions(test_nt_ui_measure_cb PRIVATE
+        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS NT_FONT_TEST_ACCESS
+        _CRT_SECURE_NO_WARNINGS)
+    target_compile_options(test_nt_ui_measure_cb PRIVATE -U_DLL)
+    nt_set_warning_flags(test_nt_ui_measure_cb)
+    nt_set_sanitizer_flags(test_nt_ui_measure_cb)
+    set_target_properties(test_nt_ui_measure_cb PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
+    add_test(NAME test_nt_ui_measure_cb COMMAND test_nt_ui_measure_cb)
+
+    # --- test_nt_ui_pointer_state -- CLAY-04 ---
+    add_executable(test_nt_ui_pointer_state
+        unit/test_nt_ui_pointer_state.c
+        ${_nt_ui_test_helper_sources}
+    )
+    target_include_directories(test_nt_ui_pointer_state PRIVATE ${_nt_ui_test_helper_includes})
+    target_link_libraries(test_nt_ui_pointer_state PRIVATE
+        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
+        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
+    )
+    target_compile_definitions(test_nt_ui_pointer_state PRIVATE
+        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
+        _CRT_SECURE_NO_WARNINGS)
+    target_compile_options(test_nt_ui_pointer_state PRIVATE -U_DLL)
+    nt_set_warning_flags(test_nt_ui_pointer_state)
+    nt_set_sanitizer_flags(test_nt_ui_pointer_state)
+    set_target_properties(test_nt_ui_pointer_state PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
+    add_test(NAME test_nt_ui_pointer_state COMMAND test_nt_ui_pointer_state)
+
+    # --- test_nt_ui_walker_dispatch -- WALK-01, WALK-04 ---
+    add_executable(test_nt_ui_walker_dispatch
+        unit/test_nt_ui_walker_dispatch.c
+        ${_nt_ui_test_helper_sources}
+    )
+    target_include_directories(test_nt_ui_walker_dispatch PRIVATE ${_nt_ui_test_helper_includes})
+    target_link_libraries(test_nt_ui_walker_dispatch PRIVATE
+        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
+        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
+    )
+    target_compile_definitions(test_nt_ui_walker_dispatch PRIVATE
+        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
+        NT_SPRITE_RENDERER_TEST_ACCESS NT_TEXT_RENDERER_TEST_ACCESS
+        _CRT_SECURE_NO_WARNINGS)
+    target_compile_options(test_nt_ui_walker_dispatch PRIVATE -U_DLL)
+    nt_set_warning_flags(test_nt_ui_walker_dispatch)
+    nt_set_sanitizer_flags(test_nt_ui_walker_dispatch)
+    set_target_properties(test_nt_ui_walker_dispatch PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
+    add_test(NAME test_nt_ui_walker_dispatch COMMAND test_nt_ui_walker_dispatch)
+
+    # --- test_nt_ui_walker_scissor -- WALK-02, WALK-03 ---
+    add_executable(test_nt_ui_walker_scissor
+        unit/test_nt_ui_walker_scissor.c
+        ${_nt_ui_test_helper_sources}
+    )
+    target_include_directories(test_nt_ui_walker_scissor PRIVATE ${_nt_ui_test_helper_includes})
+    target_link_libraries(test_nt_ui_walker_scissor PRIVATE
+        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
+        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
+    )
+    target_compile_definitions(test_nt_ui_walker_scissor PRIVATE
+        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
+        _CRT_SECURE_NO_WARNINGS)
+    target_compile_options(test_nt_ui_walker_scissor PRIVATE -U_DLL)
+    nt_set_warning_flags(test_nt_ui_walker_scissor)
+    nt_set_sanitizer_flags(test_nt_ui_walker_scissor)
+    set_target_properties(test_nt_ui_walker_scissor PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
+    add_test(NAME test_nt_ui_walker_scissor COMMAND test_nt_ui_walker_scissor)
+
+    # --- test_nt_ui_walker_custom -- WALK-05 ---
+    add_executable(test_nt_ui_walker_custom
+        unit/test_nt_ui_walker_custom.c
+        ${_nt_ui_test_helper_sources}
+    )
+    target_include_directories(test_nt_ui_walker_custom PRIVATE ${_nt_ui_test_helper_includes})
+    target_link_libraries(test_nt_ui_walker_custom PRIVATE
+        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
+        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
+    )
+    target_compile_definitions(test_nt_ui_walker_custom PRIVATE
+        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
+        _CRT_SECURE_NO_WARNINGS)
+    target_compile_options(test_nt_ui_walker_custom PRIVATE -U_DLL)
+    nt_set_warning_flags(test_nt_ui_walker_custom)
+    nt_set_sanitizer_flags(test_nt_ui_walker_custom)
+    set_target_properties(test_nt_ui_walker_custom PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
+    add_test(NAME test_nt_ui_walker_custom COMMAND test_nt_ui_walker_custom)
+
+    # --- test_nt_ui_walker_flush -- WALK-06 ---
+    add_executable(test_nt_ui_walker_flush
+        unit/test_nt_ui_walker_flush.c
+        ${_nt_ui_test_helper_sources}
+    )
+    target_include_directories(test_nt_ui_walker_flush PRIVATE ${_nt_ui_test_helper_includes})
+    target_link_libraries(test_nt_ui_walker_flush PRIVATE
+        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
+        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
+    )
+    target_compile_definitions(test_nt_ui_walker_flush PRIVATE
+        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
+        NT_SPRITE_RENDERER_TEST_ACCESS NT_TEXT_RENDERER_TEST_ACCESS
+        _CRT_SECURE_NO_WARNINGS)
+    target_compile_options(test_nt_ui_walker_flush PRIVATE -U_DLL)
+    nt_set_warning_flags(test_nt_ui_walker_flush)
+    nt_set_sanitizer_flags(test_nt_ui_walker_flush)
+    set_target_properties(test_nt_ui_walker_flush PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
+    add_test(NAME test_nt_ui_walker_flush COMMAND test_nt_ui_walker_flush)
+
+    # --- test_nt_ui_walker_readonly -- UI-06, UI-07 + pre-walk assert death-tests ---
+    add_executable(test_nt_ui_walker_readonly
+        unit/test_nt_ui_walker_readonly.c
+        ${_nt_ui_test_helper_sources}
+    )
+    target_include_directories(test_nt_ui_walker_readonly PRIVATE ${_nt_ui_test_helper_includes})
+    target_link_libraries(test_nt_ui_walker_readonly PRIVATE
+        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
+        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
+    )
+    target_compile_definitions(test_nt_ui_walker_readonly PRIVATE
+        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
+        _CRT_SECURE_NO_WARNINGS)
+    target_compile_options(test_nt_ui_walker_readonly PRIVATE -U_DLL)
+    nt_set_warning_flags(test_nt_ui_walker_readonly)
+    nt_set_sanitizer_flags(test_nt_ui_walker_readonly)
+    set_target_properties(test_nt_ui_walker_readonly PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
+    add_test(NAME test_nt_ui_walker_readonly COMMAND test_nt_ui_walker_readonly)
+
+    # --- test_nt_ui_stats -- WALK-09 ---
+    add_executable(test_nt_ui_stats
+        unit/test_nt_ui_stats.c
+        ${_nt_ui_test_helper_sources}
+    )
+    target_include_directories(test_nt_ui_stats PRIVATE ${_nt_ui_test_helper_includes})
+    target_link_libraries(test_nt_ui_stats PRIVATE
+        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
+        nt_resource nt_hash nt_pool nt_atlas nt_stats nt_gfx_stub nt_core unity
+    )
+    target_compile_definitions(test_nt_ui_stats PRIVATE
+        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS NT_STATS_TEST_ACCESS
+        _CRT_SECURE_NO_WARNINGS)
+    target_compile_options(test_nt_ui_stats PRIVATE -U_DLL)
+    nt_set_warning_flags(test_nt_ui_stats)
+    nt_set_sanitizer_flags(test_nt_ui_stats)
+    set_target_properties(test_nt_ui_stats PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
+    add_test(NAME test_nt_ui_stats COMMAND test_nt_ui_stats)
+
 endif()
 
 # --- WASM smoke test (Node.js loading via -sMODULARIZE) ---

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -599,7 +599,7 @@ if(NOT EMSCRIPTEN)
     target_include_directories(test_nt_ui_walker_dispatch PRIVATE ${_nt_ui_test_helper_includes})
     target_link_libraries(test_nt_ui_walker_dispatch PRIVATE
         nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
-        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
+        nt_resource nt_hash nt_pool nt_atlas nt_stats nt_gfx_stub nt_core unity
     )
     target_compile_definitions(test_nt_ui_walker_dispatch PRIVATE
         NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
@@ -620,7 +620,7 @@ if(NOT EMSCRIPTEN)
     target_include_directories(test_nt_ui_walker_scissor PRIVATE ${_nt_ui_test_helper_includes})
     target_link_libraries(test_nt_ui_walker_scissor PRIVATE
         nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
-        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
+        nt_resource nt_hash nt_pool nt_atlas nt_stats nt_gfx_stub nt_core unity
     )
     target_compile_definitions(test_nt_ui_walker_scissor PRIVATE
         NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
@@ -640,7 +640,7 @@ if(NOT EMSCRIPTEN)
     target_include_directories(test_nt_ui_walker_custom PRIVATE ${_nt_ui_test_helper_includes})
     target_link_libraries(test_nt_ui_walker_custom PRIVATE
         nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
-        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
+        nt_resource nt_hash nt_pool nt_atlas nt_stats nt_gfx_stub nt_core unity
     )
     target_compile_definitions(test_nt_ui_walker_custom PRIVATE
         NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
@@ -660,7 +660,7 @@ if(NOT EMSCRIPTEN)
     target_include_directories(test_nt_ui_walker_flush PRIVATE ${_nt_ui_test_helper_includes})
     target_link_libraries(test_nt_ui_walker_flush PRIVATE
         nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
-        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
+        nt_resource nt_hash nt_pool nt_atlas nt_stats nt_gfx_stub nt_core unity
     )
     target_compile_definitions(test_nt_ui_walker_flush PRIVATE
         NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
@@ -681,7 +681,7 @@ if(NOT EMSCRIPTEN)
     target_include_directories(test_nt_ui_walker_readonly PRIVATE ${_nt_ui_test_helper_includes})
     target_link_libraries(test_nt_ui_walker_readonly PRIVATE
         nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
-        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
+        nt_resource nt_hash nt_pool nt_atlas nt_stats nt_gfx_stub nt_core unity
     )
     target_compile_definitions(test_nt_ui_walker_readonly PRIVATE
         NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -452,6 +452,7 @@ if(NOT EMSCRIPTEN)
     set(_nt_ui_test_helper_sources
         unit/test_helpers/ui_atlas.c
         unit/test_helpers/nt_assert_trap.c
+        unit/test_helpers/ui_walker_fixture.c
     )
 
     # Helpers need `tests/unit/` on the include path so

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -465,6 +465,11 @@ if(NOT EMSCRIPTEN)
     # ui_atlas helper can link.
     target_compile_definitions(nt_atlas PRIVATE NT_ATLAS_TEST_ACCESS)
 
+    # Force nt_ui to expose NT_UI_TEST_ACCESS symbols
+    # (nt_ui_test_inframe_ctx + walk-counter probes) so test binaries
+    # that opt into NT_UI_TEST_ACCESS can link.
+    target_compile_definitions(nt_ui PRIVATE NT_UI_TEST_ACCESS)
+
     # --- test_nt_sprite_renderer_emit_region -- D-52-01/02 + Drift 4 ---
     add_executable(test_nt_sprite_renderer_emit_region
         unit/test_nt_sprite_renderer_emit_region.c

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,27 @@
 # Native unit tests (Unity framework via CTest)
 # WASM tests run through CTest via Node.js when available
+#
+# NT_TEST_ACCESS: single shared define that gates every module's test
+# surface (the `// #region test_access` block at the bottom of each
+# header). Applied at directory level here so all binaries below pick
+# it up automatically; engine library targets that expose test surface
+# get it explicitly so their compilation matches.
 
 if(NOT EMSCRIPTEN)
+    # Tests-wide define + engine libs that have a test surface. New module
+    # with test surface? Add its target name to NT_TEST_ACCESS_LIBS below.
+    add_compile_definitions(NT_TEST_ACCESS)
+    set(NT_TEST_ACCESS_LIBS
+        nt_atlas nt_ui nt_gfx nt_gfx_stub nt_font nt_text_renderer
+        nt_resource nt_sprite_renderer nt_mesh_renderer nt_stats
+        nt_shape_renderer
+    )
+    foreach(_lib IN LISTS NT_TEST_ACCESS_LIBS)
+        if(TARGET ${_lib})
+            target_compile_definitions(${_lib} PRIVATE NT_TEST_ACCESS)
+        endif()
+    endforeach()
+
     add_executable(test_core unit/test_core.c)
     target_link_libraries(test_core PRIVATE nt_core unity)
 
@@ -149,14 +169,12 @@ if(NOT EMSCRIPTEN)
         nt_sprite_renderer nt_text_renderer nt_font nt_material
         nt_resource nt_hash nt_pool nt_gfx_stub unity
     )
-    target_compile_definitions(test_nt_gfx_scissor PRIVATE NT_GFX_TEST_ACCESS _CRT_SECURE_NO_WARNINGS)
-    target_compile_definitions(nt_gfx_stub PRIVATE NT_GFX_TEST_ACCESS)
+    target_compile_definitions(test_nt_gfx_scissor PRIVATE _CRT_SECURE_NO_WARNINGS)
     nt_setup_test_target(test_nt_gfx_scissor)
 
     # --- Shape module tests ---
     add_executable(test_shape unit/test_shape.c)
     target_link_libraries(test_shape PRIVATE nt_shape_renderer nt_gfx_stub unity)
-    target_compile_definitions(test_shape PRIVATE NT_SHAPE_RENDERER_TEST_ACCESS)
     nt_set_warning_flags(test_shape)
     nt_set_sanitizer_flags(test_shape)
     set_target_properties(test_shape PROPERTIES
@@ -227,8 +245,7 @@ if(NOT EMSCRIPTEN)
     # --- Font module tests ---
     add_executable(test_font unit/test_font.c)
     target_link_libraries(test_font PRIVATE nt_font nt_gfx_stub nt_resource nt_hash nt_pool unity)
-    target_compile_definitions(test_font PRIVATE NT_FONT_TEST_ACCESS _CRT_SECURE_NO_WARNINGS)
-    target_compile_definitions(nt_font PRIVATE NT_FONT_TEST_ACCESS)
+    target_compile_definitions(test_font PRIVATE _CRT_SECURE_NO_WARNINGS)
     target_compile_options(nt_font PRIVATE -U_DLL)
     nt_setup_test_target(test_font)
 
@@ -237,14 +254,13 @@ if(NOT EMSCRIPTEN)
     # Uses nt_time_nanos() for the ns clock (same module used by test_time).
     add_executable(test_nt_font_measure_bench unit/test_nt_font_measure_bench.c)
     target_link_libraries(test_nt_font_measure_bench PRIVATE nt_font nt_gfx_stub nt_resource nt_hash nt_pool nt_time unity)
-    target_compile_definitions(test_nt_font_measure_bench PRIVATE NT_FONT_TEST_ACCESS _CRT_SECURE_NO_WARNINGS)
+    target_compile_definitions(test_nt_font_measure_bench PRIVATE _CRT_SECURE_NO_WARNINGS)
     nt_setup_test_target(test_nt_font_measure_bench)
 
     # --- Text renderer module tests ---
     add_executable(test_text_renderer unit/test_text_renderer.c)
     target_link_libraries(test_text_renderer PRIVATE nt_text_renderer nt_font nt_gfx_stub nt_resource nt_hash nt_pool nt_material nt_time unity)
-    target_compile_definitions(test_text_renderer PRIVATE NT_TEXT_RENDERER_TEST_ACCESS NT_FONT_TEST_ACCESS _CRT_SECURE_NO_WARNINGS)
-    target_compile_definitions(nt_text_renderer PRIVATE NT_TEXT_RENDERER_TEST_ACCESS)
+    target_compile_definitions(test_text_renderer PRIVATE _CRT_SECURE_NO_WARNINGS)
     nt_setup_test_target(test_text_renderer)
 
     # --- Material module tests ---
@@ -273,15 +289,13 @@ if(NOT EMSCRIPTEN)
     # --- Resource module tests ---
     add_executable(test_resource unit/test_resource.c)
     target_link_libraries(test_resource PRIVATE nt_resource unity)
-    target_compile_definitions(test_resource PRIVATE NT_RESOURCE_TEST_ACCESS _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE)
-    target_compile_definitions(nt_resource PRIVATE NT_RESOURCE_TEST_ACCESS)
+    target_compile_definitions(test_resource PRIVATE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE)
     nt_setup_test_target(test_resource WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 
     # --- Atlas module tests ---
     add_executable(test_atlas unit/test_atlas.c)
     target_link_libraries(test_atlas PRIVATE nt_atlas nt_resource nt_hash unity)
-    target_compile_definitions(test_atlas PRIVATE NT_ATLAS_TEST_ACCESS _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE)
-    target_compile_definitions(nt_atlas PRIVATE NT_ATLAS_TEST_ACCESS)
+    target_compile_definitions(test_atlas PRIVATE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE)
     nt_setup_test_target(test_atlas)
 
     # --- Sprite component tests ---
@@ -289,7 +303,7 @@ if(NOT EMSCRIPTEN)
     target_link_libraries(test_sprite_comp PRIVATE
         nt_sprite_comp nt_atlas nt_entity nt_resource nt_hash nt_pool nt_shared unity
     )
-    target_compile_definitions(test_sprite_comp PRIVATE NT_ATLAS_TEST_ACCESS _CRT_SECURE_NO_WARNINGS)
+    target_compile_definitions(test_sprite_comp PRIVATE _CRT_SECURE_NO_WARNINGS)
     nt_setup_test_target(test_sprite_comp)
 
     # --- HTTP module tests ---
@@ -321,10 +335,7 @@ if(NOT EMSCRIPTEN)
         nt_entity nt_transform_comp nt_mesh_comp nt_material_comp nt_drawable_comp
         nt_material nt_resource nt_hash unity
     )
-    target_compile_definitions(test_mesh_renderer PRIVATE
-        NT_MESH_RENDERER_TEST_ACCESS
-        _CRT_SECURE_NO_WARNINGS
-    )
+    target_compile_definitions(test_mesh_renderer PRIVATE _CRT_SECURE_NO_WARNINGS)
     nt_set_warning_flags(test_mesh_renderer)
     nt_set_sanitizer_flags(test_mesh_renderer)
     set_target_properties(test_mesh_renderer PROPERTIES
@@ -340,18 +351,8 @@ if(NOT EMSCRIPTEN)
         nt_resource nt_hash nt_pool nt_entity nt_shared nt_gfx_stub unity
     )
     target_compile_definitions(test_sprite_renderer PRIVATE
-        NT_SPRITE_RENDERER_TEST_ACCESS
-        NT_ATLAS_TEST_ACCESS
-        NT_GFX_STUB_TEST_ACCESS
-        NT_GFX_TEST_ACCESS
-        _CRT_SECURE_NO_WARNINGS
-        _CRT_NONSTDC_NO_DEPRECATE
+        _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE
     )
-    target_compile_definitions(nt_sprite_renderer PRIVATE NT_SPRITE_RENDERER_TEST_ACCESS)
-    # nt_gfx_stub also compiles nt_gfx.c — needs NT_GFX_TEST_ACCESS for the
-    # real-backend test hook (sampler cache inspection) the test uses.
-    target_compile_definitions(nt_gfx_stub PRIVATE NT_GFX_STUB_TEST_ACCESS NT_GFX_TEST_ACCESS)
-    target_compile_definitions(nt_gfx PRIVATE NT_GFX_TEST_ACCESS)
     nt_setup_test_target(test_sprite_renderer)
 
     # --- Stats module tests (DEMO-04..06 + Pitfall 9 / Issue 2 coverage) ---
@@ -360,23 +361,12 @@ if(NOT EMSCRIPTEN)
         nt_stats nt_text_renderer nt_font nt_material nt_resource
         nt_gfx_stub nt_hash nt_pool unity
     )
-    target_compile_definitions(test_stats PRIVATE
-        NT_STATS_TEST_ACCESS
-        NT_TEXT_RENDERER_TEST_ACCESS
-        _CRT_SECURE_NO_WARNINGS
-    )
-    target_compile_definitions(nt_stats PRIVATE NT_STATS_TEST_ACCESS)
-    target_compile_definitions(nt_text_renderer PRIVATE NT_TEXT_RENDERER_TEST_ACCESS)
+    target_compile_definitions(test_stats PRIVATE _CRT_SECURE_NO_WARNINGS)
     nt_setup_test_target(test_stats)
 
-    # --- Phase 52: nt_ui module + walker MVP tests ---
-    # All tests use stub gfx backend + Phase 51 NT_GFX_TEST_ACCESS probes.
-    # nt_ui tests additionally use NT_UI_TEST_ACCESS for in-frame/walk probes.
-    # Death-tests use the shared NT_TEST_EXPECT_ASSERT macro (Revision Issue 3).
-
-    # Shared helper sources compiled into each binary.
-    # - ui_atlas: produces minimal_ui_atlas via NT_ATLAS_TEST_ACCESS (Revision Issue 4)
-    # - nt_assert_trap: NT_TEST_EXPECT_ASSERT death-test helper (Revision Issue 3)
+    # --- nt_ui module + walker tests ---
+    # Stub gfx backend + Unity. Death-tests use the shared
+    # NT_TEST_EXPECT_ASSERT macro (test_helpers/nt_assert_trap).
     set(_nt_ui_test_helper_sources
         unit/test_helpers/ui_atlas.c
         unit/test_helpers/nt_assert_trap.c
@@ -389,197 +379,60 @@ if(NOT EMSCRIPTEN)
         "${CMAKE_CURRENT_SOURCE_DIR}/unit"
     )
 
-    # Force nt_atlas to expose NT_ATLAS_TEST_ACCESS symbols
-    # (nt_atlas_test_drive_resolve, nt_atlas_test_drive_cleanup) so the
-    # ui_atlas helper can link.
-    target_compile_definitions(nt_atlas PRIVATE NT_ATLAS_TEST_ACCESS)
-
-    # Force nt_ui to expose NT_UI_TEST_ACCESS symbols
-    # (nt_ui_test_inframe_ctx + walk-counter probes) so test binaries
-    # that opt into NT_UI_TEST_ACCESS can link.
-    target_compile_definitions(nt_ui PRIVATE NT_UI_TEST_ACCESS)
-
-    # --- test_nt_sprite_renderer_emit_region -- D-52-01/02 + Drift 4 ---
     add_executable(test_nt_sprite_renderer_emit_region
         unit/test_nt_sprite_renderer_emit_region.c
         ${_nt_ui_test_helper_sources}
     )
     target_include_directories(test_nt_sprite_renderer_emit_region PRIVATE ${_nt_ui_test_helper_includes})
+    # nt_ui is linked because the shared ui_walker_fixture helper -- which
+    # every nt_ui-test binary depends on -- now compiles unconditionally
+    # under the unified NT_TEST_ACCESS define.
     target_link_libraries(test_nt_sprite_renderer_emit_region PRIVATE
-        nt_sprite_renderer nt_text_renderer nt_font nt_material
+        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
         nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
     )
-    target_compile_definitions(test_nt_sprite_renderer_emit_region PRIVATE
-        NT_GFX_TEST_ACCESS NT_SPRITE_RENDERER_TEST_ACCESS NT_ATLAS_TEST_ACCESS
-        _CRT_SECURE_NO_WARNINGS)
-    target_compile_definitions(nt_gfx_stub PRIVATE NT_GFX_TEST_ACCESS)
+    target_compile_definitions(test_nt_sprite_renderer_emit_region PRIVATE _CRT_SECURE_NO_WARNINGS)
     nt_setup_test_target(test_nt_sprite_renderer_emit_region)
 
-    # --- test_nt_ui_lifecycle -- UI-01, UI-02 ---
-    add_executable(test_nt_ui_lifecycle
-        unit/test_nt_ui_lifecycle.c
-        ${_nt_ui_test_helper_sources}
-    )
-    target_include_directories(test_nt_ui_lifecycle PRIVATE ${_nt_ui_test_helper_includes})
-    target_link_libraries(test_nt_ui_lifecycle PRIVATE
-        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
-        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
-    )
-    target_compile_definitions(test_nt_ui_lifecycle PRIVATE
-        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
-        _CRT_SECURE_NO_WARNINGS)
-    nt_setup_test_target(test_nt_ui_lifecycle)
-
-    # --- test_nt_ui_multictx -- UI-03 ---
-    add_executable(test_nt_ui_multictx
-        unit/test_nt_ui_multictx.c
-        ${_nt_ui_test_helper_sources}
-    )
-    target_include_directories(test_nt_ui_multictx PRIVATE ${_nt_ui_test_helper_includes})
-    target_link_libraries(test_nt_ui_multictx PRIVATE
-        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
-        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
-    )
-    target_compile_definitions(test_nt_ui_multictx PRIVATE
-        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
-        _CRT_SECURE_NO_WARNINGS)
-    nt_setup_test_target(test_nt_ui_multictx)
-
-    # --- test_nt_ui_begin_end -- UI-04, UI-05, UI-08 ---
-    add_executable(test_nt_ui_begin_end
-        unit/test_nt_ui_begin_end.c
-        ${_nt_ui_test_helper_sources}
-    )
-    target_include_directories(test_nt_ui_begin_end PRIVATE ${_nt_ui_test_helper_includes})
-    target_link_libraries(test_nt_ui_begin_end PRIVATE
-        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
-        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
-    )
-    target_compile_definitions(test_nt_ui_begin_end PRIVATE
-        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
-        _CRT_SECURE_NO_WARNINGS)
-    nt_setup_test_target(test_nt_ui_begin_end)
-
-    # --- test_nt_ui_measure_cb -- CLAY-03 ---
-    add_executable(test_nt_ui_measure_cb
-        unit/test_nt_ui_measure_cb.c
-        ${_nt_ui_test_helper_sources}
-    )
-    target_include_directories(test_nt_ui_measure_cb PRIVATE ${_nt_ui_test_helper_includes})
-    target_link_libraries(test_nt_ui_measure_cb PRIVATE
-        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
-        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
-    )
-    target_compile_definitions(test_nt_ui_measure_cb PRIVATE
-        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS NT_FONT_TEST_ACCESS
-        _CRT_SECURE_NO_WARNINGS)
-    nt_setup_test_target(test_nt_ui_measure_cb)
-
-    # --- test_nt_ui_pointer_state -- CLAY-04 ---
-    add_executable(test_nt_ui_pointer_state
-        unit/test_nt_ui_pointer_state.c
-        ${_nt_ui_test_helper_sources}
-    )
-    target_include_directories(test_nt_ui_pointer_state PRIVATE ${_nt_ui_test_helper_includes})
-    target_link_libraries(test_nt_ui_pointer_state PRIVATE
-        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
-        nt_resource nt_hash nt_pool nt_atlas nt_gfx_stub nt_core unity
-    )
-    target_compile_definitions(test_nt_ui_pointer_state PRIVATE
-        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
-        _CRT_SECURE_NO_WARNINGS)
-    nt_setup_test_target(test_nt_ui_pointer_state)
-
-    # --- test_nt_ui_walker_dispatch -- WALK-01, WALK-04 ---
-    add_executable(test_nt_ui_walker_dispatch
-        unit/test_nt_ui_walker_dispatch.c
-        ${_nt_ui_test_helper_sources}
-    )
-    target_include_directories(test_nt_ui_walker_dispatch PRIVATE ${_nt_ui_test_helper_includes})
-    target_link_libraries(test_nt_ui_walker_dispatch PRIVATE
+    # Shared list of libs every nt_ui test binary links against. Stub gfx
+    # backend; nt_stats included for walker tests that record draw_calls /
+    # element_count via the public getter forwards.
+    set(_nt_ui_test_libs
         nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
         nt_resource nt_hash nt_pool nt_atlas nt_stats nt_gfx_stub nt_core unity
     )
-    target_compile_definitions(test_nt_ui_walker_dispatch PRIVATE
-        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
-        NT_SPRITE_RENDERER_TEST_ACCESS NT_TEXT_RENDERER_TEST_ACCESS
-        _CRT_SECURE_NO_WARNINGS)
-    nt_setup_test_target(test_nt_ui_walker_dispatch)
 
-    # --- test_nt_ui_walker_scissor -- WALK-02, WALK-03 ---
-    add_executable(test_nt_ui_walker_scissor
-        unit/test_nt_ui_walker_scissor.c
-        ${_nt_ui_test_helper_sources}
+    set(_nt_ui_test_names
+        test_nt_ui_lifecycle
+        test_nt_ui_multictx
+        test_nt_ui_begin_end
+        test_nt_ui_measure_cb
+        test_nt_ui_pointer_state
+        test_nt_ui_walker_dispatch
+        test_nt_ui_walker_scissor
+        test_nt_ui_walker_custom
+        test_nt_ui_walker_flush
+        test_nt_ui_walker_readonly
     )
-    target_include_directories(test_nt_ui_walker_scissor PRIVATE ${_nt_ui_test_helper_includes})
-    target_link_libraries(test_nt_ui_walker_scissor PRIVATE
-        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
-        nt_resource nt_hash nt_pool nt_atlas nt_stats nt_gfx_stub nt_core unity
-    )
-    target_compile_definitions(test_nt_ui_walker_scissor PRIVATE
-        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
-        _CRT_SECURE_NO_WARNINGS)
-    nt_setup_test_target(test_nt_ui_walker_scissor)
 
-    # --- test_nt_ui_walker_custom -- WALK-05 ---
-    add_executable(test_nt_ui_walker_custom
-        unit/test_nt_ui_walker_custom.c
-        ${_nt_ui_test_helper_sources}
-    )
-    target_include_directories(test_nt_ui_walker_custom PRIVATE ${_nt_ui_test_helper_includes})
-    target_link_libraries(test_nt_ui_walker_custom PRIVATE
-        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
-        nt_resource nt_hash nt_pool nt_atlas nt_stats nt_gfx_stub nt_core unity
-    )
-    target_compile_definitions(test_nt_ui_walker_custom PRIVATE
-        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
-        _CRT_SECURE_NO_WARNINGS)
-    nt_setup_test_target(test_nt_ui_walker_custom)
+    foreach(_t IN LISTS _nt_ui_test_names)
+        add_executable(${_t}
+            unit/${_t}.c
+            ${_nt_ui_test_helper_sources}
+        )
+        target_include_directories(${_t} PRIVATE ${_nt_ui_test_helper_includes})
+        target_link_libraries(${_t} PRIVATE ${_nt_ui_test_libs})
+        target_compile_definitions(${_t} PRIVATE _CRT_SECURE_NO_WARNINGS)
+        nt_setup_test_target(${_t})
+    endforeach()
 
-    # --- test_nt_ui_walker_flush -- WALK-06 ---
-    add_executable(test_nt_ui_walker_flush
-        unit/test_nt_ui_walker_flush.c
-        ${_nt_ui_test_helper_sources}
-    )
-    target_include_directories(test_nt_ui_walker_flush PRIVATE ${_nt_ui_test_helper_includes})
-    target_link_libraries(test_nt_ui_walker_flush PRIVATE
-        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
-        nt_resource nt_hash nt_pool nt_atlas nt_stats nt_gfx_stub nt_core unity
-    )
-    target_compile_definitions(test_nt_ui_walker_flush PRIVATE
-        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
-        NT_SPRITE_RENDERER_TEST_ACCESS NT_TEXT_RENDERER_TEST_ACCESS
-        _CRT_SECURE_NO_WARNINGS)
-    nt_setup_test_target(test_nt_ui_walker_flush)
-
-    # --- test_nt_ui_walker_readonly -- UI-06, UI-07 + pre-walk assert death-tests ---
-    add_executable(test_nt_ui_walker_readonly
-        unit/test_nt_ui_walker_readonly.c
-        ${_nt_ui_test_helper_sources}
-    )
-    target_include_directories(test_nt_ui_walker_readonly PRIVATE ${_nt_ui_test_helper_includes})
-    target_link_libraries(test_nt_ui_walker_readonly PRIVATE
-        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
-        nt_resource nt_hash nt_pool nt_atlas nt_stats nt_gfx_stub nt_core unity
-    )
-    target_compile_definitions(test_nt_ui_walker_readonly PRIVATE
-        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
-        _CRT_SECURE_NO_WARNINGS)
-    nt_setup_test_target(test_nt_ui_walker_readonly)
-
-    # --- test_nt_ui_stats -- WALK-09 ---
     add_executable(test_nt_ui_stats
         unit/test_nt_ui_stats.c
         ${_nt_ui_test_helper_sources}
     )
     target_include_directories(test_nt_ui_stats PRIVATE ${_nt_ui_test_helper_includes})
-    target_link_libraries(test_nt_ui_stats PRIVATE
-        nt_ui nt_sprite_renderer nt_text_renderer nt_font nt_material
-        nt_resource nt_hash nt_pool nt_atlas nt_stats nt_gfx_stub nt_core unity
-    )
-    target_compile_definitions(test_nt_ui_stats PRIVATE
-        NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS NT_STATS_TEST_ACCESS
-        _CRT_SECURE_NO_WARNINGS)
+    target_link_libraries(test_nt_ui_stats PRIVATE ${_nt_ui_test_libs})
+    target_compile_definitions(test_nt_ui_stats PRIVATE _CRT_SECURE_NO_WARNINGS)
     nt_setup_test_target(test_nt_ui_stats)
 
 endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -151,13 +151,7 @@ if(NOT EMSCRIPTEN)
     )
     target_compile_definitions(test_nt_gfx_scissor PRIVATE NT_GFX_TEST_ACCESS _CRT_SECURE_NO_WARNINGS)
     target_compile_definitions(nt_gfx_stub PRIVATE NT_GFX_TEST_ACCESS)
-    target_compile_options(test_nt_gfx_scissor PRIVATE -U_DLL)
-    nt_set_warning_flags(test_nt_gfx_scissor)
-    nt_set_sanitizer_flags(test_nt_gfx_scissor)
-    set_target_properties(test_nt_gfx_scissor PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}"
-    )
-    add_test(NAME test_nt_gfx_scissor COMMAND test_nt_gfx_scissor)
+    nt_setup_test_target(test_nt_gfx_scissor)
 
     # --- Shape module tests ---
     add_executable(test_shape unit/test_shape.c)
@@ -234,15 +228,9 @@ if(NOT EMSCRIPTEN)
     add_executable(test_font unit/test_font.c)
     target_link_libraries(test_font PRIVATE nt_font nt_gfx_stub nt_resource nt_hash nt_pool unity)
     target_compile_definitions(test_font PRIVATE NT_FONT_TEST_ACCESS _CRT_SECURE_NO_WARNINGS)
-    target_compile_options(test_font PRIVATE -U_DLL)
     target_compile_definitions(nt_font PRIVATE NT_FONT_TEST_ACCESS)
     target_compile_options(nt_font PRIVATE -U_DLL)
-    nt_set_warning_flags(test_font)
-    nt_set_sanitizer_flags(test_font)
-    set_target_properties(test_font PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}"
-    )
-    add_test(NAME test_font COMMAND test_font)
+    nt_setup_test_target(test_font)
 
     # --- Font measure benchmark ---
     # Measures hit vs miss ns/call for the nt_font_measure_n LRU cache.
@@ -250,26 +238,14 @@ if(NOT EMSCRIPTEN)
     add_executable(test_nt_font_measure_bench unit/test_nt_font_measure_bench.c)
     target_link_libraries(test_nt_font_measure_bench PRIVATE nt_font nt_gfx_stub nt_resource nt_hash nt_pool nt_time unity)
     target_compile_definitions(test_nt_font_measure_bench PRIVATE NT_FONT_TEST_ACCESS _CRT_SECURE_NO_WARNINGS)
-    target_compile_options(test_nt_font_measure_bench PRIVATE -U_DLL)
-    nt_set_warning_flags(test_nt_font_measure_bench)
-    nt_set_sanitizer_flags(test_nt_font_measure_bench)
-    set_target_properties(test_nt_font_measure_bench PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}"
-    )
-    add_test(NAME test_nt_font_measure_bench COMMAND test_nt_font_measure_bench)
+    nt_setup_test_target(test_nt_font_measure_bench)
 
     # --- Text renderer module tests ---
     add_executable(test_text_renderer unit/test_text_renderer.c)
     target_link_libraries(test_text_renderer PRIVATE nt_text_renderer nt_font nt_gfx_stub nt_resource nt_hash nt_pool nt_material nt_time unity)
     target_compile_definitions(test_text_renderer PRIVATE NT_TEXT_RENDERER_TEST_ACCESS NT_FONT_TEST_ACCESS _CRT_SECURE_NO_WARNINGS)
     target_compile_definitions(nt_text_renderer PRIVATE NT_TEXT_RENDERER_TEST_ACCESS)
-    target_compile_options(test_text_renderer PRIVATE -U_DLL)
-    nt_set_warning_flags(test_text_renderer)
-    nt_set_sanitizer_flags(test_text_renderer)
-    set_target_properties(test_text_renderer PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}"
-    )
-    add_test(NAME test_text_renderer COMMAND test_text_renderer)
+    nt_setup_test_target(test_text_renderer)
 
     # --- Material module tests ---
     add_executable(test_material unit/test_material.c)
@@ -298,29 +274,15 @@ if(NOT EMSCRIPTEN)
     add_executable(test_resource unit/test_resource.c)
     target_link_libraries(test_resource PRIVATE nt_resource unity)
     target_compile_definitions(test_resource PRIVATE NT_RESOURCE_TEST_ACCESS _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE)
-    target_compile_options(test_resource PRIVATE -U_DLL)
     target_compile_definitions(nt_resource PRIVATE NT_RESOURCE_TEST_ACCESS)
-    nt_set_warning_flags(test_resource)
-    nt_set_sanitizer_flags(test_resource)
-    set_target_properties(test_resource PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}"
-    )
-    add_test(NAME test_resource COMMAND test_resource
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-    )
+    nt_setup_test_target(test_resource WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 
     # --- Atlas module tests ---
     add_executable(test_atlas unit/test_atlas.c)
     target_link_libraries(test_atlas PRIVATE nt_atlas nt_resource nt_hash unity)
     target_compile_definitions(test_atlas PRIVATE NT_ATLAS_TEST_ACCESS _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE)
-    target_compile_options(test_atlas PRIVATE -U_DLL)
     target_compile_definitions(nt_atlas PRIVATE NT_ATLAS_TEST_ACCESS)
-    nt_set_warning_flags(test_atlas)
-    nt_set_sanitizer_flags(test_atlas)
-    set_target_properties(test_atlas PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}"
-    )
-    add_test(NAME test_atlas COMMAND test_atlas)
+    nt_setup_test_target(test_atlas)
 
     # --- Sprite component tests ---
     add_executable(test_sprite_comp unit/test_sprite_comp.c)
@@ -328,13 +290,7 @@ if(NOT EMSCRIPTEN)
         nt_sprite_comp nt_atlas nt_entity nt_resource nt_hash nt_pool nt_shared unity
     )
     target_compile_definitions(test_sprite_comp PRIVATE NT_ATLAS_TEST_ACCESS _CRT_SECURE_NO_WARNINGS)
-    target_compile_options(test_sprite_comp PRIVATE -U_DLL)
-    nt_set_warning_flags(test_sprite_comp)
-    nt_set_sanitizer_flags(test_sprite_comp)
-    set_target_properties(test_sprite_comp PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}"
-    )
-    add_test(NAME test_sprite_comp COMMAND test_sprite_comp)
+    nt_setup_test_target(test_sprite_comp)
 
     # --- HTTP module tests ---
     add_executable(test_http unit/test_http.c)
@@ -350,29 +306,13 @@ if(NOT EMSCRIPTEN)
     add_executable(test_fs unit/test_fs.c)
     target_link_libraries(test_fs PRIVATE nt_fs unity)
     target_compile_definitions(test_fs PRIVATE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE)
-    target_compile_options(test_fs PRIVATE -U_DLL)
-    nt_set_warning_flags(test_fs)
-    nt_set_sanitizer_flags(test_fs)
-    set_target_properties(test_fs PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}"
-    )
-    add_test(NAME test_fs COMMAND test_fs
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-    )
+    nt_setup_test_target(test_fs WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 
     # --- Builder tests ---
     add_executable(test_builder unit/test_builder.c)
     target_link_libraries(test_builder PRIVATE nt_builder unity)
     target_compile_definitions(test_builder PRIVATE _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE)
-    target_compile_options(test_builder PRIVATE -U_DLL)
-    nt_set_warning_flags(test_builder)
-    nt_set_sanitizer_flags(test_builder)
-    set_target_properties(test_builder PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}"
-    )
-    add_test(NAME test_builder COMMAND test_builder
-        WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
-    )
+    nt_setup_test_target(test_builder WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}")
 
     # --- Mesh renderer tests ---
     add_executable(test_mesh_renderer unit/test_mesh_renderer.c)
@@ -412,13 +352,7 @@ if(NOT EMSCRIPTEN)
     # real-backend test hook (sampler cache inspection) the test uses.
     target_compile_definitions(nt_gfx_stub PRIVATE NT_GFX_STUB_TEST_ACCESS NT_GFX_TEST_ACCESS)
     target_compile_definitions(nt_gfx PRIVATE NT_GFX_TEST_ACCESS)
-    target_compile_options(test_sprite_renderer PRIVATE -U_DLL)
-    nt_set_warning_flags(test_sprite_renderer)
-    nt_set_sanitizer_flags(test_sprite_renderer)
-    set_target_properties(test_sprite_renderer PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}"
-    )
-    add_test(NAME test_sprite_renderer COMMAND test_sprite_renderer)
+    nt_setup_test_target(test_sprite_renderer)
 
     # --- Stats module tests (DEMO-04..06 + Pitfall 9 / Issue 2 coverage) ---
     add_executable(test_stats unit/test_stats.c)
@@ -433,13 +367,7 @@ if(NOT EMSCRIPTEN)
     )
     target_compile_definitions(nt_stats PRIVATE NT_STATS_TEST_ACCESS)
     target_compile_definitions(nt_text_renderer PRIVATE NT_TEXT_RENDERER_TEST_ACCESS)
-    target_compile_options(test_stats PRIVATE -U_DLL)
-    nt_set_warning_flags(test_stats)
-    nt_set_sanitizer_flags(test_stats)
-    set_target_properties(test_stats PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}"
-    )
-    add_test(NAME test_stats COMMAND test_stats)
+    nt_setup_test_target(test_stats)
 
     # --- Phase 52: nt_ui module + walker MVP tests ---
     # All tests use stub gfx backend + Phase 51 NT_GFX_TEST_ACCESS probes.
@@ -485,12 +413,7 @@ if(NOT EMSCRIPTEN)
         NT_GFX_TEST_ACCESS NT_SPRITE_RENDERER_TEST_ACCESS NT_ATLAS_TEST_ACCESS
         _CRT_SECURE_NO_WARNINGS)
     target_compile_definitions(nt_gfx_stub PRIVATE NT_GFX_TEST_ACCESS)
-    target_compile_options(test_nt_sprite_renderer_emit_region PRIVATE -U_DLL)
-    nt_set_warning_flags(test_nt_sprite_renderer_emit_region)
-    nt_set_sanitizer_flags(test_nt_sprite_renderer_emit_region)
-    set_target_properties(test_nt_sprite_renderer_emit_region PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
-    add_test(NAME test_nt_sprite_renderer_emit_region COMMAND test_nt_sprite_renderer_emit_region)
+    nt_setup_test_target(test_nt_sprite_renderer_emit_region)
 
     # --- test_nt_ui_lifecycle -- UI-01, UI-02 ---
     add_executable(test_nt_ui_lifecycle
@@ -505,12 +428,7 @@ if(NOT EMSCRIPTEN)
     target_compile_definitions(test_nt_ui_lifecycle PRIVATE
         NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
         _CRT_SECURE_NO_WARNINGS)
-    target_compile_options(test_nt_ui_lifecycle PRIVATE -U_DLL)
-    nt_set_warning_flags(test_nt_ui_lifecycle)
-    nt_set_sanitizer_flags(test_nt_ui_lifecycle)
-    set_target_properties(test_nt_ui_lifecycle PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
-    add_test(NAME test_nt_ui_lifecycle COMMAND test_nt_ui_lifecycle)
+    nt_setup_test_target(test_nt_ui_lifecycle)
 
     # --- test_nt_ui_multictx -- UI-03 ---
     add_executable(test_nt_ui_multictx
@@ -525,12 +443,7 @@ if(NOT EMSCRIPTEN)
     target_compile_definitions(test_nt_ui_multictx PRIVATE
         NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
         _CRT_SECURE_NO_WARNINGS)
-    target_compile_options(test_nt_ui_multictx PRIVATE -U_DLL)
-    nt_set_warning_flags(test_nt_ui_multictx)
-    nt_set_sanitizer_flags(test_nt_ui_multictx)
-    set_target_properties(test_nt_ui_multictx PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
-    add_test(NAME test_nt_ui_multictx COMMAND test_nt_ui_multictx)
+    nt_setup_test_target(test_nt_ui_multictx)
 
     # --- test_nt_ui_begin_end -- UI-04, UI-05, UI-08 ---
     add_executable(test_nt_ui_begin_end
@@ -545,12 +458,7 @@ if(NOT EMSCRIPTEN)
     target_compile_definitions(test_nt_ui_begin_end PRIVATE
         NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
         _CRT_SECURE_NO_WARNINGS)
-    target_compile_options(test_nt_ui_begin_end PRIVATE -U_DLL)
-    nt_set_warning_flags(test_nt_ui_begin_end)
-    nt_set_sanitizer_flags(test_nt_ui_begin_end)
-    set_target_properties(test_nt_ui_begin_end PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
-    add_test(NAME test_nt_ui_begin_end COMMAND test_nt_ui_begin_end)
+    nt_setup_test_target(test_nt_ui_begin_end)
 
     # --- test_nt_ui_measure_cb -- CLAY-03 ---
     add_executable(test_nt_ui_measure_cb
@@ -565,12 +473,7 @@ if(NOT EMSCRIPTEN)
     target_compile_definitions(test_nt_ui_measure_cb PRIVATE
         NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS NT_FONT_TEST_ACCESS
         _CRT_SECURE_NO_WARNINGS)
-    target_compile_options(test_nt_ui_measure_cb PRIVATE -U_DLL)
-    nt_set_warning_flags(test_nt_ui_measure_cb)
-    nt_set_sanitizer_flags(test_nt_ui_measure_cb)
-    set_target_properties(test_nt_ui_measure_cb PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
-    add_test(NAME test_nt_ui_measure_cb COMMAND test_nt_ui_measure_cb)
+    nt_setup_test_target(test_nt_ui_measure_cb)
 
     # --- test_nt_ui_pointer_state -- CLAY-04 ---
     add_executable(test_nt_ui_pointer_state
@@ -585,12 +488,7 @@ if(NOT EMSCRIPTEN)
     target_compile_definitions(test_nt_ui_pointer_state PRIVATE
         NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
         _CRT_SECURE_NO_WARNINGS)
-    target_compile_options(test_nt_ui_pointer_state PRIVATE -U_DLL)
-    nt_set_warning_flags(test_nt_ui_pointer_state)
-    nt_set_sanitizer_flags(test_nt_ui_pointer_state)
-    set_target_properties(test_nt_ui_pointer_state PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
-    add_test(NAME test_nt_ui_pointer_state COMMAND test_nt_ui_pointer_state)
+    nt_setup_test_target(test_nt_ui_pointer_state)
 
     # --- test_nt_ui_walker_dispatch -- WALK-01, WALK-04 ---
     add_executable(test_nt_ui_walker_dispatch
@@ -606,12 +504,7 @@ if(NOT EMSCRIPTEN)
         NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
         NT_SPRITE_RENDERER_TEST_ACCESS NT_TEXT_RENDERER_TEST_ACCESS
         _CRT_SECURE_NO_WARNINGS)
-    target_compile_options(test_nt_ui_walker_dispatch PRIVATE -U_DLL)
-    nt_set_warning_flags(test_nt_ui_walker_dispatch)
-    nt_set_sanitizer_flags(test_nt_ui_walker_dispatch)
-    set_target_properties(test_nt_ui_walker_dispatch PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
-    add_test(NAME test_nt_ui_walker_dispatch COMMAND test_nt_ui_walker_dispatch)
+    nt_setup_test_target(test_nt_ui_walker_dispatch)
 
     # --- test_nt_ui_walker_scissor -- WALK-02, WALK-03 ---
     add_executable(test_nt_ui_walker_scissor
@@ -626,12 +519,7 @@ if(NOT EMSCRIPTEN)
     target_compile_definitions(test_nt_ui_walker_scissor PRIVATE
         NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
         _CRT_SECURE_NO_WARNINGS)
-    target_compile_options(test_nt_ui_walker_scissor PRIVATE -U_DLL)
-    nt_set_warning_flags(test_nt_ui_walker_scissor)
-    nt_set_sanitizer_flags(test_nt_ui_walker_scissor)
-    set_target_properties(test_nt_ui_walker_scissor PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
-    add_test(NAME test_nt_ui_walker_scissor COMMAND test_nt_ui_walker_scissor)
+    nt_setup_test_target(test_nt_ui_walker_scissor)
 
     # --- test_nt_ui_walker_custom -- WALK-05 ---
     add_executable(test_nt_ui_walker_custom
@@ -646,12 +534,7 @@ if(NOT EMSCRIPTEN)
     target_compile_definitions(test_nt_ui_walker_custom PRIVATE
         NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
         _CRT_SECURE_NO_WARNINGS)
-    target_compile_options(test_nt_ui_walker_custom PRIVATE -U_DLL)
-    nt_set_warning_flags(test_nt_ui_walker_custom)
-    nt_set_sanitizer_flags(test_nt_ui_walker_custom)
-    set_target_properties(test_nt_ui_walker_custom PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
-    add_test(NAME test_nt_ui_walker_custom COMMAND test_nt_ui_walker_custom)
+    nt_setup_test_target(test_nt_ui_walker_custom)
 
     # --- test_nt_ui_walker_flush -- WALK-06 ---
     add_executable(test_nt_ui_walker_flush
@@ -667,12 +550,7 @@ if(NOT EMSCRIPTEN)
         NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
         NT_SPRITE_RENDERER_TEST_ACCESS NT_TEXT_RENDERER_TEST_ACCESS
         _CRT_SECURE_NO_WARNINGS)
-    target_compile_options(test_nt_ui_walker_flush PRIVATE -U_DLL)
-    nt_set_warning_flags(test_nt_ui_walker_flush)
-    nt_set_sanitizer_flags(test_nt_ui_walker_flush)
-    set_target_properties(test_nt_ui_walker_flush PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
-    add_test(NAME test_nt_ui_walker_flush COMMAND test_nt_ui_walker_flush)
+    nt_setup_test_target(test_nt_ui_walker_flush)
 
     # --- test_nt_ui_walker_readonly -- UI-06, UI-07 + pre-walk assert death-tests ---
     add_executable(test_nt_ui_walker_readonly
@@ -687,12 +565,7 @@ if(NOT EMSCRIPTEN)
     target_compile_definitions(test_nt_ui_walker_readonly PRIVATE
         NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS
         _CRT_SECURE_NO_WARNINGS)
-    target_compile_options(test_nt_ui_walker_readonly PRIVATE -U_DLL)
-    nt_set_warning_flags(test_nt_ui_walker_readonly)
-    nt_set_sanitizer_flags(test_nt_ui_walker_readonly)
-    set_target_properties(test_nt_ui_walker_readonly PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
-    add_test(NAME test_nt_ui_walker_readonly COMMAND test_nt_ui_walker_readonly)
+    nt_setup_test_target(test_nt_ui_walker_readonly)
 
     # --- test_nt_ui_stats -- WALK-09 ---
     add_executable(test_nt_ui_stats
@@ -707,12 +580,7 @@ if(NOT EMSCRIPTEN)
     target_compile_definitions(test_nt_ui_stats PRIVATE
         NT_GFX_TEST_ACCESS NT_UI_TEST_ACCESS NT_ATLAS_TEST_ACCESS NT_STATS_TEST_ACCESS
         _CRT_SECURE_NO_WARNINGS)
-    target_compile_options(test_nt_ui_stats PRIVATE -U_DLL)
-    nt_set_warning_flags(test_nt_ui_stats)
-    nt_set_sanitizer_flags(test_nt_ui_stats)
-    set_target_properties(test_nt_ui_stats PROPERTIES
-        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}")
-    add_test(NAME test_nt_ui_stats COMMAND test_nt_ui_stats)
+    nt_setup_test_target(test_nt_ui_stats)
 
 endif()
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,7 +14,7 @@ if(NOT EMSCRIPTEN)
     set(NT_TEST_ACCESS_LIBS
         nt_atlas nt_ui nt_gfx nt_gfx_stub nt_font nt_text_renderer
         nt_resource nt_sprite_renderer nt_mesh_renderer nt_stats
-        nt_shape_renderer
+        nt_shape_renderer nt_mem_scratch
     )
     foreach(_lib IN LISTS NT_TEST_ACCESS_LIBS)
         if(TARGET ${_lib})
@@ -354,6 +354,24 @@ if(NOT EMSCRIPTEN)
         _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE
     )
     nt_setup_test_target(test_sprite_renderer)
+
+    # --- nt_mem_scratch tests ---
+    add_executable(test_nt_mem_scratch unit/test_nt_mem_scratch.c unit/test_helpers/nt_assert_trap.c)
+    target_link_libraries(test_nt_mem_scratch PRIVATE
+        nt_mem_scratch nt_core unity
+    )
+    target_include_directories(test_nt_mem_scratch PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/unit")
+    target_compile_definitions(test_nt_mem_scratch PRIVATE _CRT_SECURE_NO_WARNINGS)
+    nt_setup_test_target(test_nt_mem_scratch)
+
+    # --- nt_ui element_data macro tests (exercises macros -> scratch path) ---
+    add_executable(test_nt_ui_element_data unit/test_nt_ui_element_data.c unit/test_helpers/nt_assert_trap.c)
+    target_link_libraries(test_nt_ui_element_data PRIVATE
+        nt_ui nt_mem_scratch nt_core unity
+    )
+    target_include_directories(test_nt_ui_element_data PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/unit")
+    target_compile_definitions(test_nt_ui_element_data PRIVATE _CRT_SECURE_NO_WARNINGS)
+    nt_setup_test_target(test_nt_ui_element_data)
 
     # --- Stats module tests (DEMO-04..06 + Pitfall 9 / Issue 2 coverage) ---
     add_executable(test_stats unit/test_stats.c)

--- a/tests/unit/test_atlas.c
+++ b/tests/unit/test_atlas.c
@@ -4,7 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-/* NT_ATLAS_TEST_ACCESS is provided by the CMake target. */
+/* NT_TEST_ACCESS is provided by the CMake target. */
 
 /* clang-format off */
 #include "atlas/nt_atlas.h"

--- a/tests/unit/test_font.c
+++ b/tests/unit/test_font.c
@@ -613,6 +613,21 @@ void test_measure_n_letter_spacing_grows_width(void) {
     free(blob);
 }
 
+/* \r must be skipped (matches nt_text_renderer_draw_n). CRLF text from
+ * Clay tokenization can leave \r in slices; measure must not add tofu width. */
+void test_measure_n_skips_carriage_return(void) {
+    uint8_t *blob = NULL;
+    nt_font_t font = make_resolved_test_font("font_cr", &blob);
+
+    nt_text_size_t plain = nt_font_measure_n(font, "ABC", 3U, 14.0F, 0.0F);
+    nt_text_size_t with_cr = nt_font_measure_n(font, "ABC\r", 4U, 14.0F, 0.0F);
+
+    TEST_ASSERT_EQUAL_INT32((int32_t)plain.width, (int32_t)with_cr.width);
+
+    nt_font_destroy(font);
+    free(blob);
+}
+
 void test_measure_n_cache_hits_on_repeat(void) {
     uint8_t *blob = NULL;
     nt_font_t font = make_resolved_test_font("font_hits", &blob);
@@ -1084,6 +1099,7 @@ int main(void) {
     RUN_TEST(test_measure_n_drops_partial_utf8);
     RUN_TEST(test_measure_n_embedded_nul_is_codepoint);
     RUN_TEST(test_measure_n_letter_spacing_grows_width);
+    RUN_TEST(test_measure_n_skips_carriage_return);
     RUN_TEST(test_measure_n_cache_hits_on_repeat);
     RUN_TEST(test_measure_n_invalidate_forces_miss);
     RUN_TEST(test_measure_n_destroy_clears_cache);

--- a/tests/unit/test_font.c
+++ b/tests/unit/test_font.c
@@ -501,17 +501,17 @@ void test_measure_n_matches_measure(void) {
     uint8_t *blob = NULL;
     nt_font_t font = make_resolved_test_font("font_eq", &blob);
 
-    nt_text_size_t a = nt_font_measure(font, "ABC", 14.0F);
-    nt_text_size_t b = nt_font_measure_n(font, "ABC", 3U, 14.0F);
+    nt_text_size_t a = nt_font_measure(font, "ABC", 14.0F, 0.0F);
+    nt_text_size_t b = nt_font_measure_n(font, "ABC", 3U, 14.0F, 0.0F);
     assert_text_size_equal(a, b);
 
     /* Empty input contract */
     nt_text_size_t zero = {0.0F, 0.0F};
-    nt_text_size_t e = nt_font_measure_n(font, "ABC", 0U, 14.0F);
+    nt_text_size_t e = nt_font_measure_n(font, "ABC", 0U, 14.0F, 0.0F);
     assert_text_size_equal(zero, e);
 
     /* NULL guard */
-    nt_text_size_t n = nt_font_measure_n(font, NULL, 4U, 14.0F);
+    nt_text_size_t n = nt_font_measure_n(font, NULL, 4U, 14.0F, 0.0F);
     assert_text_size_equal(zero, n);
 
     nt_font_destroy(font);
@@ -527,8 +527,8 @@ void test_measure_n_does_not_over_read(void) {
     /* "ABC" + poison 'B' + filler; bounded measure must ignore the poison.
        Intentionally NOT NUL-terminated — tests that _n stops at len, not at NUL. */
     const char buf[8] = {'A', 'B', 'C', 'B', 'X', 'X', 'X', 'X'};
-    nt_text_size_t bounded = nt_font_measure_n(font, buf, 3U, 14.0F);
-    nt_text_size_t reference = nt_font_measure(font, "ABC", 14.0F);
+    nt_text_size_t bounded = nt_font_measure_n(font, buf, 3U, 14.0F, 0.0F);
+    nt_text_size_t reference = nt_font_measure(font, "ABC", 14.0F, 0.0F);
 
     /* If _n over-read into the poison 'B', bounded.width would exceed reference.width. */
     assert_text_size_equal(reference, bounded);
@@ -547,8 +547,8 @@ void test_measure_n_drops_partial_utf8(void) {
      * mid-multibyte. The UTF-8 state machine recovers via NT_UTF8_REJECT
      * and the loop exits with only 'A' measured. */
     const char partial[] = {'A', (char)0xC3, 0};
-    nt_text_size_t bounded = nt_font_measure_n(font, partial, 2U, 14.0F);
-    nt_text_size_t reference = nt_font_measure(font, "A", 14.0F);
+    nt_text_size_t bounded = nt_font_measure_n(font, partial, 2U, 14.0F, 0.0F);
+    nt_text_size_t reference = nt_font_measure(font, "A", 14.0F, 0.0F);
 
     assert_text_size_equal(reference, bounded);
 
@@ -569,9 +569,9 @@ void test_measure_n_embedded_nul_is_codepoint(void) {
     /* "A\0B" — 3 bytes. _n should measure A + tofu(0) + B; _measure (wrapper)
      * stops at the embedded NUL and measures only A. The two MUST differ. */
     const char with_nul[3] = {'A', '\0', 'B'};
-    nt_text_size_t n_full = nt_font_measure_n(font, with_nul, 3U, 14.0F);
-    nt_text_size_t wrapper_truncated = nt_font_measure(font, with_nul, 14.0F);
-    nt_text_size_t reference_a = nt_font_measure(font, "A", 14.0F);
+    nt_text_size_t n_full = nt_font_measure_n(font, with_nul, 3U, 14.0F, 0.0F);
+    nt_text_size_t wrapper_truncated = nt_font_measure(font, with_nul, 14.0F, 0.0F);
+    nt_text_size_t reference_a = nt_font_measure(font, "A", 14.0F, 0.0F);
 
     /* Wrapper stopped at the NUL: width matches a bare "A". */
     assert_text_size_equal(reference_a, wrapper_truncated);
@@ -586,6 +586,33 @@ void test_measure_n_embedded_nul_is_codepoint(void) {
 
 /* ---- FONT-02: 200 identical calls produce 199 hits + 1 miss ---- */
 
+/* letter_spacing adds (N-1) * spacing pixels for N visible glyphs.
+ * 0 spacing must match the baseline; non-zero spacing widens the result by
+ * the expected amount; bypassing the measure cache when spacing != 0.
+ * Integer-truncated compare keeps the test free of UNITY float macros
+ * (UNITY_EXCLUDE_FLOAT is set repo-wide). */
+void test_measure_n_letter_spacing_grows_width(void) {
+    uint8_t *blob = NULL;
+    nt_font_t font = make_resolved_test_font("font_ls", &blob);
+
+    /* 3 glyphs ABC: 2 gaps between them -> +10px width with spacing=5. */
+    nt_text_size_t baseline = nt_font_measure_n(font, "ABC", 3U, 14.0F, 0.0F);
+    nt_text_size_t spaced = nt_font_measure_n(font, "ABC", 3U, 14.0F, 5.0F);
+    const int32_t base_w = (int32_t)baseline.width;
+    const int32_t sp_w = (int32_t)spaced.width;
+    TEST_ASSERT_EQUAL_INT32(base_w + 10, sp_w);
+    /* Height unaffected by horizontal spacing. */
+    TEST_ASSERT_EQUAL_INT32((int32_t)baseline.height, (int32_t)spaced.height);
+
+    /* Single-glyph: 0 gaps -- letter_spacing has no effect. */
+    nt_text_size_t one_base = nt_font_measure_n(font, "A", 1U, 14.0F, 0.0F);
+    nt_text_size_t one_spaced = nt_font_measure_n(font, "A", 1U, 14.0F, 5.0F);
+    TEST_ASSERT_EQUAL_INT32((int32_t)one_base.width, (int32_t)one_spaced.width);
+
+    nt_font_destroy(font);
+    free(blob);
+}
+
 void test_measure_n_cache_hits_on_repeat(void) {
     uint8_t *blob = NULL;
     nt_font_t font = make_resolved_test_font("font_hits", &blob);
@@ -594,7 +621,7 @@ void test_measure_n_cache_hits_on_repeat(void) {
     nt_font_test_reset_measure_counters();
 
     for (int i = 0; i < 200; i++) {
-        (void)nt_font_measure_n(font, "ABC", 3U, 14.0F);
+        (void)nt_font_measure_n(font, "ABC", 3U, 14.0F, 0.0F);
     }
 
     TEST_ASSERT_EQUAL_UINT32(199U, nt_font_test_measure_cache_hits(font));
@@ -613,13 +640,13 @@ void test_measure_n_invalidate_forces_miss(void) {
     nt_font_measure_invalidate(font);
     nt_font_test_reset_measure_counters();
 
-    (void)nt_font_measure_n(font, "AB", 2U, 14.0F); /* miss */
-    (void)nt_font_measure_n(font, "AB", 2U, 14.0F); /* hit */
+    (void)nt_font_measure_n(font, "AB", 2U, 14.0F, 0.0F); /* miss */
+    (void)nt_font_measure_n(font, "AB", 2U, 14.0F, 0.0F); /* hit */
     TEST_ASSERT_EQUAL_UINT32(1U, nt_font_test_measure_cache_hits(font));
     TEST_ASSERT_EQUAL_UINT32(1U, nt_font_test_measure_cache_misses(font));
 
     nt_font_measure_invalidate_cache();
-    (void)nt_font_measure_n(font, "AB", 2U, 14.0F);                        /* miss again after invalidate */
+    (void)nt_font_measure_n(font, "AB", 2U, 14.0F, 0.0F);                  /* miss again after invalidate */
     TEST_ASSERT_EQUAL_UINT32(1U, nt_font_test_measure_cache_hits(font));   /* unchanged */
     TEST_ASSERT_EQUAL_UINT32(2U, nt_font_test_measure_cache_misses(font)); /* +1 */
 
@@ -634,7 +661,7 @@ void test_measure_n_destroy_clears_cache(void) {
     nt_font_t font_a = make_resolved_test_font("font_d_a", &blob_a);
 
     nt_font_test_reset_measure_counters();
-    (void)nt_font_measure_n(font_a, "ABC", 3U, 14.0F); /* warm slot */
+    (void)nt_font_measure_n(font_a, "ABC", 3U, 14.0F, 0.0F); /* warm slot */
     TEST_ASSERT_EQUAL_UINT32(1U, nt_font_test_measure_cache_misses(font_a));
 
     /* Destroy releases pool slot via memset(slot, 0, sizeof(*slot)); next
@@ -646,7 +673,7 @@ void test_measure_n_destroy_clears_cache(void) {
     nt_font_t font_b = make_resolved_test_font("font_d_b", &blob_b);
 
     nt_font_test_reset_measure_counters();
-    (void)nt_font_measure_n(font_b, "ABC", 3U, 14.0F);
+    (void)nt_font_measure_n(font_b, "ABC", 3U, 14.0F, 0.0F);
     /* Must be a miss — slot's cache was cleared on destroy. */
     TEST_ASSERT_EQUAL_UINT32(0U, nt_font_test_measure_cache_hits(font_b));
     TEST_ASSERT_EQUAL_UINT32(1U, nt_font_test_measure_cache_misses(font_b));
@@ -675,9 +702,9 @@ void test_measure_n_cache_disabled(void) {
     /* 100 identical calls. With cache disabled, every call is a full measure
      * AND neither hit nor miss counter is incremented (counters track cache
      * activity, not raw measure calls). Result must still be correct. */
-    nt_text_size_t first = nt_font_measure_n(font, "ABC", 3U, 14.0F);
+    nt_text_size_t first = nt_font_measure_n(font, "ABC", 3U, 14.0F, 0.0F);
     for (int i = 0; i < 99; i++) {
-        nt_text_size_t r = nt_font_measure_n(font, "ABC", 3U, 14.0F);
+        nt_text_size_t r = nt_font_measure_n(font, "ABC", 3U, 14.0F, 0.0F);
         assert_text_size_equal(first, r);
     }
     TEST_ASSERT_EQUAL_UINT32(0U, nt_font_test_measure_cache_hits(font));
@@ -705,8 +732,8 @@ void test_measure_n_invalidates_on_resource_change(void) {
     nt_font_test_reset_measure_counters();
 
     /* Warm the cache for the same string twice — first miss, then hit. */
-    (void)nt_font_measure_n(font, "AB", 2U, 14.0F);
-    (void)nt_font_measure_n(font, "AB", 2U, 14.0F);
+    (void)nt_font_measure_n(font, "AB", 2U, 14.0F, 0.0F);
+    (void)nt_font_measure_n(font, "AB", 2U, 14.0F, 0.0F);
     TEST_ASSERT_EQUAL_UINT32(1U, nt_font_test_measure_cache_hits(font));
     TEST_ASSERT_EQUAL_UINT32(1U, nt_font_test_measure_cache_misses(font));
 
@@ -722,7 +749,7 @@ void test_measure_n_invalidates_on_resource_change(void) {
 
     /* Re-measure the same string — without the cache invalidation fix this
      * is a HIT (counter unchanged). With the fix it's a MISS (counter +1). */
-    (void)nt_font_measure_n(font, "AB", 2U, 14.0F);
+    (void)nt_font_measure_n(font, "AB", 2U, 14.0F, 0.0F);
     TEST_ASSERT_EQUAL_UINT32(1U, nt_font_test_measure_cache_hits(font));   /* unchanged */
     TEST_ASSERT_EQUAL_UINT32(2U, nt_font_test_measure_cache_misses(font)); /* +1 */
 
@@ -751,7 +778,7 @@ void test_measure_n_cache_custom_size(void) {
     /* 200 identical calls → 1 miss + 199 hits, just like the default-size test.
      * Verifies that a non-default POT size still produces correct counters. */
     for (int i = 0; i < 200; i++) {
-        (void)nt_font_measure_n(font, "AB", 2U, 14.0F);
+        (void)nt_font_measure_n(font, "AB", 2U, 14.0F, 0.0F);
     }
     TEST_ASSERT_EQUAL_UINT32(199U, nt_font_test_measure_cache_hits(font));
     TEST_ASSERT_EQUAL_UINT32(1U, nt_font_test_measure_cache_misses(font));
@@ -791,8 +818,8 @@ void test_measure_n_invalidates_on_resource_unload(void) {
     nt_font_test_reset_measure_counters();
 
     /* Warm cache: measure twice → 1 miss + 1 hit. */
-    nt_text_size_t live = nt_font_measure_n(font, "AB", 2U, 14.0F);
-    (void)nt_font_measure_n(font, "AB", 2U, 14.0F);
+    nt_text_size_t live = nt_font_measure_n(font, "AB", 2U, 14.0F, 0.0F);
+    (void)nt_font_measure_n(font, "AB", 2U, 14.0F, 0.0F);
     TEST_ASSERT_EQUAL_UINT32(1U, nt_font_test_measure_cache_hits(font));
     TEST_ASSERT_EQUAL_UINT32(1U, nt_font_test_measure_cache_misses(font));
     TEST_ASSERT_TRUE(live.width > 0.0F);
@@ -812,7 +839,7 @@ void test_measure_n_invalidates_on_resource_unload(void) {
     /* Counters frozen — measure_n hit the !metrics_set short-circuit
      * before the cache lookup. (UNITY_EXCLUDE_FLOAT, so TEST_ASSERT_TRUE
      * for the zero check.) */
-    nt_text_size_t after = nt_font_measure_n(font, "AB", 2U, 14.0F);
+    nt_text_size_t after = nt_font_measure_n(font, "AB", 2U, 14.0F, 0.0F);
     TEST_ASSERT_TRUE(after.width == 0.0F);
     TEST_ASSERT_TRUE(after.height == 0.0F);
     TEST_ASSERT_EQUAL_UINT32(1U, nt_font_test_measure_cache_hits(font));
@@ -863,7 +890,7 @@ void test_font_recovers_after_remount(void) {
 
     nt_font_metrics_t recovered = nt_font_get_metrics(font);
     TEST_ASSERT_NOT_EQUAL_UINT16(0U, recovered.units_per_em);
-    nt_text_size_t m = nt_font_measure_n(font, "AB", 2U, 14.0F);
+    nt_text_size_t m = nt_font_measure_n(font, "AB", 2U, 14.0F, 0.0F);
     TEST_ASSERT_TRUE(m.width > 0.0F);
 
     nt_font_destroy(font);
@@ -946,8 +973,8 @@ void test_font_file_pack_unmount_cleans_state(void) {
     nt_font_step();
 
     nt_font_test_reset_measure_counters();
-    (void)nt_font_measure_n(font, "AB", 2U, 14.0F);
-    (void)nt_font_measure_n(font, "AB", 2U, 14.0F);
+    (void)nt_font_measure_n(font, "AB", 2U, 14.0F, 0.0F);
+    (void)nt_font_measure_n(font, "AB", 2U, 14.0F, 0.0F);
     TEST_ASSERT_EQUAL_UINT32(1U, nt_font_test_measure_cache_hits(font));
     uint32_t gen_before = nt_font_get_cache_generation(font);
 
@@ -958,7 +985,7 @@ void test_font_file_pack_unmount_cleans_state(void) {
     TEST_ASSERT_EQUAL_UINT16(0U, nt_font_get_metrics(font).units_per_em);
     TEST_ASSERT_TRUE(nt_font_get_cache_generation(font) > gen_before);
 
-    nt_text_size_t after = nt_font_measure_n(font, "AB", 2U, 14.0F);
+    nt_text_size_t after = nt_font_measure_n(font, "AB", 2U, 14.0F, 0.0F);
     TEST_ASSERT_TRUE(after.width == 0.0F);
     TEST_ASSERT_TRUE(after.height == 0.0F);
     TEST_ASSERT_EQUAL_UINT32(1U, nt_font_test_measure_cache_hits(font));   /* unchanged */
@@ -1056,6 +1083,7 @@ int main(void) {
     RUN_TEST(test_measure_n_does_not_over_read);
     RUN_TEST(test_measure_n_drops_partial_utf8);
     RUN_TEST(test_measure_n_embedded_nul_is_codepoint);
+    RUN_TEST(test_measure_n_letter_spacing_grows_width);
     RUN_TEST(test_measure_n_cache_hits_on_repeat);
     RUN_TEST(test_measure_n_invalidate_forces_miss);
     RUN_TEST(test_measure_n_destroy_clears_cache);

--- a/tests/unit/test_helpers/nt_assert_trap.c
+++ b/tests/unit/test_helpers/nt_assert_trap.c
@@ -16,7 +16,6 @@ static void nt_test_assert_handler(const char *expr, const char *file, int line)
     (void)line;
     if (nt_test_assert_armed) {
         if (expr) {
-            /* snprintf-bounded copy, safe even if expr longer than buffer */
             (void)snprintf(nt_test_assert_last_expr, sizeof(nt_test_assert_last_expr), "%s", expr);
         }
         longjmp(nt_test_assert_jmp, 1);

--- a/tests/unit/test_helpers/nt_assert_trap.c
+++ b/tests/unit/test_helpers/nt_assert_trap.c
@@ -1,0 +1,32 @@
+#include "test_helpers/nt_assert_trap.h"
+
+#include <setjmp.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "core/nt_assert.h"
+
+jmp_buf nt_test_assert_jmp;
+bool nt_test_assert_armed = false;
+char nt_test_assert_last_expr[256] = {0};
+
+static void nt_test_assert_handler(const char *expr, const char *file, int line) {
+    (void)file;
+    (void)line;
+    if (nt_test_assert_armed) {
+        if (expr) {
+            /* snprintf-bounded copy, safe even if expr longer than buffer */
+            (void)snprintf(nt_test_assert_last_expr, sizeof(nt_test_assert_last_expr), "%s", expr);
+        }
+        longjmp(nt_test_assert_jmp, 1);
+    }
+    /* Not armed: let __builtin_trap downstream of the handler crash the test
+     * loudly — this is an unexpected assert and should fail the run. */
+}
+
+void nt_test_assert_install(void) {
+    if (nt_assert_handler != nt_test_assert_handler) {
+        nt_assert_handler = nt_test_assert_handler;
+    }
+}

--- a/tests/unit/test_helpers/nt_assert_trap.h
+++ b/tests/unit/test_helpers/nt_assert_trap.h
@@ -1,0 +1,54 @@
+#ifndef NT_TEST_HELPER_ASSERT_TRAP_H
+#define NT_TEST_HELPER_ASSERT_TRAP_H
+
+#include <setjmp.h>
+#include <stdbool.h>
+
+#include "unity.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* setjmp/longjmp-based assert trap for death-tests.
+ * Usage:
+ *   nt_test_assert_install();          // in setUp (or once globally)
+ *   NT_TEST_EXPECT_ASSERT(stmt);       // wraps a statement expected to fire NT_ASSERT
+ *
+ * Requires NT_ASSERT_MODE == NT_ASSERT_FULL (default for NT_DEBUG builds, which
+ * is the native-debug preset where ctest runs).
+ *
+ * NT_TEST_EXPECT_ASSERT contract:
+ *   - arms the trap (sets nt_test_assert_armed = true)
+ *   - setjmp baseline
+ *   - executes stmt
+ *   - if stmt returns without firing NT_ASSERT  -> TEST_FAIL_MESSAGE
+ *   - if stmt fires NT_ASSERT                   -> handler longjmps back here; trap disarmed; test continues
+ *   - __builtin_trap in nt_assert.h follows the handler call but is unreachable
+ *     because the handler longjmps first.
+ */
+
+extern jmp_buf nt_test_assert_jmp;
+extern bool nt_test_assert_armed;
+extern char nt_test_assert_last_expr[256];
+
+/* Install nt_test_assert_handler into nt_assert_handler. Idempotent. */
+void nt_test_assert_install(void);
+
+#define NT_TEST_EXPECT_ASSERT(stmt)                                                                                                                                                                    \
+    do {                                                                                                                                                                                               \
+        nt_test_assert_install();                                                                                                                                                                      \
+        nt_test_assert_armed = true;                                                                                                                                                                   \
+        if (setjmp(nt_test_assert_jmp) == 0) {                                                                                                                                                         \
+            stmt;                                                                                                                                                                                      \
+            nt_test_assert_armed = false;                                                                                                                                                              \
+            TEST_FAIL_MESSAGE("expected NT_ASSERT did not fire: " #stmt);                                                                                                                              \
+        }                                                                                                                                                                                              \
+        nt_test_assert_armed = false;                                                                                                                                                                  \
+    } while (0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NT_TEST_HELPER_ASSERT_TRAP_H */

--- a/tests/unit/test_helpers/nt_assert_trap.h
+++ b/tests/unit/test_helpers/nt_assert_trap.h
@@ -11,28 +11,20 @@ extern "C" {
 #endif
 
 /* setjmp/longjmp-based assert trap for death-tests.
- * Usage:
- *   nt_test_assert_install();          // in setUp (or once globally)
- *   NT_TEST_EXPECT_ASSERT(stmt);       // wraps a statement expected to fire NT_ASSERT
  *
- * Requires NT_ASSERT_MODE == NT_ASSERT_FULL (default for NT_DEBUG builds, which
- * is the native-debug preset where ctest runs).
+ *   nt_test_assert_install();    // setUp (or once globally)
+ *   NT_TEST_EXPECT_ASSERT(stmt); // stmt MUST fire NT_ASSERT, else FAIL
  *
- * NT_TEST_EXPECT_ASSERT contract:
- *   - arms the trap (sets nt_test_assert_armed = true)
- *   - setjmp baseline
- *   - executes stmt
- *   - if stmt returns without firing NT_ASSERT  -> TEST_FAIL_MESSAGE
- *   - if stmt fires NT_ASSERT                   -> handler longjmps back here; trap disarmed; test continues
- *   - __builtin_trap in nt_assert.h follows the handler call but is unreachable
- *     because the handler longjmps first.
- */
+ * Requires NT_ASSERT_MODE == NT_ASSERT_FULL (default in NT_DEBUG builds).
+ * The macro arms the trap, setjmp baseline, runs stmt; if NT_ASSERT
+ * fires the installed handler longjmps back and the test continues.
+ * If stmt returns normally, TEST_FAIL_MESSAGE. */
 
 extern jmp_buf nt_test_assert_jmp;
 extern bool nt_test_assert_armed;
 extern char nt_test_assert_last_expr[256];
 
-/* Install nt_test_assert_handler into nt_assert_handler. Idempotent. */
+/* Idempotent: installs the trap into nt_assert_handler. */
 void nt_test_assert_install(void);
 
 #define NT_TEST_EXPECT_ASSERT(stmt)                                                                                                                                                                    \

--- a/tests/unit/test_helpers/ui_atlas.c
+++ b/tests/unit/test_helpers/ui_atlas.c
@@ -18,33 +18,19 @@
 #include "nt_pack_format.h"
 #include "resource/nt_resource.h"
 
-/* ---- Synthetic atlas blob layout (matches engine/atlas/nt_atlas_format.h) ----
+/* Synthetic atlas blob layout (matches engine/atlas/nt_atlas_format.h):
  *
- *  NtAtlasHeader (28 bytes)
- *  uint64_t texture_resource_ids[1]    -> page 0 (uses NT_UI_ATLAS_PAGE_RID)
- *  NtAtlasRegion regions[2]            -> region 0: white 4-vert; region 1: hull 6-vert
- *  NtAtlasVertex vertices[10]          -> 4 (white) + 6 (polygon hull)
- *  uint16_t      indices[18]           -> 6 (white) + 12 (hull)
+ *   NtAtlasHeader     (28 bytes)
+ *   page resource id  (8 bytes)
+ *   NtAtlasRegion[2]  (region 0 = 4-vert white quad, region 1 = 6-vert hull)
+ *   NtAtlasVertex[10]
+ *   uint16[18]        (6 indices for white + 12 for hull)
  *
- * Plan 04 Task 2.3 finalization (Path (a) committed): the helper now stands
- * up a real virtual pack and parses the synthetic blob through
- * nt_resource_parse_pack + the atlas activator's full on_resolve /
- * on_post_resolve path. That gives us a real nt_resource_t handle that
- * nt_resource_is_ready() returns true for, and that nt_atlas_get_region()
- * resolves against via nt_resource_get_user_data.
- *
- * Page-0 texture is registered as a separate high-priority virtual pack
- * pointing at a 1x1 white nt_texture_t -- the sprite renderer's emit path
- * calls nt_resource_get(page_resource) to bind a texture id, which must
- * be non-zero.
- *
- * Prerequisites the test must run before minimal_ui_atlas_create():
- *   - nt_hash_init
- *   - nt_gfx_init (any backend; stub is fine)
- *   - nt_resource_init
- *   - nt_atlas_init                          (registers the NT_ASSET_ATLAS activator)
- * After create, two nt_resource_step() calls drive resolve -> post-resolve
- * (page texture request publishes on the second step). */
+ * Mounts the blob as a real virtual pack so nt_resource_is_ready returns
+ * true and nt_atlas_get_region resolves through the regular activator
+ * path. Page 0 is a separate high-priority virtual pack with a 1x1 white
+ * texture so the sprite renderer's nt_resource_get(page_resource) returns
+ * a non-zero texture id. */
 
 #define UI_ATLAS_REGION_COUNT 2u
 #define UI_ATLAS_PAGE_COUNT 1u
@@ -61,13 +47,11 @@
 #define UI_ATLAS_INDEX_OFFSET (UI_ATLAS_VERTEX_OFFSET + UI_ATLAS_VERTICES_SIZE)
 #define UI_ATLAS_BLOB_SIZE (UI_ATLAS_INDEX_OFFSET + UI_ATLAS_INDICES_SIZE)
 
-/* Stable resource ids (unique-per-test-binary; counter-suffixed so multiple
- * create/destroy cycles in one binary don't collide on resource-table slots
- * that were tombstoned by destroy). */
+/* Counter-suffixed pack names so multiple create/destroy cycles in one
+ * binary don't collide on tombstoned resource-table slots. */
 static uint32_t s_helper_counter;
 
-/* Pack blob lives in the helper's BSS / heap -- nt_resource_parse_pack
- * keeps a reference until the pack is unmounted. We free on destroy. */
+/* nt_resource_parse_pack keeps a reference to the blob until unmount. */
 static uint8_t *s_pack_blob;
 static uint32_t s_pack_total;
 static nt_hash32_t s_atlas_pack_id;

--- a/tests/unit/test_helpers/ui_atlas.c
+++ b/tests/unit/test_helpers/ui_atlas.c
@@ -4,7 +4,9 @@
 #include <stdint.h>
 #include <string.h>
 
-#define NT_ATLAS_TEST_ACCESS
+#ifndef NT_ATLAS_TEST_ACCESS
+#define NT_ATLAS_TEST_ACCESS 1
+#endif
 #include "atlas/nt_atlas.h"
 #include "nt_atlas_format.h"
 

--- a/tests/unit/test_helpers/ui_atlas.c
+++ b/tests/unit/test_helpers/ui_atlas.c
@@ -1,0 +1,186 @@
+#include "test_helpers/ui_atlas.h"
+
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#define NT_ATLAS_TEST_ACCESS
+#include "atlas/nt_atlas.h"
+#include "nt_atlas_format.h"
+
+/* ---- Synthetic atlas blob layout (matches engine/atlas/nt_atlas_format.h) ----
+ *
+ *  NtAtlasHeader (28 bytes)
+ *  uint64_t texture_resource_ids[1]    -> page 0 (placeholder hash)
+ *  NtAtlasRegion regions[2]            -> region 0: white 4-vert; region 1: hull 6-vert
+ *  NtAtlasVertex vertices[10]          -> 4 (white) + 6 (polygon hull)
+ *  uint16_t      indices[18]           -> 6 (white: two triangles) + 12 (hull: 4 triangles)
+ *
+ * Offsets are computed at build time so the blob is contiguous BSS data.
+ */
+
+#define UI_ATLAS_REGION_COUNT 2u
+#define UI_ATLAS_PAGE_COUNT 1u
+#define UI_ATLAS_VERTEX_COUNT 10u
+#define UI_ATLAS_INDEX_COUNT 18u
+
+#define UI_ATLAS_HEADER_SIZE 28u
+#define UI_ATLAS_PAGE_IDS_SIZE (UI_ATLAS_PAGE_COUNT * 8u)
+#define UI_ATLAS_REGIONS_SIZE (UI_ATLAS_REGION_COUNT * 40u)
+#define UI_ATLAS_VERTICES_SIZE (UI_ATLAS_VERTEX_COUNT * 8u)
+#define UI_ATLAS_INDICES_SIZE (UI_ATLAS_INDEX_COUNT * 2u)
+
+#define UI_ATLAS_VERTEX_OFFSET (UI_ATLAS_HEADER_SIZE + UI_ATLAS_PAGE_IDS_SIZE + UI_ATLAS_REGIONS_SIZE)
+#define UI_ATLAS_INDEX_OFFSET (UI_ATLAS_VERTEX_OFFSET + UI_ATLAS_VERTICES_SIZE)
+#define UI_ATLAS_TOTAL_SIZE (UI_ATLAS_INDEX_OFFSET + UI_ATLAS_INDICES_SIZE)
+
+/* Synthetic blob lives in BSS — built lazily on first create. */
+static uint8_t s_blob[UI_ATLAS_TOTAL_SIZE];
+static int s_blob_built = 0;
+
+/* Cached parsed data (from nt_atlas_test_drive_resolve). Plan 02 Task 2.3
+ * finalizes resource-handle wiring so nt_resource_is_ready returns true.
+ * Wave 0 ships the blob constructor + committed test-access call; the public
+ * API shape is locked. */
+static void *s_atlas_user_data = NULL;
+
+static void ui_atlas_build_blob(void) {
+    if (s_blob_built) {
+        return;
+    }
+    memset(s_blob, 0, sizeof s_blob);
+
+    /* ---- Header ---- */
+    NtAtlasHeader hdr = {
+        .magic = NT_ATLAS_MAGIC,
+        .version = NT_ATLAS_VERSION,
+        .region_count = (uint16_t)UI_ATLAS_REGION_COUNT,
+        .page_count = (uint16_t)UI_ATLAS_PAGE_COUNT,
+        ._pad = 0,
+        .vertex_offset = UI_ATLAS_VERTEX_OFFSET,
+        .total_vertex_count = UI_ATLAS_VERTEX_COUNT,
+        .index_offset = UI_ATLAS_INDEX_OFFSET,
+        .total_index_count = UI_ATLAS_INDEX_COUNT,
+    };
+    memcpy(s_blob + 0, &hdr, sizeof hdr);
+
+    /* ---- Page resource id (placeholder; runtime uses its own slot lookup) ---- */
+    uint64_t page_id = 0xC0FFEE00ULL;
+    memcpy(s_blob + UI_ATLAS_HEADER_SIZE, &page_id, sizeof page_id);
+
+    /* ---- Region 0: 1x1 white quad, 4 verts, 6 indices ---- */
+    NtAtlasRegion region0 = {
+        .name_hash = 0x57484954454E4555ULL, /* arbitrary hash for "white" */
+        .source_w = 1,
+        .source_h = 1,
+        .trim_offset_x = 0,
+        .trim_offset_y = 0,
+        .origin_x = 0.0f,
+        .origin_y = 0.0f,
+        .vertex_start = 0,
+        .index_start = 0,
+        .vertex_count = 4,
+        .page_index = 0,
+        .transform = 0,
+        .index_count = 6,
+        .flags = 0,
+        ._reserved = {0, 0, 0},
+    };
+    memcpy(s_blob + UI_ATLAS_HEADER_SIZE + UI_ATLAS_PAGE_IDS_SIZE, &region0, sizeof region0);
+
+    /* ---- Region 1: 6-vertex polygon hull (12 indices = 4 fan triangles) ---- */
+    NtAtlasRegion region1 = {
+        .name_hash = 0x504F4C59474F4E32ULL, /* arbitrary hash for "polygon2" */
+        .source_w = 16,
+        .source_h = 16,
+        .trim_offset_x = 0,
+        .trim_offset_y = 0,
+        .origin_x = 0.5f,
+        .origin_y = 0.5f,
+        .vertex_start = 4,
+        .index_start = 6,
+        .vertex_count = 6,
+        .page_index = 0,
+        .transform = 0,
+        .index_count = 12,
+        .flags = 0,
+        ._reserved = {0, 0, 0},
+    };
+    memcpy(s_blob + UI_ATLAS_HEADER_SIZE + UI_ATLAS_PAGE_IDS_SIZE + 40, &region1, sizeof region1);
+
+    /* ---- Vertices: 4 white (corners of 1x1) + 6 polygon-hull ---- */
+    NtAtlasVertex verts[UI_ATLAS_VERTEX_COUNT] = {
+        /* white quad (trim-local space 0..1, atlas UV 0..0xFFFF) */
+        {0, 0, 0, 0},
+        {1, 0, 0xFFFF, 0},
+        {1, 1, 0xFFFF, 0xFFFF},
+        {0, 1, 0, 0xFFFF},
+        /* polygon hull (6 verts, hexagon-ish) */
+        {0, 8, 0, 0x8000},
+        {8, 0, 0x8000, 0},
+        {16, 8, 0xFFFF, 0x8000},
+        {16, 8, 0xFFFF, 0x8000},
+        {8, 16, 0x8000, 0xFFFF},
+        {0, 8, 0, 0x8000},
+    };
+    memcpy(s_blob + UI_ATLAS_VERTEX_OFFSET, verts, sizeof verts);
+
+    /* ---- Indices: white (0..3 fan -> 2 tris) + polygon (fan over 4 tris) ---- */
+    uint16_t indices[UI_ATLAS_INDEX_COUNT] = {
+        /* white: 0,1,2 + 0,2,3 */
+        0,
+        1,
+        2,
+        0,
+        2,
+        3,
+        /* polygon-hull fan (vertices local 0..5): 0,1,2 0,2,3 0,3,4 0,4,5 */
+        0,
+        1,
+        2,
+        0,
+        2,
+        3,
+        0,
+        3,
+        4,
+        0,
+        4,
+        5,
+    };
+    memcpy(s_blob + UI_ATLAS_INDEX_OFFSET, indices, sizeof indices);
+
+    s_blob_built = 1;
+}
+
+minimal_ui_atlas_t minimal_ui_atlas_create(void) {
+    ui_atlas_build_blob();
+
+    /* Drive the atlas activator's on_resolve callback directly (Revision Issue 4
+     * committed path — nt_atlas_test_drive_resolve from NT_ATLAS_TEST_ACCESS).
+     * This parses the synthetic blob into an nt_atlas_data_t* without standing
+     * up the resource system. Plan 02 Task 2.3 finalizes the nt_resource_t
+     * wiring so nt_resource_is_ready(handle) returns true; until then the
+     * handle is INVALID and callers must use nt_atlas_test_* accessors. */
+    nt_atlas_test_drive_resolve(s_blob, (uint32_t)sizeof s_blob, &s_atlas_user_data);
+
+    minimal_ui_atlas_t result = {
+        .handle = NT_RESOURCE_INVALID, /* TODO Plan 02 Task 2.3 */
+        .white_region_idx = 0,
+        .polygon_region_idx = 1,
+    };
+    return result;
+}
+
+void minimal_ui_atlas_destroy(minimal_ui_atlas_t *atlas) {
+    if (atlas == NULL) {
+        return;
+    }
+    if (s_atlas_user_data != NULL) {
+        nt_atlas_test_drive_cleanup(s_atlas_user_data);
+        s_atlas_user_data = NULL;
+    }
+    atlas->handle = NT_RESOURCE_INVALID;
+    atlas->white_region_idx = 0;
+    atlas->polygon_region_idx = 0;
+}

--- a/tests/unit/test_helpers/ui_atlas.c
+++ b/tests/unit/test_helpers/ui_atlas.c
@@ -47,19 +47,14 @@
 #define UI_ATLAS_INDEX_OFFSET (UI_ATLAS_VERTEX_OFFSET + UI_ATLAS_VERTICES_SIZE)
 #define UI_ATLAS_BLOB_SIZE (UI_ATLAS_INDEX_OFFSET + UI_ATLAS_INDICES_SIZE)
 
-/* Counter-suffixed pack names so multiple create/destroy cycles in one
- * binary don't collide on tombstoned resource-table slots. */
+/* Pack name suffix counter so multiple coexisting instances (and
+ * sequential create/destroy cycles) don't collide on tombstoned
+ * resource-table slots. Monotonic across the whole test binary. */
 static uint32_t s_helper_counter;
 
-/* nt_resource_parse_pack keeps a reference to the blob until unmount. */
-static uint8_t *s_pack_blob;
-static uint32_t s_pack_total;
-static nt_hash32_t s_atlas_pack_id;
-static nt_hash32_t s_page_pack_id;
-static nt_texture_t s_page_tex;
 static const uint8_t s_white_pixel[4] = {255, 255, 255, 255};
 
-static void ui_atlas_build_inner_blob(uint8_t *out_blob) {
+static void ui_atlas_build_inner_blob(uint8_t *out_blob, uint32_t suffix) {
     memset(out_blob, 0, UI_ATLAS_BLOB_SIZE);
 
     /* ---- Header ---- */
@@ -78,7 +73,7 @@ static void ui_atlas_build_inner_blob(uint8_t *out_blob) {
 
     /* ---- Page resource id (must match the page-pack registration below) ---- */
     char page_name[64];
-    (void)snprintf(page_name, sizeof page_name, "ui_atlas_page_%u", s_helper_counter);
+    (void)snprintf(page_name, sizeof page_name, "ui_atlas_page_%u", suffix);
     uint64_t page_rid = nt_hash64_str(page_name).value;
     memcpy(out_blob + UI_ATLAS_HEADER_SIZE, &page_rid, sizeof page_rid);
 
@@ -167,9 +162,9 @@ static void ui_atlas_build_inner_blob(uint8_t *out_blob) {
 
 /* Wrap the inner atlas blob in a real NEOPAK envelope so nt_resource_parse_pack
  * accepts it. The resulting pack contains exactly one NT_ASSET_ATLAS entry. */
-static uint8_t *ui_atlas_build_pack_blob(uint64_t atlas_rid, uint32_t *out_total) {
+static uint8_t *ui_atlas_build_pack_blob(uint64_t atlas_rid, uint32_t suffix, uint32_t *out_total) {
     uint8_t inner[UI_ATLAS_BLOB_SIZE];
-    ui_atlas_build_inner_blob(inner);
+    ui_atlas_build_inner_blob(inner, suffix);
 
     const uint32_t raw_header = (uint32_t)(sizeof(NtPackHeader) + sizeof(NtAssetEntry));
     const uint32_t header_size = (raw_header + (NT_PACK_DATA_ALIGN - 1U)) & ~(uint32_t)(NT_PACK_DATA_ALIGN - 1U);
@@ -207,72 +202,62 @@ static uint8_t *ui_atlas_build_pack_blob(uint64_t atlas_rid, uint32_t *out_total
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 minimal_ui_atlas_t minimal_ui_atlas_create(void) {
-    s_helper_counter++;
+    minimal_ui_atlas_t out = {0};
+    const uint32_t suffix = ++s_helper_counter;
 
-    /* Page texture pack (high priority so atlas_on_post_resolve's
-     * nt_resource_request for the page id succeeds). */
+    /* Page pack at high priority so the atlas activator's post-resolve
+     * nt_resource_request for the page id finds a registered slot. */
     char page_pack[64];
     char page_name[64];
-    (void)snprintf(page_pack, sizeof page_pack, "ui_atlas_page_pack_%u", s_helper_counter);
-    (void)snprintf(page_name, sizeof page_name, "ui_atlas_page_%u", s_helper_counter);
-    s_page_pack_id = nt_hash32_str(page_pack);
-    NT_ASSERT(nt_resource_create_pack(s_page_pack_id, 100) == NT_OK);
-    s_page_tex = nt_gfx_make_texture(&(nt_texture_desc_t){.width = 1, .height = 1, .data = s_white_pixel, .label = "ui_atlas_white_page"});
-    NT_ASSERT(s_page_tex.id != 0);
-    NT_ASSERT(nt_resource_register(s_page_pack_id, nt_hash64_str(page_name), NT_ASSET_TEXTURE, s_page_tex.id) == NT_OK);
+    (void)snprintf(page_pack, sizeof page_pack, "ui_atlas_page_pack_%u", suffix);
+    (void)snprintf(page_name, sizeof page_name, "ui_atlas_page_%u", suffix);
+    out._page_pack_id = nt_hash32_str(page_pack);
+    NT_ASSERT(nt_resource_create_pack(out._page_pack_id, 100) == NT_OK);
+    out._page_tex = nt_gfx_make_texture(&(nt_texture_desc_t){.width = 1, .height = 1, .data = s_white_pixel, .label = "ui_atlas_white_page"});
+    NT_ASSERT(out._page_tex.id != 0);
+    NT_ASSERT(nt_resource_register(out._page_pack_id, nt_hash64_str(page_name), NT_ASSET_TEXTURE, out._page_tex.id) == NT_OK);
 
-    /* Atlas pack: mount, parse blob, request handle. */
     char atlas_pack[64];
     char atlas_name[64];
-    (void)snprintf(atlas_pack, sizeof atlas_pack, "ui_atlas_pack_%u", s_helper_counter);
-    (void)snprintf(atlas_name, sizeof atlas_name, "ui_atlas_%u", s_helper_counter);
-    s_atlas_pack_id = nt_hash32_str(atlas_pack);
+    (void)snprintf(atlas_pack, sizeof atlas_pack, "ui_atlas_pack_%u", suffix);
+    (void)snprintf(atlas_name, sizeof atlas_name, "ui_atlas_%u", suffix);
+    out._atlas_pack_id = nt_hash32_str(atlas_pack);
     nt_hash64_t atlas_rid = nt_hash64_str(atlas_name);
 
-    NT_ASSERT(nt_resource_mount(s_atlas_pack_id, 0) == NT_OK);
-    s_pack_blob = ui_atlas_build_pack_blob(atlas_rid.value, &s_pack_total);
-    NT_ASSERT(nt_resource_parse_pack(s_atlas_pack_id, s_pack_blob, s_pack_total) == NT_OK);
+    NT_ASSERT(nt_resource_mount(out._atlas_pack_id, 0) == NT_OK);
+    out._pack_blob = ui_atlas_build_pack_blob(atlas_rid.value, suffix, &out._pack_total);
+    NT_ASSERT(nt_resource_parse_pack(out._atlas_pack_id, out._pack_blob, out._pack_total) == NT_OK);
 
     nt_resource_t atlas = nt_resource_request(atlas_rid, NT_ASSET_ATLAS);
     NT_ASSERT(atlas.id != 0);
-    /* Two steps: first runs on_resolve+on_post_resolve (which queues a
-     * page-texture nt_resource_request); second publishes the page slot
-     * and lets nt_resource_is_ready(atlas) return true (AUX_BACKED
-     * behavior). */
+    /* Two steps: first runs on_resolve + on_post_resolve (which queues a
+     * page-texture request); second publishes the page slot so
+     * nt_resource_is_ready(atlas) returns true. */
     nt_resource_step();
     nt_resource_step();
     NT_ASSERT(nt_resource_is_ready(atlas));
 
-    minimal_ui_atlas_t result = {
-        .handle = atlas,
-        .white_region_idx = 0,
-        .polygon_region_idx = 1,
-    };
-    return result;
+    out.handle = atlas;
+    out.white_region_idx = 0;
+    out.polygon_region_idx = 1;
+    return out;
 }
 
 void minimal_ui_atlas_destroy(minimal_ui_atlas_t *atlas) {
     if (atlas == NULL) {
         return;
     }
-    if (s_atlas_pack_id.value != 0) {
-        nt_resource_unmount(s_atlas_pack_id);
-        s_atlas_pack_id = (nt_hash32_t){0};
+    if (atlas->_atlas_pack_id.value != 0) {
+        nt_resource_unmount(atlas->_atlas_pack_id);
     }
-    if (s_page_pack_id.value != 0) {
-        /* Unregister the page resource before destroying the texture so the
+    if (atlas->_page_pack_id.value != 0) {
+        /* Unmount the page pack BEFORE destroying the texture so the
          * resource system doesn't dangle on the runtime handle. */
-        nt_resource_unmount(s_page_pack_id);
-        s_page_pack_id = (nt_hash32_t){0};
+        nt_resource_unmount(atlas->_page_pack_id);
     }
-    if (s_page_tex.id != 0) {
-        nt_gfx_destroy_texture(s_page_tex);
-        s_page_tex = (nt_texture_t){0};
+    if (atlas->_page_tex.id != 0) {
+        nt_gfx_destroy_texture(atlas->_page_tex);
     }
-    free(s_pack_blob);
-    s_pack_blob = NULL;
-    s_pack_total = 0;
-    atlas->handle = NT_RESOURCE_INVALID;
-    atlas->white_region_idx = 0;
-    atlas->polygon_region_idx = 0;
+    free(atlas->_pack_blob);
+    *atlas = (minimal_ui_atlas_t){0};
 }

--- a/tests/unit/test_helpers/ui_atlas.c
+++ b/tests/unit/test_helpers/ui_atlas.c
@@ -105,8 +105,8 @@ static void ui_atlas_build_inner_blob(uint8_t *out_blob) {
         .source_h = 1,
         .trim_offset_x = 0,
         .trim_offset_y = 0,
-        .origin_x = 0.0f,
-        .origin_y = 0.0f,
+        .origin_x = 0.0F,
+        .origin_y = 0.0F,
         .vertex_start = 0,
         .index_start = 0,
         .vertex_count = 4,
@@ -116,7 +116,7 @@ static void ui_atlas_build_inner_blob(uint8_t *out_blob) {
         .flags = NT_ATLAS_REGION_FLAG_QUAD_012023,
         ._reserved = {0, 0, 0},
     };
-    memcpy(out_blob + UI_ATLAS_HEADER_SIZE + UI_ATLAS_PAGE_IDS_SIZE, &region0, sizeof region0);
+    memcpy(out_blob + (size_t)UI_ATLAS_HEADER_SIZE + (size_t)UI_ATLAS_PAGE_IDS_SIZE, &region0, sizeof region0);
 
     /* ---- Region 1: 6-vertex polygon hull (12 indices = 4 fan triangles) ---- */
     NtAtlasRegion region1 = {
@@ -125,8 +125,8 @@ static void ui_atlas_build_inner_blob(uint8_t *out_blob) {
         .source_h = 16,
         .trim_offset_x = 0,
         .trim_offset_y = 0,
-        .origin_x = 0.5f,
-        .origin_y = 0.5f,
+        .origin_x = 0.5F,
+        .origin_y = 0.5F,
         .vertex_start = 4,
         .index_start = 6,
         .vertex_count = 6,
@@ -136,7 +136,7 @@ static void ui_atlas_build_inner_blob(uint8_t *out_blob) {
         .flags = 0,
         ._reserved = {0, 0, 0},
     };
-    memcpy(out_blob + UI_ATLAS_HEADER_SIZE + UI_ATLAS_PAGE_IDS_SIZE + 40, &region1, sizeof region1);
+    memcpy(out_blob + (size_t)UI_ATLAS_HEADER_SIZE + (size_t)UI_ATLAS_PAGE_IDS_SIZE + 40U, &region1, sizeof region1);
 
     /* ---- Vertices: 4 white + 6 polygon-hull ---- */
     NtAtlasVertex verts[UI_ATLAS_VERTEX_COUNT] = {
@@ -188,9 +188,9 @@ static uint8_t *ui_atlas_build_pack_blob(uint64_t atlas_rid, uint32_t *out_total
     ui_atlas_build_inner_blob(inner);
 
     const uint32_t raw_header = (uint32_t)(sizeof(NtPackHeader) + sizeof(NtAssetEntry));
-    const uint32_t header_size = (raw_header + (NT_PACK_DATA_ALIGN - 1u)) & ~(uint32_t)(NT_PACK_DATA_ALIGN - 1u);
+    const uint32_t header_size = (raw_header + (NT_PACK_DATA_ALIGN - 1U)) & ~(uint32_t)(NT_PACK_DATA_ALIGN - 1U);
     const uint32_t atlas_offset = header_size;
-    const uint32_t aligned_atlas = (UI_ATLAS_BLOB_SIZE + (NT_PACK_ASSET_ALIGN - 1u)) & ~(uint32_t)(NT_PACK_ASSET_ALIGN - 1u);
+    const uint32_t aligned_atlas = (UI_ATLAS_BLOB_SIZE + (NT_PACK_ASSET_ALIGN - 1U)) & ~(uint32_t)(NT_PACK_ASSET_ALIGN - 1U);
     const uint32_t total_size = atlas_offset + aligned_atlas;
 
     uint8_t *pack_blob = (uint8_t *)calloc(1, total_size);
@@ -221,6 +221,7 @@ static uint8_t *ui_atlas_build_pack_blob(uint64_t atlas_rid, uint32_t *out_total
     return pack_blob;
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 minimal_ui_atlas_t minimal_ui_atlas_create(void) {
     s_helper_counter++;
 

--- a/tests/unit/test_helpers/ui_atlas.c
+++ b/tests/unit/test_helpers/ui_atlas.c
@@ -6,8 +6,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#ifndef NT_ATLAS_TEST_ACCESS
-#define NT_ATLAS_TEST_ACCESS 1
+#ifndef NT_TEST_ACCESS
+#define NT_TEST_ACCESS 1
 #endif
 #include "atlas/nt_atlas.h"
 #include "core/nt_assert.h"

--- a/tests/unit/test_helpers/ui_atlas.c
+++ b/tests/unit/test_helpers/ui_atlas.c
@@ -2,24 +2,49 @@
 
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #ifndef NT_ATLAS_TEST_ACCESS
 #define NT_ATLAS_TEST_ACCESS 1
 #endif
 #include "atlas/nt_atlas.h"
+#include "core/nt_assert.h"
+#include "graphics/nt_gfx.h"
+#include "hash/nt_hash.h"
 #include "nt_atlas_format.h"
+#include "nt_crc32.h"
+#include "nt_pack_format.h"
+#include "resource/nt_resource.h"
 
 /* ---- Synthetic atlas blob layout (matches engine/atlas/nt_atlas_format.h) ----
  *
  *  NtAtlasHeader (28 bytes)
- *  uint64_t texture_resource_ids[1]    -> page 0 (placeholder hash)
+ *  uint64_t texture_resource_ids[1]    -> page 0 (uses NT_UI_ATLAS_PAGE_RID)
  *  NtAtlasRegion regions[2]            -> region 0: white 4-vert; region 1: hull 6-vert
  *  NtAtlasVertex vertices[10]          -> 4 (white) + 6 (polygon hull)
- *  uint16_t      indices[18]           -> 6 (white: two triangles) + 12 (hull: 4 triangles)
+ *  uint16_t      indices[18]           -> 6 (white) + 12 (hull)
  *
- * Offsets are computed at build time so the blob is contiguous BSS data.
- */
+ * Plan 04 Task 2.3 finalization (Path (a) committed): the helper now stands
+ * up a real virtual pack and parses the synthetic blob through
+ * nt_resource_parse_pack + the atlas activator's full on_resolve /
+ * on_post_resolve path. That gives us a real nt_resource_t handle that
+ * nt_resource_is_ready() returns true for, and that nt_atlas_get_region()
+ * resolves against via nt_resource_get_user_data.
+ *
+ * Page-0 texture is registered as a separate high-priority virtual pack
+ * pointing at a 1x1 white nt_texture_t -- the sprite renderer's emit path
+ * calls nt_resource_get(page_resource) to bind a texture id, which must
+ * be non-zero.
+ *
+ * Prerequisites the test must run before minimal_ui_atlas_create():
+ *   - nt_hash_init
+ *   - nt_gfx_init (any backend; stub is fine)
+ *   - nt_resource_init
+ *   - nt_atlas_init                          (registers the NT_ASSET_ATLAS activator)
+ * After create, two nt_resource_step() calls drive resolve -> post-resolve
+ * (page texture request publishes on the second step). */
 
 #define UI_ATLAS_REGION_COUNT 2u
 #define UI_ATLAS_PAGE_COUNT 1u
@@ -34,35 +59,24 @@
 
 #define UI_ATLAS_VERTEX_OFFSET (UI_ATLAS_HEADER_SIZE + UI_ATLAS_PAGE_IDS_SIZE + UI_ATLAS_REGIONS_SIZE)
 #define UI_ATLAS_INDEX_OFFSET (UI_ATLAS_VERTEX_OFFSET + UI_ATLAS_VERTICES_SIZE)
-#define UI_ATLAS_TOTAL_SIZE (UI_ATLAS_INDEX_OFFSET + UI_ATLAS_INDICES_SIZE)
+#define UI_ATLAS_BLOB_SIZE (UI_ATLAS_INDEX_OFFSET + UI_ATLAS_INDICES_SIZE)
 
-/* Synthetic blob lives in BSS — built lazily on first create. */
-static uint8_t s_blob[UI_ATLAS_TOTAL_SIZE];
-static int s_blob_built = 0;
+/* Stable resource ids (unique-per-test-binary; counter-suffixed so multiple
+ * create/destroy cycles in one binary don't collide on resource-table slots
+ * that were tombstoned by destroy). */
+static uint32_t s_helper_counter;
 
-/* Cached parsed data (from nt_atlas_test_drive_resolve).
- *
- * Plan 02 Task 2.3 status (Revision Issue 4 committed path):
- *   - Helper uses NT_ATLAS_TEST_ACCESS nt_atlas_test_drive_resolve which
- *     parses the synthetic blob into an nt_atlas_data_t* directly. This
- *     is sufficient for Plan 02 unit tests (lifecycle, multictx,
- *     begin_end) -- none of which call nt_ui_walk, so none assert on
- *     nt_resource_is_ready(handle).
- *   - Plan 04 walker tests will be the first consumers that need
- *     nt_resource_is_ready == true. At that time Plan 04 chooses path
- *     (a) drive nt_resource_create_pack + register virtual pack with the
- *     ad as runtime user_data, OR path (b) add a small
- *     nt_atlas_test_register_synthetic_atlas helper under
- *     NT_ATLAS_TEST_ACCESS that wraps the slot allocation. The current
- *     helper API surface (handle field in minimal_ui_atlas_t) is
- *     unchanged regardless of which path Plan 04 picks. */
-static void *s_atlas_user_data = NULL;
+/* Pack blob lives in the helper's BSS / heap -- nt_resource_parse_pack
+ * keeps a reference until the pack is unmounted. We free on destroy. */
+static uint8_t *s_pack_blob;
+static uint32_t s_pack_total;
+static nt_hash32_t s_atlas_pack_id;
+static nt_hash32_t s_page_pack_id;
+static nt_texture_t s_page_tex;
+static const uint8_t s_white_pixel[4] = {255, 255, 255, 255};
 
-static void ui_atlas_build_blob(void) {
-    if (s_blob_built) {
-        return;
-    }
-    memset(s_blob, 0, sizeof s_blob);
+static void ui_atlas_build_inner_blob(uint8_t *out_blob) {
+    memset(out_blob, 0, UI_ATLAS_BLOB_SIZE);
 
     /* ---- Header ---- */
     NtAtlasHeader hdr = {
@@ -76,15 +90,17 @@ static void ui_atlas_build_blob(void) {
         .index_offset = UI_ATLAS_INDEX_OFFSET,
         .total_index_count = UI_ATLAS_INDEX_COUNT,
     };
-    memcpy(s_blob + 0, &hdr, sizeof hdr);
+    memcpy(out_blob + 0, &hdr, sizeof hdr);
 
-    /* ---- Page resource id (placeholder; runtime uses its own slot lookup) ---- */
-    uint64_t page_id = 0xC0FFEE00ULL;
-    memcpy(s_blob + UI_ATLAS_HEADER_SIZE, &page_id, sizeof page_id);
+    /* ---- Page resource id (must match the page-pack registration below) ---- */
+    char page_name[64];
+    (void)snprintf(page_name, sizeof page_name, "ui_atlas_page_%u", s_helper_counter);
+    uint64_t page_rid = nt_hash64_str(page_name).value;
+    memcpy(out_blob + UI_ATLAS_HEADER_SIZE, &page_rid, sizeof page_rid);
 
-    /* ---- Region 0: 1x1 white quad, 4 verts, 6 indices ---- */
+    /* ---- Region 0: 1x1 white quad ---- */
     NtAtlasRegion region0 = {
-        .name_hash = 0x57484954454E4555ULL, /* arbitrary hash for "white" */
+        .name_hash = 0x57484954454E4555ULL, /* "WHITEENU" */
         .source_w = 1,
         .source_h = 1,
         .trim_offset_x = 0,
@@ -97,14 +113,14 @@ static void ui_atlas_build_blob(void) {
         .page_index = 0,
         .transform = 0,
         .index_count = 6,
-        .flags = 0,
+        .flags = NT_ATLAS_REGION_FLAG_QUAD_012023,
         ._reserved = {0, 0, 0},
     };
-    memcpy(s_blob + UI_ATLAS_HEADER_SIZE + UI_ATLAS_PAGE_IDS_SIZE, &region0, sizeof region0);
+    memcpy(out_blob + UI_ATLAS_HEADER_SIZE + UI_ATLAS_PAGE_IDS_SIZE, &region0, sizeof region0);
 
     /* ---- Region 1: 6-vertex polygon hull (12 indices = 4 fan triangles) ---- */
     NtAtlasRegion region1 = {
-        .name_hash = 0x504F4C59474F4E32ULL, /* arbitrary hash for "polygon2" */
+        .name_hash = 0x504F4C59474F4E32ULL, /* "POLYGON2" */
         .source_w = 16,
         .source_h = 16,
         .trim_offset_x = 0,
@@ -120,26 +136,26 @@ static void ui_atlas_build_blob(void) {
         .flags = 0,
         ._reserved = {0, 0, 0},
     };
-    memcpy(s_blob + UI_ATLAS_HEADER_SIZE + UI_ATLAS_PAGE_IDS_SIZE + 40, &region1, sizeof region1);
+    memcpy(out_blob + UI_ATLAS_HEADER_SIZE + UI_ATLAS_PAGE_IDS_SIZE + 40, &region1, sizeof region1);
 
-    /* ---- Vertices: 4 white (corners of 1x1) + 6 polygon-hull ---- */
+    /* ---- Vertices: 4 white + 6 polygon-hull ---- */
     NtAtlasVertex verts[UI_ATLAS_VERTEX_COUNT] = {
-        /* white quad (trim-local space 0..1, atlas UV 0..0xFFFF) */
+        /* white quad (trim-local 0..1, atlas UV 0..0xFFFF) */
         {0, 0, 0, 0},
         {1, 0, 0xFFFF, 0},
         {1, 1, 0xFFFF, 0xFFFF},
         {0, 1, 0, 0xFFFF},
-        /* polygon hull (6 verts, hexagon-ish) */
+        /* polygon hull (hexagon-ish, 6 unique verts) */
         {0, 8, 0, 0x8000},
         {8, 0, 0x8000, 0},
         {16, 8, 0xFFFF, 0x8000},
-        {16, 8, 0xFFFF, 0x8000},
+        {16, 16, 0xFFFF, 0xFFFF},
         {8, 16, 0x8000, 0xFFFF},
         {0, 8, 0, 0x8000},
     };
-    memcpy(s_blob + UI_ATLAS_VERTEX_OFFSET, verts, sizeof verts);
+    memcpy(out_blob + UI_ATLAS_VERTEX_OFFSET, verts, sizeof verts);
 
-    /* ---- Indices: white (0..3 fan -> 2 tris) + polygon (fan over 4 tris) ---- */
+    /* ---- Indices ---- */
     uint16_t indices[UI_ATLAS_INDEX_COUNT] = {
         /* white: 0,1,2 + 0,2,3 */
         0,
@@ -148,7 +164,7 @@ static void ui_atlas_build_blob(void) {
         0,
         2,
         3,
-        /* polygon-hull fan (vertices local 0..5): 0,1,2 0,2,3 0,3,4 0,4,5 */
+        /* polygon-hull fan: 0,1,2 / 0,2,3 / 0,3,4 / 0,4,5 */
         0,
         1,
         2,
@@ -162,24 +178,88 @@ static void ui_atlas_build_blob(void) {
         4,
         5,
     };
-    memcpy(s_blob + UI_ATLAS_INDEX_OFFSET, indices, sizeof indices);
+    memcpy(out_blob + UI_ATLAS_INDEX_OFFSET, indices, sizeof indices);
+}
 
-    s_blob_built = 1;
+/* Wrap the inner atlas blob in a real NEOPAK envelope so nt_resource_parse_pack
+ * accepts it. The resulting pack contains exactly one NT_ASSET_ATLAS entry. */
+static uint8_t *ui_atlas_build_pack_blob(uint64_t atlas_rid, uint32_t *out_total) {
+    uint8_t inner[UI_ATLAS_BLOB_SIZE];
+    ui_atlas_build_inner_blob(inner);
+
+    const uint32_t raw_header = (uint32_t)(sizeof(NtPackHeader) + sizeof(NtAssetEntry));
+    const uint32_t header_size = (raw_header + (NT_PACK_DATA_ALIGN - 1u)) & ~(uint32_t)(NT_PACK_DATA_ALIGN - 1u);
+    const uint32_t atlas_offset = header_size;
+    const uint32_t aligned_atlas = (UI_ATLAS_BLOB_SIZE + (NT_PACK_ASSET_ALIGN - 1u)) & ~(uint32_t)(NT_PACK_ASSET_ALIGN - 1u);
+    const uint32_t total_size = atlas_offset + aligned_atlas;
+
+    uint8_t *pack_blob = (uint8_t *)calloc(1, total_size);
+    NT_ASSERT(pack_blob != NULL);
+
+    NtPackHeader *ph = (NtPackHeader *)pack_blob;
+    ph->magic = NT_PACK_MAGIC;
+    ph->version = NT_PACK_VERSION;
+    ph->asset_count = 1;
+    ph->header_size = header_size;
+    ph->total_size = total_size;
+    ph->meta_offset = 0;
+    ph->meta_count = 0;
+
+    NtAssetEntry *entry = (NtAssetEntry *)(pack_blob + sizeof(NtPackHeader));
+    entry->resource_id = atlas_rid;
+    entry->asset_type = NT_ASSET_ATLAS;
+    entry->format_version = NT_ATLAS_VERSION;
+    entry->offset = atlas_offset;
+    entry->size = UI_ATLAS_BLOB_SIZE;
+    entry->meta_offset = 0;
+    entry->_pad = 0;
+
+    memcpy(pack_blob + atlas_offset, inner, UI_ATLAS_BLOB_SIZE);
+    ph->checksum = nt_crc32(pack_blob + header_size, total_size - header_size);
+
+    *out_total = total_size;
+    return pack_blob;
 }
 
 minimal_ui_atlas_t minimal_ui_atlas_create(void) {
-    ui_atlas_build_blob();
+    s_helper_counter++;
 
-    /* Drive the atlas activator's on_resolve callback directly (Revision Issue 4
-     * committed path — nt_atlas_test_drive_resolve from NT_ATLAS_TEST_ACCESS).
-     * This parses the synthetic blob into an nt_atlas_data_t* without standing
-     * up the resource system. Plan 02 Task 2.3 finalizes the nt_resource_t
-     * wiring so nt_resource_is_ready(handle) returns true; until then the
-     * handle is INVALID and callers must use nt_atlas_test_* accessors. */
-    nt_atlas_test_drive_resolve(s_blob, (uint32_t)sizeof s_blob, &s_atlas_user_data);
+    /* Page texture pack (high priority so atlas_on_post_resolve's
+     * nt_resource_request for the page id succeeds). */
+    char page_pack[64];
+    char page_name[64];
+    (void)snprintf(page_pack, sizeof page_pack, "ui_atlas_page_pack_%u", s_helper_counter);
+    (void)snprintf(page_name, sizeof page_name, "ui_atlas_page_%u", s_helper_counter);
+    s_page_pack_id = nt_hash32_str(page_pack);
+    NT_ASSERT(nt_resource_create_pack(s_page_pack_id, 100) == NT_OK);
+    s_page_tex = nt_gfx_make_texture(&(nt_texture_desc_t){.width = 1, .height = 1, .data = s_white_pixel, .label = "ui_atlas_white_page"});
+    NT_ASSERT(s_page_tex.id != 0);
+    NT_ASSERT(nt_resource_register(s_page_pack_id, nt_hash64_str(page_name), NT_ASSET_TEXTURE, s_page_tex.id) == NT_OK);
+
+    /* Atlas pack: mount, parse blob, request handle. */
+    char atlas_pack[64];
+    char atlas_name[64];
+    (void)snprintf(atlas_pack, sizeof atlas_pack, "ui_atlas_pack_%u", s_helper_counter);
+    (void)snprintf(atlas_name, sizeof atlas_name, "ui_atlas_%u", s_helper_counter);
+    s_atlas_pack_id = nt_hash32_str(atlas_pack);
+    nt_hash64_t atlas_rid = nt_hash64_str(atlas_name);
+
+    NT_ASSERT(nt_resource_mount(s_atlas_pack_id, 0) == NT_OK);
+    s_pack_blob = ui_atlas_build_pack_blob(atlas_rid.value, &s_pack_total);
+    NT_ASSERT(nt_resource_parse_pack(s_atlas_pack_id, s_pack_blob, s_pack_total) == NT_OK);
+
+    nt_resource_t atlas = nt_resource_request(atlas_rid, NT_ASSET_ATLAS);
+    NT_ASSERT(atlas.id != 0);
+    /* Two steps: first runs on_resolve+on_post_resolve (which queues a
+     * page-texture nt_resource_request); second publishes the page slot
+     * and lets nt_resource_is_ready(atlas) return true (AUX_BACKED
+     * behavior). */
+    nt_resource_step();
+    nt_resource_step();
+    NT_ASSERT(nt_resource_is_ready(atlas));
 
     minimal_ui_atlas_t result = {
-        .handle = NT_RESOURCE_INVALID, /* TODO Plan 02 Task 2.3 */
+        .handle = atlas,
         .white_region_idx = 0,
         .polygon_region_idx = 1,
     };
@@ -190,10 +270,23 @@ void minimal_ui_atlas_destroy(minimal_ui_atlas_t *atlas) {
     if (atlas == NULL) {
         return;
     }
-    if (s_atlas_user_data != NULL) {
-        nt_atlas_test_drive_cleanup(s_atlas_user_data);
-        s_atlas_user_data = NULL;
+    if (s_atlas_pack_id.value != 0) {
+        nt_resource_unmount(s_atlas_pack_id);
+        s_atlas_pack_id = (nt_hash32_t){0};
     }
+    if (s_page_pack_id.value != 0) {
+        /* Unregister the page resource before destroying the texture so the
+         * resource system doesn't dangle on the runtime handle. */
+        nt_resource_unmount(s_page_pack_id);
+        s_page_pack_id = (nt_hash32_t){0};
+    }
+    if (s_page_tex.id != 0) {
+        nt_gfx_destroy_texture(s_page_tex);
+        s_page_tex = (nt_texture_t){0};
+    }
+    free(s_pack_blob);
+    s_pack_blob = NULL;
+    s_pack_total = 0;
     atlas->handle = NT_RESOURCE_INVALID;
     atlas->white_region_idx = 0;
     atlas->polygon_region_idx = 0;

--- a/tests/unit/test_helpers/ui_atlas.c
+++ b/tests/unit/test_helpers/ui_atlas.c
@@ -40,10 +40,22 @@
 static uint8_t s_blob[UI_ATLAS_TOTAL_SIZE];
 static int s_blob_built = 0;
 
-/* Cached parsed data (from nt_atlas_test_drive_resolve). Plan 02 Task 2.3
- * finalizes resource-handle wiring so nt_resource_is_ready returns true.
- * Wave 0 ships the blob constructor + committed test-access call; the public
- * API shape is locked. */
+/* Cached parsed data (from nt_atlas_test_drive_resolve).
+ *
+ * Plan 02 Task 2.3 status (Revision Issue 4 committed path):
+ *   - Helper uses NT_ATLAS_TEST_ACCESS nt_atlas_test_drive_resolve which
+ *     parses the synthetic blob into an nt_atlas_data_t* directly. This
+ *     is sufficient for Plan 02 unit tests (lifecycle, multictx,
+ *     begin_end) -- none of which call nt_ui_walk, so none assert on
+ *     nt_resource_is_ready(handle).
+ *   - Plan 04 walker tests will be the first consumers that need
+ *     nt_resource_is_ready == true. At that time Plan 04 chooses path
+ *     (a) drive nt_resource_create_pack + register virtual pack with the
+ *     ad as runtime user_data, OR path (b) add a small
+ *     nt_atlas_test_register_synthetic_atlas helper under
+ *     NT_ATLAS_TEST_ACCESS that wraps the slot allocation. The current
+ *     helper API surface (handle field in minimal_ui_atlas_t) is
+ *     unchanged regardless of which path Plan 04 picks. */
 static void *s_atlas_user_data = NULL;
 
 static void ui_atlas_build_blob(void) {

--- a/tests/unit/test_helpers/ui_atlas.h
+++ b/tests/unit/test_helpers/ui_atlas.h
@@ -9,12 +9,20 @@
 extern "C" {
 #endif
 
-/* Produces a fake "UI atlas" resource handle that nt_resource_is_ready returns
+/* Produces a real UI atlas resource handle that nt_resource_is_ready returns
  * true for and that has a 1x1 white region at index 0 (4 verts) and a
  * 6-vertex polygon region at index 1 (for polygon-hull preservation tests).
  *
- * Built via NT_ATLAS_TEST_ACCESS nt_atlas_test_drive_resolve — bypasses pack
- * loading. (Revision Issue 4 committed path.)
+ * Plan 04 Task 2.3 finalization (Path (a) committed): mounts a virtual pack
+ * containing a synthetic atlas blob and parses it through the full atlas
+ * activator (on_resolve + on_post_resolve). Also registers a 1x1 white
+ * texture as page 0 so emit_region can resolve a real page texture handle.
+ *
+ * Prerequisites (caller must call BEFORE minimal_ui_atlas_create):
+ *   - nt_hash_init
+ *   - nt_gfx_init (any backend; stub OK)
+ *   - nt_resource_init
+ *   - nt_atlas_init
  *
  * Lifetime: valid until minimal_ui_atlas_destroy is called. */
 typedef struct {

--- a/tests/unit/test_helpers/ui_atlas.h
+++ b/tests/unit/test_helpers/ui_atlas.h
@@ -9,22 +9,13 @@
 extern "C" {
 #endif
 
-/* Produces a real UI atlas resource handle that nt_resource_is_ready returns
- * true for and that has a 1x1 white region at index 0 (4 verts) and a
- * 6-vertex polygon region at index 1 (for polygon-hull preservation tests).
+/* Mounts a virtual pack with a synthetic atlas blob and parses it
+ * through the full atlas activator, yielding a real READY resource
+ * handle with a 1x1 white region at index 0 (4 verts) and a 6-vertex
+ * polygon region at index 1 (for polygon-hull preservation tests).
  *
- * Plan 04 Task 2.3 finalization (Path (a) committed): mounts a virtual pack
- * containing a synthetic atlas blob and parses it through the full atlas
- * activator (on_resolve + on_post_resolve). Also registers a 1x1 white
- * texture as page 0 so emit_region can resolve a real page texture handle.
- *
- * Prerequisites (caller must call BEFORE minimal_ui_atlas_create):
- *   - nt_hash_init
- *   - nt_gfx_init (any backend; stub OK)
- *   - nt_resource_init
- *   - nt_atlas_init
- *
- * Lifetime: valid until minimal_ui_atlas_destroy is called. */
+ * Caller must have init'd nt_hash, nt_gfx, nt_resource, nt_atlas before
+ * calling create. Lifetime: valid until destroy. */
 typedef struct {
     nt_resource_t handle;
     uint32_t white_region_idx;   /* always 0 */

--- a/tests/unit/test_helpers/ui_atlas.h
+++ b/tests/unit/test_helpers/ui_atlas.h
@@ -1,0 +1,33 @@
+#ifndef NT_TEST_HELPER_UI_ATLAS_H
+#define NT_TEST_HELPER_UI_ATLAS_H
+
+#include <stdint.h>
+
+#include "resource/nt_resource.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Produces a fake "UI atlas" resource handle that nt_resource_is_ready returns
+ * true for and that has a 1x1 white region at index 0 (4 verts) and a
+ * 6-vertex polygon region at index 1 (for polygon-hull preservation tests).
+ *
+ * Built via NT_ATLAS_TEST_ACCESS nt_atlas_test_drive_resolve — bypasses pack
+ * loading. (Revision Issue 4 committed path.)
+ *
+ * Lifetime: valid until minimal_ui_atlas_destroy is called. */
+typedef struct {
+    nt_resource_t handle;
+    uint32_t white_region_idx;   /* always 0 */
+    uint32_t polygon_region_idx; /* always 1 */
+} minimal_ui_atlas_t;
+
+minimal_ui_atlas_t minimal_ui_atlas_create(void);
+void minimal_ui_atlas_destroy(minimal_ui_atlas_t *atlas);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NT_TEST_HELPER_UI_ATLAS_H */

--- a/tests/unit/test_helpers/ui_atlas.h
+++ b/tests/unit/test_helpers/ui_atlas.h
@@ -3,6 +3,8 @@
 
 #include <stdint.h>
 
+#include "graphics/nt_gfx.h"
+#include "hash/nt_hash.h"
 #include "resource/nt_resource.h"
 
 #ifdef __cplusplus
@@ -15,11 +17,21 @@ extern "C" {
  * polygon region at index 1 (for polygon-hull preservation tests).
  *
  * Caller must have init'd nt_hash, nt_gfx, nt_resource, nt_atlas before
- * calling create. Lifetime: valid until destroy. */
+ * calling create. Lifetime: valid until destroy.
+ *
+ * Multiple instances coexist (each owns its own pack ids + blob), so
+ * tests that need two atlases get two with no interaction. */
 typedef struct {
     nt_resource_t handle;
     uint32_t white_region_idx;   /* always 0 */
     uint32_t polygon_region_idx; /* always 1 */
+
+    /* Implementation-private. Do not access directly. */
+    void *_pack_blob;
+    uint32_t _pack_total;
+    nt_hash32_t _atlas_pack_id;
+    nt_hash32_t _page_pack_id;
+    nt_texture_t _page_tex;
 } minimal_ui_atlas_t;
 
 minimal_ui_atlas_t minimal_ui_atlas_create(void);

--- a/tests/unit/test_helpers/ui_test_arena.h
+++ b/tests/unit/test_helpers/ui_test_arena.h
@@ -1,0 +1,8 @@
+#ifndef NT_TEST_HELPER_UI_TEST_ARENA_H
+#define NT_TEST_HELPER_UI_TEST_ARENA_H
+
+/* Comfortable static-array size for nt_ui ctx arena in tests. Public API
+ * uses nt_ui_min_arena_size() for exact runtime sizing. */
+#define NT_UI_TEST_ARENA_SIZE (1U * 1024U * 1024U)
+
+#endif /* NT_TEST_HELPER_UI_TEST_ARENA_H */

--- a/tests/unit/test_helpers/ui_walker_fixture.c
+++ b/tests/unit/test_helpers/ui_walker_fixture.c
@@ -1,0 +1,138 @@
+#include "test_helpers/ui_walker_fixture.h"
+
+/* The fixture body is only compiled into test binaries that opt into
+ * nt_ui (NT_UI_TEST_ACCESS). Other test binaries -- notably
+ * test_nt_sprite_renderer_emit_region, which lives in the same helper
+ * sources list but does NOT link nt_ui -- get an empty TU and avoid
+ * the unresolved nt_ui_create_context / nt_ui_set_* symbols. */
+#ifdef NT_UI_TEST_ACCESS
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "atlas/nt_atlas.h"
+#include "core/nt_assert.h"
+#include "font/nt_font.h"
+#include "graphics/nt_gfx.h"
+#include "hash/nt_hash.h"
+#include "material/nt_material.h"
+#include "nt_pack_format.h"
+#include "renderers/nt_sprite_renderer.h"
+#include "renderers/nt_text_renderer.h"
+#include "resource/nt_resource.h"
+#include "stats/nt_stats.h"
+#include "unity.h"
+
+/* Per-binary counter so multiple ui_walker_fixture_make_material() calls
+ * inside the same test process do not collide on virtual-pack ids. */
+static uint32_t s_vpack_counter;
+
+nt_material_t ui_walker_fixture_make_material(void) {
+    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "void main(){}", .label = "walker_vs"});
+    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "void main(){}", .label = "walker_fs"});
+
+    char pack_name[64];
+    char vs_name[64];
+    char fs_name[64];
+    (void)snprintf(pack_name, sizeof pack_name, "walker_mat_pack_%u", s_vpack_counter);
+    (void)snprintf(vs_name, sizeof vs_name, "walker_vs_%u", s_vpack_counter);
+    (void)snprintf(fs_name, sizeof fs_name, "walker_fs_%u", s_vpack_counter);
+    s_vpack_counter++;
+
+    const nt_hash32_t pid = nt_hash32_str(pack_name);
+    const nt_hash64_t vs_rid = nt_hash64_str(vs_name);
+    const nt_hash64_t fs_rid = nt_hash64_str(fs_name);
+
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pid, 0));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, vs_rid, NT_ASSET_SHADER_CODE, vs.id));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, fs_rid, NT_ASSET_SHADER_CODE, fs.id));
+
+    const nt_resource_t vs_res = nt_resource_request(vs_rid, NT_ASSET_SHADER_CODE);
+    const nt_resource_t fs_res = nt_resource_request(fs_rid, NT_ASSET_SHADER_CODE);
+    nt_resource_step();
+
+    nt_material_create_desc_t desc;
+    memset(&desc, 0, sizeof desc);
+    desc.vs = vs_res;
+    desc.fs = fs_res;
+    desc.depth_test = false;
+    desc.depth_write = false;
+    desc.cull_mode = NT_CULL_NONE;
+    desc.color_mode = NT_COLOR_MODE_NONE;
+    desc.label = "walker_test_material";
+
+    const nt_material_t mat = nt_material_create(&desc);
+    nt_material_step();
+    return mat;
+}
+
+void ui_walker_fixture_init(ui_walker_fixture_t *fx, void *arena, size_t arena_size, ui_walker_fx_bind_t bind) {
+    NT_ASSERT(fx != NULL);
+    NT_ASSERT(arena != NULL);
+    memset(fx, 0, sizeof *fx);
+    s_vpack_counter = 0;
+
+    nt_hash_init(&(nt_hash_desc_t){0});
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_pipelines = 16, .max_buffers = 64, .max_textures = 32, .max_meshes = 16});
+    nt_resource_init(&(nt_resource_desc_t){0});
+    nt_atlas_init();
+    nt_font_init(&(nt_font_desc_t){.max_fonts = 4});
+    nt_material_init(&(nt_material_desc_t){.max_materials = 32});
+
+    /* Open a frame/pass so sprite/text renderers can draw_indexed without
+     * tripping the stub gfx backend's "no active pass" guard (mirrors the
+     * test_nt_sprite_renderer setUp). */
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+
+    nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
+    nt_text_renderer_init();
+
+    /* The walker calls nt_stats_count at exit; init the module here so the
+     * NT_ASSERT(s_stats.initialized) check inside nt_stats_count never fires. */
+    nt_stats_init(NULL);
+
+    fx->atlas = minimal_ui_atlas_create();
+    fx->sprite_material = ui_walker_fixture_make_material();
+    fx->text_material = ui_walker_fixture_make_material();
+
+    fx->ctx = nt_ui_create_context(arena, arena_size);
+    TEST_ASSERT_NOT_NULL(fx->ctx);
+
+    if ((bind & UI_WALKER_FX_BIND_ATLAS) != 0u) {
+        nt_ui_set_atlas_white_region(fx->ctx, fx->atlas.handle, fx->atlas.white_region_idx);
+    }
+    if ((bind & UI_WALKER_FX_BIND_SPRITE_MATERIAL) != 0u) {
+        nt_ui_set_sprite_material(fx->ctx, fx->sprite_material);
+    }
+    if ((bind & UI_WALKER_FX_BIND_TEXT_MATERIAL) != 0u) {
+        nt_ui_set_text_material(fx->ctx, fx->text_material);
+    }
+    nt_ui_set_custom_handler(fx->ctx, NULL, NULL);
+}
+
+void ui_walker_fixture_shutdown(ui_walker_fixture_t *fx) {
+    NT_ASSERT(fx != NULL);
+    if (fx->ctx != NULL) {
+        nt_ui_destroy_context(fx->ctx);
+        fx->ctx = NULL;
+    }
+    minimal_ui_atlas_destroy(&fx->atlas);
+
+    nt_stats_shutdown();
+    nt_sprite_renderer_shutdown();
+    nt_text_renderer_shutdown();
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    nt_material_shutdown();
+    nt_font_shutdown();
+    nt_atlas_test_reset();
+    nt_resource_shutdown();
+    nt_gfx_shutdown();
+    nt_hash_shutdown();
+}
+
+#endif /* NT_UI_TEST_ACCESS */

--- a/tests/unit/test_helpers/ui_walker_fixture.c
+++ b/tests/unit/test_helpers/ui_walker_fixture.c
@@ -101,13 +101,13 @@ void ui_walker_fixture_init(ui_walker_fixture_t *fx, void *arena, size_t arena_s
     fx->ctx = nt_ui_create_context(arena, arena_size);
     TEST_ASSERT_NOT_NULL(fx->ctx);
 
-    if ((bind & UI_WALKER_FX_BIND_ATLAS) != 0u) {
+    if ((bind & UI_WALKER_FX_BIND_ATLAS) != 0U) {
         nt_ui_set_atlas_white_region(fx->ctx, fx->atlas.handle, fx->atlas.white_region_idx);
     }
-    if ((bind & UI_WALKER_FX_BIND_SPRITE_MATERIAL) != 0u) {
+    if ((bind & UI_WALKER_FX_BIND_SPRITE_MATERIAL) != 0U) {
         nt_ui_set_sprite_material(fx->ctx, fx->sprite_material);
     }
-    if ((bind & UI_WALKER_FX_BIND_TEXT_MATERIAL) != 0u) {
+    if ((bind & UI_WALKER_FX_BIND_TEXT_MATERIAL) != 0U) {
         nt_ui_set_text_material(fx->ctx, fx->text_material);
     }
     nt_ui_set_custom_handler(fx->ctx, NULL, NULL);

--- a/tests/unit/test_helpers/ui_walker_fixture.c
+++ b/tests/unit/test_helpers/ui_walker_fixture.c
@@ -1,11 +1,11 @@
 #include "test_helpers/ui_walker_fixture.h"
 
 /* The fixture body is only compiled into test binaries that opt into
- * nt_ui (NT_UI_TEST_ACCESS). Other test binaries -- notably
+ * nt_ui (NT_TEST_ACCESS). Other test binaries -- notably
  * test_nt_sprite_renderer_emit_region, which lives in the same helper
  * sources list but does NOT link nt_ui -- get an empty TU and avoid
  * the unresolved nt_ui_create_context / nt_ui_set_* symbols. */
-#ifdef NT_UI_TEST_ACCESS
+#ifdef NT_TEST_ACCESS
 
 #include <stddef.h>
 #include <stdint.h>
@@ -134,4 +134,4 @@ void ui_walker_fixture_shutdown(ui_walker_fixture_t *fx) {
     nt_hash_shutdown();
 }
 
-#endif /* NT_UI_TEST_ACCESS */
+#endif /* NT_TEST_ACCESS */

--- a/tests/unit/test_helpers/ui_walker_fixture.c
+++ b/tests/unit/test_helpers/ui_walker_fixture.c
@@ -84,6 +84,7 @@ void ui_walker_fixture_init(ui_walker_fixture_t *fx, void *arena, size_t arena_s
 
     nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
     nt_text_renderer_init();
+    nt_ui_module_init();
 
     /* nt_stats is NOT init'd here -- nt_ui_walk does not depend on it.
      * Tests that need nt_stats (e.g. test_nt_ui_stats verifying the
@@ -94,8 +95,21 @@ void ui_walker_fixture_init(ui_walker_fixture_t *fx, void *arena, size_t arena_s
     fx->sprite_material = ui_walker_fixture_make_material();
     fx->text_material = ui_walker_fixture_make_material();
 
-    fx->ctx = nt_ui_create_context(arena, arena_size);
+    /* Stub font: valid pool slot, no resource attached. nt_font_valid() is
+     * true so walker's contract assert passes, but units_per_em stays 0 so
+     * nt_text_renderer_draw_n early-returns before any glyph work. */
+    fx->stub_font = nt_font_create(&(nt_font_create_desc_t){
+        .curve_texture_width = 64,
+        .curve_texture_height = 64,
+        .band_texture_height = 16,
+        .band_count = 4,
+        .measure_cache_size = 0,
+    });
+
+    const nt_ui_create_desc_t desc = nt_ui_create_desc_defaults();
+    fx->ctx = nt_ui_create_context(arena, arena_size, &desc);
     TEST_ASSERT_NOT_NULL(fx->ctx);
+    nt_ui_set_font(fx->ctx, 0U, fx->stub_font);
 
     if ((bind & UI_WALKER_FX_BIND_ATLAS) != 0U) {
         nt_ui_set_atlas_white_region(fx->ctx, fx->atlas.handle, fx->atlas.white_region_idx);
@@ -115,8 +129,12 @@ void ui_walker_fixture_shutdown(ui_walker_fixture_t *fx) {
         nt_ui_destroy_context(fx->ctx);
         fx->ctx = NULL;
     }
+    if (nt_font_valid(fx->stub_font)) {
+        nt_font_destroy(fx->stub_font);
+    }
     minimal_ui_atlas_destroy(&fx->atlas);
 
+    nt_ui_module_shutdown();
     nt_sprite_renderer_shutdown();
     nt_text_renderer_shutdown();
     nt_gfx_end_pass();

--- a/tests/unit/test_helpers/ui_walker_fixture.c
+++ b/tests/unit/test_helpers/ui_walker_fixture.c
@@ -22,7 +22,6 @@
 #include "renderers/nt_sprite_renderer.h"
 #include "renderers/nt_text_renderer.h"
 #include "resource/nt_resource.h"
-#include "stats/nt_stats.h"
 #include "unity.h"
 
 /* Per-binary counter so multiple ui_walker_fixture_make_material() calls
@@ -90,9 +89,10 @@ void ui_walker_fixture_init(ui_walker_fixture_t *fx, void *arena, size_t arena_s
     nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
     nt_text_renderer_init();
 
-    /* The walker calls nt_stats_count at exit; init the module here so the
-     * NT_ASSERT(s_stats.initialized) check inside nt_stats_count never fires. */
-    nt_stats_init(NULL);
+    /* nt_stats is NOT init'd here -- nt_ui_walk does not depend on it.
+     * Tests that need nt_stats (e.g. test_nt_ui_stats verifying the
+     * metrics-bridge pattern) init/shutdown it themselves around the
+     * fixture calls. */
 
     fx->atlas = minimal_ui_atlas_create();
     fx->sprite_material = ui_walker_fixture_make_material();
@@ -121,7 +121,6 @@ void ui_walker_fixture_shutdown(ui_walker_fixture_t *fx) {
     }
     minimal_ui_atlas_destroy(&fx->atlas);
 
-    nt_stats_shutdown();
     nt_sprite_renderer_shutdown();
     nt_text_renderer_shutdown();
     nt_gfx_end_pass();

--- a/tests/unit/test_helpers/ui_walker_fixture.c
+++ b/tests/unit/test_helpers/ui_walker_fixture.c
@@ -1,10 +1,6 @@
 #include "test_helpers/ui_walker_fixture.h"
 
-/* The fixture body is only compiled into test binaries that opt into
- * nt_ui (NT_TEST_ACCESS). Other test binaries -- notably
- * test_nt_sprite_renderer_emit_region, which lives in the same helper
- * sources list but does NOT link nt_ui -- get an empty TU and avoid
- * the unresolved nt_ui_create_context / nt_ui_set_* symbols. */
+/* Empty TU when NT_TEST_ACCESS undefined (helper compiled into non-UI binaries). */
 #ifdef NT_TEST_ACCESS
 
 #include <stddef.h>

--- a/tests/unit/test_helpers/ui_walker_fixture.h
+++ b/tests/unit/test_helpers/ui_walker_fixture.h
@@ -1,30 +1,7 @@
 #ifndef NT_TEST_HELPER_UI_WALKER_FIXTURE_H
 #define NT_TEST_HELPER_UI_WALKER_FIXTURE_H
 
-/* Shared test fixture for nt_ui walker tests.
- *
- * Replaces ~110 lines of duplicated setUp / tearDown + make_test_material
- * across the five test_nt_ui_walker_*.c binaries and test_nt_ui_stats.c.
- *
- * Typical usage:
- *
- *     alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
- *     static ui_walker_fixture_t s_fx;
- *
- *     void setUp(void) {
- *         ui_walker_fixture_init(&s_fx, s_arena, sizeof s_arena, UI_WALKER_FX_BIND_ALL);
- *     }
- *     void tearDown(void) {
- *         ui_walker_fixture_shutdown(&s_fx);
- *     }
- *
- *     // ... tests reference s_fx.ctx, s_fx.atlas, s_fx.sprite_material, ...
- *
- * Death-tests for "setter not called before walk" pass a partial bind mask:
- *
- *     ui_walker_fixture_init(&s_fx, ..., UI_WALKER_FX_BIND_ALL & ~UI_WALKER_FX_BIND_ATLAS);
- *     NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
- */
+/* Shared setUp/tearDown for nt_ui walker tests. */
 
 #include <stdint.h>
 
@@ -36,14 +13,8 @@
 extern "C" {
 #endif
 
-/* Per-field bind mask. Controls which walker setters fixture_init calls
- * on the freshly-created context. A field whose bit is zero stays at the
- * zero-initialised default -- walker asserts will fire on its absence.
- *
- * Underlying type is uint32_t (not an enum) because callers combine bits
- * arbitrarily -- e.g. ALL & ~ATLAS produces a valid mask value (6) that
- * isn't an enum member; an enum type would trip clang-analyzer's
- * EnumCastOutOfRange check on every such expression. */
+/* Bit-mask of walker setters fixture_init calls; uint32_t so `ALL & ~MASK`
+ * is well-defined (an enum type would trip EnumCastOutOfRange). */
 typedef uint32_t ui_walker_fx_bind_t;
 
 #define UI_WALKER_FX_BIND_NONE ((ui_walker_fx_bind_t)0U)
@@ -59,24 +30,9 @@ typedef struct {
     nt_material_t text_material;
 } ui_walker_fixture_t;
 
-/* Brings up nt_hash, nt_gfx (stub), nt_resource, nt_atlas, nt_font,
- * nt_material, nt_sprite_renderer, nt_text_renderer, nt_stats; opens a
- * gfx frame/pass; creates the ui_atlas helper and two test materials;
- * creates the nt_ui context in the caller's arena; then calls the
- * walker setters selected by `bind`. The custom handler is always
- * cleared to (NULL, NULL).
- *
- * Aborts via Unity TEST_ASSERT if any subsystem fails to initialise. */
 void ui_walker_fixture_init(ui_walker_fixture_t *fx, void *arena, size_t arena_size, ui_walker_fx_bind_t bind);
-
-/* Tears down everything ui_walker_fixture_init brought up, in reverse
- * order. Safe to call after a partial init failure (best-effort). */
 void ui_walker_fixture_shutdown(ui_walker_fixture_t *fx);
-
-/* Allocates an additional test material backed by a fresh virtual pack
- * (unique vs / fs shader resource ids per call). Tests that need more
- * than the two materials fixture_init builds (e.g. flush-boundary tests)
- * use this. Asserts the renderer is initialised. */
+/* Extra material backed by a fresh virtual pack -- unique vs/fs per call. */
 nt_material_t ui_walker_fixture_make_material(void);
 
 #ifdef __cplusplus

--- a/tests/unit/test_helpers/ui_walker_fixture.h
+++ b/tests/unit/test_helpers/ui_walker_fixture.h
@@ -8,6 +8,7 @@
 #include "font/nt_font.h"
 #include "material/nt_material.h"
 #include "test_helpers/ui_atlas.h"
+#include "test_helpers/ui_test_arena.h"
 #include "ui/nt_ui.h"
 
 #ifdef __cplusplus

--- a/tests/unit/test_helpers/ui_walker_fixture.h
+++ b/tests/unit/test_helpers/ui_walker_fixture.h
@@ -1,0 +1,81 @@
+#ifndef NT_TEST_HELPER_UI_WALKER_FIXTURE_H
+#define NT_TEST_HELPER_UI_WALKER_FIXTURE_H
+
+/* Shared test fixture for nt_ui walker tests.
+ *
+ * Replaces ~110 lines of duplicated setUp / tearDown + make_test_material
+ * across the five test_nt_ui_walker_*.c binaries and test_nt_ui_stats.c.
+ *
+ * Typical usage:
+ *
+ *     static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+ *     static ui_walker_fixture_t s_fx;
+ *
+ *     void setUp(void) {
+ *         ui_walker_fixture_init(&s_fx, s_arena, sizeof s_arena, UI_WALKER_FX_BIND_ALL);
+ *     }
+ *     void tearDown(void) {
+ *         ui_walker_fixture_shutdown(&s_fx);
+ *     }
+ *
+ *     // ... tests reference s_fx.ctx, s_fx.atlas, s_fx.sprite_material, ...
+ *
+ * Death-tests for "setter not called before walk" pass a partial bind mask:
+ *
+ *     ui_walker_fixture_init(&s_fx, ..., UI_WALKER_FX_BIND_ALL & ~UI_WALKER_FX_BIND_ATLAS);
+ *     NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
+ */
+
+#include <stdint.h>
+
+#include "material/nt_material.h"
+#include "test_helpers/ui_atlas.h"
+#include "ui/nt_ui.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Per-field bind mask. Controls which walker setters fixture_init calls
+ * on the freshly-created context. A field whose bit is zero stays at the
+ * zero-initialised default -- walker asserts will fire on its absence. */
+typedef enum {
+    UI_WALKER_FX_BIND_NONE = 0,
+    UI_WALKER_FX_BIND_ATLAS = 1u << 0,
+    UI_WALKER_FX_BIND_SPRITE_MATERIAL = 1u << 1,
+    UI_WALKER_FX_BIND_TEXT_MATERIAL = 1u << 2,
+    UI_WALKER_FX_BIND_ALL = UI_WALKER_FX_BIND_ATLAS | UI_WALKER_FX_BIND_SPRITE_MATERIAL | UI_WALKER_FX_BIND_TEXT_MATERIAL,
+} ui_walker_fx_bind_t;
+
+typedef struct {
+    nt_ui_context_t *ctx;
+    minimal_ui_atlas_t atlas;
+    nt_material_t sprite_material;
+    nt_material_t text_material;
+} ui_walker_fixture_t;
+
+/* Brings up nt_hash, nt_gfx (stub), nt_resource, nt_atlas, nt_font,
+ * nt_material, nt_sprite_renderer, nt_text_renderer, nt_stats; opens a
+ * gfx frame/pass; creates the ui_atlas helper and two test materials;
+ * creates the nt_ui context in the caller's arena; then calls the
+ * walker setters selected by `bind`. The custom handler is always
+ * cleared to (NULL, NULL).
+ *
+ * Aborts via Unity TEST_ASSERT if any subsystem fails to initialise. */
+void ui_walker_fixture_init(ui_walker_fixture_t *fx, void *arena, size_t arena_size, ui_walker_fx_bind_t bind);
+
+/* Tears down everything ui_walker_fixture_init brought up, in reverse
+ * order. Safe to call after a partial init failure (best-effort). */
+void ui_walker_fixture_shutdown(ui_walker_fixture_t *fx);
+
+/* Allocates an additional test material backed by a fresh virtual pack
+ * (unique vs / fs shader resource ids per call). Tests that need more
+ * than the two materials fixture_init builds (e.g. flush-boundary tests)
+ * use this. Asserts the renderer is initialised. */
+nt_material_t ui_walker_fixture_make_material(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NT_TEST_HELPER_UI_WALKER_FIXTURE_H */

--- a/tests/unit/test_helpers/ui_walker_fixture.h
+++ b/tests/unit/test_helpers/ui_walker_fixture.h
@@ -8,7 +8,7 @@
  *
  * Typical usage:
  *
- *     static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+ *     alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
  *     static ui_walker_fixture_t s_fx;
  *
  *     void setUp(void) {

--- a/tests/unit/test_helpers/ui_walker_fixture.h
+++ b/tests/unit/test_helpers/ui_walker_fixture.h
@@ -5,6 +5,7 @@
 
 #include <stdint.h>
 
+#include "font/nt_font.h"
 #include "material/nt_material.h"
 #include "test_helpers/ui_atlas.h"
 #include "ui/nt_ui.h"
@@ -28,6 +29,11 @@ typedef struct {
     minimal_ui_atlas_t atlas;
     nt_material_t sprite_material;
     nt_material_t text_material;
+    /* Empty font handle bound to ctx->fonts[0]. Passes nt_font_valid check
+     * (pool slot occupied) but has no resource data, so nt_text_renderer
+     * silently skips at the units_per_em==0 guard. Lets walker tests
+     * traverse TEXT commands without setting up real font blob/atlas. */
+    nt_font_t stub_font;
 } ui_walker_fixture_t;
 
 void ui_walker_fixture_init(ui_walker_fixture_t *fx, void *arena, size_t arena_size, ui_walker_fx_bind_t bind);

--- a/tests/unit/test_helpers/ui_walker_fixture.h
+++ b/tests/unit/test_helpers/ui_walker_fixture.h
@@ -38,14 +38,19 @@ extern "C" {
 
 /* Per-field bind mask. Controls which walker setters fixture_init calls
  * on the freshly-created context. A field whose bit is zero stays at the
- * zero-initialised default -- walker asserts will fire on its absence. */
-typedef enum {
-    UI_WALKER_FX_BIND_NONE = 0,
-    UI_WALKER_FX_BIND_ATLAS = 1u << 0,
-    UI_WALKER_FX_BIND_SPRITE_MATERIAL = 1u << 1,
-    UI_WALKER_FX_BIND_TEXT_MATERIAL = 1u << 2,
-    UI_WALKER_FX_BIND_ALL = UI_WALKER_FX_BIND_ATLAS | UI_WALKER_FX_BIND_SPRITE_MATERIAL | UI_WALKER_FX_BIND_TEXT_MATERIAL,
-} ui_walker_fx_bind_t;
+ * zero-initialised default -- walker asserts will fire on its absence.
+ *
+ * Underlying type is uint32_t (not an enum) because callers combine bits
+ * arbitrarily -- e.g. ALL & ~ATLAS produces a valid mask value (6) that
+ * isn't an enum member; an enum type would trip clang-analyzer's
+ * EnumCastOutOfRange check on every such expression. */
+typedef uint32_t ui_walker_fx_bind_t;
+
+#define UI_WALKER_FX_BIND_NONE ((ui_walker_fx_bind_t)0U)
+#define UI_WALKER_FX_BIND_ATLAS ((ui_walker_fx_bind_t)(1U << 0))
+#define UI_WALKER_FX_BIND_SPRITE_MATERIAL ((ui_walker_fx_bind_t)(1U << 1))
+#define UI_WALKER_FX_BIND_TEXT_MATERIAL ((ui_walker_fx_bind_t)(1U << 2))
+#define UI_WALKER_FX_BIND_ALL (UI_WALKER_FX_BIND_ATLAS | UI_WALKER_FX_BIND_SPRITE_MATERIAL | UI_WALKER_FX_BIND_TEXT_MATERIAL)
 
 typedef struct {
     nt_ui_context_t *ctx;

--- a/tests/unit/test_mesh_renderer.c
+++ b/tests/unit/test_mesh_renderer.c
@@ -3,7 +3,7 @@
 #include <string.h>
 
 /* clang-format off */
-/* NT_MESH_RENDERER_TEST_ACCESS defined via CMake target_compile_definitions */
+/* NT_TEST_ACCESS defined via CMake target_compile_definitions */
 #include "renderers/nt_mesh_renderer.h"
 #include "graphics/nt_gfx.h"
 #include "entity/nt_entity.h"

--- a/tests/unit/test_nt_font_measure_bench.c
+++ b/tests/unit/test_nt_font_measure_bench.c
@@ -186,13 +186,13 @@ static void bench_cache_hit_steady_state(void) {
     nt_font_measure_invalidate(font);
 
     /* Warm-up: one call to populate the slot. */
-    (void)nt_font_measure_n(font, "Hello, world", 12U, 14.0F);
+    (void)nt_font_measure_n(font, "Hello, world", 12U, 14.0F, 0.0F);
 
     const int n_calls = 1000;
     const uint64_t t0 = nt_time_nanos();
     nt_text_size_t sink = {0.0F, 0.0F};
     for (int i = 0; i < n_calls; i++) {
-        sink = nt_font_measure_n(font, "Hello, world", 12U, 14.0F);
+        sink = nt_font_measure_n(font, "Hello, world", 12U, 14.0F, 0.0F);
     }
     const uint64_t t1 = nt_time_nanos();
     (void)sink; /* prevent dead-code elimination */
@@ -228,7 +228,7 @@ static void bench_cache_miss_unique(void) {
     const uint64_t t0 = nt_time_nanos();
     nt_text_size_t sink = {0.0F, 0.0F};
     for (int i = 0; i < n_calls; i++) {
-        sink = nt_font_measure_n(font, labels[i], strlen(labels[i]), 14.0F);
+        sink = nt_font_measure_n(font, labels[i], strlen(labels[i]), 14.0F, 0.0F);
     }
     const uint64_t t1 = nt_time_nanos();
     (void)sink;
@@ -261,13 +261,13 @@ static void bench_long_string_hit(void) {
     const size_t plen = sizeof(paragraph) - 1U;
 
     /* Warm-up populates the slot. */
-    (void)nt_font_measure_n(font, paragraph, plen, 14.0F);
+    (void)nt_font_measure_n(font, paragraph, plen, 14.0F, 0.0F);
 
     const int n_calls = 1000;
     const uint64_t t0 = nt_time_nanos();
     nt_text_size_t sink = {0.0F, 0.0F};
     for (int i = 0; i < n_calls; i++) {
-        sink = nt_font_measure_n(font, paragraph, plen, 14.0F);
+        sink = nt_font_measure_n(font, paragraph, plen, 14.0F, 0.0F);
     }
     const uint64_t t1 = nt_time_nanos();
     (void)sink;
@@ -305,7 +305,7 @@ static void bench_long_string_miss(void) {
     const uint64_t t0 = nt_time_nanos();
     nt_text_size_t sink = {0.0F, 0.0F};
     for (int i = 0; i < n_calls; i++) {
-        sink = nt_font_measure_n(font, texts[i], sizeof(texts[i]) - 1U, 14.0F);
+        sink = nt_font_measure_n(font, texts[i], sizeof(texts[i]) - 1U, 14.0F, 0.0F);
     }
     const uint64_t t1 = nt_time_nanos();
     (void)sink;
@@ -335,7 +335,7 @@ static void bench_mixed_ui(void) {
     }
     /* Pre-warm the cache for hot labels (simulates frame N>1 of stable UI) */
     for (int i = 0; i < hot_count; i++) {
-        (void)nt_font_measure_n(font, hot[i], strlen(hot[i]), 14.0F);
+        (void)nt_font_measure_n(font, hot[i], strlen(hot[i]), 14.0F, 0.0F);
     }
 
     /* 240 fresh status labels (12 frames × 20 unique per frame) */
@@ -351,11 +351,11 @@ static void bench_mixed_ui(void) {
     int fresh_idx = 0;
     for (int frame = 0; frame < frames; frame++) {
         for (int i = 0; i < hot_count; i++) {
-            sink = nt_font_measure_n(font, hot[i], strlen(hot[i]), 14.0F);
+            sink = nt_font_measure_n(font, hot[i], strlen(hot[i]), 14.0F, 0.0F);
         }
         for (int i = 0; i < fresh_per_frame; i++) {
             const char *s = fresh[fresh_idx++];
-            sink = nt_font_measure_n(font, s, strlen(s), 14.0F);
+            sink = nt_font_measure_n(font, s, strlen(s), 14.0F, 0.0F);
         }
     }
     const uint64_t t1 = nt_time_nanos();

--- a/tests/unit/test_nt_gfx_scissor.c
+++ b/tests/unit/test_nt_gfx_scissor.c
@@ -1,4 +1,4 @@
-/* Scissor and viewport API round-trip via NT_GFX_TEST_ACCESS probes. */
+/* Scissor and viewport API round-trip via NT_TEST_ACCESS probes. */
 
 #include <stdbool.h>
 #include <stdint.h>

--- a/tests/unit/test_nt_mem_scratch.c
+++ b/tests/unit/test_nt_mem_scratch.c
@@ -1,0 +1,129 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "memory/nt_mem_scratch.h"
+#include "test_helpers/nt_assert_trap.h"
+#include "unity.h"
+
+void setUp(void) { nt_test_assert_install(); }
+void tearDown(void) {}
+
+static void teardown_if_init(void) {
+    /* Used after each death-test path where init/shutdown state is uncertain. */
+    if (nt_mem_scratch_test_size() > 0U) {
+        nt_mem_scratch_shutdown();
+    }
+}
+
+static void test_init_then_shutdown(void) {
+    nt_mem_scratch_init(4096U);
+    TEST_ASSERT_EQUAL_UINT64(4096U, (uint64_t)nt_mem_scratch_test_size());
+    TEST_ASSERT_EQUAL_UINT64(0U, (uint64_t)nt_mem_scratch_test_used());
+    nt_mem_scratch_shutdown();
+    TEST_ASSERT_EQUAL_UINT64(0U, (uint64_t)nt_mem_scratch_test_size());
+}
+
+static void test_alloc_advances_used(void) {
+    nt_mem_scratch_init(4096U);
+    void *a = nt_mem_scratch_alloc(16U, 8U);
+    TEST_ASSERT_NOT_NULL(a);
+    TEST_ASSERT_EQUAL_UINT64(16U, (uint64_t)nt_mem_scratch_test_used());
+    void *b = nt_mem_scratch_alloc(32U, 8U);
+    TEST_ASSERT_NOT_NULL(b);
+    TEST_ASSERT_EQUAL_UINT64(48U, (uint64_t)nt_mem_scratch_test_used());
+    TEST_ASSERT_TRUE((uint8_t *)b == (uint8_t *)a + 16);
+    nt_mem_scratch_shutdown();
+}
+
+/* Caller asks for align=8 starting at used=3 -> next alloc must land at 8. */
+static void test_alloc_aligns_up(void) {
+    nt_mem_scratch_init(4096U);
+    (void)nt_mem_scratch_alloc(3U, 1U); /* leave used at 3 */
+    TEST_ASSERT_EQUAL_UINT64(3U, (uint64_t)nt_mem_scratch_test_used());
+    uint8_t *p = (uint8_t *)nt_mem_scratch_alloc(8U, 8U);
+    /* p's address must be 8-aligned. */
+    TEST_ASSERT_EQUAL_UINT64(0U, (uint64_t)((uintptr_t)p & 7U));
+    /* used jumped from 3 to 8 (padding) then +8 alloc => 16. */
+    TEST_ASSERT_EQUAL_UINT64(16U, (uint64_t)nt_mem_scratch_test_used());
+    nt_mem_scratch_shutdown();
+}
+
+static void test_reset_clears_used(void) {
+    nt_mem_scratch_init(4096U);
+    (void)nt_mem_scratch_alloc(128U, 8U);
+    TEST_ASSERT_EQUAL_UINT64(128U, (uint64_t)nt_mem_scratch_test_used());
+    nt_mem_scratch_reset();
+    TEST_ASSERT_EQUAL_UINT64(0U, (uint64_t)nt_mem_scratch_test_used());
+    /* Next alloc starts from the base again. */
+    void *p = nt_mem_scratch_alloc(16U, 8U);
+    TEST_ASSERT_EQUAL_UINT64(16U, (uint64_t)nt_mem_scratch_test_used());
+    (void)p;
+    nt_mem_scratch_shutdown();
+}
+
+static void test_overflow_asserts(void) {
+    nt_mem_scratch_init(64U);
+    (void)nt_mem_scratch_alloc(32U, 8U);
+    NT_TEST_EXPECT_ASSERT(nt_mem_scratch_alloc(64U, 8U));
+    teardown_if_init();
+}
+
+static void test_double_init_asserts(void) {
+    nt_mem_scratch_init(1024U);
+    NT_TEST_EXPECT_ASSERT(nt_mem_scratch_init(1024U));
+    teardown_if_init();
+}
+
+static void test_shutdown_without_init_asserts(void) { NT_TEST_EXPECT_ASSERT(nt_mem_scratch_shutdown()); }
+
+static void test_alloc_without_init_asserts(void) { NT_TEST_EXPECT_ASSERT(nt_mem_scratch_alloc(16U, 8U)); }
+
+static void test_reset_without_init_asserts(void) { NT_TEST_EXPECT_ASSERT(nt_mem_scratch_reset()); }
+
+static void test_non_pow2_align_asserts(void) {
+    nt_mem_scratch_init(1024U);
+    NT_TEST_EXPECT_ASSERT(nt_mem_scratch_alloc(16U, 3U));
+    teardown_if_init();
+}
+
+/* Typed macro returns a properly aligned pointer. */
+static void test_alloc_typed_macro(void) {
+    nt_mem_scratch_init(4096U);
+    uint64_t *p = NT_MEM_SCRATCH_ALLOC(uint64_t);
+    TEST_ASSERT_NOT_NULL(p);
+    TEST_ASSERT_EQUAL_UINT64(0U, (uint64_t)((uintptr_t)p & 7U));
+    *p = 0xCAFEBABEDEADBEEFULL;
+    TEST_ASSERT_EQUAL_UINT64(0xCAFEBABEDEADBEEFULL, *p);
+    nt_mem_scratch_shutdown();
+}
+
+static void test_alloc_array_macro(void) {
+    nt_mem_scratch_init(4096U);
+    uint32_t *arr = NT_MEM_SCRATCH_ALLOC_ARRAY(uint32_t, 16);
+    TEST_ASSERT_NOT_NULL(arr);
+    for (uint32_t i = 0U; i < 16U; ++i) {
+        arr[i] = i;
+    }
+    for (uint32_t i = 0U; i < 16U; ++i) {
+        TEST_ASSERT_EQUAL_UINT32(i, arr[i]);
+    }
+    nt_mem_scratch_shutdown();
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_init_then_shutdown);
+    RUN_TEST(test_alloc_advances_used);
+    RUN_TEST(test_alloc_aligns_up);
+    RUN_TEST(test_reset_clears_used);
+    RUN_TEST(test_overflow_asserts);
+    RUN_TEST(test_double_init_asserts);
+    RUN_TEST(test_shutdown_without_init_asserts);
+    RUN_TEST(test_alloc_without_init_asserts);
+    RUN_TEST(test_reset_without_init_asserts);
+    RUN_TEST(test_non_pow2_align_asserts);
+    RUN_TEST(test_alloc_typed_macro);
+    RUN_TEST(test_alloc_array_macro);
+    return UNITY_END();
+}

--- a/tests/unit/test_nt_mem_scratch.c
+++ b/tests/unit/test_nt_mem_scratch.c
@@ -87,6 +87,20 @@ static void test_non_pow2_align_asserts(void) {
     teardown_if_init();
 }
 
+/* align beyond malloc's max_align_t guarantee asserts. */
+static void test_align_over_max_asserts(void) {
+    nt_mem_scratch_init(1024U);
+    NT_TEST_EXPECT_ASSERT(nt_mem_scratch_alloc(16U, 4096U));
+    teardown_if_init();
+}
+
+/* alloc_array overflow assert: count * elem_size beyond SIZE_MAX. */
+static void test_alloc_array_overflow_asserts(void) {
+    nt_mem_scratch_init(1024U);
+    NT_TEST_EXPECT_ASSERT(nt_mem_scratch_alloc_array(sizeof(uint64_t), (size_t)-1, 8U));
+    teardown_if_init();
+}
+
 /* Typed macro returns a properly aligned pointer. */
 static void test_alloc_typed_macro(void) {
     nt_mem_scratch_init(4096U);
@@ -123,6 +137,8 @@ int main(void) {
     RUN_TEST(test_alloc_without_init_asserts);
     RUN_TEST(test_reset_without_init_asserts);
     RUN_TEST(test_non_pow2_align_asserts);
+    RUN_TEST(test_align_over_max_asserts);
+    RUN_TEST(test_alloc_array_overflow_asserts);
     RUN_TEST(test_alloc_typed_macro);
     RUN_TEST(test_alloc_array_macro);
     return UNITY_END();

--- a/tests/unit/test_nt_sprite_renderer_emit_region.c
+++ b/tests/unit/test_nt_sprite_renderer_emit_region.c
@@ -1,18 +1,8 @@
-/* tests/unit/test_nt_sprite_renderer_emit_region.c
- *
- * Plan 52-01: D-52-01/02 emit_region API + capacity guard + polygon-hull
- * vertex_count preservation + Drift 4 (set_material auto-flush).
- *
- * Setup mirrors test_sprite_renderer.c — full resource system + real atlas
- * + real material via nt_material_create. The Wave 0 minimal_ui_atlas helper
- * defers nt_resource_t wiring to Plan 02 Task 2.3 (TODO comment in that
- * helper), so until 02 lands we cannot use it for emit_region tests because
- * emit_region asserts nt_resource_is_ready(atlas). This file stands up the
- * full pipeline locally — same pattern as the existing test_sprite_renderer
- * binary.
- */
+/* Mirrors test_sprite_renderer.c setup -- full resource system + real
+ * atlas + real material via nt_material_create -- because emit_region
+ * asserts nt_resource_is_ready(atlas). */
 
-/* System headers before Unity to avoid noreturn / __declspec conflict on MSVC */
+/* System headers before Unity -- avoids __declspec(noreturn) clash on MSVC. */
 #include <math.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -324,7 +314,7 @@ void tearDown(void) {
     s_pack_blob_count = 0;
 }
 
-/* ---- Test 1: D-52-01 direct call writes vertex_count verts ---- */
+/* ---- Test 1: direct call writes vertex_count verts ---- */
 
 static void test_emit_region_direct_call(void) {
     nt_sprite_renderer_desc_t rd = nt_sprite_renderer_desc_defaults();
@@ -352,7 +342,7 @@ static void test_emit_region_direct_call(void) {
     nt_sprite_renderer_flush();
 }
 
-/* ---- Test 2: D-52-01 capacity guard auto-flush + reopen ---- */
+/* ---- Test 2: capacity guard auto-flush + reopen ---- */
 
 static void test_emit_region_capacity_guard(void) {
     nt_sprite_renderer_desc_t rd = nt_sprite_renderer_desc_defaults();
@@ -383,7 +373,7 @@ static void test_emit_region_capacity_guard(void) {
     TEST_ASSERT_GREATER_OR_EQUAL_UINT32(2U, nt_sprite_renderer_test_draw_call_count());
 }
 
-/* ---- Test 3: D-52-04 polygon-hull vertex_count preserved ---- */
+/* ---- Test 3: polygon-hull vertex_count preserved ---- */
 
 static void test_emit_region_polygon_hull_vertex_count_preserved(void) {
     nt_sprite_renderer_desc_t rd = nt_sprite_renderer_desc_defaults();
@@ -404,7 +394,7 @@ static void test_emit_region_polygon_hull_vertex_count_preserved(void) {
     nt_sprite_renderer_flush();
 }
 
-/* ---- Test 4: Drift 4 set_material auto-flush on change ---- */
+/* ---- Test 4: set_material auto-flush on change ---- */
 
 static void test_set_material_auto_flush_on_change(void) {
     nt_sprite_renderer_desc_t rd = nt_sprite_renderer_desc_defaults();

--- a/tests/unit/test_nt_sprite_renderer_emit_region.c
+++ b/tests/unit/test_nt_sprite_renderer_emit_region.c
@@ -343,7 +343,7 @@ static void test_emit_region_direct_call(void) {
     const float m[16] = {
         32.0F, 0.0F, 0.0F, 0.0F, 0.0F, 32.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 10.0F, 20.0F, 0.0F, 1.0F,
     };
-    nt_sprite_renderer_emit_region(s_atlas_res, FIXTURE_WHITE_REGION_IDX, m, 0.0F, 0.0F, 0xFFFFFFFFU, /*flip=*/0U);
+    nt_sprite_renderer_emit_region(s_atlas_res, FIXTURE_WHITE_REGION_IDX, m, 0.0F, 0.0F, 0xFFFFFFFFU, /*flip_bits=*/0U);
 
     /* Probe captured BEFORE flush resets vertex_count. */
     TEST_ASSERT_EQUAL_UINT32(4, nt_sprite_renderer_test_last_emit_vertex_count());

--- a/tests/unit/test_nt_sprite_renderer_emit_region.c
+++ b/tests/unit/test_nt_sprite_renderer_emit_region.c
@@ -10,7 +10,7 @@
 #include <string.h>
 
 /* clang-format off */
-/* NT_SPRITE_RENDERER_TEST_ACCESS / NT_ATLAS_TEST_ACCESS provided via CMake */
+/* NT_TEST_ACCESS / NT_TEST_ACCESS provided via CMake */
 #include "atlas/nt_atlas.h"
 #include "graphics/nt_gfx.h"
 #include "hash/nt_hash.h"

--- a/tests/unit/test_nt_sprite_renderer_emit_region.c
+++ b/tests/unit/test_nt_sprite_renderer_emit_region.c
@@ -1,29 +1,445 @@
-/* tests/unit/test_nt_sprite_renderer_emit_region.c — Plan 52-00 stub
+/* tests/unit/test_nt_sprite_renderer_emit_region.c
  *
- * Covers D-52-01 / D-52-02 emit_region API + capacity guard + polygon-hull
- * vertex_count preservation. Drift 4 (set_material auto-flush) also lands here.
- * Wave 0 ships TEST_IGNORE bodies; Plan 52-01 fills with real assertions.
+ * Plan 52-01: D-52-01/02 emit_region API + capacity guard + polygon-hull
+ * vertex_count preservation + Drift 4 (set_material auto-flush).
+ *
+ * Setup mirrors test_sprite_renderer.c — full resource system + real atlas
+ * + real material via nt_material_create. The Wave 0 minimal_ui_atlas helper
+ * defers nt_resource_t wiring to Plan 02 Task 2.3 (TODO comment in that
+ * helper), so until 02 lands we cannot use it for emit_region tests because
+ * emit_region asserts nt_resource_is_ready(atlas). This file stands up the
+ * full pipeline locally — same pattern as the existing test_sprite_renderer
+ * binary.
  */
 
-#include <stdbool.h>
+/* System headers before Unity to avoid noreturn / __declspec conflict on MSVC */
+#include <math.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* clang-format off */
+/* NT_SPRITE_RENDERER_TEST_ACCESS / NT_ATLAS_TEST_ACCESS provided via CMake */
+#include "atlas/nt_atlas.h"
+#include "graphics/nt_gfx.h"
+#include "hash/nt_hash.h"
+#include "material/nt_material.h"
+#include "nt_atlas_format.h"
+#include "nt_crc32.h"
+#include "nt_pack_format.h"
+#include "renderers/nt_sprite_renderer.h"
+#include "resource/nt_resource.h"
 
 #include "unity.h"
+/* clang-format on */
 
-void setUp(void) {}
-void tearDown(void) {}
+/* ---- Atlas fixture: 1 white 4-vert quad + 1 polygon 6-vert ---- */
 
-/* D-52-01: nt_sprite_renderer_emit_region single-emit, mat4 by pointer, color packed */
-static void test_emit_region_direct_call(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-01"); }
+#define FIXTURE_WHITE_HASH 0xA00ULL   /* white, 4 verts, 6 indices */
+#define FIXTURE_POLYGON_HASH 0xB00ULL /* polygon, 6 verts, 12 indices */
+#define FIXTURE_PAGE0_RID 0x7100ULL
 
-/* D-52-01: capacity guard — overflow triggers flush+reopen */
-static void test_emit_region_capacity_guard(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-01"); }
+#define FIXTURE_WHITE_REGION_IDX 0u
+#define FIXTURE_POLYGON_REGION_IDX 1u
 
-/* D-52-04: polygon-hull regions preserve vertex_count (6 verts in == 6 verts out) */
-static void test_emit_region_polygon_hull_vertex_count_preserved(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-01"); }
+typedef struct {
+    const NtAtlasRegion *regions;
+    uint16_t region_count;
+    const NtAtlasVertex *vertices;
+    uint32_t total_vertex_count;
+    const uint16_t *indices;
+    uint32_t total_index_count;
+    const uint64_t *page_ids;
+    uint16_t page_count;
+} atlas_blob_spec_t;
 
-/* Drift 4: nt_sprite_renderer_set_material auto-flushes on material change */
-static void test_set_material_auto_flush_on_change(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-01"); }
+static uint32_t build_atlas_blob(uint8_t *out, uint32_t cap, const atlas_blob_spec_t *spec) {
+    const uint32_t page_bytes = (uint32_t)spec->page_count * (uint32_t)sizeof(uint64_t);
+    const uint32_t region_bytes = (uint32_t)spec->region_count * (uint32_t)sizeof(NtAtlasRegion);
+    const uint32_t vertex_bytes = spec->total_vertex_count * (uint32_t)sizeof(NtAtlasVertex);
+    const uint32_t index_bytes = spec->total_index_count * (uint32_t)sizeof(uint16_t);
+    const uint32_t vertex_offset = (uint32_t)sizeof(NtAtlasHeader) + page_bytes + region_bytes;
+    const uint32_t index_offset = vertex_offset + vertex_bytes;
+    const uint32_t total = index_offset + index_bytes;
+
+    TEST_ASSERT_MESSAGE(total <= cap, "atlas blob buffer too small");
+    memset(out, 0, total);
+
+    NtAtlasHeader *hdr = (NtAtlasHeader *)out;
+    hdr->magic = NT_ATLAS_MAGIC;
+    hdr->version = NT_ATLAS_VERSION;
+    hdr->region_count = spec->region_count;
+    hdr->page_count = spec->page_count;
+    hdr->_pad = 0;
+    hdr->vertex_offset = vertex_offset;
+    hdr->total_vertex_count = spec->total_vertex_count;
+    hdr->index_offset = index_offset;
+    hdr->total_index_count = spec->total_index_count;
+
+    if (page_bytes > 0) {
+        memcpy(out + sizeof(NtAtlasHeader), spec->page_ids, page_bytes);
+    }
+    if (region_bytes > 0) {
+        memcpy(out + sizeof(NtAtlasHeader) + page_bytes, spec->regions, region_bytes);
+    }
+    if (vertex_bytes > 0) {
+        memcpy(out + vertex_offset, spec->vertices, vertex_bytes);
+    }
+    if (index_bytes > 0) {
+        memcpy(out + index_offset, spec->indices, index_bytes);
+    }
+
+    return total;
+}
+
+static uint32_t build_test_atlas(uint8_t *atlas_blob, uint32_t cap) {
+    /* Layout: [white verts: 4] [poly verts: 6] = 10 verts
+     *         [white idx: 6] [poly idx: 12] = 18 indices */
+    NtAtlasVertex verts[10];
+    uint16_t indices[18];
+    for (uint16_t i = 0; i < 10; i++) {
+        verts[i].local_x = (int16_t)(i * 10);
+        verts[i].local_y = (int16_t)(i * 20);
+        verts[i].atlas_u = (uint16_t)(i * 1000);
+        verts[i].atlas_v = (uint16_t)(i * 2000);
+    }
+    /* white quad: 0,1,2 / 0,2,3 */
+    indices[0] = 0;
+    indices[1] = 1;
+    indices[2] = 2;
+    indices[3] = 0;
+    indices[4] = 2;
+    indices[5] = 3;
+    /* polygon fan: 0,1,2 / 0,2,3 / 0,3,4 / 0,4,5 */
+    indices[6] = 0;
+    indices[7] = 1;
+    indices[8] = 2;
+    indices[9] = 0;
+    indices[10] = 2;
+    indices[11] = 3;
+    indices[12] = 0;
+    indices[13] = 3;
+    indices[14] = 4;
+    indices[15] = 0;
+    indices[16] = 4;
+    indices[17] = 5;
+
+    NtAtlasRegion regions[2];
+    memset(regions, 0, sizeof(regions));
+    regions[0].name_hash = FIXTURE_WHITE_HASH;
+    regions[0].source_w = 1;
+    regions[0].source_h = 1;
+    regions[0].origin_x = 0.0F;
+    regions[0].origin_y = 0.0F;
+    regions[0].vertex_start = 0;
+    regions[0].index_start = 0;
+    regions[0].vertex_count = 4;
+    regions[0].index_count = 6;
+    regions[0].page_index = 0;
+    regions[0].transform = 0;
+    regions[0].flags = NT_ATLAS_REGION_FLAG_QUAD_012023;
+
+    regions[1].name_hash = FIXTURE_POLYGON_HASH;
+    regions[1].source_w = 16;
+    regions[1].source_h = 16;
+    regions[1].origin_x = 0.5F;
+    regions[1].origin_y = 0.5F;
+    regions[1].vertex_start = 4;
+    regions[1].index_start = 6;
+    regions[1].vertex_count = 6;
+    regions[1].index_count = 12;
+    regions[1].page_index = 0;
+    regions[1].transform = 0;
+
+    uint64_t page_ids[1] = {FIXTURE_PAGE0_RID};
+    atlas_blob_spec_t spec = {
+        .regions = regions,
+        .region_count = 2,
+        .vertices = verts,
+        .total_vertex_count = 10,
+        .indices = indices,
+        .total_index_count = 18,
+        .page_ids = page_ids,
+        .page_count = 1,
+    };
+    return build_atlas_blob(atlas_blob, cap, &spec);
+}
+
+static uint8_t *build_pack_blob(uint64_t atlas_rid, const uint8_t *atlas_blob, uint32_t atlas_blob_size, uint32_t *out_total) {
+    const uint32_t raw_header = (uint32_t)(sizeof(NtPackHeader) + sizeof(NtAssetEntry));
+    const uint32_t header_size = (raw_header + (NT_PACK_DATA_ALIGN - 1U)) & ~(uint32_t)(NT_PACK_DATA_ALIGN - 1U);
+    const uint32_t atlas_offset = header_size;
+    const uint32_t aligned_atlas = (atlas_blob_size + (NT_PACK_ASSET_ALIGN - 1U)) & ~(uint32_t)(NT_PACK_ASSET_ALIGN - 1U);
+    const uint32_t total_size = atlas_offset + aligned_atlas;
+
+    uint8_t *pack_blob = (uint8_t *)calloc(1, total_size);
+    TEST_ASSERT_NOT_NULL(pack_blob);
+
+    NtPackHeader *ph = (NtPackHeader *)pack_blob;
+    ph->magic = NT_PACK_MAGIC;
+    ph->version = NT_PACK_VERSION;
+    ph->asset_count = 1;
+    ph->header_size = header_size;
+    ph->total_size = total_size;
+    ph->meta_offset = 0;
+    ph->meta_count = 0;
+
+    NtAssetEntry *entry = (NtAssetEntry *)(pack_blob + sizeof(NtPackHeader));
+    entry[0].resource_id = atlas_rid;
+    entry[0].asset_type = NT_ASSET_ATLAS;
+    entry[0].format_version = NT_ATLAS_VERSION;
+    entry[0].offset = atlas_offset;
+    entry[0].size = atlas_blob_size;
+    entry[0].meta_offset = 0;
+    entry[0]._pad = 0;
+
+    memcpy(pack_blob + atlas_offset, atlas_blob, atlas_blob_size);
+    ph->checksum = nt_crc32(pack_blob + header_size, total_size - header_size);
+
+    *out_total = total_size;
+    return pack_blob;
+}
+
+/* ---- Shared test state ---- */
+
+#define MAX_PACK_BLOBS 4
+static uint8_t *s_pack_blobs[MAX_PACK_BLOBS];
+static uint8_t s_pack_blob_count;
+static nt_resource_t s_atlas_res;
+static uint32_t s_vpack_counter;
+static const uint8_t s_white_pixel[4] = {255, 255, 255, 255};
+
+static nt_resource_t register_test_atlas(uint64_t atlas_rid) {
+    uint8_t atlas_blob[1024];
+    uint32_t atlas_blob_size = build_test_atlas(atlas_blob, sizeof(atlas_blob));
+
+    uint32_t pack_total = 0;
+    uint8_t *pack_blob = build_pack_blob(atlas_rid, atlas_blob, atlas_blob_size, &pack_total);
+    TEST_ASSERT_TRUE_MESSAGE(s_pack_blob_count < MAX_PACK_BLOBS, "pack blob fixture overflow");
+    s_pack_blobs[s_pack_blob_count++] = pack_blob;
+
+    char pack_name[32];
+    (void)snprintf(pack_name, sizeof(pack_name), "atlas_pack_%u", s_vpack_counter++);
+    nt_hash32_t pid = nt_hash32_str(pack_name);
+
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid, 0));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(pid, pack_blob, pack_total));
+
+    nt_resource_t atlas = nt_resource_request((nt_hash64_t){.value = atlas_rid}, NT_ASSET_ATLAS);
+    TEST_ASSERT_TRUE(atlas.id != 0);
+    nt_resource_step();
+    /* atlas_on_post_resolve requests page texture slots; a second step
+     * publishes those newly requested slots before tests draw. */
+    nt_resource_step();
+    TEST_ASSERT_TRUE(nt_resource_is_ready(atlas));
+    return atlas;
+}
+
+static nt_material_t create_test_material(void) {
+    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "void main(){}", .label = "sprite_vs"});
+    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "void main(){}", .label = "sprite_fs"});
+
+    char vs_name[64];
+    char fs_name[64];
+    char pack_name[64];
+    (void)snprintf(vs_name, sizeof(vs_name), "test_er_vs_%u", s_vpack_counter);
+    (void)snprintf(fs_name, sizeof(fs_name), "test_er_fs_%u", s_vpack_counter);
+    (void)snprintf(pack_name, sizeof(pack_name), "mat_pack_%u", s_vpack_counter++);
+
+    nt_hash32_t pid = nt_hash32_str(pack_name);
+    nt_hash64_t vs_rid = nt_hash64_str(vs_name);
+    nt_hash64_t fs_rid = nt_hash64_str(fs_name);
+
+    nt_resource_create_pack(pid, 0);
+    nt_resource_register(pid, vs_rid, NT_ASSET_SHADER_CODE, vs.id);
+    nt_resource_register(pid, fs_rid, NT_ASSET_SHADER_CODE, fs.id);
+
+    nt_resource_t vs_res = nt_resource_request(vs_rid, NT_ASSET_SHADER_CODE);
+    nt_resource_t fs_res = nt_resource_request(fs_rid, NT_ASSET_SHADER_CODE);
+    nt_resource_step();
+
+    nt_material_create_desc_t desc;
+    memset(&desc, 0, sizeof(desc));
+    desc.vs = vs_res;
+    desc.fs = fs_res;
+    desc.depth_test = false;
+    desc.depth_write = false;
+    desc.cull_mode = NT_CULL_NONE;
+    desc.color_mode = NT_COLOR_MODE_NONE;
+    desc.label = "test_emit_region_material";
+
+    nt_material_t mat = nt_material_create(&desc);
+    nt_material_step();
+    return mat;
+}
+
+/* ---- setUp / tearDown ---- */
+
+void setUp(void) {
+    s_pack_blob_count = 0;
+    memset((void *)s_pack_blobs, 0, sizeof(s_pack_blobs));
+    s_atlas_res = NT_RESOURCE_INVALID;
+    s_vpack_counter = 0;
+
+    nt_hash_init(&(nt_hash_desc_t){0});
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_pipelines = 16, .max_buffers = 64, .max_textures = 32, .max_meshes = 16});
+    nt_resource_init(&(nt_resource_desc_t){0});
+    nt_atlas_init();
+
+    /* Pre-register a page-0 texture in a high-priority pack so the atlas
+     * post-resolve hooks up a real page texture handle (sprite renderer
+     * needs nt_resource_get(page) != 0 to write into a cmd). */
+    nt_hash32_t page_pid = nt_hash32_str("emit_region_pages");
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(page_pid, 100));
+    nt_texture_t page0 = nt_gfx_make_texture(&(nt_texture_desc_t){.width = 1, .height = 1, .data = s_white_pixel, .label = "page0"});
+    TEST_ASSERT_TRUE(page0.id != 0);
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(page_pid, (nt_hash64_t){FIXTURE_PAGE0_RID}, NT_ASSET_TEXTURE, page0.id));
+
+    nt_material_init(&(nt_material_desc_t){.max_materials = 32});
+
+    /* Begin frame/pass so flush's draw_indexed doesn't trip the gfx-stub
+     * assert (mirrors test_sprite_renderer setUp). */
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+}
+
+void tearDown(void) {
+    if (nt_sprite_renderer_test_initialized()) {
+        nt_sprite_renderer_shutdown();
+    }
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    nt_material_shutdown();
+    nt_atlas_test_reset();
+    nt_resource_shutdown();
+    nt_gfx_shutdown();
+    nt_hash_shutdown();
+
+    for (uint8_t i = 0; i < s_pack_blob_count; i++) {
+        free(s_pack_blobs[i]);
+        s_pack_blobs[i] = NULL;
+    }
+    s_pack_blob_count = 0;
+}
+
+/* ---- Test 1: D-52-01 direct call writes vertex_count verts ---- */
+
+static void test_emit_region_direct_call(void) {
+    nt_sprite_renderer_desc_t rd = nt_sprite_renderer_desc_defaults();
+    TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&rd));
+
+    s_atlas_res = register_test_atlas(0xA1ULL);
+    nt_material_t mat = create_test_material();
+
+    nt_sprite_renderer_set_material(mat);
+
+    /* Identity scale 32 / translate (10, 20) screen mat4, row-major.
+     * mat4 layout used by the renderer: column-major in memory, columns 0..3.
+     * emit_region_resolved reads m[0/4/12] (col0) / m[1/5/13] / m[2/6/14] /
+     * — same convention as transform_comp.world_matrices. We pass the same
+     * shape: m[0]=scale_x, m[5]=scale_y, m[12]=tx, m[13]=ty, m[15]=1. */
+    const float m[16] = {
+        32.0F, 0.0F, 0.0F, 0.0F, 0.0F, 32.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 10.0F, 20.0F, 0.0F, 1.0F,
+    };
+    nt_sprite_renderer_emit_region(s_atlas_res, FIXTURE_WHITE_REGION_IDX, m, 0.0F, 0.0F, 0xFFFFFFFFU, /*flip=*/0U);
+
+    /* Probe captured BEFORE flush resets vertex_count. */
+    TEST_ASSERT_EQUAL_UINT32(4, nt_sprite_renderer_test_last_emit_vertex_count());
+    TEST_ASSERT_EQUAL_UINT32(6, nt_sprite_renderer_test_last_emit_index_count());
+
+    nt_sprite_renderer_flush();
+}
+
+/* ---- Test 2: D-52-01 capacity guard auto-flush + reopen ---- */
+
+static void test_emit_region_capacity_guard(void) {
+    nt_sprite_renderer_desc_t rd = nt_sprite_renderer_desc_defaults();
+    TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&rd));
+
+    s_atlas_res = register_test_atlas(0xA2ULL);
+    nt_material_t mat = create_test_material();
+    nt_sprite_renderer_set_material(mat);
+
+    /* Identity mat4 (col0=1, col1=1, w=1). */
+    const float m[16] = {
+        1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F,
+    };
+
+    /* Emit enough quads to overflow staging at least once. 16384/4=4096
+     * quads fit before the capacity guard trips. Emit 4097 to force exactly
+     * one auto-flush+reopen. */
+    const uint32_t quad_capacity = NT_SPRITE_RENDERER_MAX_VERTICES / 4U;
+    const uint32_t emit_count = quad_capacity + 2U;
+    for (uint32_t i = 0; i < emit_count; ++i) {
+        nt_sprite_renderer_emit_region(s_atlas_res, FIXTURE_WHITE_REGION_IDX, m, 0.0F, 0.0F, 0xFFFFFFFFU, 0U);
+    }
+    /* Final explicit flush so the per-renderer counter captures the trailing chunk. */
+    nt_sprite_renderer_flush();
+
+    /* At least 2 draw calls must have happened — one from the capacity-
+     * triggered auto-flush mid-loop + one from the final flush. */
+    TEST_ASSERT_GREATER_OR_EQUAL_UINT32(2U, nt_sprite_renderer_test_draw_call_count());
+}
+
+/* ---- Test 3: D-52-04 polygon-hull vertex_count preserved ---- */
+
+static void test_emit_region_polygon_hull_vertex_count_preserved(void) {
+    nt_sprite_renderer_desc_t rd = nt_sprite_renderer_desc_defaults();
+    TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&rd));
+
+    s_atlas_res = register_test_atlas(0xA3ULL);
+    nt_material_t mat = create_test_material();
+    nt_sprite_renderer_set_material(mat);
+
+    const float m[16] = {
+        1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F,
+    };
+    nt_sprite_renderer_emit_region(s_atlas_res, FIXTURE_POLYGON_REGION_IDX, m, 0.5F, 0.5F, 0xFFFFFFFFU, 0U);
+
+    TEST_ASSERT_EQUAL_UINT32(6, nt_sprite_renderer_test_last_emit_vertex_count());
+    TEST_ASSERT_EQUAL_UINT32(12, nt_sprite_renderer_test_last_emit_index_count());
+
+    nt_sprite_renderer_flush();
+}
+
+/* ---- Test 4: Drift 4 set_material auto-flush on change ---- */
+
+static void test_set_material_auto_flush_on_change(void) {
+    nt_sprite_renderer_desc_t rd = nt_sprite_renderer_desc_defaults();
+    TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&rd));
+
+    s_atlas_res = register_test_atlas(0xA4ULL);
+    nt_material_t mat_a = create_test_material();
+    nt_material_t mat_b = create_test_material();
+    TEST_ASSERT_NOT_EQUAL(mat_a.id, mat_b.id);
+
+    const float m[16] = {
+        1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F,
+    };
+
+    nt_sprite_renderer_set_material(mat_a);
+    nt_sprite_renderer_emit_region(s_atlas_res, FIXTURE_WHITE_REGION_IDX, m, 0.0F, 0.0F, 0xFFFFFFFFU, 0U);
+
+    /* Same handle re-binding does NOT flush (current_mat still .id of mat_a,
+     * cmd_count > 0 after the emit above so the no-op branch fires). */
+    const uint32_t calls_before_same = nt_sprite_renderer_test_draw_call_count();
+    nt_sprite_renderer_set_material(mat_a);
+    nt_sprite_renderer_emit_region(s_atlas_res, FIXTURE_WHITE_REGION_IDX, m, 0.0F, 0.0F, 0xFFFFFFFFU, 0U);
+    TEST_ASSERT_EQUAL_UINT32(calls_before_same, nt_sprite_renderer_test_draw_call_count());
+
+    /* Different .id triggers auto-flush (one extra draw call recorded). */
+    nt_sprite_renderer_set_material(mat_b);
+    const uint32_t calls_after_change = nt_sprite_renderer_test_draw_call_count();
+    TEST_ASSERT_EQUAL_UINT32(calls_before_same + 1U, calls_after_change);
+
+    /* Subsequent emit on mat_b still works (cmd reopened). */
+    nt_sprite_renderer_emit_region(s_atlas_res, FIXTURE_WHITE_REGION_IDX, m, 0.0F, 0.0F, 0xFFFFFFFFU, 0U);
+    TEST_ASSERT_EQUAL_UINT32(4, nt_sprite_renderer_test_last_emit_vertex_count());
+
+    nt_sprite_renderer_flush();
+}
 
 int main(void) {
     UNITY_BEGIN();

--- a/tests/unit/test_nt_sprite_renderer_emit_region.c
+++ b/tests/unit/test_nt_sprite_renderer_emit_region.c
@@ -1,0 +1,35 @@
+/* tests/unit/test_nt_sprite_renderer_emit_region.c — Plan 52-00 stub
+ *
+ * Covers D-52-01 / D-52-02 emit_region API + capacity guard + polygon-hull
+ * vertex_count preservation. Drift 4 (set_material auto-flush) also lands here.
+ * Wave 0 ships TEST_IGNORE bodies; Plan 52-01 fills with real assertions.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* D-52-01: nt_sprite_renderer_emit_region single-emit, mat4 by pointer, color packed */
+static void test_emit_region_direct_call(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-01"); }
+
+/* D-52-01: capacity guard — overflow triggers flush+reopen */
+static void test_emit_region_capacity_guard(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-01"); }
+
+/* D-52-04: polygon-hull regions preserve vertex_count (6 verts in == 6 verts out) */
+static void test_emit_region_polygon_hull_vertex_count_preserved(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-01"); }
+
+/* Drift 4: nt_sprite_renderer_set_material auto-flushes on material change */
+static void test_set_material_auto_flush_on_change(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-01"); }
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_emit_region_direct_call);
+    RUN_TEST(test_emit_region_capacity_guard);
+    RUN_TEST(test_emit_region_polygon_hull_vertex_count_preserved);
+    RUN_TEST(test_set_material_auto_flush_on_change);
+    return UNITY_END();
+}

--- a/tests/unit/test_nt_ui_begin_end.c
+++ b/tests/unit/test_nt_ui_begin_end.c
@@ -73,6 +73,23 @@ static void test_end_clears_in_frame(void) {
     nt_ui_destroy_context(a);
 }
 
+/* Symmetric with begin: end nulls Clay's current so stray CLAY_* between
+ * frames fails loudly instead of corrupting the just-frozen layout. */
+static void test_end_clears_clay_current(void) {
+    nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a, &s_ui_desc);
+    TEST_ASSERT_NOT_NULL(a);
+
+    nt_pointer_t mouse;
+    memset(&mouse, 0, sizeof mouse);
+
+    nt_ui_begin(a, 800.0F, 600.0F, &mouse);
+    TEST_ASSERT_EQUAL_PTR(a->clay, Clay_GetCurrentContext());
+    nt_ui_end(a);
+    TEST_ASSERT_NULL(Clay_GetCurrentContext());
+
+    nt_ui_destroy_context(a);
+}
+
 static void test_end_without_begin_asserts(void) {
     nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(a);
@@ -87,6 +104,7 @@ int main(void) {
     RUN_TEST(test_begin_sets_current_ctx);
     RUN_TEST(test_stray_nested_begin_asserts);
     RUN_TEST(test_end_clears_in_frame);
+    RUN_TEST(test_end_clears_clay_current);
     RUN_TEST(test_end_without_begin_asserts);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_begin_end.c
+++ b/tests/unit/test_nt_ui_begin_end.c
@@ -15,7 +15,7 @@
 
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_a[NT_UI_DEFAULT_ARENA_SIZE];
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_b[NT_UI_DEFAULT_ARENA_SIZE];
-static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT};
+static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT, .max_scissor_depth = NT_UI_WALKER_MAX_SCISSOR_DEPTH};
 
 void setUp(void) {
     nt_test_assert_install();

--- a/tests/unit/test_nt_ui_begin_end.c
+++ b/tests/unit/test_nt_ui_begin_end.c
@@ -1,0 +1,35 @@
+/* tests/unit/test_nt_ui_begin_end.c — Plan 52-00 stub
+ *
+ * Covers UI-04 / UI-05 / UI-08 (begin/end lifecycle + stray-nested-begin
+ * assert). Wave 0 ships TEST_IGNORE bodies; Plan 52-02 fills with real
+ * assertions.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* UI-04: nt_ui_begin sets Clay_GetCurrentContext == ctx->clay */
+static void test_begin_sets_current_ctx(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-02"); }
+
+/* UI-08 / D-52-12: stray nested begin (begin c1 → begin c2 with c1 in_frame) asserts */
+static void test_stray_nested_begin_asserts(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-02"); }
+
+/* UI-05: nt_ui_end clears g_nt_ui_inframe_ctx and ctx->in_frame */
+static void test_end_clears_in_frame(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-02"); }
+
+/* UI-05 / D-52-12: end called without begin asserts (death-test) */
+static void test_end_without_begin_asserts(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-02"); }
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_begin_sets_current_ctx);
+    RUN_TEST(test_stray_nested_begin_asserts);
+    RUN_TEST(test_end_clears_in_frame);
+    RUN_TEST(test_end_without_begin_asserts);
+    return UNITY_END();
+}

--- a/tests/unit/test_nt_ui_begin_end.c
+++ b/tests/unit/test_nt_ui_begin_end.c
@@ -20,8 +20,8 @@
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-static uint64_t s_arena_a[NT_UI_DEFAULT_ARENA_SIZE / 8u];
-static uint64_t s_arena_b[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+static uint64_t s_arena_a[NT_UI_DEFAULT_ARENA_SIZE / 8U];
+static uint64_t s_arena_b[NT_UI_DEFAULT_ARENA_SIZE / 8U];
 
 void setUp(void) { nt_test_assert_install(); }
 void tearDown(void) {
@@ -42,7 +42,7 @@ static void test_begin_sets_current_ctx(void) {
     nt_pointer_t mouse;
     memset(&mouse, 0, sizeof mouse);
 
-    nt_ui_begin(a, 800.0f, 600.0f, &mouse);
+    nt_ui_begin(a, 800.0F, 600.0F, &mouse);
     TEST_ASSERT_EQUAL_PTR(a->clay, Clay_GetCurrentContext());
     nt_ui_end(a);
 
@@ -60,9 +60,9 @@ static void test_stray_nested_begin_asserts(void) {
     nt_pointer_t mouse;
     memset(&mouse, 0, sizeof mouse);
 
-    nt_ui_begin(a, 800.0f, 600.0f, &mouse);
+    nt_ui_begin(a, 800.0F, 600.0F, &mouse);
     /* The second begin must fire NT_ASSERT(g_nt_ui_inframe_ctx == NULL). */
-    NT_TEST_EXPECT_ASSERT(nt_ui_begin(b, 800.0f, 600.0f, &mouse));
+    NT_TEST_EXPECT_ASSERT(nt_ui_begin(b, 800.0F, 600.0F, &mouse));
     /* Recover: a is still in-frame (assert fired before begin mutated
      * any state), so end it cleanly. */
     nt_ui_end(a);
@@ -79,7 +79,7 @@ static void test_end_clears_in_frame(void) {
     nt_pointer_t mouse;
     memset(&mouse, 0, sizeof mouse);
 
-    nt_ui_begin(a, 800.0f, 600.0f, &mouse);
+    nt_ui_begin(a, 800.0F, 600.0F, &mouse);
     TEST_ASSERT_TRUE(a->in_frame);
     TEST_ASSERT_EQUAL_PTR(a, nt_ui_test_inframe_ctx());
 

--- a/tests/unit/test_nt_ui_begin_end.c
+++ b/tests/unit/test_nt_ui_begin_end.c
@@ -15,12 +15,16 @@
 
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_a[NT_UI_DEFAULT_ARENA_SIZE];
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_b[NT_UI_DEFAULT_ARENA_SIZE];
+static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT};
 
-void setUp(void) { nt_test_assert_install(); }
-void tearDown(void) {}
+void setUp(void) {
+    nt_test_assert_install();
+    nt_ui_module_init();
+}
+void tearDown(void) { nt_ui_module_shutdown(); }
 
 static void test_begin_sets_current_ctx(void) {
-    nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a);
+    nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(a);
 
     nt_pointer_t mouse;
@@ -34,8 +38,8 @@ static void test_begin_sets_current_ctx(void) {
 }
 
 static void test_stray_nested_begin_asserts(void) {
-    nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a);
-    nt_ui_context_t *b = nt_ui_create_context(s_arena_b, sizeof s_arena_b);
+    nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a, &s_ui_desc);
+    nt_ui_context_t *b = nt_ui_create_context(s_arena_b, sizeof s_arena_b, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(a);
     TEST_ASSERT_NOT_NULL(b);
 
@@ -52,7 +56,7 @@ static void test_stray_nested_begin_asserts(void) {
 }
 
 static void test_end_clears_in_frame(void) {
-    nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a);
+    nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(a);
 
     nt_pointer_t mouse;
@@ -70,7 +74,7 @@ static void test_end_clears_in_frame(void) {
 }
 
 static void test_end_without_begin_asserts(void) {
-    nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a);
+    nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(a);
 
     NT_TEST_EXPECT_ASSERT(nt_ui_end(a));

--- a/tests/unit/test_nt_ui_begin_end.c
+++ b/tests/unit/test_nt_ui_begin_end.c
@@ -20,8 +20,8 @@
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-static uint64_t s_arena_a[NT_UI_DEFAULT_ARENA_SIZE / 8U];
-static uint64_t s_arena_b[NT_UI_DEFAULT_ARENA_SIZE / 8U];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_a[NT_UI_DEFAULT_ARENA_SIZE];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_b[NT_UI_DEFAULT_ARENA_SIZE];
 
 void setUp(void) { nt_test_assert_install(); }
 void tearDown(void) {

--- a/tests/unit/test_nt_ui_begin_end.c
+++ b/tests/unit/test_nt_ui_begin_end.c
@@ -1,16 +1,9 @@
-/* tests/unit/test_nt_ui_begin_end.c -- Plan 52-02
- *
- * Covers UI-04 (begin sets Clay current to ctx->clay), UI-05 (end
- * clears in-frame state), UI-08 / D-52-12 (stray-nested begin asserts,
- * end-without-begin asserts).
- *
- * Revision Issue 3: death-tests use NT_TEST_EXPECT_ASSERT; no Unity-
- * ignore fallback (the assert-trap macro replaces all prior stubs).
- */
-
+/* System headers before Unity -- avoids __declspec(noreturn) clash on MSVC. */
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "clay.h"
@@ -24,17 +17,8 @@ alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_a[NT_UI_DEFAULT_ARENA_SIZE];
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_b[NT_UI_DEFAULT_ARENA_SIZE];
 
 void setUp(void) { nt_test_assert_install(); }
-void tearDown(void) {
-    /* If a previous test left the global in-frame state dirty (e.g. a
-     * death-test fired before nt_ui_end could clear it), make sure
-     * subsequent tests start from a clean slate. The death-test handler
-     * longjmps out of nt_ui_begin AFTER the assert fires but BEFORE the
-     * in_frame=true line -- so this should already be clean. Still
-     * defensive. */
-}
+void tearDown(void) {}
 
-/* UI-04: nt_ui_begin sets Clay current context to ctx->clay (FIRST
- * executable action in begin; CP-03 prevention). */
 static void test_begin_sets_current_ctx(void) {
     nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a);
     TEST_ASSERT_NOT_NULL(a);
@@ -49,8 +33,6 @@ static void test_begin_sets_current_ctx(void) {
     nt_ui_destroy_context(a);
 }
 
-/* UI-08 / D-52-12 death-test: stray nested begin (a is in-frame, then
- * begin b) asserts on g_nt_ui_inframe_ctx == NULL. */
 static void test_stray_nested_begin_asserts(void) {
     nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a);
     nt_ui_context_t *b = nt_ui_create_context(s_arena_b, sizeof s_arena_b);
@@ -61,17 +43,14 @@ static void test_stray_nested_begin_asserts(void) {
     memset(&mouse, 0, sizeof mouse);
 
     nt_ui_begin(a, 800.0F, 600.0F, &mouse);
-    /* The second begin must fire NT_ASSERT(g_nt_ui_inframe_ctx == NULL). */
     NT_TEST_EXPECT_ASSERT(nt_ui_begin(b, 800.0F, 600.0F, &mouse));
-    /* Recover: a is still in-frame (assert fired before begin mutated
-     * any state), so end it cleanly. */
+    /* Assert fires before begin mutates state, so a is still in-frame. */
     nt_ui_end(a);
 
     nt_ui_destroy_context(a);
     nt_ui_destroy_context(b);
 }
 
-/* UI-05: nt_ui_end clears module in-frame ctx and ctx->in_frame flag. */
 static void test_end_clears_in_frame(void) {
     nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a);
     TEST_ASSERT_NOT_NULL(a);
@@ -90,13 +69,10 @@ static void test_end_clears_in_frame(void) {
     nt_ui_destroy_context(a);
 }
 
-/* UI-05 / D-52-12 death-test: end without a prior begin asserts on
- * ctx->in_frame. */
 static void test_end_without_begin_asserts(void) {
     nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a);
     TEST_ASSERT_NOT_NULL(a);
 
-    /* No begin -- end should assert on ctx->in_frame. */
     NT_TEST_EXPECT_ASSERT(nt_ui_end(a));
 
     nt_ui_destroy_context(a);

--- a/tests/unit/test_nt_ui_begin_end.c
+++ b/tests/unit/test_nt_ui_begin_end.c
@@ -9,12 +9,13 @@
 #include "clay.h"
 #include "input/nt_input.h"
 #include "test_helpers/nt_assert_trap.h"
+#include "test_helpers/ui_test_arena.h"
 #include "ui/nt_ui.h"
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_a[NT_UI_DEFAULT_ARENA_SIZE];
-alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_b[NT_UI_DEFAULT_ARENA_SIZE];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_a[NT_UI_TEST_ARENA_SIZE];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_b[NT_UI_TEST_ARENA_SIZE];
 static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT, .max_scissor_depth = NT_UI_WALKER_MAX_SCISSOR_DEPTH};
 
 void setUp(void) {

--- a/tests/unit/test_nt_ui_begin_end.c
+++ b/tests/unit/test_nt_ui_begin_end.c
@@ -1,29 +1,106 @@
-/* tests/unit/test_nt_ui_begin_end.c — Plan 52-00 stub
+/* tests/unit/test_nt_ui_begin_end.c -- Plan 52-02
  *
- * Covers UI-04 / UI-05 / UI-08 (begin/end lifecycle + stray-nested-begin
- * assert). Wave 0 ships TEST_IGNORE bodies; Plan 52-02 fills with real
- * assertions.
+ * Covers UI-04 (begin sets Clay current to ctx->clay), UI-05 (end
+ * clears in-frame state), UI-08 / D-52-12 (stray-nested begin asserts,
+ * end-without-begin asserts).
+ *
+ * Revision Issue 3: death-tests use NT_TEST_EXPECT_ASSERT; no Unity-
+ * ignore fallback (the assert-trap macro replaces all prior stubs).
  */
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
+#include "clay.h"
+#include "input/nt_input.h"
+#include "test_helpers/nt_assert_trap.h"
+#include "ui/nt_ui.h"
+#include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-void setUp(void) {}
-void tearDown(void) {}
+static uint64_t s_arena_a[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+static uint64_t s_arena_b[NT_UI_DEFAULT_ARENA_SIZE / 8u];
 
-/* UI-04: nt_ui_begin sets Clay_GetCurrentContext == ctx->clay */
-static void test_begin_sets_current_ctx(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-02"); }
+void setUp(void) { nt_test_assert_install(); }
+void tearDown(void) {
+    /* If a previous test left the global in-frame state dirty (e.g. a
+     * death-test fired before nt_ui_end could clear it), make sure
+     * subsequent tests start from a clean slate. The death-test handler
+     * longjmps out of nt_ui_begin AFTER the assert fires but BEFORE the
+     * in_frame=true line -- so this should already be clean. Still
+     * defensive. */
+}
 
-/* UI-08 / D-52-12: stray nested begin (begin c1 → begin c2 with c1 in_frame) asserts */
-static void test_stray_nested_begin_asserts(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-02"); }
+/* UI-04: nt_ui_begin sets Clay current context to ctx->clay (FIRST
+ * executable action in begin; CP-03 prevention). */
+static void test_begin_sets_current_ctx(void) {
+    nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a);
+    TEST_ASSERT_NOT_NULL(a);
 
-/* UI-05: nt_ui_end clears g_nt_ui_inframe_ctx and ctx->in_frame */
-static void test_end_clears_in_frame(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-02"); }
+    nt_pointer_t mouse;
+    memset(&mouse, 0, sizeof mouse);
 
-/* UI-05 / D-52-12: end called without begin asserts (death-test) */
-static void test_end_without_begin_asserts(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-02"); }
+    nt_ui_begin(a, 800.0f, 600.0f, &mouse);
+    TEST_ASSERT_EQUAL_PTR(a->clay, Clay_GetCurrentContext());
+    nt_ui_end(a);
+
+    nt_ui_destroy_context(a);
+}
+
+/* UI-08 / D-52-12 death-test: stray nested begin (a is in-frame, then
+ * begin b) asserts on g_nt_ui_inframe_ctx == NULL. */
+static void test_stray_nested_begin_asserts(void) {
+    nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a);
+    nt_ui_context_t *b = nt_ui_create_context(s_arena_b, sizeof s_arena_b);
+    TEST_ASSERT_NOT_NULL(a);
+    TEST_ASSERT_NOT_NULL(b);
+
+    nt_pointer_t mouse;
+    memset(&mouse, 0, sizeof mouse);
+
+    nt_ui_begin(a, 800.0f, 600.0f, &mouse);
+    /* The second begin must fire NT_ASSERT(g_nt_ui_inframe_ctx == NULL). */
+    NT_TEST_EXPECT_ASSERT(nt_ui_begin(b, 800.0f, 600.0f, &mouse));
+    /* Recover: a is still in-frame (assert fired before begin mutated
+     * any state), so end it cleanly. */
+    nt_ui_end(a);
+
+    nt_ui_destroy_context(a);
+    nt_ui_destroy_context(b);
+}
+
+/* UI-05: nt_ui_end clears module in-frame ctx and ctx->in_frame flag. */
+static void test_end_clears_in_frame(void) {
+    nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a);
+    TEST_ASSERT_NOT_NULL(a);
+
+    nt_pointer_t mouse;
+    memset(&mouse, 0, sizeof mouse);
+
+    nt_ui_begin(a, 800.0f, 600.0f, &mouse);
+    TEST_ASSERT_TRUE(a->in_frame);
+    TEST_ASSERT_EQUAL_PTR(a, nt_ui_test_inframe_ctx());
+
+    nt_ui_end(a);
+    TEST_ASSERT_FALSE(a->in_frame);
+    TEST_ASSERT_NULL(nt_ui_test_inframe_ctx());
+
+    nt_ui_destroy_context(a);
+}
+
+/* UI-05 / D-52-12 death-test: end without a prior begin asserts on
+ * ctx->in_frame. */
+static void test_end_without_begin_asserts(void) {
+    nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a);
+    TEST_ASSERT_NOT_NULL(a);
+
+    /* No begin -- end should assert on ctx->in_frame. */
+    NT_TEST_EXPECT_ASSERT(nt_ui_end(a));
+
+    nt_ui_destroy_context(a);
+}
 
 int main(void) {
     UNITY_BEGIN();

--- a/tests/unit/test_nt_ui_begin_end.c
+++ b/tests/unit/test_nt_ui_begin_end.c
@@ -16,7 +16,7 @@
 
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_a[NT_UI_TEST_ARENA_SIZE];
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_b[NT_UI_TEST_ARENA_SIZE];
-static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT, .max_scissor_depth = NT_UI_WALKER_MAX_SCISSOR_DEPTH};
+static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT};
 
 void setUp(void) {
     nt_test_assert_install();

--- a/tests/unit/test_nt_ui_element_data.c
+++ b/tests/unit/test_nt_ui_element_data.c
@@ -1,0 +1,74 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+
+#include "memory/nt_mem_scratch.h"
+#include "test_helpers/nt_assert_trap.h"
+#include "ui/nt_ui.h"
+#include "unity.h"
+
+void setUp(void) {
+    nt_test_assert_install();
+    nt_mem_scratch_init(4096U);
+}
+
+void tearDown(void) { nt_mem_scratch_shutdown(); }
+
+/* NT_UI_DATA_LAYER returns a valid ptr with layer set and user_data=NULL. */
+static void test_layer_only_macro(void) {
+    nt_ui_element_data_t *d = (nt_ui_element_data_t *)NT_UI_DATA_LAYER(5);
+    TEST_ASSERT_NOT_NULL(d);
+    TEST_ASSERT_EQUAL_UINT8(5U, d->layer);
+    TEST_ASSERT_NULL(d->user_data);
+}
+
+/* NT_UI_DATA_FULL sets both layer and user_data. */
+static void test_full_macro(void) {
+    int payload = 42;
+    nt_ui_element_data_t *d = (nt_ui_element_data_t *)NT_UI_DATA_FULL(7, &payload);
+    TEST_ASSERT_NOT_NULL(d);
+    TEST_ASSERT_EQUAL_UINT8(7U, d->layer);
+    TEST_ASSERT_EQUAL_PTR(&payload, d->user_data);
+}
+
+/* Each macro call advances scratch usage (proves allocation actually happens). */
+static void test_macro_uses_scratch(void) {
+    const size_t before = nt_mem_scratch_test_used();
+    (void)NT_UI_DATA_LAYER(0);
+    const size_t after_first = nt_mem_scratch_test_used();
+    TEST_ASSERT_TRUE(after_first > before);
+    (void)NT_UI_DATA_FULL(1, NULL);
+    const size_t after_second = nt_mem_scratch_test_used();
+    TEST_ASSERT_TRUE(after_second > after_first);
+}
+
+/* Two macro calls return distinct pointers. */
+static void test_macro_distinct_allocations(void) {
+    nt_ui_element_data_t *a = (nt_ui_element_data_t *)NT_UI_DATA_LAYER(3);
+    nt_ui_element_data_t *b = (nt_ui_element_data_t *)NT_UI_DATA_LAYER(4);
+    TEST_ASSERT_TRUE(a != b);
+    TEST_ASSERT_EQUAL_UINT8(3U, a->layer);
+    TEST_ASSERT_EQUAL_UINT8(4U, b->layer);
+}
+
+/* scratch_reset invalidates prior pointers; next macro call starts from base. */
+static void test_reset_releases_macro_storage(void) {
+    (void)NT_UI_DATA_LAYER(1);
+    const size_t after_alloc = nt_mem_scratch_test_used();
+    TEST_ASSERT_TRUE(after_alloc > 0U);
+    nt_mem_scratch_reset();
+    TEST_ASSERT_EQUAL_UINT64(0U, (uint64_t)nt_mem_scratch_test_used());
+    /* Macro still works after reset. */
+    nt_ui_element_data_t *d = (nt_ui_element_data_t *)NT_UI_DATA_LAYER(2);
+    TEST_ASSERT_EQUAL_UINT8(2U, d->layer);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_layer_only_macro);
+    RUN_TEST(test_full_macro);
+    RUN_TEST(test_macro_uses_scratch);
+    RUN_TEST(test_macro_distinct_allocations);
+    RUN_TEST(test_reset_releases_macro_storage);
+    return UNITY_END();
+}

--- a/tests/unit/test_nt_ui_lifecycle.c
+++ b/tests/unit/test_nt_ui_lifecycle.c
@@ -7,11 +7,12 @@
 #include <string.h>
 
 #include "test_helpers/nt_assert_trap.h"
+#include "test_helpers/ui_test_arena.h"
 #include "ui/nt_ui.h"
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_u64[NT_UI_DEFAULT_ARENA_SIZE];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_u64[NT_UI_TEST_ARENA_SIZE];
 static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT, .max_scissor_depth = NT_UI_WALKER_MAX_SCISSOR_DEPTH};
 
 void setUp(void) {
@@ -112,7 +113,7 @@ static void test_create_context_restores_clay_default(void) {
     const int32_t cache_before = nt_ui_test_clay_default_max_measure_text_word_cache_count();
     nt_ui_create_desc_t custom = nt_ui_create_desc_defaults();
     custom.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT * 2U;
-    alignas(NT_UI_ARENA_ALIGN) static uint8_t big_arena[NT_UI_DEFAULT_ARENA_SIZE * 4U];
+    alignas(NT_UI_ARENA_ALIGN) static uint8_t big_arena[NT_UI_TEST_ARENA_SIZE * 4U];
     nt_ui_context_t *ctx = nt_ui_create_context(big_arena, sizeof big_arena, &custom);
     TEST_ASSERT_NOT_NULL(ctx);
     TEST_ASSERT_EQUAL_INT32(elems_before, nt_ui_test_clay_default_max_element_count());

--- a/tests/unit/test_nt_ui_lifecycle.c
+++ b/tests/unit/test_nt_ui_lifecycle.c
@@ -20,7 +20,7 @@
  * NT_UI_DEFAULT_ARENA_SIZE is 8 MiB -- divide by 8 to size in uint64_t.
  * Re-used across tests; setUp memsets to 0xAB so the "destroy preserves
  * bytes" case can verify caller-owned memory is untouched. */
-static uint64_t s_arena_u64[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+static uint64_t s_arena_u64[NT_UI_DEFAULT_ARENA_SIZE / 8U];
 
 void setUp(void) { nt_test_assert_install(); }
 void tearDown(void) {}
@@ -30,7 +30,11 @@ static void test_create_destroy(void) {
     void *arena = (void *)s_arena_u64;
     nt_ui_context_t *ctx = nt_ui_create_context(arena, sizeof s_arena_u64);
     TEST_ASSERT_NOT_NULL(ctx);
-    /* ctx is placed in the first ~256 bytes of the arena (D-52-10). */
+    /* ctx is placed in the first ~256 bytes of the arena (D-52-10).
+     * Unity's TEST_ASSERT_EQUAL_PTR macro casts both args through void*, which
+     * tidy flags as "casting through void"; the cast IS the macro contract so
+     * the cleanest suppression is a NOLINT. */
+    // NOLINTNEXTLINE(bugprone-casting-through-void)
     TEST_ASSERT_EQUAL_PTR(arena, (void *)ctx);
     nt_ui_destroy_context(ctx);
 }
@@ -41,8 +45,8 @@ static void test_min_arena_size(void) {
     /* Clay's minimum + ctx struct + alignment slack must clearly exceed
      * a trivial threshold. 4 KiB is well below the real value (Clay v0.14
      * minimum is typically ~tens of KiB). */
-    TEST_ASSERT_GREATER_THAN_size_t(0u, min);
-    TEST_ASSERT_GREATER_OR_EQUAL_size_t(4096u, min);
+    TEST_ASSERT_GREATER_THAN_size_t(0U, min);
+    TEST_ASSERT_GREATER_OR_EQUAL_size_t(4096U, min);
     /* And smaller than the default arena (8 MiB) -- create must succeed
      * with the default. */
     TEST_ASSERT_LESS_OR_EQUAL_size_t((size_t)NT_UI_DEFAULT_ARENA_SIZE, min);
@@ -55,7 +59,7 @@ static void test_misaligned_assert(void) {
     /* base is 8-aligned; base+1 is guaranteed misaligned. The arena is
      * still oversized -- the misalign should trip before any size check. */
     void *misaligned = (void *)(base + 1);
-    NT_TEST_EXPECT_ASSERT(nt_ui_create_context(misaligned, sizeof s_arena_u64 - 1u));
+    NT_TEST_EXPECT_ASSERT(nt_ui_create_context(misaligned, sizeof s_arena_u64 - 1U));
 }
 
 /* UI-02: destroy preserves arena bytes beyond the ctx struct (caller
@@ -69,16 +73,16 @@ static void test_destroy_preserves_arena(void) {
      * point of UI-02 is that destroy_context does NOT memset / free the
      * caller's bytes. After destroy, the sentinel should still be there
      * because destroy only touches sizeof(nt_ui_context_t) at the head. */
-    const size_t tail_start = (size_t)NT_UI_DEFAULT_ARENA_SIZE - 4096u;
-    memset(bytes + tail_start, 0xAB, 4096u);
+    const size_t tail_start = (size_t)NT_UI_DEFAULT_ARENA_SIZE - 4096U;
+    memset(bytes + tail_start, 0xAB, 4096U);
 
     nt_ui_context_t *ctx = nt_ui_create_context((void *)s_arena_u64, sizeof s_arena_u64);
     TEST_ASSERT_NOT_NULL(ctx);
     nt_ui_destroy_context(ctx);
 
     /* Tail bytes survive destroy. */
-    for (size_t i = 0; i < 4096u; i += 64u) {
-        TEST_ASSERT_EQUAL_UINT8(0xABu, bytes[tail_start + i]);
+    for (size_t i = 0; i < 4096U; i += 64U) {
+        TEST_ASSERT_EQUAL_UINT8(0xABU, bytes[tail_start + i]);
     }
 }
 

--- a/tests/unit/test_nt_ui_lifecycle.c
+++ b/tests/unit/test_nt_ui_lifecycle.c
@@ -12,7 +12,7 @@
 #include "unity.h"
 
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_u64[NT_UI_DEFAULT_ARENA_SIZE];
-static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT};
+static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT, .max_scissor_depth = NT_UI_WALKER_MAX_SCISSOR_DEPTH};
 
 void setUp(void) {
     nt_test_assert_install();

--- a/tests/unit/test_nt_ui_lifecycle.c
+++ b/tests/unit/test_nt_ui_lifecycle.c
@@ -20,8 +20,6 @@ static void test_create_destroy(void) {
     void *arena = (void *)s_arena_u64;
     nt_ui_context_t *ctx = nt_ui_create_context(arena, sizeof s_arena_u64);
     TEST_ASSERT_NOT_NULL(ctx);
-    /* ctx is placed at arena base; TEST_ASSERT_EQUAL_PTR casts through
-     * void* by Unity contract -- NOLINT silences the resulting tidy warn. */
     // NOLINTNEXTLINE(bugprone-casting-through-void)
     TEST_ASSERT_EQUAL_PTR(arena, (void *)ctx);
     nt_ui_destroy_context(ctx);

--- a/tests/unit/test_nt_ui_lifecycle.c
+++ b/tests/unit/test_nt_ui_lifecycle.c
@@ -76,14 +76,12 @@ static void test_destroy_in_frame_asserts(void) {
     nt_ui_destroy_context(ctx);
 }
 
-/* destroy_context must null Clay's global current_ptr when it dangles at
- * the just-destroyed ctx -- nt_ui_begin parks Clay's current pointer inside
- * the arena, and memset zeroes the Clay_Context behind that pointer. */
+/* begin parks Clay's current_ptr into the arena; destroy must null it
+ * before memset or Clay holds a dangling pointer. */
 static void test_destroy_clears_dangling_clay_current(void) {
     nt_ui_context_t *ctx = nt_ui_create_context(s_arena_u64, sizeof s_arena_u64, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(ctx);
 
-    /* Drive a begin/end pair so Clay's current_ptr points at ctx->clay. */
     nt_pointer_t mouse;
     memset(&mouse, 0, sizeof mouse);
     nt_ui_begin(ctx, 800.0F, 600.0F, &mouse);
@@ -91,28 +89,24 @@ static void test_destroy_clears_dangling_clay_current(void) {
     TEST_ASSERT_NOT_NULL(Clay_GetCurrentContext());
 
     nt_ui_destroy_context(ctx);
-    /* Without the fix, Clay still holds a pointer into the now-zeroed arena. */
     TEST_ASSERT_NULL(Clay_GetCurrentContext());
 }
 
-/* nt_ui_min_arena_size must be a pure query: even though it has to set
- * Clay's global default to compute Clay_MinMemorySize(), it must restore
- * the prior value so external Clay consumers don't see our scratch state. */
+/* Pure-query contract: must restore Clay's global default. */
 static void test_min_arena_size_restores_clay_default(void) {
     const int32_t before = nt_ui_test_clay_default_max_element_count();
     nt_ui_create_desc_t custom = nt_ui_create_desc_defaults();
-    custom.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT * 2U; /* != before */
+    custom.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT * 2U;
     (void)nt_ui_min_arena_size(&custom);
     TEST_ASSERT_EQUAL_INT32(before, nt_ui_test_clay_default_max_element_count());
 }
 
-/* create_context likewise must restore Clay's global default after staging
- * desc->max_elements into it for Clay_Initialize to inherit. */
+/* create_context stages desc->max_elements into Clay's global, must restore. */
 static void test_create_context_restores_clay_default(void) {
     const int32_t before = nt_ui_test_clay_default_max_element_count();
     nt_ui_create_desc_t custom = nt_ui_create_desc_defaults();
-    custom.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT * 2U; /* != before */
-    /* Need a bigger arena because larger max_elements grows Clay's arena. */
+    custom.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT * 2U;
+    /* Larger max_elements needs proportionally larger arena. */
     alignas(NT_UI_ARENA_ALIGN) static uint8_t big_arena[NT_UI_DEFAULT_ARENA_SIZE * 4U];
     nt_ui_context_t *ctx = nt_ui_create_context(big_arena, sizeof big_arena, &custom);
     TEST_ASSERT_NOT_NULL(ctx);
@@ -120,19 +114,14 @@ static void test_create_context_restores_clay_default(void) {
     nt_ui_destroy_context(ctx);
 }
 
-/* create_context must not leak active-ctx selection: Clay_Initialize
- * unconditionally sets current=new, so create must save/restore. Caller's
- * pre-create current (NULL if none) must survive. */
+/* Clay_Initialize unconditionally sets current=new; create must save/restore
+ * so the caller doesn't inherit our new ctx without calling nt_ui_begin. */
 static void test_create_context_restores_clay_current(void) {
-    /* No active Clay context at this point (module_init from setUp doesn't
-     * create any). Clay_GetCurrentContext returns NULL. */
     TEST_ASSERT_NULL(Clay_GetCurrentContext());
 
     nt_ui_context_t *ctx = nt_ui_create_context(s_arena_u64, sizeof s_arena_u64, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(ctx);
 
-    /* After create, current must still be NULL -- user owns active-ctx
-     * selection via nt_ui_begin. */
     TEST_ASSERT_NULL(Clay_GetCurrentContext());
 
     nt_ui_destroy_context(ctx);

--- a/tests/unit/test_nt_ui_lifecycle.c
+++ b/tests/unit/test_nt_ui_lifecycle.c
@@ -58,11 +58,28 @@ static void test_destroy_preserves_arena(void) {
     TEST_ASSERT_EQUAL_MEMORY(kSentinel, sentinel_ptr, sizeof kSentinel);
 }
 
+/* destroy_context on a mid-frame ctx must assert. */
+static void test_destroy_in_frame_asserts(void) {
+    nt_ui_context_t *ctx = nt_ui_create_context(s_arena_u64, sizeof s_arena_u64);
+    TEST_ASSERT_NOT_NULL(ctx);
+
+    /* begin requires a pointer struct + the arena to be backed by nt_input
+     * etc., but we only need ctx->in_frame=true for this assert path. Forge
+     * it directly via the internal header. */
+    ctx->in_frame = true;
+    NT_TEST_EXPECT_ASSERT(nt_ui_destroy_context(ctx));
+
+    /* Clean up: clear in_frame manually so the real destroy succeeds. */
+    ctx->in_frame = false;
+    nt_ui_destroy_context(ctx);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_create_destroy);
     RUN_TEST(test_min_arena_size);
     RUN_TEST(test_misaligned_assert);
     RUN_TEST(test_destroy_preserves_arena);
+    RUN_TEST(test_destroy_in_frame_asserts);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_lifecycle.c
+++ b/tests/unit/test_nt_ui_lifecycle.c
@@ -1,89 +1,61 @@
-/* tests/unit/test_nt_ui_lifecycle.c -- Plan 52-02
- *
- * Covers UI-01 (create_context + min_arena_size + misalign assert) and
- * UI-02 (destroy preserves arena bytes -- caller owns memory).
- *
- * Revision Issue 3: death-tests use NT_TEST_EXPECT_ASSERT; no Unity-
- * ignore fallback (the assert-trap macro replaces all prior stubs).
- */
-
+/* System headers before Unity -- avoids __declspec(noreturn) clash on MSVC. */
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "test_helpers/nt_assert_trap.h"
 #include "ui/nt_ui.h"
+#include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-/* 8-byte aligned static arena via uint64_t backing array.
- * NT_UI_DEFAULT_ARENA_SIZE is 8 MiB -- divide by 8 to size in uint64_t.
- * Re-used across tests; setUp memsets to 0xAB so the "destroy preserves
- * bytes" case can verify caller-owned memory is untouched. */
-static uint64_t s_arena_u64[NT_UI_DEFAULT_ARENA_SIZE / 8U];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_u64[NT_UI_DEFAULT_ARENA_SIZE];
 
 void setUp(void) { nt_test_assert_install(); }
 void tearDown(void) {}
 
-/* UI-01: create returns non-NULL, destroy does not blow up. */
 static void test_create_destroy(void) {
     void *arena = (void *)s_arena_u64;
     nt_ui_context_t *ctx = nt_ui_create_context(arena, sizeof s_arena_u64);
     TEST_ASSERT_NOT_NULL(ctx);
-    /* ctx is placed in the first ~256 bytes of the arena (D-52-10).
-     * Unity's TEST_ASSERT_EQUAL_PTR macro casts both args through void*, which
-     * tidy flags as "casting through void"; the cast IS the macro contract so
-     * the cleanest suppression is a NOLINT. */
+    /* ctx is placed at arena base; TEST_ASSERT_EQUAL_PTR casts through
+     * void* by Unity contract -- NOLINT silences the resulting tidy warn. */
     // NOLINTNEXTLINE(bugprone-casting-through-void)
     TEST_ASSERT_EQUAL_PTR(arena, (void *)ctx);
     nt_ui_destroy_context(ctx);
 }
 
-/* UI-01: min_arena_size > 0 and includes Clay_MinMemorySize headroom. */
 static void test_min_arena_size(void) {
     size_t min = nt_ui_min_arena_size();
-    /* Clay's minimum + ctx struct + alignment slack must clearly exceed
-     * a trivial threshold. 4 KiB is well below the real value (Clay v0.14
-     * minimum is typically ~tens of KiB). */
-    TEST_ASSERT_GREATER_THAN_size_t(0U, min);
-    TEST_ASSERT_GREATER_OR_EQUAL_size_t(4096U, min);
-    /* And smaller than the default arena (8 MiB) -- create must succeed
-     * with the default. */
-    TEST_ASSERT_LESS_OR_EQUAL_size_t((size_t)NT_UI_DEFAULT_ARENA_SIZE, min);
+    TEST_ASSERT_GREATER_THAN(0, min);
+    /* min must cover ctx struct + Clay_MinMemorySize. */
+    TEST_ASSERT_GREATER_OR_EQUAL(sizeof(struct nt_ui_context) /* approx */, min);
 }
 
-/* UI-01 death-test: misaligned arena pointer asserts.
- * Construct a deliberately mis-aligned pointer by offsetting by 1 byte. */
+/* Death-test: arena pointer misaligned by 1 byte must assert. */
 static void test_misaligned_assert(void) {
-    uint8_t *base = (uint8_t *)s_arena_u64;
-    /* base is 8-aligned; base+1 is guaranteed misaligned. The arena is
-     * still oversized -- the misalign should trip before any size check. */
-    void *misaligned = (void *)(base + 1);
-    NT_TEST_EXPECT_ASSERT(nt_ui_create_context(misaligned, sizeof s_arena_u64 - 1U));
+    /* Offset the aligned arena by 1 to make it 1-byte-aligned. */
+    void *bad_arena = (void *)((char *)s_arena_u64 + 1);
+    NT_TEST_EXPECT_ASSERT(nt_ui_create_context(bad_arena, sizeof s_arena_u64 - 1));
 }
 
-/* UI-02: destroy preserves arena bytes beyond the ctx struct (caller
- * owns the memory). Fill the tail with a sentinel before create, then
- * verify it survives create + destroy. */
+/* destroy zeros the ctx struct but does NOT touch the rest of the arena
+ * (caller owns memory). Verify bytes past sizeof(ctx) are preserved. */
 static void test_destroy_preserves_arena(void) {
-    uint8_t *bytes = (uint8_t *)s_arena_u64;
-    /* Bytes [4096..8192) are well past the ctx struct (~256 B) and the
-     * Clay arena will USE some range starting right after the ctx. We
-     * pick a region that overlaps Clay memory only conceptually: the
-     * point of UI-02 is that destroy_context does NOT memset / free the
-     * caller's bytes. After destroy, the sentinel should still be there
-     * because destroy only touches sizeof(nt_ui_context_t) at the head. */
-    const size_t tail_start = (size_t)NT_UI_DEFAULT_ARENA_SIZE - 4096U;
-    memset(bytes + tail_start, 0xAB, 4096U);
-
-    nt_ui_context_t *ctx = nt_ui_create_context((void *)s_arena_u64, sizeof s_arena_u64);
+    nt_ui_context_t *ctx = nt_ui_create_context(s_arena_u64, sizeof s_arena_u64);
     TEST_ASSERT_NOT_NULL(ctx);
+
+    /* Plant a sentinel at a high offset that ctx cannot reach. */
+    const size_t sentinel_offset = sizeof s_arena_u64 - 16;
+    uint8_t *sentinel_ptr = (uint8_t *)s_arena_u64 + sentinel_offset;
+    static const uint8_t kSentinel[8] = {0xDE, 0xAD, 0xBE, 0xEF, 0xCA, 0xFE, 0xBA, 0xBE};
+    memcpy(sentinel_ptr, kSentinel, sizeof kSentinel);
+
     nt_ui_destroy_context(ctx);
 
-    /* Tail bytes survive destroy. */
-    for (size_t i = 0; i < 4096U; i += 64U) {
-        TEST_ASSERT_EQUAL_UINT8(0xABU, bytes[tail_start + i]);
-    }
+    TEST_ASSERT_EQUAL_MEMORY(kSentinel, sentinel_ptr, sizeof kSentinel);
 }
 
 int main(void) {

--- a/tests/unit/test_nt_ui_lifecycle.c
+++ b/tests/unit/test_nt_ui_lifecycle.c
@@ -1,0 +1,35 @@
+/* tests/unit/test_nt_ui_lifecycle.c — Plan 52-00 stub
+ *
+ * Covers UI-01 (create_context + min_arena_size + misalign assert) and UI-02
+ * (destroy preserves arena bytes). Wave 0 ships TEST_IGNORE bodies; Plan 52-02
+ * fills with real assertions.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* UI-01: create_context returns non-NULL given valid arena */
+static void test_create_destroy(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-02"); }
+
+/* UI-01: min_arena_size matches Clay_MinMemorySize + sizeof(ctx) + padding */
+static void test_min_arena_size(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-02"); }
+
+/* UI-01: misaligned arena asserts (death-test — uses NT_TEST_EXPECT_ASSERT in Plan 02) */
+static void test_misaligned_assert(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-02"); }
+
+/* UI-02: destroy preserves arena bytes (caller owns memory) */
+static void test_destroy_preserves_arena(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-02"); }
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_create_destroy);
+    RUN_TEST(test_min_arena_size);
+    RUN_TEST(test_misaligned_assert);
+    RUN_TEST(test_destroy_preserves_arena);
+    return UNITY_END();
+}

--- a/tests/unit/test_nt_ui_lifecycle.c
+++ b/tests/unit/test_nt_ui_lifecycle.c
@@ -13,7 +13,7 @@
 #include "unity.h"
 
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_u64[NT_UI_TEST_ARENA_SIZE];
-static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT, .max_scissor_depth = NT_UI_WALKER_MAX_SCISSOR_DEPTH};
+static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT};
 
 void setUp(void) {
     nt_test_assert_install();

--- a/tests/unit/test_nt_ui_lifecycle.c
+++ b/tests/unit/test_nt_ui_lifecycle.c
@@ -95,6 +95,31 @@ static void test_destroy_clears_dangling_clay_current(void) {
     TEST_ASSERT_NULL(Clay_GetCurrentContext());
 }
 
+/* nt_ui_min_arena_size must be a pure query: even though it has to set
+ * Clay's global default to compute Clay_MinMemorySize(), it must restore
+ * the prior value so external Clay consumers don't see our scratch state. */
+static void test_min_arena_size_restores_clay_default(void) {
+    const int32_t before = nt_ui_test_clay_default_max_element_count();
+    nt_ui_create_desc_t custom = nt_ui_create_desc_defaults();
+    custom.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT * 2U; /* != before */
+    (void)nt_ui_min_arena_size(&custom);
+    TEST_ASSERT_EQUAL_INT32(before, nt_ui_test_clay_default_max_element_count());
+}
+
+/* create_context likewise must restore Clay's global default after staging
+ * desc->max_elements into it for Clay_Initialize to inherit. */
+static void test_create_context_restores_clay_default(void) {
+    const int32_t before = nt_ui_test_clay_default_max_element_count();
+    nt_ui_create_desc_t custom = nt_ui_create_desc_defaults();
+    custom.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT * 2U; /* != before */
+    /* Need a bigger arena because larger max_elements grows Clay's arena. */
+    alignas(NT_UI_ARENA_ALIGN) static uint8_t big_arena[NT_UI_DEFAULT_ARENA_SIZE * 4U];
+    nt_ui_context_t *ctx = nt_ui_create_context(big_arena, sizeof big_arena, &custom);
+    TEST_ASSERT_NOT_NULL(ctx);
+    TEST_ASSERT_EQUAL_INT32(before, nt_ui_test_clay_default_max_element_count());
+    nt_ui_destroy_context(ctx);
+}
+
 /* create_context must not leak active-ctx selection: Clay_Initialize
  * unconditionally sets current=new, so create must save/restore. Caller's
  * pre-create current (NULL if none) must survive. */
@@ -122,5 +147,7 @@ int main(void) {
     RUN_TEST(test_destroy_in_frame_asserts);
     RUN_TEST(test_create_context_restores_clay_current);
     RUN_TEST(test_destroy_clears_dangling_clay_current);
+    RUN_TEST(test_min_arena_size_restores_clay_default);
+    RUN_TEST(test_create_context_restores_clay_default);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_lifecycle.c
+++ b/tests/unit/test_nt_ui_lifecycle.c
@@ -92,25 +92,29 @@ static void test_destroy_clears_dangling_clay_current(void) {
     TEST_ASSERT_NULL(Clay_GetCurrentContext());
 }
 
-/* Pure-query contract: must restore Clay's global default. */
+/* Pure-query contract: must restore BOTH Clay globals (element count and
+ * the paired text-cache count = N*2 that Clay_SetMaxElementCount also writes). */
 static void test_min_arena_size_restores_clay_default(void) {
-    const int32_t before = nt_ui_test_clay_default_max_element_count();
+    const int32_t elems_before = nt_ui_test_clay_default_max_element_count();
+    const int32_t cache_before = nt_ui_test_clay_default_max_measure_text_word_cache_count();
     nt_ui_create_desc_t custom = nt_ui_create_desc_defaults();
     custom.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT * 2U;
     (void)nt_ui_min_arena_size(&custom);
-    TEST_ASSERT_EQUAL_INT32(before, nt_ui_test_clay_default_max_element_count());
+    TEST_ASSERT_EQUAL_INT32(elems_before, nt_ui_test_clay_default_max_element_count());
+    TEST_ASSERT_EQUAL_INT32(cache_before, nt_ui_test_clay_default_max_measure_text_word_cache_count());
 }
 
-/* create_context stages desc->max_elements into Clay's global, must restore. */
+/* create_context stages desc->max_elements into Clay's globals; must restore both. */
 static void test_create_context_restores_clay_default(void) {
-    const int32_t before = nt_ui_test_clay_default_max_element_count();
+    const int32_t elems_before = nt_ui_test_clay_default_max_element_count();
+    const int32_t cache_before = nt_ui_test_clay_default_max_measure_text_word_cache_count();
     nt_ui_create_desc_t custom = nt_ui_create_desc_defaults();
     custom.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT * 2U;
-    /* Larger max_elements needs proportionally larger arena. */
     alignas(NT_UI_ARENA_ALIGN) static uint8_t big_arena[NT_UI_DEFAULT_ARENA_SIZE * 4U];
     nt_ui_context_t *ctx = nt_ui_create_context(big_arena, sizeof big_arena, &custom);
     TEST_ASSERT_NOT_NULL(ctx);
-    TEST_ASSERT_EQUAL_INT32(before, nt_ui_test_clay_default_max_element_count());
+    TEST_ASSERT_EQUAL_INT32(elems_before, nt_ui_test_clay_default_max_element_count());
+    TEST_ASSERT_EQUAL_INT32(cache_before, nt_ui_test_clay_default_max_measure_text_word_cache_count());
     nt_ui_destroy_context(ctx);
 }
 

--- a/tests/unit/test_nt_ui_lifecycle.c
+++ b/tests/unit/test_nt_ui_lifecycle.c
@@ -76,8 +76,9 @@ static void test_destroy_in_frame_asserts(void) {
     nt_ui_destroy_context(ctx);
 }
 
-/* begin parks Clay's current_ptr into the arena; destroy must null it
- * before memset or Clay holds a dangling pointer. */
+/* Defense-in-depth: even though nt_ui_end nulls Clay current, destroy must
+ * still null it if external code re-parked it at our ctx between end and
+ * destroy. Simulate the re-park manually to keep the destroy guard tested. */
 static void test_destroy_clears_dangling_clay_current(void) {
     nt_ui_context_t *ctx = nt_ui_create_context(s_arena_u64, sizeof s_arena_u64, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(ctx);
@@ -86,6 +87,7 @@ static void test_destroy_clears_dangling_clay_current(void) {
     memset(&mouse, 0, sizeof mouse);
     nt_ui_begin(ctx, 800.0F, 600.0F, &mouse);
     nt_ui_end(ctx);
+    Clay_SetCurrentContext(ctx->clay); /* simulate stray restore */
     TEST_ASSERT_NOT_NULL(Clay_GetCurrentContext());
 
     nt_ui_destroy_context(ctx);

--- a/tests/unit/test_nt_ui_lifecycle.c
+++ b/tests/unit/test_nt_ui_lifecycle.c
@@ -1,29 +1,86 @@
-/* tests/unit/test_nt_ui_lifecycle.c — Plan 52-00 stub
+/* tests/unit/test_nt_ui_lifecycle.c -- Plan 52-02
  *
- * Covers UI-01 (create_context + min_arena_size + misalign assert) and UI-02
- * (destroy preserves arena bytes). Wave 0 ships TEST_IGNORE bodies; Plan 52-02
- * fills with real assertions.
+ * Covers UI-01 (create_context + min_arena_size + misalign assert) and
+ * UI-02 (destroy preserves arena bytes -- caller owns memory).
+ *
+ * Revision Issue 3: death-tests use NT_TEST_EXPECT_ASSERT; no Unity-
+ * ignore fallback (the assert-trap macro replaces all prior stubs).
  */
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
+#include "test_helpers/nt_assert_trap.h"
+#include "ui/nt_ui.h"
 #include "unity.h"
 
-void setUp(void) {}
+/* 8-byte aligned static arena via uint64_t backing array.
+ * NT_UI_DEFAULT_ARENA_SIZE is 8 MiB -- divide by 8 to size in uint64_t.
+ * Re-used across tests; setUp memsets to 0xAB so the "destroy preserves
+ * bytes" case can verify caller-owned memory is untouched. */
+static uint64_t s_arena_u64[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+
+void setUp(void) { nt_test_assert_install(); }
 void tearDown(void) {}
 
-/* UI-01: create_context returns non-NULL given valid arena */
-static void test_create_destroy(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-02"); }
+/* UI-01: create returns non-NULL, destroy does not blow up. */
+static void test_create_destroy(void) {
+    void *arena = (void *)s_arena_u64;
+    nt_ui_context_t *ctx = nt_ui_create_context(arena, sizeof s_arena_u64);
+    TEST_ASSERT_NOT_NULL(ctx);
+    /* ctx is placed in the first ~256 bytes of the arena (D-52-10). */
+    TEST_ASSERT_EQUAL_PTR(arena, (void *)ctx);
+    nt_ui_destroy_context(ctx);
+}
 
-/* UI-01: min_arena_size matches Clay_MinMemorySize + sizeof(ctx) + padding */
-static void test_min_arena_size(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-02"); }
+/* UI-01: min_arena_size > 0 and includes Clay_MinMemorySize headroom. */
+static void test_min_arena_size(void) {
+    size_t min = nt_ui_min_arena_size();
+    /* Clay's minimum + ctx struct + alignment slack must clearly exceed
+     * a trivial threshold. 4 KiB is well below the real value (Clay v0.14
+     * minimum is typically ~tens of KiB). */
+    TEST_ASSERT_GREATER_THAN_size_t(0u, min);
+    TEST_ASSERT_GREATER_OR_EQUAL_size_t(4096u, min);
+    /* And smaller than the default arena (8 MiB) -- create must succeed
+     * with the default. */
+    TEST_ASSERT_LESS_OR_EQUAL_size_t((size_t)NT_UI_DEFAULT_ARENA_SIZE, min);
+}
 
-/* UI-01: misaligned arena asserts (death-test — uses NT_TEST_EXPECT_ASSERT in Plan 02) */
-static void test_misaligned_assert(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-02"); }
+/* UI-01 death-test: misaligned arena pointer asserts.
+ * Construct a deliberately mis-aligned pointer by offsetting by 1 byte. */
+static void test_misaligned_assert(void) {
+    uint8_t *base = (uint8_t *)s_arena_u64;
+    /* base is 8-aligned; base+1 is guaranteed misaligned. The arena is
+     * still oversized -- the misalign should trip before any size check. */
+    void *misaligned = (void *)(base + 1);
+    NT_TEST_EXPECT_ASSERT(nt_ui_create_context(misaligned, sizeof s_arena_u64 - 1u));
+}
 
-/* UI-02: destroy preserves arena bytes (caller owns memory) */
-static void test_destroy_preserves_arena(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-02"); }
+/* UI-02: destroy preserves arena bytes beyond the ctx struct (caller
+ * owns the memory). Fill the tail with a sentinel before create, then
+ * verify it survives create + destroy. */
+static void test_destroy_preserves_arena(void) {
+    uint8_t *bytes = (uint8_t *)s_arena_u64;
+    /* Bytes [4096..8192) are well past the ctx struct (~256 B) and the
+     * Clay arena will USE some range starting right after the ctx. We
+     * pick a region that overlaps Clay memory only conceptually: the
+     * point of UI-02 is that destroy_context does NOT memset / free the
+     * caller's bytes. After destroy, the sentinel should still be there
+     * because destroy only touches sizeof(nt_ui_context_t) at the head. */
+    const size_t tail_start = (size_t)NT_UI_DEFAULT_ARENA_SIZE - 4096u;
+    memset(bytes + tail_start, 0xAB, 4096u);
+
+    nt_ui_context_t *ctx = nt_ui_create_context((void *)s_arena_u64, sizeof s_arena_u64);
+    TEST_ASSERT_NOT_NULL(ctx);
+    nt_ui_destroy_context(ctx);
+
+    /* Tail bytes survive destroy. */
+    for (size_t i = 0; i < 4096u; i += 64u) {
+        TEST_ASSERT_EQUAL_UINT8(0xABu, bytes[tail_start + i]);
+    }
+}
 
 int main(void) {
     UNITY_BEGIN();

--- a/tests/unit/test_nt_ui_lifecycle.c
+++ b/tests/unit/test_nt_ui_lifecycle.c
@@ -12,13 +12,17 @@
 #include "unity.h"
 
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_u64[NT_UI_DEFAULT_ARENA_SIZE];
+static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT};
 
-void setUp(void) { nt_test_assert_install(); }
-void tearDown(void) {}
+void setUp(void) {
+    nt_test_assert_install();
+    nt_ui_module_init();
+}
+void tearDown(void) { nt_ui_module_shutdown(); }
 
 static void test_create_destroy(void) {
     void *arena = (void *)s_arena_u64;
-    nt_ui_context_t *ctx = nt_ui_create_context(arena, sizeof s_arena_u64);
+    nt_ui_context_t *ctx = nt_ui_create_context(arena, sizeof s_arena_u64, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(ctx);
     // NOLINTNEXTLINE(bugprone-casting-through-void)
     TEST_ASSERT_EQUAL_PTR(arena, (void *)ctx);
@@ -26,7 +30,7 @@ static void test_create_destroy(void) {
 }
 
 static void test_min_arena_size(void) {
-    size_t min = nt_ui_min_arena_size();
+    size_t min = nt_ui_min_arena_size(&s_ui_desc);
     TEST_ASSERT_GREATER_THAN(0, min);
     /* min must cover ctx struct + Clay_MinMemorySize. */
     TEST_ASSERT_GREATER_OR_EQUAL(sizeof(struct nt_ui_context) /* approx */, min);
@@ -36,13 +40,13 @@ static void test_min_arena_size(void) {
 static void test_misaligned_assert(void) {
     /* Offset the aligned arena by 1 to make it 1-byte-aligned. */
     void *bad_arena = (void *)((char *)s_arena_u64 + 1);
-    NT_TEST_EXPECT_ASSERT(nt_ui_create_context(bad_arena, sizeof s_arena_u64 - 1));
+    NT_TEST_EXPECT_ASSERT(nt_ui_create_context(bad_arena, sizeof s_arena_u64 - 1, &s_ui_desc));
 }
 
 /* destroy zeros the ctx struct but does NOT touch the rest of the arena
  * (caller owns memory). Verify bytes past sizeof(ctx) are preserved. */
 static void test_destroy_preserves_arena(void) {
-    nt_ui_context_t *ctx = nt_ui_create_context(s_arena_u64, sizeof s_arena_u64);
+    nt_ui_context_t *ctx = nt_ui_create_context(s_arena_u64, sizeof s_arena_u64, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(ctx);
 
     /* Plant a sentinel at a high offset that ctx cannot reach. */
@@ -58,7 +62,7 @@ static void test_destroy_preserves_arena(void) {
 
 /* destroy_context on a mid-frame ctx must assert. */
 static void test_destroy_in_frame_asserts(void) {
-    nt_ui_context_t *ctx = nt_ui_create_context(s_arena_u64, sizeof s_arena_u64);
+    nt_ui_context_t *ctx = nt_ui_create_context(s_arena_u64, sizeof s_arena_u64, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(ctx);
 
     /* begin requires a pointer struct + the arena to be backed by nt_input

--- a/tests/unit/test_nt_ui_lifecycle.c
+++ b/tests/unit/test_nt_ui_lifecycle.c
@@ -76,6 +76,43 @@ static void test_destroy_in_frame_asserts(void) {
     nt_ui_destroy_context(ctx);
 }
 
+/* destroy_context must null Clay's global current_ptr when it dangles at
+ * the just-destroyed ctx -- nt_ui_begin parks Clay's current pointer inside
+ * the arena, and memset zeroes the Clay_Context behind that pointer. */
+static void test_destroy_clears_dangling_clay_current(void) {
+    nt_ui_context_t *ctx = nt_ui_create_context(s_arena_u64, sizeof s_arena_u64, &s_ui_desc);
+    TEST_ASSERT_NOT_NULL(ctx);
+
+    /* Drive a begin/end pair so Clay's current_ptr points at ctx->clay. */
+    nt_pointer_t mouse;
+    memset(&mouse, 0, sizeof mouse);
+    nt_ui_begin(ctx, 800.0F, 600.0F, &mouse);
+    nt_ui_end(ctx);
+    TEST_ASSERT_NOT_NULL(Clay_GetCurrentContext());
+
+    nt_ui_destroy_context(ctx);
+    /* Without the fix, Clay still holds a pointer into the now-zeroed arena. */
+    TEST_ASSERT_NULL(Clay_GetCurrentContext());
+}
+
+/* create_context must not leak active-ctx selection: Clay_Initialize
+ * unconditionally sets current=new, so create must save/restore. Caller's
+ * pre-create current (NULL if none) must survive. */
+static void test_create_context_restores_clay_current(void) {
+    /* No active Clay context at this point (module_init from setUp doesn't
+     * create any). Clay_GetCurrentContext returns NULL. */
+    TEST_ASSERT_NULL(Clay_GetCurrentContext());
+
+    nt_ui_context_t *ctx = nt_ui_create_context(s_arena_u64, sizeof s_arena_u64, &s_ui_desc);
+    TEST_ASSERT_NOT_NULL(ctx);
+
+    /* After create, current must still be NULL -- user owns active-ctx
+     * selection via nt_ui_begin. */
+    TEST_ASSERT_NULL(Clay_GetCurrentContext());
+
+    nt_ui_destroy_context(ctx);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_create_destroy);
@@ -83,5 +120,7 @@ int main(void) {
     RUN_TEST(test_misaligned_assert);
     RUN_TEST(test_destroy_preserves_arena);
     RUN_TEST(test_destroy_in_frame_asserts);
+    RUN_TEST(test_create_context_restores_clay_current);
+    RUN_TEST(test_destroy_clears_dangling_clay_current);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_measure_cb.c
+++ b/tests/unit/test_nt_ui_measure_cb.c
@@ -1,10 +1,4 @@
-/* Verifies the Clay measure callback wiring: declare a CLAY_TEXT inside
- * begin/end and inspect the resulting TEXT render command's bounding box
- * (Clay calls the measure callback during EndLayout's layout pass).
- *
- * Unity's TEST_ASSERT_*_FLOAT is compiled out via UNITY_EXCLUDE_FLOAT;
- * floats compared via TEST_ASSERT_EQUAL_MEMORY on bit-stable struct
- * copies or via integer truncation for "non-zero" gates. */
+/* Floats compared via memcmp/integer (UNITY_EXCLUDE_FLOAT). */
 
 /* System headers before Unity -- avoids __declspec(noreturn) clash on MSVC. */
 #include <setjmp.h>
@@ -161,20 +155,14 @@ void tearDown(void) {
 
 /* ---- Helpers ---- */
 
-/* Bit-exact "is this float zero?" test (handles +0/-0 identically with the
- * uint32 bit cast: -0.0f bit pattern is 0x80000000, +0.0f is 0x00000000.
- * We only emit non-negative widths/heights from the callback, so either
- * pattern would actually be diagnostic of "zero". For simplicity we accept
- * both. */
+/* Accept +0 / -0. */
 static bool float_is_zero_bits(float f) {
     uint32_t b;
     memcpy(&b, &f, sizeof b);
     return (b == 0U) || (b == 0x80000000U);
 }
 
-/* Drive Clay through a one-element CLAY_TEXT declaration and return the
- * resulting TEXT render command bounding box. Bounding box {0,0,0,0} if
- * no TEXT command was emitted (e.g. element culled or measure returned 0). */
+/* Returns the bbox of the emitted TEXT cmd; {0,0,0,0} if none emitted. */
 static Clay_BoundingBox declare_and_measure_text(nt_ui_context_t *ctx, const char *utf8, uint16_t font_id, uint16_t font_size) {
     nt_pointer_t mouse;
     memset(&mouse, 0, sizeof mouse);

--- a/tests/unit/test_nt_ui_measure_cb.c
+++ b/tests/unit/test_nt_ui_measure_cb.c
@@ -25,6 +25,7 @@
 /* clang-format on */
 
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
+static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT};
 
 /* Per-test counter so virtual-pack ids stay unique across the binary. */
 static uint32_t s_vpack_counter;
@@ -143,10 +144,12 @@ void setUp(void) {
     nt_hash_init(&(nt_hash_desc_t){0});
     nt_resource_init(&(nt_resource_desc_t){0});
     nt_font_init(&(nt_font_desc_t){.max_fonts = 4});
+    nt_ui_module_init();
     s_vpack_counter = 0;
 }
 
 void tearDown(void) {
+    nt_ui_module_shutdown();
     nt_font_shutdown();
     nt_resource_shutdown();
     nt_hash_shutdown();
@@ -193,7 +196,7 @@ static Clay_BoundingBox declare_and_measure_text(nt_ui_context_t *ctx, const cha
  * firing CLAY_ERROR_TYPE_TEXT_MEASUREMENT_FUNCTION_NOT_PROVIDED is itself
  * evidence that the measure callback is wired. */
 static void test_measure_callback_wired(void) {
-    nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena);
+    nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(ctx);
 
     /* No font set at slot 0 -> callback should hit the nt_font_valid early
@@ -214,13 +217,13 @@ static void test_measure_callback_forwards_to_font_measure_n(void) {
     nt_font_t font = make_resolved_test_font("measure_cb_forward", &blob);
     TEST_ASSERT_TRUE(nt_font_valid(font));
 
-    nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena);
+    nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(ctx);
     nt_ui_set_font(ctx, 0U, font);
 
     /* Independent ground truth: invoke the exact same measure path the
      * callback takes (with the size cast to float matching uint16_t->float). */
-    nt_text_size_t expected = nt_font_measure_n(font, "ABC", 3U, 14.0F);
+    nt_text_size_t expected = nt_font_measure_n(font, "ABC", 3U, 14.0F, 0.0F);
     /* Sanity: the resolved test font must produce positive dimensions for
      * a 3-glyph "ABC" measurement. If this fails the test_font setup is
      * broken, not the callback. */
@@ -251,11 +254,64 @@ static void test_measure_callback_forwards_to_font_measure_n(void) {
     free(blob);
 }
 
+/* Variant with explicit letterSpacing on the text config. */
+static Clay_BoundingBox declare_and_measure_text_ls(nt_ui_context_t *ctx, const char *utf8, uint16_t font_id, uint16_t font_size, uint16_t letter_spacing) {
+    nt_pointer_t mouse;
+    memset(&mouse, 0, sizeof mouse);
+
+    nt_ui_begin(ctx, 800.0F, 600.0F, &mouse);
+    Clay_String s = {.length = (int32_t)strlen(utf8), .chars = utf8};
+    CLAY_TEXT(s, CLAY_TEXT_CONFIG({.fontId = font_id, .fontSize = font_size, .letterSpacing = letter_spacing}));
+    nt_ui_end(ctx);
+
+    Clay_BoundingBox empty = {0};
+    for (int32_t i = 0; i < ctx->frozen_cmds.length; ++i) {
+        Clay_RenderCommand *c = &ctx->frozen_cmds.internalArray[i];
+        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_TEXT) {
+            return c->boundingBox;
+        }
+    }
+    return empty;
+}
+
+/* Clay's MeasureTextCached subtracts one letterSpacing slot from the
+ * line width (clay.h line 1677). The bridge has to compensate by adding
+ * one trailing slot so Clay's final bbox matches the renderer's CSS-style
+ * (N-1)*ls width. Without the bridge fix the bbox is short by exactly
+ * one letterSpacing. */
+static void test_measure_callback_letter_spacing_matches_render_width(void) {
+    uint8_t *blob = NULL;
+    nt_font_t font = make_resolved_test_font("measure_cb_ls", &blob);
+    TEST_ASSERT_TRUE(nt_font_valid(font));
+
+    nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena, &s_ui_desc);
+    TEST_ASSERT_NOT_NULL(ctx);
+    nt_ui_set_font(ctx, 0U, font);
+
+    /* CSS-style render width is exactly what nt_font_measure_n returns. */
+    nt_text_size_t expected = nt_font_measure_n(font, "ABC", 3U, 14.0F, 5.0F);
+    TEST_ASSERT_FALSE(float_is_zero_bits(expected.width));
+
+    Clay_BoundingBox bb = declare_and_measure_text_ls(ctx, "ABC", 0U, 14U, 5U);
+
+    /* Clay quantizes layout to int pixels in some paths; allow 1 px tolerance.
+     * Without the bridge fix this would be off by exactly letterSpacing=5. */
+    const int32_t exp_w = (int32_t)expected.width;
+    const int32_t got_w = (int32_t)bb.width;
+    const int32_t diff_w = (got_w > exp_w) ? (got_w - exp_w) : (exp_w - got_w);
+    TEST_ASSERT_LESS_OR_EQUAL_INT32(1, diff_w);
+    TEST_ASSERT_GREATER_THAN_INT32(0, got_w);
+
+    nt_ui_destroy_context(ctx);
+    nt_font_destroy(font);
+    free(blob);
+}
+
 /* with no font slot populated the callback returns {0,0} via the
  * nt_font_valid early-return path -- proves the guard branch fires before
  * the (would-be-crashing) nt_font_measure_n call. */
 static void test_measure_callback_invalid_font_returns_zero(void) {
-    nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena);
+    nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(ctx);
     /* Deliberately leave ctx->fonts[0] = NT_FONT_INVALID (zeroed by create). */
 
@@ -270,6 +326,7 @@ int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_measure_callback_wired);
     RUN_TEST(test_measure_callback_forwards_to_font_measure_n);
+    RUN_TEST(test_measure_callback_letter_spacing_matches_render_width);
     RUN_TEST(test_measure_callback_invalid_font_returns_zero);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_measure_cb.c
+++ b/tests/unit/test_nt_ui_measure_cb.c
@@ -1,0 +1,28 @@
+/* tests/unit/test_nt_ui_measure_cb.c — Plan 52-00 stub
+ *
+ * Covers CLAY-03 (Clay_SetMeasureTextFunction → nt_font_measure_n). Wave 0
+ * ships TEST_IGNORE bodies; Plan 52-03 fills with real assertions.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* CLAY-03: measure callback wired at module init; verified via direct invocation
+ * or through Clay's measure-function-registered state. */
+static void test_measure_callback_wired(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-03"); }
+
+/* CLAY-03: callback forwards Clay_StringSlice (chars+length) to nt_font_measure_n
+ * with proper font_id → nt_font_t resolution. */
+static void test_measure_callback_forwards_to_font_measure_n(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-03"); }
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_measure_callback_wired);
+    RUN_TEST(test_measure_callback_forwards_to_font_measure_n);
+    return UNITY_END();
+}

--- a/tests/unit/test_nt_ui_measure_cb.c
+++ b/tests/unit/test_nt_ui_measure_cb.c
@@ -1,24 +1,12 @@
-/* tests/unit/test_nt_ui_measure_cb.c -- Plan 52-03
+/* Verifies the Clay measure callback wiring: declare a CLAY_TEXT inside
+ * begin/end and inspect the resulting TEXT render command's bounding box
+ * (Clay calls the measure callback during EndLayout's layout pass).
  *
- * Covers CLAY-03 / D-52-14: Clay_SetMeasureTextFunction is wired at
- * module init, and the callback forwards to nt_font_measure_n via the
- * per-context font registry. Edge contracts (invalid ctx, out-of-range
- * fontId, invalid font handle) return zero dimensions without crashing.
- *
- * Verification strategy: declare a CLAY_TEXT element inside nt_ui_begin /
- * nt_ui_end and inspect the resulting TEXT render command's bounding box
- * after Clay_EndLayout. Clay drives the measure callback during the
- * EndLayout layout pass; the box width/height reflect what the callback
- * returned.
- *
- * Unity's TEST_ASSERT_*_FLOAT macros are compiled out via UNITY_EXCLUDE_
- * FLOAT (matches the v1.7 test_stats / Phase 51 test_font precedent).
- * Float comparisons go through TEST_ASSERT_EQUAL_MEMORY on bit-stable
- * struct copies, or through integer truncation when only a "non-zero"
- * gate is needed.
- */
+ * Unity's TEST_ASSERT_*_FLOAT is compiled out via UNITY_EXCLUDE_FLOAT;
+ * floats compared via TEST_ASSERT_EQUAL_MEMORY on bit-stable struct
+ * copies or via integer truncation for "non-zero" gates. */
 
-/* System headers before Unity to avoid noreturn / __declspec conflict on MSVC */
+/* System headers before Unity -- avoids __declspec(noreturn) clash on MSVC. */
 #include <setjmp.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -42,10 +30,9 @@
 #include "unity.h"
 /* clang-format on */
 
-/* 8-byte aligned static arena via uint64_t backing array. */
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
 
-/* Virtual pack id counter to keep registrations unique across tests. */
+/* Per-test counter so virtual-pack ids stay unique across the binary. */
 static uint32_t s_vpack_counter;
 
 /* ---- Test font blob builder (mirrors test_font.c with 3 glyphs A/B/C) ---- */
@@ -212,7 +199,7 @@ static Clay_BoundingBox declare_and_measure_text(nt_ui_context_t *ctx, const cha
 
 /* ---- Tests ---- */
 
-/* CLAY-03: Clay_SetMeasureTextFunction is wired during nt_ui_create_context.
+/* Clay_SetMeasureTextFunction is wired during nt_ui_create_context.
  * Covariance check: with no font registered the callback returns {0,0} via
  * the nt_font_valid branch. The fact that Clay_EndLayout completes without
  * firing CLAY_ERROR_TYPE_TEXT_MEASUREMENT_FUNCTION_NOT_PROVIDED is itself
@@ -231,7 +218,7 @@ static void test_measure_callback_wired(void) {
     nt_ui_destroy_context(ctx);
 }
 
-/* CLAY-03: callback forwards Clay_StringSlice -> nt_font_measure_n with
+/* callback forwards Clay_StringSlice -> nt_font_measure_n with
  * proper font_id resolution. Compares the TEXT command bounding box
  * against an independent direct nt_font_measure_n call. */
 static void test_measure_callback_forwards_to_font_measure_n(void) {
@@ -276,7 +263,7 @@ static void test_measure_callback_forwards_to_font_measure_n(void) {
     free(blob);
 }
 
-/* CLAY-03: with no font slot populated the callback returns {0,0} via the
+/* with no font slot populated the callback returns {0,0} via the
  * nt_font_valid early-return path -- proves the guard branch fires before
  * the (would-be-crashing) nt_font_measure_n call. */
 static void test_measure_callback_invalid_font_returns_zero(void) {

--- a/tests/unit/test_nt_ui_measure_cb.c
+++ b/tests/unit/test_nt_ui_measure_cb.c
@@ -26,7 +26,7 @@
 /* clang-format on */
 
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
-static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT};
+static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT, .max_scissor_depth = NT_UI_WALKER_MAX_SCISSOR_DEPTH};
 
 /* Per-test counter so virtual-pack ids stay unique across the binary. */
 static uint32_t s_vpack_counter;

--- a/tests/unit/test_nt_ui_measure_cb.c
+++ b/tests/unit/test_nt_ui_measure_cb.c
@@ -19,6 +19,7 @@
 #include "nt_font_format.h"
 #include "nt_pack_format.h"
 #include "resource/nt_resource.h"
+#include "test_helpers/nt_assert_trap.h"
 #include "ui/nt_ui.h"
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
@@ -140,6 +141,7 @@ static nt_font_t make_resolved_test_font(const char *name, uint8_t **out_blob) {
 /* ---- Unity setUp / tearDown ---- */
 
 void setUp(void) {
+    nt_test_assert_install();
     nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_pipelines = 4, .max_buffers = 8, .max_textures = 32, .max_meshes = 8});
     nt_hash_init(&(nt_hash_desc_t){0});
     nt_resource_init(&(nt_resource_desc_t){0});
@@ -195,18 +197,19 @@ static Clay_BoundingBox declare_and_measure_text(nt_ui_context_t *ctx, const cha
  * the nt_font_valid branch. The fact that Clay_EndLayout completes without
  * firing CLAY_ERROR_TYPE_TEXT_MEASUREMENT_FUNCTION_NOT_PROVIDED is itself
  * evidence that the measure callback is wired. */
-static void test_measure_callback_wired(void) {
+/* measure_cb runs DURING Clay layout (nt_ui_end). Unbound font slot is a
+ * contract violation symmetric with emit_text -- asserts here (one frame
+ * earlier than the walker would catch it).
+ *
+ * Death-test caveat: assert handler longjmps OUT of nt_ui_end, leaving
+ * ctx->in_frame=true and g_nt_ui_inframe_ctx dangling. We skip destroy
+ * (would trip its own in_frame guard with armed=false handler -> trap).
+ * Static arena gets reused next test; module_init clears the globals. */
+static void test_measure_callback_unbound_font_asserts(void) {
     nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(ctx);
-
-    /* No font set at slot 0 -> callback should hit the nt_font_valid early
-     * return and produce a 0-width TEXT command bounding box (or no TEXT
-     * command at all, depending on Clay's culling). */
-    Clay_BoundingBox bb = declare_and_measure_text(ctx, "ABC", 0U, 14U);
-    TEST_ASSERT_TRUE(float_is_zero_bits(bb.width));
-    TEST_ASSERT_TRUE(float_is_zero_bits(bb.height));
-
-    nt_ui_destroy_context(ctx);
+    /* No font set at slot 0 -> measure_cb fires during nt_ui_end and asserts. */
+    NT_TEST_EXPECT_ASSERT(declare_and_measure_text(ctx, "ABC", 0U, 14U));
 }
 
 /* callback forwards Clay_StringSlice -> nt_font_measure_n with
@@ -310,23 +313,22 @@ static void test_measure_callback_letter_spacing_matches_render_width(void) {
 /* with no font slot populated the callback returns {0,0} via the
  * nt_font_valid early-return path -- proves the guard branch fires before
  * the (would-be-crashing) nt_font_measure_n call. */
-static void test_measure_callback_invalid_font_returns_zero(void) {
+/* fontId >= NT_UI_MAX_FONTS is a contract violation in CLAY_TEXT_CONFIG --
+ * measure_cb asserts symmetrically with emit_text. Destroy skipped for the
+ * same reason as test_measure_callback_unbound_font_asserts above. */
+static void test_measure_callback_out_of_range_font_asserts(void) {
     nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(ctx);
-    /* Deliberately leave ctx->fonts[0] = NT_FONT_INVALID (zeroed by create). */
-
-    Clay_BoundingBox bb = declare_and_measure_text(ctx, "ABC", 0U, 14U);
-    TEST_ASSERT_TRUE(float_is_zero_bits(bb.width));
-    TEST_ASSERT_TRUE(float_is_zero_bits(bb.height));
-
-    nt_ui_destroy_context(ctx);
+    NT_TEST_EXPECT_ASSERT(declare_and_measure_text(ctx, "ABC", NT_UI_MAX_FONTS, 14U));
 }
 
 int main(void) {
+    (void)setvbuf(stdout, NULL, _IONBF, 0);
     UNITY_BEGIN();
-    RUN_TEST(test_measure_callback_wired);
+    /* Happy-path tests first so a crashing death-test doesn't hide them. */
     RUN_TEST(test_measure_callback_forwards_to_font_measure_n);
     RUN_TEST(test_measure_callback_letter_spacing_matches_render_width);
-    RUN_TEST(test_measure_callback_invalid_font_returns_zero);
+    RUN_TEST(test_measure_callback_unbound_font_asserts);
+    RUN_TEST(test_measure_callback_out_of_range_font_asserts);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_measure_cb.c
+++ b/tests/unit/test_nt_ui_measure_cb.c
@@ -20,12 +20,13 @@
 #include "nt_pack_format.h"
 #include "resource/nt_resource.h"
 #include "test_helpers/nt_assert_trap.h"
+#include "test_helpers/ui_test_arena.h"
 #include "ui/nt_ui.h"
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 /* clang-format on */
 
-alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_TEST_ARENA_SIZE];
 static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT, .max_scissor_depth = NT_UI_WALKER_MAX_SCISSOR_DEPTH};
 
 /* Per-test counter so virtual-pack ids stay unique across the binary. */

--- a/tests/unit/test_nt_ui_measure_cb.c
+++ b/tests/unit/test_nt_ui_measure_cb.c
@@ -192,29 +192,17 @@ static Clay_BoundingBox declare_and_measure_text(nt_ui_context_t *ctx, const cha
 
 /* ---- Tests ---- */
 
-/* Clay_SetMeasureTextFunction is wired during nt_ui_create_context.
- * Covariance check: with no font registered the callback returns {0,0} via
- * the nt_font_valid branch. The fact that Clay_EndLayout completes without
- * firing CLAY_ERROR_TYPE_TEXT_MEASUREMENT_FUNCTION_NOT_PROVIDED is itself
- * evidence that the measure callback is wired. */
-/* measure_cb runs DURING Clay layout (nt_ui_end). Unbound font slot is a
- * contract violation symmetric with emit_text -- asserts here (one frame
- * earlier than the walker would catch it).
- *
- * Death-test caveat: assert handler longjmps OUT of nt_ui_end, leaving
- * ctx->in_frame=true and g_nt_ui_inframe_ctx dangling. We skip destroy
- * (would trip its own in_frame guard with armed=false handler -> trap).
- * Static arena gets reused next test; module_init clears the globals. */
+/* measure_cb fires during nt_ui_end; unbound font asserts here, one frame
+ * earlier than emit_text. Destroy skipped: assert longjmps leave ctx->in_frame=1
+ * and trip destroy's own guard with disarmed handler -> trap. Static arena
+ * gets reused next test; module_init clears the globals. */
 static void test_measure_callback_unbound_font_asserts(void) {
     nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(ctx);
-    /* No font set at slot 0 -> measure_cb fires during nt_ui_end and asserts. */
     NT_TEST_EXPECT_ASSERT(declare_and_measure_text(ctx, "ABC", 0U, 14U));
 }
 
-/* callback forwards Clay_StringSlice -> nt_font_measure_n with
- * proper font_id resolution. Compares the TEXT command bounding box
- * against an independent direct nt_font_measure_n call. */
+/* Compare Clay bbox against a direct nt_font_measure_n on the same input. */
 static void test_measure_callback_forwards_to_font_measure_n(void) {
     uint8_t *blob = NULL;
     nt_font_t font = make_resolved_test_font("measure_cb_forward", &blob);
@@ -224,20 +212,14 @@ static void test_measure_callback_forwards_to_font_measure_n(void) {
     TEST_ASSERT_NOT_NULL(ctx);
     nt_ui_set_font(ctx, 0U, font);
 
-    /* Independent ground truth: invoke the exact same measure path the
-     * callback takes (with the size cast to float matching uint16_t->float). */
     nt_text_size_t expected = nt_font_measure_n(font, "ABC", 3U, 14.0F, 0.0F);
-    /* Sanity: the resolved test font must produce positive dimensions for
-     * a 3-glyph "ABC" measurement. If this fails the test_font setup is
-     * broken, not the callback. */
     TEST_ASSERT_FALSE(float_is_zero_bits(expected.width));
     TEST_ASSERT_FALSE(float_is_zero_bits(expected.height));
 
     Clay_BoundingBox bb = declare_and_measure_text(ctx, "ABC", 0U, 14U);
 
-    /* Clay can round/quantize the bbox slightly during layout; compare
-     * via integer truncation with a 1 px tolerance window. The truncation
-     * keeps the comparison free of UNITY_EXCLUDE_FLOAT macros. */
+    /* Clay quantizes layout to int; ±1px tolerance via integer truncation
+     * (UNITY_EXCLUDE_FLOAT is on). */
     const int32_t exp_w = (int32_t)expected.width;
     const int32_t exp_h = (int32_t)expected.height;
     const int32_t got_w = (int32_t)bb.width;
@@ -246,9 +228,6 @@ static void test_measure_callback_forwards_to_font_measure_n(void) {
     const int32_t diff_h = (got_h > exp_h) ? (got_h - exp_h) : (exp_h - got_h);
     TEST_ASSERT_LESS_OR_EQUAL_INT32(1, diff_w);
     TEST_ASSERT_LESS_OR_EQUAL_INT32(1, diff_h);
-    /* And that we did get a positive measurement back -- if Clay culled
-     * the element or the callback returned {0,0} unexpectedly, both
-     * dimensions would be zero. */
     TEST_ASSERT_GREATER_THAN_INT32(0, got_w);
     TEST_ASSERT_GREATER_THAN_INT32(0, got_h);
 
@@ -257,7 +236,7 @@ static void test_measure_callback_forwards_to_font_measure_n(void) {
     free(blob);
 }
 
-/* Variant with explicit letterSpacing on the text config. */
+/* declare_and_measure_text with explicit letterSpacing. */
 static Clay_BoundingBox declare_and_measure_text_ls(nt_ui_context_t *ctx, const char *utf8, uint16_t font_id, uint16_t font_size, uint16_t letter_spacing) {
     nt_pointer_t mouse;
     memset(&mouse, 0, sizeof mouse);
@@ -277,11 +256,7 @@ static Clay_BoundingBox declare_and_measure_text_ls(nt_ui_context_t *ctx, const 
     return empty;
 }
 
-/* Clay's MeasureTextCached subtracts one letterSpacing slot from the
- * line width (clay.h line 1677). The bridge has to compensate by adding
- * one trailing slot so Clay's final bbox matches the renderer's CSS-style
- * (N-1)*ls width. Without the bridge fix the bbox is short by exactly
- * one letterSpacing. */
+/* Bridge adds a trailing letterSpacing to compensate Clay's -1 at line 1677. */
 static void test_measure_callback_letter_spacing_matches_render_width(void) {
     uint8_t *blob = NULL;
     nt_font_t font = make_resolved_test_font("measure_cb_ls", &blob);
@@ -291,14 +266,13 @@ static void test_measure_callback_letter_spacing_matches_render_width(void) {
     TEST_ASSERT_NOT_NULL(ctx);
     nt_ui_set_font(ctx, 0U, font);
 
-    /* CSS-style render width is exactly what nt_font_measure_n returns. */
     nt_text_size_t expected = nt_font_measure_n(font, "ABC", 3U, 14.0F, 5.0F);
     TEST_ASSERT_FALSE(float_is_zero_bits(expected.width));
 
     Clay_BoundingBox bb = declare_and_measure_text_ls(ctx, "ABC", 0U, 14U, 5U);
 
-    /* Clay quantizes layout to int pixels in some paths; allow 1 px tolerance.
-     * Without the bridge fix this would be off by exactly letterSpacing=5. */
+    /* ±1px tolerance for Clay's int quantization. Without the bridge fix the
+     * bbox would be short by exactly letterSpacing=5. */
     const int32_t exp_w = (int32_t)expected.width;
     const int32_t got_w = (int32_t)bb.width;
     const int32_t diff_w = (got_w > exp_w) ? (got_w - exp_w) : (exp_w - got_w);
@@ -310,12 +284,7 @@ static void test_measure_callback_letter_spacing_matches_render_width(void) {
     free(blob);
 }
 
-/* with no font slot populated the callback returns {0,0} via the
- * nt_font_valid early-return path -- proves the guard branch fires before
- * the (would-be-crashing) nt_font_measure_n call. */
-/* fontId >= NT_UI_MAX_FONTS is a contract violation in CLAY_TEXT_CONFIG --
- * measure_cb asserts symmetrically with emit_text. Destroy skipped for the
- * same reason as test_measure_callback_unbound_font_asserts above. */
+/* fontId >= NT_UI_MAX_FONTS in CLAY_TEXT_CONFIG asserts in measure_cb. */
 static void test_measure_callback_out_of_range_font_asserts(void) {
     nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(ctx);

--- a/tests/unit/test_nt_ui_measure_cb.c
+++ b/tests/unit/test_nt_ui_measure_cb.c
@@ -43,7 +43,7 @@
 /* clang-format on */
 
 /* 8-byte aligned static arena via uint64_t backing array. */
-static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8U];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
 
 /* Virtual pack id counter to keep registrations unique across tests. */
 static uint32_t s_vpack_counter;

--- a/tests/unit/test_nt_ui_measure_cb.c
+++ b/tests/unit/test_nt_ui_measure_cb.c
@@ -27,7 +27,7 @@
 /* clang-format on */
 
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_TEST_ARENA_SIZE];
-static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT, .max_scissor_depth = NT_UI_WALKER_MAX_SCISSOR_DEPTH};
+static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT};
 
 /* Per-test counter so virtual-pack ids stay unique across the binary. */
 static uint32_t s_vpack_counter;

--- a/tests/unit/test_nt_ui_measure_cb.c
+++ b/tests/unit/test_nt_ui_measure_cb.c
@@ -1,28 +1,296 @@
-/* tests/unit/test_nt_ui_measure_cb.c — Plan 52-00 stub
+/* tests/unit/test_nt_ui_measure_cb.c -- Plan 52-03
  *
- * Covers CLAY-03 (Clay_SetMeasureTextFunction → nt_font_measure_n). Wave 0
- * ships TEST_IGNORE bodies; Plan 52-03 fills with real assertions.
+ * Covers CLAY-03 / D-52-14: Clay_SetMeasureTextFunction is wired at
+ * module init, and the callback forwards to nt_font_measure_n via the
+ * per-context font registry. Edge contracts (invalid ctx, out-of-range
+ * fontId, invalid font handle) return zero dimensions without crashing.
+ *
+ * Verification strategy: declare a CLAY_TEXT element inside nt_ui_begin /
+ * nt_ui_end and inspect the resulting TEXT render command's bounding box
+ * after Clay_EndLayout. Clay drives the measure callback during the
+ * EndLayout layout pass; the box width/height reflect what the callback
+ * returned.
+ *
+ * Unity's TEST_ASSERT_*_FLOAT macros are compiled out via UNITY_EXCLUDE_
+ * FLOAT (matches the v1.7 test_stats / Phase 51 test_font precedent).
+ * Float comparisons go through TEST_ASSERT_EQUAL_MEMORY on bit-stable
+ * struct copies, or through integer truncation when only a "non-zero"
+ * gate is needed.
  */
 
+/* System headers before Unity to avoid noreturn / __declspec conflict on MSVC */
+#include <setjmp.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
+/* clang-format off */
+#include "clay.h"
+#include "core/nt_assert.h"
+#include "font/nt_font.h"
+#include "graphics/nt_gfx.h"
+#include "hash/nt_hash.h"
+#include "input/nt_input.h"
+#include "nt_font_format.h"
+#include "nt_pack_format.h"
+#include "resource/nt_resource.h"
+#include "ui/nt_ui.h"
+#include "ui/nt_ui_internal.h"
 #include "unity.h"
+/* clang-format on */
 
-void setUp(void) {}
-void tearDown(void) {}
+/* 8-byte aligned static arena via uint64_t backing array. */
+static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
 
-/* CLAY-03: measure callback wired at module init; verified via direct invocation
- * or through Clay's measure-function-registered state. */
-static void test_measure_callback_wired(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-03"); }
+/* Virtual pack id counter to keep registrations unique across tests. */
+static uint32_t s_vpack_counter;
 
-/* CLAY-03: callback forwards Clay_StringSlice (chars+length) to nt_font_measure_n
- * with proper font_id → nt_font_t resolution. */
-static void test_measure_callback_forwards_to_font_measure_n(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-03"); }
+/* ---- Test font blob builder (mirrors test_font.c with 3 glyphs A/B/C) ---- */
+
+static uint8_t *build_test_font_blob(uint32_t *out_size) {
+    /* 1 contour with 2 line segments per glyph = 18 bytes per glyph. */
+    const uint32_t contour_size = 18u;
+    const uint32_t header_size = (uint32_t)sizeof(NtFontAssetHeader);
+    const uint32_t glyphs_size = 3u * (uint32_t)sizeof(NtFontGlyphEntry);
+    const uint32_t total_size = header_size + glyphs_size + (3u * contour_size);
+
+    uint8_t *blob = (uint8_t *)calloc(total_size, 1u);
+    NT_ASSERT(blob);
+
+    NtFontAssetHeader hdr;
+    memset(&hdr, 0, sizeof hdr);
+    hdr.magic = NT_FONT_MAGIC;
+    hdr.version = NT_FONT_VERSION;
+    hdr.glyph_count = 3;
+    hdr.units_per_em = 1000;
+    hdr.ascent = 800;
+    hdr.descent = -200;
+    hdr.line_gap = 0;
+    memcpy(blob, &hdr, sizeof hdr);
+
+    const uint32_t data_base = header_size + glyphs_size;
+    const uint32_t cp[3] = {'A', 'B', 'C'};
+    for (int g = 0; g < 3; ++g) {
+        NtFontGlyphEntry e;
+        memset(&e, 0, sizeof e);
+        e.codepoint = cp[g];
+        e.data_offset = data_base + ((uint32_t)g * contour_size);
+        e.advance = 500;
+        e.bbox_x0 = 0;
+        e.bbox_y0 = -200;
+        e.bbox_x1 = 400;
+        e.bbox_y1 = 800;
+        e.curve_count = 2;
+        e.kern_count = 0;
+        memcpy(blob + header_size + ((size_t)g * sizeof(NtFontGlyphEntry)), &e, sizeof e);
+    }
+
+    for (int g = 0; g < 3; ++g) {
+        uint8_t *wp = blob + data_base + ((size_t)g * contour_size);
+        uint16_t cc = 1u, sc = 2u;
+        memcpy(wp, &cc, 2);
+        wp += 2;
+        memcpy(wp, &sc, 2);
+        wp += 2;
+        int16_t sx = 0, sy = 0;
+        memcpy(wp, &sx, 2);
+        wp += 2;
+        memcpy(wp, &sy, 2);
+        wp += 2;
+        wp[0] = 0;
+        wp[1] = 0;
+        wp += 2;
+        int16_t d1x = 400, d1y = 0;
+        memcpy(wp, &d1x, 2);
+        wp += 2;
+        memcpy(wp, &d1y, 2);
+        wp += 2;
+        int16_t d2x = 0, d2y = 800;
+        memcpy(wp, &d2x, 2);
+        wp += 2;
+        memcpy(wp, &d2y, 2);
+    }
+
+    *out_size = total_size;
+    return blob;
+}
+
+static nt_resource_t register_font_resource(const char *name, const uint8_t *blob, uint32_t blob_size) {
+    uint32_t data_handle = nt_font_test_register_data(blob, blob_size);
+
+    char pack_name[64];
+    (void)snprintf(pack_name, sizeof pack_name, "fp_%s_%u", name, s_vpack_counter++);
+    nt_hash32_t pid = nt_hash32_str(pack_name);
+    nt_hash64_t rid = nt_hash64_str(name);
+    nt_resource_create_pack(pid, 0);
+    nt_resource_register(pid, rid, NT_ASSET_FONT, data_handle);
+    return nt_resource_request(rid, NT_ASSET_FONT);
+}
+
+static nt_font_t make_resolved_test_font(const char *name, uint8_t **out_blob) {
+    nt_font_create_desc_t fd = {
+        .curve_texture_width = 64,
+        .curve_texture_height = 64,
+        .band_texture_height = 16,
+        .band_count = 4,
+        .measure_cache_size = 256,
+    };
+    nt_font_t font = nt_font_create(&fd);
+
+    uint32_t blob_size = 0;
+    uint8_t *blob = build_test_font_blob(&blob_size);
+    nt_resource_t res = register_font_resource(name, blob, blob_size);
+    nt_font_add(font, res);
+    nt_resource_step();
+    nt_font_step();
+
+    *out_blob = blob;
+    return font;
+}
+
+/* ---- Unity setUp / tearDown ---- */
+
+void setUp(void) {
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_pipelines = 4, .max_buffers = 8, .max_textures = 32, .max_meshes = 8});
+    nt_hash_init(&(nt_hash_desc_t){0});
+    nt_resource_init(&(nt_resource_desc_t){0});
+    nt_font_init(&(nt_font_desc_t){.max_fonts = 4});
+    s_vpack_counter = 0;
+}
+
+void tearDown(void) {
+    nt_font_shutdown();
+    nt_resource_shutdown();
+    nt_hash_shutdown();
+    nt_gfx_shutdown();
+}
+
+/* ---- Helpers ---- */
+
+/* Bit-exact "is this float zero?" test (handles +0/-0 identically with the
+ * uint32 bit cast: -0.0f bit pattern is 0x80000000, +0.0f is 0x00000000.
+ * We only emit non-negative widths/heights from the callback, so either
+ * pattern would actually be diagnostic of "zero". For simplicity we accept
+ * both. */
+static bool float_is_zero_bits(float f) {
+    uint32_t b;
+    memcpy(&b, &f, sizeof b);
+    return (b == 0u) || (b == 0x80000000u);
+}
+
+/* Drive Clay through a one-element CLAY_TEXT declaration and return the
+ * resulting TEXT render command bounding box. Bounding box {0,0,0,0} if
+ * no TEXT command was emitted (e.g. element culled or measure returned 0). */
+static Clay_BoundingBox declare_and_measure_text(nt_ui_context_t *ctx, const char *utf8, uint16_t font_id, uint16_t font_size) {
+    nt_pointer_t mouse;
+    memset(&mouse, 0, sizeof mouse);
+
+    nt_ui_begin(ctx, 800.0f, 600.0f, &mouse);
+
+    /* Build a Clay_String wrapper from the literal. CLAY_TEXT's first arg
+     * is a Clay_String value (not a pointer). */
+    Clay_String s = {.length = (int32_t)strlen(utf8), .chars = utf8};
+    CLAY_TEXT(s, CLAY_TEXT_CONFIG({.fontId = font_id, .fontSize = font_size}));
+    nt_ui_end(ctx);
+
+    Clay_BoundingBox empty = {0};
+    for (int32_t i = 0; i < ctx->frozen_cmds.length; ++i) {
+        Clay_RenderCommand *c = &ctx->frozen_cmds.internalArray[i];
+        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_TEXT) {
+            return c->boundingBox;
+        }
+    }
+    return empty;
+}
+
+/* ---- Tests ---- */
+
+/* CLAY-03: Clay_SetMeasureTextFunction is wired during nt_ui_create_context.
+ * Covariance check: with no font registered the callback returns {0,0} via
+ * the nt_font_valid branch. The fact that Clay_EndLayout completes without
+ * firing CLAY_ERROR_TYPE_TEXT_MEASUREMENT_FUNCTION_NOT_PROVIDED is itself
+ * evidence that the measure callback is wired. */
+static void test_measure_callback_wired(void) {
+    nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena);
+    TEST_ASSERT_NOT_NULL(ctx);
+
+    /* No font set at slot 0 -> callback should hit the nt_font_valid early
+     * return and produce a 0-width TEXT command bounding box (or no TEXT
+     * command at all, depending on Clay's culling). */
+    Clay_BoundingBox bb = declare_and_measure_text(ctx, "ABC", 0u, 14u);
+    TEST_ASSERT_TRUE(float_is_zero_bits(bb.width));
+    TEST_ASSERT_TRUE(float_is_zero_bits(bb.height));
+
+    nt_ui_destroy_context(ctx);
+}
+
+/* CLAY-03: callback forwards Clay_StringSlice -> nt_font_measure_n with
+ * proper font_id resolution. Compares the TEXT command bounding box
+ * against an independent direct nt_font_measure_n call. */
+static void test_measure_callback_forwards_to_font_measure_n(void) {
+    uint8_t *blob = NULL;
+    nt_font_t font = make_resolved_test_font("measure_cb_forward", &blob);
+    TEST_ASSERT_TRUE(nt_font_valid(font));
+
+    nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena);
+    TEST_ASSERT_NOT_NULL(ctx);
+    nt_ui_set_font(ctx, 0u, font);
+
+    /* Independent ground truth: invoke the exact same measure path the
+     * callback takes (with the size cast to float matching uint16_t->float). */
+    nt_text_size_t expected = nt_font_measure_n(font, "ABC", 3u, 14.0f);
+    /* Sanity: the resolved test font must produce positive dimensions for
+     * a 3-glyph "ABC" measurement. If this fails the test_font setup is
+     * broken, not the callback. */
+    TEST_ASSERT_FALSE(float_is_zero_bits(expected.width));
+    TEST_ASSERT_FALSE(float_is_zero_bits(expected.height));
+
+    Clay_BoundingBox bb = declare_and_measure_text(ctx, "ABC", 0u, 14u);
+
+    /* Clay can round/quantize the bbox slightly during layout; compare
+     * via integer truncation with a 1 px tolerance window. The truncation
+     * keeps the comparison free of UNITY_EXCLUDE_FLOAT macros. */
+    const int32_t exp_w = (int32_t)expected.width;
+    const int32_t exp_h = (int32_t)expected.height;
+    const int32_t got_w = (int32_t)bb.width;
+    const int32_t got_h = (int32_t)bb.height;
+    const int32_t diff_w = (got_w > exp_w) ? (got_w - exp_w) : (exp_w - got_w);
+    const int32_t diff_h = (got_h > exp_h) ? (got_h - exp_h) : (exp_h - got_h);
+    TEST_ASSERT_LESS_OR_EQUAL_INT32(1, diff_w);
+    TEST_ASSERT_LESS_OR_EQUAL_INT32(1, diff_h);
+    /* And that we did get a positive measurement back -- if Clay culled
+     * the element or the callback returned {0,0} unexpectedly, both
+     * dimensions would be zero. */
+    TEST_ASSERT_GREATER_THAN_INT32(0, got_w);
+    TEST_ASSERT_GREATER_THAN_INT32(0, got_h);
+
+    nt_ui_destroy_context(ctx);
+    nt_font_destroy(font);
+    free(blob);
+}
+
+/* CLAY-03: with no font slot populated the callback returns {0,0} via the
+ * nt_font_valid early-return path -- proves the guard branch fires before
+ * the (would-be-crashing) nt_font_measure_n call. */
+static void test_measure_callback_invalid_font_returns_zero(void) {
+    nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena);
+    TEST_ASSERT_NOT_NULL(ctx);
+    /* Deliberately leave ctx->fonts[0] = NT_FONT_INVALID (zeroed by create). */
+
+    Clay_BoundingBox bb = declare_and_measure_text(ctx, "ABC", 0u, 14u);
+    TEST_ASSERT_TRUE(float_is_zero_bits(bb.width));
+    TEST_ASSERT_TRUE(float_is_zero_bits(bb.height));
+
+    nt_ui_destroy_context(ctx);
+}
 
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_measure_callback_wired);
     RUN_TEST(test_measure_callback_forwards_to_font_measure_n);
+    RUN_TEST(test_measure_callback_invalid_font_returns_zero);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_measure_cb.c
+++ b/tests/unit/test_nt_ui_measure_cb.c
@@ -43,7 +43,7 @@
 /* clang-format on */
 
 /* 8-byte aligned static arena via uint64_t backing array. */
-static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8U];
 
 /* Virtual pack id counter to keep registrations unique across tests. */
 static uint32_t s_vpack_counter;
@@ -52,12 +52,12 @@ static uint32_t s_vpack_counter;
 
 static uint8_t *build_test_font_blob(uint32_t *out_size) {
     /* 1 contour with 2 line segments per glyph = 18 bytes per glyph. */
-    const uint32_t contour_size = 18u;
+    const uint32_t contour_size = 18U;
     const uint32_t header_size = (uint32_t)sizeof(NtFontAssetHeader);
-    const uint32_t glyphs_size = 3u * (uint32_t)sizeof(NtFontGlyphEntry);
-    const uint32_t total_size = header_size + glyphs_size + (3u * contour_size);
+    const uint32_t glyphs_size = 3U * (uint32_t)sizeof(NtFontGlyphEntry);
+    const uint32_t total_size = header_size + glyphs_size + (3U * contour_size);
 
-    uint8_t *blob = (uint8_t *)calloc(total_size, 1u);
+    uint8_t *blob = (uint8_t *)calloc(total_size, 1U);
     NT_ASSERT(blob);
 
     NtFontAssetHeader hdr;
@@ -90,12 +90,14 @@ static uint8_t *build_test_font_blob(uint32_t *out_size) {
 
     for (int g = 0; g < 3; ++g) {
         uint8_t *wp = blob + data_base + ((size_t)g * contour_size);
-        uint16_t cc = 1u, sc = 2u;
+        uint16_t cc = 1U;
+        uint16_t sc = 2U;
         memcpy(wp, &cc, 2);
         wp += 2;
         memcpy(wp, &sc, 2);
         wp += 2;
-        int16_t sx = 0, sy = 0;
+        int16_t sx = 0;
+        int16_t sy = 0;
         memcpy(wp, &sx, 2);
         wp += 2;
         memcpy(wp, &sy, 2);
@@ -103,12 +105,14 @@ static uint8_t *build_test_font_blob(uint32_t *out_size) {
         wp[0] = 0;
         wp[1] = 0;
         wp += 2;
-        int16_t d1x = 400, d1y = 0;
+        int16_t d1x = 400;
+        int16_t d1y = 0;
         memcpy(wp, &d1x, 2);
         wp += 2;
         memcpy(wp, &d1y, 2);
         wp += 2;
-        int16_t d2x = 0, d2y = 800;
+        int16_t d2x = 0;
+        int16_t d2y = 800;
         memcpy(wp, &d2x, 2);
         wp += 2;
         memcpy(wp, &d2y, 2);
@@ -178,7 +182,7 @@ void tearDown(void) {
 static bool float_is_zero_bits(float f) {
     uint32_t b;
     memcpy(&b, &f, sizeof b);
-    return (b == 0u) || (b == 0x80000000u);
+    return (b == 0U) || (b == 0x80000000U);
 }
 
 /* Drive Clay through a one-element CLAY_TEXT declaration and return the
@@ -188,7 +192,7 @@ static Clay_BoundingBox declare_and_measure_text(nt_ui_context_t *ctx, const cha
     nt_pointer_t mouse;
     memset(&mouse, 0, sizeof mouse);
 
-    nt_ui_begin(ctx, 800.0f, 600.0f, &mouse);
+    nt_ui_begin(ctx, 800.0F, 600.0F, &mouse);
 
     /* Build a Clay_String wrapper from the literal. CLAY_TEXT's first arg
      * is a Clay_String value (not a pointer). */
@@ -220,7 +224,7 @@ static void test_measure_callback_wired(void) {
     /* No font set at slot 0 -> callback should hit the nt_font_valid early
      * return and produce a 0-width TEXT command bounding box (or no TEXT
      * command at all, depending on Clay's culling). */
-    Clay_BoundingBox bb = declare_and_measure_text(ctx, "ABC", 0u, 14u);
+    Clay_BoundingBox bb = declare_and_measure_text(ctx, "ABC", 0U, 14U);
     TEST_ASSERT_TRUE(float_is_zero_bits(bb.width));
     TEST_ASSERT_TRUE(float_is_zero_bits(bb.height));
 
@@ -237,18 +241,18 @@ static void test_measure_callback_forwards_to_font_measure_n(void) {
 
     nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena);
     TEST_ASSERT_NOT_NULL(ctx);
-    nt_ui_set_font(ctx, 0u, font);
+    nt_ui_set_font(ctx, 0U, font);
 
     /* Independent ground truth: invoke the exact same measure path the
      * callback takes (with the size cast to float matching uint16_t->float). */
-    nt_text_size_t expected = nt_font_measure_n(font, "ABC", 3u, 14.0f);
+    nt_text_size_t expected = nt_font_measure_n(font, "ABC", 3U, 14.0F);
     /* Sanity: the resolved test font must produce positive dimensions for
      * a 3-glyph "ABC" measurement. If this fails the test_font setup is
      * broken, not the callback. */
     TEST_ASSERT_FALSE(float_is_zero_bits(expected.width));
     TEST_ASSERT_FALSE(float_is_zero_bits(expected.height));
 
-    Clay_BoundingBox bb = declare_and_measure_text(ctx, "ABC", 0u, 14u);
+    Clay_BoundingBox bb = declare_and_measure_text(ctx, "ABC", 0U, 14U);
 
     /* Clay can round/quantize the bbox slightly during layout; compare
      * via integer truncation with a 1 px tolerance window. The truncation
@@ -280,7 +284,7 @@ static void test_measure_callback_invalid_font_returns_zero(void) {
     TEST_ASSERT_NOT_NULL(ctx);
     /* Deliberately leave ctx->fonts[0] = NT_FONT_INVALID (zeroed by create). */
 
-    Clay_BoundingBox bb = declare_and_measure_text(ctx, "ABC", 0u, 14u);
+    Clay_BoundingBox bb = declare_and_measure_text(ctx, "ABC", 0U, 14U);
     TEST_ASSERT_TRUE(float_is_zero_bits(bb.width));
     TEST_ASSERT_TRUE(float_is_zero_bits(bb.height));
 

--- a/tests/unit/test_nt_ui_multictx.c
+++ b/tests/unit/test_nt_ui_multictx.c
@@ -1,12 +1,9 @@
-/* tests/unit/test_nt_ui_multictx.c -- Plan 52-02
- *
- * Covers UI-03 (multiple contexts coexist; per-ctx Clay context
- * isolation) and the multi-context invariant D-52-12.
- */
-
+/* System headers before Unity -- avoids __declspec(noreturn) clash on MSVC. */
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "clay.h"
@@ -16,7 +13,6 @@
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-/* Three independently sized arenas (8 MiB each, 8-aligned via uint64_t). */
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_a[NT_UI_DEFAULT_ARENA_SIZE];
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_b[NT_UI_DEFAULT_ARENA_SIZE];
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_c[NT_UI_DEFAULT_ARENA_SIZE];
@@ -24,9 +20,9 @@ alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_c[NT_UI_DEFAULT_ARENA_SIZE];
 void setUp(void) { nt_test_assert_install(); }
 void tearDown(void) {}
 
-/* UI-03 + D-52-14: three contexts coexist; nt_ui_begin makes
- * Clay_GetCurrentContext match ctx->clay; after end the in-frame
- * tracker is cleared. */
+/* Three contexts coexist; begin/end pairs interleave correctly with
+ * Clay_GetCurrentContext switching per ctx and the in-frame tracker
+ * clearing on each end. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void test_three_ctx_interleave(void) {
     nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a);
@@ -69,7 +65,7 @@ static void test_three_ctx_interleave(void) {
     nt_ui_destroy_context(c);
 }
 
-/* UI-03: per-ctx in_frame isolation across sequential begin/end. */
+/* Per-ctx in_frame isolation across sequential begin/end. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void test_per_ctx_in_frame_isolation(void) {
     nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a);

--- a/tests/unit/test_nt_ui_multictx.c
+++ b/tests/unit/test_nt_ui_multictx.c
@@ -16,18 +16,22 @@
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_a[NT_UI_DEFAULT_ARENA_SIZE];
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_b[NT_UI_DEFAULT_ARENA_SIZE];
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_c[NT_UI_DEFAULT_ARENA_SIZE];
+static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT};
 
-void setUp(void) { nt_test_assert_install(); }
-void tearDown(void) {}
+void setUp(void) {
+    nt_test_assert_install();
+    nt_ui_module_init();
+}
+void tearDown(void) { nt_ui_module_shutdown(); }
 
 /* Three contexts coexist; begin/end pairs interleave correctly with
  * Clay_GetCurrentContext switching per ctx and the in-frame tracker
  * clearing on each end. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void test_three_ctx_interleave(void) {
-    nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a);
-    nt_ui_context_t *b = nt_ui_create_context(s_arena_b, sizeof s_arena_b);
-    nt_ui_context_t *c = nt_ui_create_context(s_arena_c, sizeof s_arena_c);
+    nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a, &s_ui_desc);
+    nt_ui_context_t *b = nt_ui_create_context(s_arena_b, sizeof s_arena_b, &s_ui_desc);
+    nt_ui_context_t *c = nt_ui_create_context(s_arena_c, sizeof s_arena_c, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(a);
     TEST_ASSERT_NOT_NULL(b);
     TEST_ASSERT_NOT_NULL(c);
@@ -68,8 +72,8 @@ static void test_three_ctx_interleave(void) {
 /* Per-ctx in_frame isolation across sequential begin/end. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void test_per_ctx_in_frame_isolation(void) {
-    nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a);
-    nt_ui_context_t *b = nt_ui_create_context(s_arena_b, sizeof s_arena_b);
+    nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a, &s_ui_desc);
+    nt_ui_context_t *b = nt_ui_create_context(s_arena_b, sizeof s_arena_b, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(a);
     TEST_ASSERT_NOT_NULL(b);
 

--- a/tests/unit/test_nt_ui_multictx.c
+++ b/tests/unit/test_nt_ui_multictx.c
@@ -9,13 +9,14 @@
 #include "clay.h"
 #include "input/nt_input.h"
 #include "test_helpers/nt_assert_trap.h"
+#include "test_helpers/ui_test_arena.h"
 #include "ui/nt_ui.h"
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_a[NT_UI_DEFAULT_ARENA_SIZE];
-alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_b[NT_UI_DEFAULT_ARENA_SIZE];
-alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_c[NT_UI_DEFAULT_ARENA_SIZE];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_a[NT_UI_TEST_ARENA_SIZE];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_b[NT_UI_TEST_ARENA_SIZE];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_c[NT_UI_TEST_ARENA_SIZE];
 static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT, .max_scissor_depth = NT_UI_WALKER_MAX_SCISSOR_DEPTH};
 
 void setUp(void) {

--- a/tests/unit/test_nt_ui_multictx.c
+++ b/tests/unit/test_nt_ui_multictx.c
@@ -1,22 +1,106 @@
-/* tests/unit/test_nt_ui_multictx.c — Plan 52-00 stub
+/* tests/unit/test_nt_ui_multictx.c -- Plan 52-02
  *
- * Covers UI-03 (3-context interleave + Clay_SetCurrentContext invariant). Wave
- * 0 ships TEST_IGNORE bodies; Plan 52-02 fills with real assertions.
+ * Covers UI-03 (multiple contexts coexist; per-ctx Clay context
+ * isolation) and the multi-context invariant D-52-12.
  */
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
+#include "clay.h"
+#include "input/nt_input.h"
+#include "test_helpers/nt_assert_trap.h"
+#include "ui/nt_ui.h"
+#include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-void setUp(void) {}
+/* Three independently sized arenas (8 MiB each, 8-aligned via uint64_t). */
+static uint64_t s_arena_a[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+static uint64_t s_arena_b[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+static uint64_t s_arena_c[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+
+void setUp(void) { nt_test_assert_install(); }
 void tearDown(void) {}
 
-/* UI-03: 3-ctx sequential interleave — Clay_GetCurrentContext switches per begin/end */
-static void test_three_ctx_interleave(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-02"); }
+/* UI-03 + D-52-14: three contexts coexist; nt_ui_begin makes
+ * Clay_GetCurrentContext match ctx->clay; after end the in-frame
+ * tracker is cleared. */
+static void test_three_ctx_interleave(void) {
+    nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a);
+    nt_ui_context_t *b = nt_ui_create_context(s_arena_b, sizeof s_arena_b);
+    nt_ui_context_t *c = nt_ui_create_context(s_arena_c, sizeof s_arena_c);
+    TEST_ASSERT_NOT_NULL(a);
+    TEST_ASSERT_NOT_NULL(b);
+    TEST_ASSERT_NOT_NULL(c);
+    /* Each ctx has its own Clay context pointer. */
+    TEST_ASSERT_NOT_EQUAL(a->clay, b->clay);
+    TEST_ASSERT_NOT_EQUAL(b->clay, c->clay);
+    TEST_ASSERT_NOT_EQUAL(a->clay, c->clay);
 
-/* UI-03: per-ctx in_frame flag isolated (begin c1 / end c1 / begin c2 / end c2) */
-static void test_per_ctx_in_frame_isolation(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-02"); }
+    nt_pointer_t mouse;
+    memset(&mouse, 0, sizeof mouse);
+
+    /* a: begin sets Clay current to a->clay; in-frame ctx is a. */
+    nt_ui_begin(a, 100.0f, 100.0f, &mouse);
+    TEST_ASSERT_EQUAL_PTR(a->clay, Clay_GetCurrentContext());
+    TEST_ASSERT_EQUAL_PTR(a, nt_ui_test_inframe_ctx());
+    nt_ui_end(a);
+    TEST_ASSERT_NULL(nt_ui_test_inframe_ctx());
+
+    /* b: same shape, different ctx. */
+    nt_ui_begin(b, 200.0f, 200.0f, &mouse);
+    TEST_ASSERT_EQUAL_PTR(b->clay, Clay_GetCurrentContext());
+    TEST_ASSERT_EQUAL_PTR(b, nt_ui_test_inframe_ctx());
+    nt_ui_end(b);
+    TEST_ASSERT_NULL(nt_ui_test_inframe_ctx());
+
+    /* c: same shape, different ctx. */
+    nt_ui_begin(c, 300.0f, 300.0f, &mouse);
+    TEST_ASSERT_EQUAL_PTR(c->clay, Clay_GetCurrentContext());
+    TEST_ASSERT_EQUAL_PTR(c, nt_ui_test_inframe_ctx());
+    nt_ui_end(c);
+    TEST_ASSERT_NULL(nt_ui_test_inframe_ctx());
+
+    nt_ui_destroy_context(a);
+    nt_ui_destroy_context(b);
+    nt_ui_destroy_context(c);
+}
+
+/* UI-03: per-ctx in_frame isolation across sequential begin/end. */
+static void test_per_ctx_in_frame_isolation(void) {
+    nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a);
+    nt_ui_context_t *b = nt_ui_create_context(s_arena_b, sizeof s_arena_b);
+    TEST_ASSERT_NOT_NULL(a);
+    TEST_ASSERT_NOT_NULL(b);
+
+    nt_pointer_t mouse;
+    memset(&mouse, 0, sizeof mouse);
+
+    /* Before any begin: no in-frame ctx, neither ctx is in_frame. */
+    TEST_ASSERT_NULL(nt_ui_test_inframe_ctx());
+    TEST_ASSERT_FALSE(a->in_frame);
+    TEST_ASSERT_FALSE(b->in_frame);
+
+    nt_ui_begin(a, 100.0f, 100.0f, &mouse);
+    TEST_ASSERT_TRUE(a->in_frame);
+    TEST_ASSERT_FALSE(b->in_frame); /* B is NOT marked in-frame */
+    TEST_ASSERT_EQUAL_PTR(a, nt_ui_test_inframe_ctx());
+    nt_ui_end(a);
+    TEST_ASSERT_FALSE(a->in_frame);
+
+    nt_ui_begin(b, 100.0f, 100.0f, &mouse);
+    TEST_ASSERT_FALSE(a->in_frame);
+    TEST_ASSERT_TRUE(b->in_frame);
+    TEST_ASSERT_EQUAL_PTR(b, nt_ui_test_inframe_ctx());
+    nt_ui_end(b);
+
+    TEST_ASSERT_NULL(nt_ui_test_inframe_ctx());
+
+    nt_ui_destroy_context(a);
+    nt_ui_destroy_context(b);
+}
 
 int main(void) {
     UNITY_BEGIN();

--- a/tests/unit/test_nt_ui_multictx.c
+++ b/tests/unit/test_nt_ui_multictx.c
@@ -17,9 +17,9 @@
 #include "unity.h"
 
 /* Three independently sized arenas (8 MiB each, 8-aligned via uint64_t). */
-static uint64_t s_arena_a[NT_UI_DEFAULT_ARENA_SIZE / 8U];
-static uint64_t s_arena_b[NT_UI_DEFAULT_ARENA_SIZE / 8U];
-static uint64_t s_arena_c[NT_UI_DEFAULT_ARENA_SIZE / 8U];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_a[NT_UI_DEFAULT_ARENA_SIZE];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_b[NT_UI_DEFAULT_ARENA_SIZE];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_c[NT_UI_DEFAULT_ARENA_SIZE];
 
 void setUp(void) { nt_test_assert_install(); }
 void tearDown(void) {}

--- a/tests/unit/test_nt_ui_multictx.c
+++ b/tests/unit/test_nt_ui_multictx.c
@@ -17,9 +17,9 @@
 #include "unity.h"
 
 /* Three independently sized arenas (8 MiB each, 8-aligned via uint64_t). */
-static uint64_t s_arena_a[NT_UI_DEFAULT_ARENA_SIZE / 8u];
-static uint64_t s_arena_b[NT_UI_DEFAULT_ARENA_SIZE / 8u];
-static uint64_t s_arena_c[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+static uint64_t s_arena_a[NT_UI_DEFAULT_ARENA_SIZE / 8U];
+static uint64_t s_arena_b[NT_UI_DEFAULT_ARENA_SIZE / 8U];
+static uint64_t s_arena_c[NT_UI_DEFAULT_ARENA_SIZE / 8U];
 
 void setUp(void) { nt_test_assert_install(); }
 void tearDown(void) {}
@@ -27,6 +27,7 @@ void tearDown(void) {}
 /* UI-03 + D-52-14: three contexts coexist; nt_ui_begin makes
  * Clay_GetCurrentContext match ctx->clay; after end the in-frame
  * tracker is cleared. */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void test_three_ctx_interleave(void) {
     nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a);
     nt_ui_context_t *b = nt_ui_create_context(s_arena_b, sizeof s_arena_b);
@@ -43,21 +44,21 @@ static void test_three_ctx_interleave(void) {
     memset(&mouse, 0, sizeof mouse);
 
     /* a: begin sets Clay current to a->clay; in-frame ctx is a. */
-    nt_ui_begin(a, 100.0f, 100.0f, &mouse);
+    nt_ui_begin(a, 100.0F, 100.0F, &mouse);
     TEST_ASSERT_EQUAL_PTR(a->clay, Clay_GetCurrentContext());
     TEST_ASSERT_EQUAL_PTR(a, nt_ui_test_inframe_ctx());
     nt_ui_end(a);
     TEST_ASSERT_NULL(nt_ui_test_inframe_ctx());
 
     /* b: same shape, different ctx. */
-    nt_ui_begin(b, 200.0f, 200.0f, &mouse);
+    nt_ui_begin(b, 200.0F, 200.0F, &mouse);
     TEST_ASSERT_EQUAL_PTR(b->clay, Clay_GetCurrentContext());
     TEST_ASSERT_EQUAL_PTR(b, nt_ui_test_inframe_ctx());
     nt_ui_end(b);
     TEST_ASSERT_NULL(nt_ui_test_inframe_ctx());
 
     /* c: same shape, different ctx. */
-    nt_ui_begin(c, 300.0f, 300.0f, &mouse);
+    nt_ui_begin(c, 300.0F, 300.0F, &mouse);
     TEST_ASSERT_EQUAL_PTR(c->clay, Clay_GetCurrentContext());
     TEST_ASSERT_EQUAL_PTR(c, nt_ui_test_inframe_ctx());
     nt_ui_end(c);
@@ -69,6 +70,7 @@ static void test_three_ctx_interleave(void) {
 }
 
 /* UI-03: per-ctx in_frame isolation across sequential begin/end. */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void test_per_ctx_in_frame_isolation(void) {
     nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a);
     nt_ui_context_t *b = nt_ui_create_context(s_arena_b, sizeof s_arena_b);
@@ -83,14 +85,14 @@ static void test_per_ctx_in_frame_isolation(void) {
     TEST_ASSERT_FALSE(a->in_frame);
     TEST_ASSERT_FALSE(b->in_frame);
 
-    nt_ui_begin(a, 100.0f, 100.0f, &mouse);
+    nt_ui_begin(a, 100.0F, 100.0F, &mouse);
     TEST_ASSERT_TRUE(a->in_frame);
     TEST_ASSERT_FALSE(b->in_frame); /* B is NOT marked in-frame */
     TEST_ASSERT_EQUAL_PTR(a, nt_ui_test_inframe_ctx());
     nt_ui_end(a);
     TEST_ASSERT_FALSE(a->in_frame);
 
-    nt_ui_begin(b, 100.0f, 100.0f, &mouse);
+    nt_ui_begin(b, 100.0F, 100.0F, &mouse);
     TEST_ASSERT_FALSE(a->in_frame);
     TEST_ASSERT_TRUE(b->in_frame);
     TEST_ASSERT_EQUAL_PTR(b, nt_ui_test_inframe_ctx());

--- a/tests/unit/test_nt_ui_multictx.c
+++ b/tests/unit/test_nt_ui_multictx.c
@@ -1,0 +1,26 @@
+/* tests/unit/test_nt_ui_multictx.c — Plan 52-00 stub
+ *
+ * Covers UI-03 (3-context interleave + Clay_SetCurrentContext invariant). Wave
+ * 0 ships TEST_IGNORE bodies; Plan 52-02 fills with real assertions.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* UI-03: 3-ctx sequential interleave — Clay_GetCurrentContext switches per begin/end */
+static void test_three_ctx_interleave(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-02"); }
+
+/* UI-03: per-ctx in_frame flag isolated (begin c1 / end c1 / begin c2 / end c2) */
+static void test_per_ctx_in_frame_isolation(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-02"); }
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_three_ctx_interleave);
+    RUN_TEST(test_per_ctx_in_frame_isolation);
+    return UNITY_END();
+}

--- a/tests/unit/test_nt_ui_multictx.c
+++ b/tests/unit/test_nt_ui_multictx.c
@@ -17,7 +17,7 @@
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_a[NT_UI_TEST_ARENA_SIZE];
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_b[NT_UI_TEST_ARENA_SIZE];
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_c[NT_UI_TEST_ARENA_SIZE];
-static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT, .max_scissor_depth = NT_UI_WALKER_MAX_SCISSOR_DEPTH};
+static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT};
 
 void setUp(void) {
     nt_test_assert_install();

--- a/tests/unit/test_nt_ui_multictx.c
+++ b/tests/unit/test_nt_ui_multictx.c
@@ -16,7 +16,7 @@
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_a[NT_UI_DEFAULT_ARENA_SIZE];
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_b[NT_UI_DEFAULT_ARENA_SIZE];
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena_c[NT_UI_DEFAULT_ARENA_SIZE];
-static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT};
+static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT, .max_scissor_depth = NT_UI_WALKER_MAX_SCISSOR_DEPTH};
 
 void setUp(void) {
     nt_test_assert_install();

--- a/tests/unit/test_nt_ui_pointer_state.c
+++ b/tests/unit/test_nt_ui_pointer_state.c
@@ -48,7 +48,7 @@ static void test_pointer_state_set_from_nt_pointer(void) {
 
     nt_ui_begin(ctx, 800.0F, 600.0F, &mouse);
 
-    /* Probe Clay's pointer state via NT_UI_TEST_ACCESS getters. */
+    /* Probe Clay's pointer state via NT_TEST_ACCESS getters. */
     TEST_ASSERT_TRUE(float_eq_bits(100.0F, nt_ui_test_clay_pointer_x(ctx)));
     TEST_ASSERT_TRUE(float_eq_bits(200.0F, nt_ui_test_clay_pointer_y(ctx)));
     TEST_ASSERT_EQUAL_INT(1, nt_ui_test_clay_pointer_down(ctx));

--- a/tests/unit/test_nt_ui_pointer_state.c
+++ b/tests/unit/test_nt_ui_pointer_state.c
@@ -14,7 +14,7 @@
 /* clang-format on */
 
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_TEST_ARENA_SIZE];
-static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT, .max_scissor_depth = NT_UI_WALKER_MAX_SCISSOR_DEPTH};
+static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT};
 
 void setUp(void) {
     /* gfx pulled in transitively via nt_font/nt_resource; stub is fine. */

--- a/tests/unit/test_nt_ui_pointer_state.c
+++ b/tests/unit/test_nt_ui_pointer_state.c
@@ -13,13 +13,18 @@
 /* clang-format on */
 
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
+static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT};
 
 void setUp(void) {
     /* gfx pulled in transitively via nt_font/nt_resource; stub is fine. */
     nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 4, .max_pipelines = 4, .max_buffers = 4, .max_textures = 4, .max_meshes = 4});
+    nt_ui_module_init();
 }
 
-void tearDown(void) { nt_gfx_shutdown(); }
+void tearDown(void) {
+    nt_ui_module_shutdown();
+    nt_gfx_shutdown();
+}
 
 /* Compare two known-finite floats with integer-equivalence: the test
  * inputs (100.0f, 200.0f, 50.0f, 75.0f) are exact float representations
@@ -35,7 +40,7 @@ static bool float_eq_bits(float a, float b) {
 /* x/y are forwarded literally; is_down=true is reflected as a
  * pressed-family Clay pointer state. */
 static void test_pointer_state_set_from_nt_pointer(void) {
-    nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena);
+    nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(ctx);
 
     nt_pointer_t mouse;
@@ -58,7 +63,7 @@ static void test_pointer_state_set_from_nt_pointer(void) {
 /* is_down=false yields released-family state, position still
  * forwarded literally. */
 static void test_pointer_state_button_released(void) {
-    nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena);
+    nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(ctx);
 
     nt_pointer_t mouse;
@@ -81,7 +86,7 @@ static void test_pointer_state_button_released(void) {
  * Setting right/middle is_down=true while left is_down=false should
  * still produce a released Clay state -- only the left button matters. */
 static void test_pointer_state_only_left_button_consumed(void) {
-    nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena);
+    nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena, &s_ui_desc);
     TEST_ASSERT_NOT_NULL(ctx);
 
     nt_pointer_t mouse;

--- a/tests/unit/test_nt_ui_pointer_state.c
+++ b/tests/unit/test_nt_ui_pointer_state.c
@@ -29,7 +29,7 @@
 #include "unity.h"
 /* clang-format on */
 
-static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8U];
 
 void setUp(void) {
     /* gfx is required because the nt_ui transitive link surface pulls it
@@ -44,7 +44,8 @@ void tearDown(void) { nt_gfx_shutdown(); }
  * inputs (100.0f, 200.0f, 50.0f, 75.0f) are exact float representations
  * so the round-trip through Clay's identity-store should be bit-stable. */
 static bool float_eq_bits(float a, float b) {
-    uint32_t pa, pb;
+    uint32_t pa;
+    uint32_t pb;
     memcpy(&pa, &a, sizeof pa);
     memcpy(&pb, &b, sizeof pb);
     return pa == pb;
@@ -58,15 +59,15 @@ static void test_pointer_state_set_from_nt_pointer(void) {
 
     nt_pointer_t mouse;
     memset(&mouse, 0, sizeof mouse);
-    mouse.x = 100.0f;
-    mouse.y = 200.0f;
+    mouse.x = 100.0F;
+    mouse.y = 200.0F;
     mouse.buttons[NT_BUTTON_LEFT].is_down = true;
 
-    nt_ui_begin(ctx, 800.0f, 600.0f, &mouse);
+    nt_ui_begin(ctx, 800.0F, 600.0F, &mouse);
 
     /* Probe Clay's pointer state via NT_UI_TEST_ACCESS getters. */
-    TEST_ASSERT_TRUE(float_eq_bits(100.0f, nt_ui_test_clay_pointer_x(ctx)));
-    TEST_ASSERT_TRUE(float_eq_bits(200.0f, nt_ui_test_clay_pointer_y(ctx)));
+    TEST_ASSERT_TRUE(float_eq_bits(100.0F, nt_ui_test_clay_pointer_x(ctx)));
+    TEST_ASSERT_TRUE(float_eq_bits(200.0F, nt_ui_test_clay_pointer_y(ctx)));
     TEST_ASSERT_EQUAL_INT(1, nt_ui_test_clay_pointer_down(ctx));
 
     nt_ui_end(ctx);
@@ -81,14 +82,14 @@ static void test_pointer_state_button_released(void) {
 
     nt_pointer_t mouse;
     memset(&mouse, 0, sizeof mouse);
-    mouse.x = 50.0f;
-    mouse.y = 75.0f;
+    mouse.x = 50.0F;
+    mouse.y = 75.0F;
     mouse.buttons[NT_BUTTON_LEFT].is_down = false;
 
-    nt_ui_begin(ctx, 800.0f, 600.0f, &mouse);
+    nt_ui_begin(ctx, 800.0F, 600.0F, &mouse);
 
-    TEST_ASSERT_TRUE(float_eq_bits(50.0f, nt_ui_test_clay_pointer_x(ctx)));
-    TEST_ASSERT_TRUE(float_eq_bits(75.0f, nt_ui_test_clay_pointer_y(ctx)));
+    TEST_ASSERT_TRUE(float_eq_bits(50.0F, nt_ui_test_clay_pointer_x(ctx)));
+    TEST_ASSERT_TRUE(float_eq_bits(75.0F, nt_ui_test_clay_pointer_y(ctx)));
     TEST_ASSERT_EQUAL_INT(0, nt_ui_test_clay_pointer_down(ctx));
 
     nt_ui_end(ctx);
@@ -104,13 +105,13 @@ static void test_pointer_state_only_left_button_consumed(void) {
 
     nt_pointer_t mouse;
     memset(&mouse, 0, sizeof mouse);
-    mouse.x = 10.0f;
-    mouse.y = 20.0f;
+    mouse.x = 10.0F;
+    mouse.y = 20.0F;
     mouse.buttons[NT_BUTTON_LEFT].is_down = false;
     mouse.buttons[NT_BUTTON_RIGHT].is_down = true;
     mouse.buttons[NT_BUTTON_MIDDLE].is_down = true;
 
-    nt_ui_begin(ctx, 800.0f, 600.0f, &mouse);
+    nt_ui_begin(ctx, 800.0F, 600.0F, &mouse);
 
     TEST_ASSERT_EQUAL_INT(0, nt_ui_test_clay_pointer_down(ctx));
 

--- a/tests/unit/test_nt_ui_pointer_state.c
+++ b/tests/unit/test_nt_ui_pointer_state.c
@@ -15,9 +15,7 @@
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
 
 void setUp(void) {
-    /* gfx is required because the nt_ui transitive link surface pulls it
-     * in via nt_font/nt_resource even though pointer-state tests don't
-     * touch GPU state directly. Stub backend is fine. */
+    /* gfx pulled in transitively via nt_font/nt_resource; stub is fine. */
     nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 4, .max_pipelines = 4, .max_buffers = 4, .max_textures = 4, .max_meshes = 4});
 }
 

--- a/tests/unit/test_nt_ui_pointer_state.c
+++ b/tests/unit/test_nt_ui_pointer_state.c
@@ -1,20 +1,3 @@
-/* tests/unit/test_nt_ui_pointer_state.c -- Plan 52-03
- *
- * Covers CLAY-04 / D-52-16: nt_ui_begin forwards pointer position and
- * left-button state to Clay_SetPointerState. Right/middle buttons and
- * wheel are intentionally NOT consumed (D-52-16 left-button only).
- *
- * Verification strategy: NT_UI_TEST_ACCESS probes nt_ui_test_clay_pointer_
- * x/y/down read ctx->clay->pointerInfo from inside nt_ui.c (where Clay's
- * struct definition is in scope via CLAY_IMPLEMENTATION). Tests pump the
- * pointer through nt_ui_begin, then snapshot the Clay-side state to
- * compare against the input nt_pointer_t.
- *
- * UNITY_EXCLUDE_FLOAT is set globally for tests; float comparisons go
- * through bit-stable uint32 conversion when the inputs are integer-valued
- * floats (matches the test_font.c precedent).
- */
-
 #include <setjmp.h>
 #include <stdbool.h>
 #include <stddef.h>
@@ -51,7 +34,7 @@ static bool float_eq_bits(float a, float b) {
     return pa == pb;
 }
 
-/* CLAY-04: x/y are forwarded literally; is_down=true is reflected as a
+/* x/y are forwarded literally; is_down=true is reflected as a
  * pressed-family Clay pointer state. */
 static void test_pointer_state_set_from_nt_pointer(void) {
     nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena);
@@ -74,7 +57,7 @@ static void test_pointer_state_set_from_nt_pointer(void) {
     nt_ui_destroy_context(ctx);
 }
 
-/* CLAY-04: is_down=false yields released-family state, position still
+/* is_down=false yields released-family state, position still
  * forwarded literally. */
 static void test_pointer_state_button_released(void) {
     nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena);
@@ -96,7 +79,7 @@ static void test_pointer_state_button_released(void) {
     nt_ui_destroy_context(ctx);
 }
 
-/* CLAY-04 + D-52-16: right and middle button state are NOT forwarded.
+/* right and middle button state are NOT forwarded.
  * Setting right/middle is_down=true while left is_down=false should
  * still produce a released Clay state -- only the left button matters. */
 static void test_pointer_state_only_left_button_consumed(void) {

--- a/tests/unit/test_nt_ui_pointer_state.c
+++ b/tests/unit/test_nt_ui_pointer_state.c
@@ -8,11 +8,12 @@
 #include "core/nt_assert.h"
 #include "graphics/nt_gfx.h"
 #include "input/nt_input.h"
+#include "test_helpers/ui_test_arena.h"
 #include "ui/nt_ui.h"
 #include "unity.h"
 /* clang-format on */
 
-alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_TEST_ARENA_SIZE];
 static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT, .max_scissor_depth = NT_UI_WALKER_MAX_SCISSOR_DEPTH};
 
 void setUp(void) {

--- a/tests/unit/test_nt_ui_pointer_state.c
+++ b/tests/unit/test_nt_ui_pointer_state.c
@@ -1,24 +1,127 @@
-/* tests/unit/test_nt_ui_pointer_state.c — Plan 52-00 stub
+/* tests/unit/test_nt_ui_pointer_state.c -- Plan 52-03
  *
- * Covers CLAY-04 (Clay_SetPointerState driven by nt_pointer_t in nt_ui_begin).
- * Wave 0 ships TEST_IGNORE bodies; Plan 52-03 fills with real assertions.
+ * Covers CLAY-04 / D-52-16: nt_ui_begin forwards pointer position and
+ * left-button state to Clay_SetPointerState. Right/middle buttons and
+ * wheel are intentionally NOT consumed (D-52-16 left-button only).
+ *
+ * Verification strategy: NT_UI_TEST_ACCESS probes nt_ui_test_clay_pointer_
+ * x/y/down read ctx->clay->pointerInfo from inside nt_ui.c (where Clay's
+ * struct definition is in scope via CLAY_IMPLEMENTATION). Tests pump the
+ * pointer through nt_ui_begin, then snapshot the Clay-side state to
+ * compare against the input nt_pointer_t.
+ *
+ * UNITY_EXCLUDE_FLOAT is set globally for tests; float comparisons go
+ * through bit-stable uint32 conversion when the inputs are integer-valued
+ * floats (matches the test_font.c precedent).
  */
 
+#include <setjmp.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
+/* clang-format off */
+#include "core/nt_assert.h"
+#include "graphics/nt_gfx.h"
+#include "input/nt_input.h"
+#include "ui/nt_ui.h"
 #include "unity.h"
+/* clang-format on */
 
-void setUp(void) {}
-void tearDown(void) {}
+static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
 
-/* CLAY-04: nt_ui_begin pulls mouse x/y/buttons[LEFT].is_down and forwards to
- * Clay_SetPointerState. Verified via Clay-side probes or via direct
- * Clay_GetPointerState observable state after nt_ui_begin returns. */
-static void test_pointer_state_set_from_nt_pointer(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-03"); }
+void setUp(void) {
+    /* gfx is required because the nt_ui transitive link surface pulls it
+     * in via nt_font/nt_resource even though pointer-state tests don't
+     * touch GPU state directly. Stub backend is fine. */
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 4, .max_pipelines = 4, .max_buffers = 4, .max_textures = 4, .max_meshes = 4});
+}
+
+void tearDown(void) { nt_gfx_shutdown(); }
+
+/* Compare two known-finite floats with integer-equivalence: the test
+ * inputs (100.0f, 200.0f, 50.0f, 75.0f) are exact float representations
+ * so the round-trip through Clay's identity-store should be bit-stable. */
+static bool float_eq_bits(float a, float b) {
+    uint32_t pa, pb;
+    memcpy(&pa, &a, sizeof pa);
+    memcpy(&pb, &b, sizeof pb);
+    return pa == pb;
+}
+
+/* CLAY-04: x/y are forwarded literally; is_down=true is reflected as a
+ * pressed-family Clay pointer state. */
+static void test_pointer_state_set_from_nt_pointer(void) {
+    nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena);
+    TEST_ASSERT_NOT_NULL(ctx);
+
+    nt_pointer_t mouse;
+    memset(&mouse, 0, sizeof mouse);
+    mouse.x = 100.0f;
+    mouse.y = 200.0f;
+    mouse.buttons[NT_BUTTON_LEFT].is_down = true;
+
+    nt_ui_begin(ctx, 800.0f, 600.0f, &mouse);
+
+    /* Probe Clay's pointer state via NT_UI_TEST_ACCESS getters. */
+    TEST_ASSERT_TRUE(float_eq_bits(100.0f, nt_ui_test_clay_pointer_x(ctx)));
+    TEST_ASSERT_TRUE(float_eq_bits(200.0f, nt_ui_test_clay_pointer_y(ctx)));
+    TEST_ASSERT_EQUAL_INT(1, nt_ui_test_clay_pointer_down(ctx));
+
+    nt_ui_end(ctx);
+    nt_ui_destroy_context(ctx);
+}
+
+/* CLAY-04: is_down=false yields released-family state, position still
+ * forwarded literally. */
+static void test_pointer_state_button_released(void) {
+    nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena);
+    TEST_ASSERT_NOT_NULL(ctx);
+
+    nt_pointer_t mouse;
+    memset(&mouse, 0, sizeof mouse);
+    mouse.x = 50.0f;
+    mouse.y = 75.0f;
+    mouse.buttons[NT_BUTTON_LEFT].is_down = false;
+
+    nt_ui_begin(ctx, 800.0f, 600.0f, &mouse);
+
+    TEST_ASSERT_TRUE(float_eq_bits(50.0f, nt_ui_test_clay_pointer_x(ctx)));
+    TEST_ASSERT_TRUE(float_eq_bits(75.0f, nt_ui_test_clay_pointer_y(ctx)));
+    TEST_ASSERT_EQUAL_INT(0, nt_ui_test_clay_pointer_down(ctx));
+
+    nt_ui_end(ctx);
+    nt_ui_destroy_context(ctx);
+}
+
+/* CLAY-04 + D-52-16: right and middle button state are NOT forwarded.
+ * Setting right/middle is_down=true while left is_down=false should
+ * still produce a released Clay state -- only the left button matters. */
+static void test_pointer_state_only_left_button_consumed(void) {
+    nt_ui_context_t *ctx = nt_ui_create_context(s_arena, sizeof s_arena);
+    TEST_ASSERT_NOT_NULL(ctx);
+
+    nt_pointer_t mouse;
+    memset(&mouse, 0, sizeof mouse);
+    mouse.x = 10.0f;
+    mouse.y = 20.0f;
+    mouse.buttons[NT_BUTTON_LEFT].is_down = false;
+    mouse.buttons[NT_BUTTON_RIGHT].is_down = true;
+    mouse.buttons[NT_BUTTON_MIDDLE].is_down = true;
+
+    nt_ui_begin(ctx, 800.0f, 600.0f, &mouse);
+
+    TEST_ASSERT_EQUAL_INT(0, nt_ui_test_clay_pointer_down(ctx));
+
+    nt_ui_end(ctx);
+    nt_ui_destroy_context(ctx);
+}
 
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_pointer_state_set_from_nt_pointer);
+    RUN_TEST(test_pointer_state_button_released);
+    RUN_TEST(test_pointer_state_only_left_button_consumed);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_pointer_state.c
+++ b/tests/unit/test_nt_ui_pointer_state.c
@@ -1,0 +1,24 @@
+/* tests/unit/test_nt_ui_pointer_state.c — Plan 52-00 stub
+ *
+ * Covers CLAY-04 (Clay_SetPointerState driven by nt_pointer_t in nt_ui_begin).
+ * Wave 0 ships TEST_IGNORE bodies; Plan 52-03 fills with real assertions.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* CLAY-04: nt_ui_begin pulls mouse x/y/buttons[LEFT].is_down and forwards to
+ * Clay_SetPointerState. Verified via Clay-side probes or via direct
+ * Clay_GetPointerState observable state after nt_ui_begin returns. */
+static void test_pointer_state_set_from_nt_pointer(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-03"); }
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_pointer_state_set_from_nt_pointer);
+    return UNITY_END();
+}

--- a/tests/unit/test_nt_ui_pointer_state.c
+++ b/tests/unit/test_nt_ui_pointer_state.c
@@ -29,7 +29,7 @@
 #include "unity.h"
 /* clang-format on */
 
-static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8U];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
 
 void setUp(void) {
     /* gfx is required because the nt_ui transitive link surface pulls it

--- a/tests/unit/test_nt_ui_pointer_state.c
+++ b/tests/unit/test_nt_ui_pointer_state.c
@@ -13,7 +13,7 @@
 /* clang-format on */
 
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
-static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT};
+static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT, .max_scissor_depth = NT_UI_WALKER_MAX_SCISSOR_DEPTH};
 
 void setUp(void) {
     /* gfx pulled in transitively via nt_font/nt_resource; stub is fine. */

--- a/tests/unit/test_nt_ui_stats.c
+++ b/tests/unit/test_nt_ui_stats.c
@@ -44,7 +44,7 @@ static void inject_frozen_cmds(int32_t count) {
  * nt_stats. After this, nt_stats_format_lines must show the value. */
 static void publish_ui_metrics_to_stats(const nt_ui_context_t *ctx) {
     nt_stats_count("ui_draw_calls", (uint64_t)nt_ui_get_last_walk_draw_calls(ctx));
-    nt_stats_count("ui_element_count", (uint64_t)nt_ui_get_last_walk_element_count(ctx));
+    nt_stats_count("ui_command_count", (uint64_t)nt_ui_get_last_walk_command_count(ctx));
 }
 
 /*after a walk that emits a RECT, the public draw-call
@@ -65,7 +65,7 @@ static void test_get_last_walk_draw_calls_after_rect(void) {
 
 /*element count equals frozen_cmds.length exactly
  * (synthetic injected array, no Clay wrapper elements). */
-static void test_get_last_walk_element_count_matches_frozen_cmds(void) {
+static void test_get_last_walk_command_count_matches_frozen_cmds(void) {
     for (int i = 0; i < 3; ++i) {
         Clay_RenderCommand *c = &s_test_cmds[i];
         c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
@@ -77,7 +77,7 @@ static void test_get_last_walk_element_count_matches_frozen_cmds(void) {
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    TEST_ASSERT_EQUAL_UINT32(3U, nt_ui_get_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(3U, nt_ui_get_last_walk_command_count(s_fx.ctx));
 }
 
 /* Bridge pattern: app forwards getter values into nt_stats; both
@@ -102,7 +102,7 @@ static void test_metrics_bridge_publishes_to_nt_stats(void) {
     char expected_draw[64];
     (void)snprintf(expected_draw, sizeof expected_draw, "ui_draw_calls: %u", (unsigned)draw_calls);
     TEST_ASSERT_NOT_NULL_MESSAGE(strstr(buf, expected_draw), "bridge: ui_draw_calls value in nt_stats must match getter output");
-    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(buf, "ui_element_count: 1"), "bridge: ui_element_count must equal frozen_cmds.length");
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(buf, "ui_command_count: 1"), "bridge: ui_command_count must equal frozen_cmds.length");
 }
 
 /* counters are SET per walk (not accumulated). Walk twice with
@@ -119,19 +119,19 @@ static void test_getters_reflect_latest_walk_only(void) {
 
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
-    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_command_count(s_fx.ctx));
 
     /* Second walk: empty array. Getter must reflect THIS walk, not the
      * accumulated total. */
     inject_frozen_cmds(0);
     nt_ui_walk(s_fx.ctx, &target);
-    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_command_count(s_fx.ctx));
 }
 
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_get_last_walk_draw_calls_after_rect);
-    RUN_TEST(test_get_last_walk_element_count_matches_frozen_cmds);
+    RUN_TEST(test_get_last_walk_command_count_matches_frozen_cmds);
     RUN_TEST(test_metrics_bridge_publishes_to_nt_stats);
     RUN_TEST(test_getters_reflect_latest_walk_only);
     return UNITY_END();

--- a/tests/unit/test_nt_ui_stats.c
+++ b/tests/unit/test_nt_ui_stats.c
@@ -1,17 +1,9 @@
-/* tests/unit/test_nt_ui_stats.c -- Plan 52-05 (refactored after nt_stats decouple)
- *
- * Covers WALK-09 / D-52-20: per-walk metrics are captured into the ctx and
- * exposed via nt_ui_get_last_walk_*. nt_ui itself no longer pushes to
- * nt_stats; this test verifies (a) the public getters return the expected
- * values after a walk and (b) the canonical bridge pattern works -- app
- * forwards getter output into nt_stats_count and the value surfaces in
- * nt_stats_format_lines.
- *
- * nt_stats lifecycle is managed locally (init/shutdown bracketing the
- * fixture), because the shared ui_walker_fixture deliberately does NOT
- * init nt_stats: walker tests don't need it, and only this test exercises
- * the metrics-bridge integration.
- */
+/* Verifies the metrics bridge: per-walk counters captured into ctx and
+ * exposed via nt_ui_get_last_walk_*, then forwarded by the test into
+ * nt_stats and read back via nt_stats_format_lines. nt_ui itself does
+ * NOT depend on nt_stats -- the shared walker fixture leaves nt_stats
+ * un-init'd; this test bookends fixture setUp/tearDown with its own
+ * nt_stats_init/shutdown. */
 
 #include <stdbool.h>
 #include <stddef.h>
@@ -60,7 +52,7 @@ static void publish_ui_metrics_to_stats(const nt_ui_context_t *ctx) {
     nt_stats_count("ui_element_count", (uint64_t)nt_ui_get_last_walk_element_count(ctx));
 }
 
-/* WALK-09 (getter): after a walk that emits a RECT, the public draw-call
+/*after a walk that emits a RECT, the public draw-call
  * getter reports >= 1 (the walker-exit flush issues at least one GL
  * draw call). */
 static void test_get_last_walk_draw_calls_after_rect(void) {
@@ -76,7 +68,7 @@ static void test_get_last_walk_draw_calls_after_rect(void) {
     TEST_ASSERT_GREATER_THAN_UINT32(0U, nt_ui_get_last_walk_draw_calls(s_fx.ctx));
 }
 
-/* WALK-09 (getter): element count equals frozen_cmds.length exactly
+/*element count equals frozen_cmds.length exactly
  * (synthetic injected array, no Clay wrapper elements). */
 static void test_get_last_walk_element_count_matches_frozen_cmds(void) {
     for (int i = 0; i < 3; ++i) {
@@ -93,7 +85,7 @@ static void test_get_last_walk_element_count_matches_frozen_cmds(void) {
     TEST_ASSERT_EQUAL_UINT32(3U, nt_ui_get_last_walk_element_count(s_fx.ctx));
 }
 
-/* WALK-09 (bridge): app forwards getter values into nt_stats; both
+/* Bridge pattern: app forwards getter values into nt_stats; both
  * counters appear in nt_stats_format_lines with the expected values. */
 static void test_metrics_bridge_publishes_to_nt_stats(void) {
     Clay_RenderCommand *c = &s_test_cmds[0];
@@ -118,7 +110,7 @@ static void test_metrics_bridge_publishes_to_nt_stats(void) {
     TEST_ASSERT_NOT_NULL_MESSAGE(strstr(buf, "ui_element_count: 1"), "bridge: ui_element_count must equal frozen_cmds.length");
 }
 
-/* WALK-09: counters are SET per walk (not accumulated). Walk twice with
+/* counters are SET per walk (not accumulated). Walk twice with
  * different command counts -- second getter call reflects second walk. */
 static void test_getters_reflect_latest_walk_only(void) {
     /* First walk: 2 RECT commands. */

--- a/tests/unit/test_nt_ui_stats.c
+++ b/tests/unit/test_nt_ui_stats.c
@@ -14,7 +14,7 @@
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_TEST_ARENA_SIZE];
 static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 8

--- a/tests/unit/test_nt_ui_stats.c
+++ b/tests/unit/test_nt_ui_stats.c
@@ -1,27 +1,255 @@
-/* tests/unit/test_nt_ui_stats.c — Plan 52-00 stub
+/* tests/unit/test_nt_ui_stats.c -- Plan 52-05
  *
- * Covers WALK-09 (ui_draw_calls + ui_element_count user counters wired at
- * nt_ui_walk exit). Wave 0 ships TEST_IGNORE bodies; Plan 52-05 fills with
- * real assertions.
+ * Covers WALK-09 / D-52-20: ui_draw_calls + ui_element_count user counters
+ * are routed through nt_stats_count at nt_ui_walk exit.
+ *
+ * nt_stats has no public read-back-by-name accessor for user counters --
+ * verification goes through (a) nt_ui_test_last_walk_* probes (per-walk
+ * statics that Plan 04 captures and Plan 05 routes to nt_stats_count) and
+ * (b) nt_stats_format_lines substring match (covers the wiring through to
+ * nt_stats' user-counter table).
  */
 
+/* System headers before Unity to avoid noreturn / __declspec conflict on MSVC */
+#include <math.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
+/* clang-format off */
+#include "atlas/nt_atlas.h"
+#include "clay.h"
+#include "core/nt_assert.h"
+#include "font/nt_font.h"
+#include "graphics/nt_gfx.h"
+#include "hash/nt_hash.h"
+#include "input/nt_input.h"
+#include "material/nt_material.h"
+#include "nt_pack_format.h"
+#include "renderers/nt_sprite_renderer.h"
+#include "renderers/nt_text_renderer.h"
+#include "resource/nt_resource.h"
+#include "stats/nt_stats.h"
+#include "test_helpers/nt_assert_trap.h"
+#include "test_helpers/ui_atlas.h"
+#include "ui/nt_ui.h"
+#include "ui/nt_ui_internal.h"
 #include "unity.h"
+/* clang-format on */
 
-void setUp(void) {}
-void tearDown(void) {}
+/* ---- Shared test fixtures ---- */
 
-/* WALK-09 / D-52-20: ui_draw_calls user counter updated by per-walk delta */
-static void test_ui_draw_calls_counter_set(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-05"); }
+static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+static minimal_ui_atlas_t s_atlas;
+static nt_material_t s_sprite_material;
+static nt_material_t s_text_material;
+static nt_ui_context_t *s_ctx;
+static uint32_t s_vpack_counter;
 
-/* WALK-09 / D-52-20: ui_element_count user counter equals iterated command count */
-static void test_ui_element_count_counter_set(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-05"); }
+#define MAX_TEST_CMDS 8
+static Clay_RenderCommand s_test_cmds[MAX_TEST_CMDS];
+
+static nt_material_t make_test_material(void) {
+    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "void main(){}", .label = "stats_vs"});
+    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "void main(){}", .label = "stats_fs"});
+
+    char pack_name[64];
+    char vs_name[64];
+    char fs_name[64];
+    (void)snprintf(pack_name, sizeof pack_name, "stats_mat_pack_%u", s_vpack_counter);
+    (void)snprintf(vs_name, sizeof vs_name, "stats_vs_%u", s_vpack_counter);
+    (void)snprintf(fs_name, sizeof fs_name, "stats_fs_%u", s_vpack_counter);
+    s_vpack_counter++;
+
+    nt_hash32_t pid = nt_hash32_str(pack_name);
+    nt_hash64_t vs_rid = nt_hash64_str(vs_name);
+    nt_hash64_t fs_rid = nt_hash64_str(fs_name);
+
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pid, 0));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, vs_rid, NT_ASSET_SHADER_CODE, vs.id));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, fs_rid, NT_ASSET_SHADER_CODE, fs.id));
+
+    nt_resource_t vs_res = nt_resource_request(vs_rid, NT_ASSET_SHADER_CODE);
+    nt_resource_t fs_res = nt_resource_request(fs_rid, NT_ASSET_SHADER_CODE);
+    nt_resource_step();
+
+    nt_material_create_desc_t desc;
+    memset(&desc, 0, sizeof desc);
+    desc.vs = vs_res;
+    desc.fs = fs_res;
+    desc.depth_test = false;
+    desc.depth_write = false;
+    desc.cull_mode = NT_CULL_NONE;
+    desc.color_mode = NT_COLOR_MODE_NONE;
+    desc.label = "stats_test_material";
+
+    nt_material_t mat = nt_material_create(&desc);
+    nt_material_step();
+    return mat;
+}
+
+void setUp(void) {
+    nt_test_assert_install();
+    s_vpack_counter = 0;
+    memset(s_test_cmds, 0, sizeof s_test_cmds);
+
+    nt_hash_init(&(nt_hash_desc_t){0});
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_pipelines = 16, .max_buffers = 64, .max_textures = 32, .max_meshes = 16});
+    nt_resource_init(&(nt_resource_desc_t){0});
+    nt_atlas_init();
+    nt_font_init(&(nt_font_desc_t){.max_fonts = 4});
+    nt_material_init(&(nt_material_desc_t){.max_materials = 32});
+
+    /* Begin a frame/pass so flush's draw_indexed doesn't trip the stub backend
+     * "no active pass" guard. */
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+
+    nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
+    nt_text_renderer_init();
+
+    /* Stats module under test -- default capacity is plenty for ui_draw_calls
+     * + ui_element_count (only 2 counters). */
+    nt_stats_init(NULL);
+
+    s_atlas = minimal_ui_atlas_create();
+    s_sprite_material = make_test_material();
+    s_text_material = make_test_material();
+
+    nt_ui_set_atlas_white_region(s_atlas.handle, s_atlas.white_region_idx);
+    nt_ui_set_sprite_material(s_sprite_material);
+    nt_ui_set_text_material(s_text_material);
+    nt_ui_set_custom_handler(NULL, NULL);
+
+    s_ctx = nt_ui_create_context(s_arena, sizeof s_arena);
+    TEST_ASSERT_NOT_NULL(s_ctx);
+}
+
+void tearDown(void) {
+    if (s_ctx != NULL) {
+        nt_ui_destroy_context(s_ctx);
+        s_ctx = NULL;
+    }
+    nt_ui_test_reset_walker_globals();
+    minimal_ui_atlas_destroy(&s_atlas);
+
+    nt_stats_shutdown();
+    nt_sprite_renderer_shutdown();
+    nt_text_renderer_shutdown();
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    nt_material_shutdown();
+    nt_font_shutdown();
+    nt_atlas_test_reset();
+    nt_resource_shutdown();
+    nt_gfx_shutdown();
+    nt_hash_shutdown();
+}
+
+static void inject_frozen_cmds(int32_t count) {
+    s_ctx->frozen_cmds.internalArray = s_test_cmds;
+    s_ctx->frozen_cmds.length = count;
+    s_ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
+}
+
+/* WALK-09 / D-52-20: after a walk that emits a RECT, the walker's per-walk
+ * draw-call delta probe is > 0 (at least the walker-exit flush ticked the
+ * gfx draw-call counter) AND nt_stats_format_lines surfaces the
+ * "ui_draw_calls" line (proving the value was routed into nt_stats). */
+static void test_ui_draw_calls_counter_set(void) {
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    c->boundingBox = (Clay_BoundingBox){.x = 0.0f, .y = 0.0f, .width = 100.0f, .height = 100.0f};
+    c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255.0f, .g = 0.0f, .b = 0.0f, .a = 255.0f};
+    inject_frozen_cmds(1);
+
+    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_walk(s_ctx, &target);
+
+    /* Per-walk delta probe: at least the walker-exit flush ticked one draw call. */
+    const uint32_t delta = nt_ui_test_last_walk_draw_call_delta();
+    TEST_ASSERT_GREATER_THAN_UINT32(0u, delta);
+
+    /* nt_stats wiring: the counter must surface in format_lines. */
+    char buf[512];
+    uint32_t n = nt_stats_format_lines(buf, sizeof buf);
+    TEST_ASSERT_GREATER_THAN_UINT32(0u, n);
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(buf, "ui_draw_calls:"), "nt_stats must contain ui_draw_calls counter after walk");
+
+    /* The delta value must match what nt_stats holds -- verify via
+     * substring of the formatted counter line. */
+    char expected[64];
+    (void)snprintf(expected, sizeof expected, "ui_draw_calls: %u", (unsigned)delta);
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(buf, expected), "ui_draw_calls value in nt_stats must match per-walk delta probe");
+}
+
+/* WALK-09 / D-52-20: ui_element_count equals frozen_cmds.length and is
+ * routed into nt_stats. */
+static void test_ui_element_count_counter_set(void) {
+    /* 3 RECT commands -> walker iterates 3 elements. */
+    for (int i = 0; i < 3; ++i) {
+        Clay_RenderCommand *c = &s_test_cmds[i];
+        c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+        c->boundingBox = (Clay_BoundingBox){.x = (float)(i * 20), .y = 0.0f, .width = 10.0f, .height = 10.0f};
+        c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 0.0f, .g = 255.0f, .b = 0.0f, .a = 255.0f};
+    }
+    inject_frozen_cmds(3);
+
+    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_walk(s_ctx, &target);
+
+    /* Element count probe matches frozen_cmds.length exactly (no Clay
+     * wrapper elements -- frozen_cmds is the injected synthetic array). */
+    TEST_ASSERT_EQUAL_UINT32(3u, nt_ui_test_last_walk_element_count());
+
+    /* nt_stats wiring. */
+    char buf[512];
+    (void)nt_stats_format_lines(buf, sizeof buf);
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(buf, "ui_element_count: 3"), "nt_stats ui_element_count must equal frozen_cmds.length");
+}
+
+/* WALK-09 / D-52-20: counters are SET per walk, not accumulated. Walk twice
+ * with different command counts -- the second walk's counter must reflect
+ * the second declaration. */
+static void test_counters_reset_per_walk(void) {
+    /* First walk: 2 RECT commands. */
+    for (int i = 0; i < 2; ++i) {
+        Clay_RenderCommand *c = &s_test_cmds[i];
+        c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+        c->boundingBox = (Clay_BoundingBox){.x = 0.0f, .y = 0.0f, .width = 10.0f, .height = 10.0f};
+        c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255.0f, .g = 255.0f, .b = 255.0f, .a = 255.0f};
+    }
+    inject_frozen_cmds(2);
+
+    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_walk(s_ctx, &target);
+
+    const uint32_t count1 = nt_ui_test_last_walk_element_count();
+    TEST_ASSERT_EQUAL_UINT32(2u, count1);
+
+    /* Second walk: empty command array. */
+    inject_frozen_cmds(0);
+    nt_ui_walk(s_ctx, &target);
+
+    const uint32_t count2 = nt_ui_test_last_walk_element_count();
+    TEST_ASSERT_EQUAL_UINT32(0u, count2);
+    TEST_ASSERT_NOT_EQUAL_MESSAGE(count1, count2, "second walk's element count must reflect the second declaration, not accumulate");
+
+    /* nt_stats also reflects the second walk's value, not the first. */
+    char buf[512];
+    (void)nt_stats_format_lines(buf, sizeof buf);
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(buf, "ui_element_count: 0"), "nt_stats ui_element_count must reflect second walk (=0), not first (=2)");
+    TEST_ASSERT_NULL_MESSAGE(strstr(buf, "ui_element_count: 2"), "old (first-walk) value must be overwritten in nt_stats");
+}
 
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_ui_draw_calls_counter_set);
     RUN_TEST(test_ui_element_count_counter_set);
+    RUN_TEST(test_counters_reset_per_walk);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_stats.c
+++ b/tests/unit/test_nt_ui_stats.c
@@ -10,149 +10,37 @@
  * nt_stats' user-counter table).
  */
 
-/* System headers before Unity to avoid noreturn / __declspec conflict on MSVC */
-#include <math.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
-/* clang-format off */
-#include "atlas/nt_atlas.h"
 #include "clay.h"
-#include "core/nt_assert.h"
-#include "font/nt_font.h"
-#include "graphics/nt_gfx.h"
-#include "hash/nt_hash.h"
-#include "input/nt_input.h"
-#include "material/nt_material.h"
-#include "nt_pack_format.h"
-#include "renderers/nt_sprite_renderer.h"
-#include "renderers/nt_text_renderer.h"
-#include "resource/nt_resource.h"
 #include "stats/nt_stats.h"
 #include "test_helpers/nt_assert_trap.h"
-#include "test_helpers/ui_atlas.h"
+#include "test_helpers/ui_walker_fixture.h"
 #include "ui/nt_ui.h"
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
-/* clang-format on */
-
-/* ---- Shared test fixtures ---- */
 
 static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
-static minimal_ui_atlas_t s_atlas;
-static nt_material_t s_sprite_material;
-static nt_material_t s_text_material;
-static nt_ui_context_t *s_ctx;
-static uint32_t s_vpack_counter;
+static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 8
 static Clay_RenderCommand s_test_cmds[MAX_TEST_CMDS];
 
-static nt_material_t make_test_material(void) {
-    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "void main(){}", .label = "stats_vs"});
-    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "void main(){}", .label = "stats_fs"});
-
-    char pack_name[64];
-    char vs_name[64];
-    char fs_name[64];
-    (void)snprintf(pack_name, sizeof pack_name, "stats_mat_pack_%u", s_vpack_counter);
-    (void)snprintf(vs_name, sizeof vs_name, "stats_vs_%u", s_vpack_counter);
-    (void)snprintf(fs_name, sizeof fs_name, "stats_fs_%u", s_vpack_counter);
-    s_vpack_counter++;
-
-    nt_hash32_t pid = nt_hash32_str(pack_name);
-    nt_hash64_t vs_rid = nt_hash64_str(vs_name);
-    nt_hash64_t fs_rid = nt_hash64_str(fs_name);
-
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pid, 0));
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, vs_rid, NT_ASSET_SHADER_CODE, vs.id));
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, fs_rid, NT_ASSET_SHADER_CODE, fs.id));
-
-    nt_resource_t vs_res = nt_resource_request(vs_rid, NT_ASSET_SHADER_CODE);
-    nt_resource_t fs_res = nt_resource_request(fs_rid, NT_ASSET_SHADER_CODE);
-    nt_resource_step();
-
-    nt_material_create_desc_t desc;
-    memset(&desc, 0, sizeof desc);
-    desc.vs = vs_res;
-    desc.fs = fs_res;
-    desc.depth_test = false;
-    desc.depth_write = false;
-    desc.cull_mode = NT_CULL_NONE;
-    desc.color_mode = NT_COLOR_MODE_NONE;
-    desc.label = "stats_test_material";
-
-    nt_material_t mat = nt_material_create(&desc);
-    nt_material_step();
-    return mat;
-}
-
 void setUp(void) {
     nt_test_assert_install();
-    s_vpack_counter = 0;
     memset(s_test_cmds, 0, sizeof s_test_cmds);
-
-    nt_hash_init(&(nt_hash_desc_t){0});
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_pipelines = 16, .max_buffers = 64, .max_textures = 32, .max_meshes = 16});
-    nt_resource_init(&(nt_resource_desc_t){0});
-    nt_atlas_init();
-    nt_font_init(&(nt_font_desc_t){.max_fonts = 4});
-    nt_material_init(&(nt_material_desc_t){.max_materials = 32});
-
-    /* Begin a frame/pass so flush's draw_indexed doesn't trip the stub backend
-     * "no active pass" guard. */
-    nt_gfx_begin_frame();
-    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
-
-    nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
-    nt_text_renderer_init();
-
-    /* Stats module under test -- default capacity is plenty for ui_draw_calls
-     * + ui_element_count (only 2 counters). */
-    nt_stats_init(NULL);
-
-    s_atlas = minimal_ui_atlas_create();
-    s_sprite_material = make_test_material();
-    s_text_material = make_test_material();
-
-    s_ctx = nt_ui_create_context(s_arena, sizeof s_arena);
-    TEST_ASSERT_NOT_NULL(s_ctx);
-
-    nt_ui_set_atlas_white_region(s_ctx, s_atlas.handle, s_atlas.white_region_idx);
-    nt_ui_set_sprite_material(s_ctx, s_sprite_material);
-    nt_ui_set_text_material(s_ctx, s_text_material);
-    nt_ui_set_custom_handler(s_ctx, NULL, NULL);
+    ui_walker_fixture_init(&s_fx, s_arena, sizeof s_arena, UI_WALKER_FX_BIND_ALL);
 }
 
-void tearDown(void) {
-    if (s_ctx != NULL) {
-        nt_ui_destroy_context(s_ctx);
-        s_ctx = NULL;
-    }
-    minimal_ui_atlas_destroy(&s_atlas);
-
-    nt_stats_shutdown();
-    nt_sprite_renderer_shutdown();
-    nt_text_renderer_shutdown();
-    nt_gfx_end_pass();
-    nt_gfx_end_frame();
-
-    nt_material_shutdown();
-    nt_font_shutdown();
-    nt_atlas_test_reset();
-    nt_resource_shutdown();
-    nt_gfx_shutdown();
-    nt_hash_shutdown();
-}
+void tearDown(void) { ui_walker_fixture_shutdown(&s_fx); }
 
 static void inject_frozen_cmds(int32_t count) {
-    s_ctx->frozen_cmds.internalArray = s_test_cmds;
-    s_ctx->frozen_cmds.length = count;
-    s_ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
+    s_fx.ctx->frozen_cmds.internalArray = s_test_cmds;
+    s_fx.ctx->frozen_cmds.length = count;
+    s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
 }
 
 /* WALK-09 / D-52-20: after a walk that emits a RECT, the walker's per-walk
@@ -167,10 +55,10 @@ static void test_ui_draw_calls_counter_set(void) {
     inject_frozen_cmds(1);
 
     nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
     /* Per-walk delta probe: at least the walker-exit flush ticked one draw call. */
-    const uint32_t delta = nt_ui_test_last_walk_draw_call_delta(s_ctx);
+    const uint32_t delta = nt_ui_test_last_walk_draw_call_delta(s_fx.ctx);
     TEST_ASSERT_GREATER_THAN_UINT32(0u, delta);
 
     /* nt_stats wiring: the counter must surface in format_lines. */
@@ -199,11 +87,11 @@ static void test_ui_element_count_counter_set(void) {
     inject_frozen_cmds(3);
 
     nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
     /* Element count probe matches frozen_cmds.length exactly (no Clay
      * wrapper elements -- frozen_cmds is the injected synthetic array). */
-    TEST_ASSERT_EQUAL_UINT32(3u, nt_ui_test_last_walk_element_count(s_ctx));
+    TEST_ASSERT_EQUAL_UINT32(3u, nt_ui_test_last_walk_element_count(s_fx.ctx));
 
     /* nt_stats wiring. */
     char buf[512];
@@ -225,16 +113,16 @@ static void test_counters_reset_per_walk(void) {
     inject_frozen_cmds(2);
 
     nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
-    const uint32_t count1 = nt_ui_test_last_walk_element_count(s_ctx);
+    const uint32_t count1 = nt_ui_test_last_walk_element_count(s_fx.ctx);
     TEST_ASSERT_EQUAL_UINT32(2u, count1);
 
     /* Second walk: empty command array. */
     inject_frozen_cmds(0);
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
-    const uint32_t count2 = nt_ui_test_last_walk_element_count(s_ctx);
+    const uint32_t count2 = nt_ui_test_last_walk_element_count(s_fx.ctx);
     TEST_ASSERT_EQUAL_UINT32(0u, count2);
     TEST_ASSERT_NOT_EQUAL_MESSAGE(count1, count2, "second walk's element count must reflect the second declaration, not accumulate");
 

--- a/tests/unit/test_nt_ui_stats.c
+++ b/tests/unit/test_nt_ui_stats.c
@@ -1,9 +1,4 @@
-/* Verifies the metrics bridge: per-walk counters captured into ctx and
- * exposed via nt_ui_get_last_walk_*, then forwarded by the test into
- * nt_stats and read back via nt_stats_format_lines. nt_ui itself does
- * NOT depend on nt_stats -- the shared walker fixture leaves nt_stats
- * un-init'd; this test bookends fixture setUp/tearDown with its own
- * nt_stats_init/shutdown. */
+/* Bridge test: nt_ui_get_last_walk_* -> nt_stats. nt_ui has no nt_stats dep. */
 
 #include <stdbool.h>
 #include <stddef.h>

--- a/tests/unit/test_nt_ui_stats.c
+++ b/tests/unit/test_nt_ui_stats.c
@@ -1,0 +1,27 @@
+/* tests/unit/test_nt_ui_stats.c — Plan 52-00 stub
+ *
+ * Covers WALK-09 (ui_draw_calls + ui_element_count user counters wired at
+ * nt_ui_walk exit). Wave 0 ships TEST_IGNORE bodies; Plan 52-05 fills with
+ * real assertions.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* WALK-09 / D-52-20: ui_draw_calls user counter updated by per-walk delta */
+static void test_ui_draw_calls_counter_set(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-05"); }
+
+/* WALK-09 / D-52-20: ui_element_count user counter equals iterated command count */
+static void test_ui_element_count_counter_set(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-05"); }
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_ui_draw_calls_counter_set);
+    RUN_TEST(test_ui_element_count_counter_set);
+    return UNITY_END();
+}

--- a/tests/unit/test_nt_ui_stats.c
+++ b/tests/unit/test_nt_ui_stats.c
@@ -1,18 +1,22 @@
-/* tests/unit/test_nt_ui_stats.c -- Plan 52-05
+/* tests/unit/test_nt_ui_stats.c -- Plan 52-05 (refactored after nt_stats decouple)
  *
- * Covers WALK-09 / D-52-20: ui_draw_calls + ui_element_count user counters
- * are routed through nt_stats_count at nt_ui_walk exit.
+ * Covers WALK-09 / D-52-20: per-walk metrics are captured into the ctx and
+ * exposed via nt_ui_get_last_walk_*. nt_ui itself no longer pushes to
+ * nt_stats; this test verifies (a) the public getters return the expected
+ * values after a walk and (b) the canonical bridge pattern works -- app
+ * forwards getter output into nt_stats_count and the value surfaces in
+ * nt_stats_format_lines.
  *
- * nt_stats has no public read-back-by-name accessor for user counters --
- * verification goes through (a) nt_ui_test_last_walk_* probes (per-walk
- * statics that Plan 04 captures and Plan 05 routes to nt_stats_count) and
- * (b) nt_stats_format_lines substring match (covers the wiring through to
- * nt_stats' user-counter table).
+ * nt_stats lifecycle is managed locally (init/shutdown bracketing the
+ * fixture), because the shared ui_walker_fixture deliberately does NOT
+ * init nt_stats: walker tests don't need it, and only this test exercises
+ * the metrics-bridge integration.
  */
 
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
 #include <string.h>
 
 #include "clay.h"
@@ -33,9 +37,15 @@ void setUp(void) {
     nt_test_assert_install();
     memset(s_test_cmds, 0, sizeof s_test_cmds);
     ui_walker_fixture_init(&s_fx, s_arena, sizeof s_arena, UI_WALKER_FX_BIND_ALL);
+    /* nt_stats is not init'd by the fixture (UI doesn't depend on it).
+     * This test exercises the metrics-bridge pattern so we init it here. */
+    nt_stats_init(NULL);
 }
 
-void tearDown(void) { ui_walker_fixture_shutdown(&s_fx); }
+void tearDown(void) {
+    nt_stats_shutdown();
+    ui_walker_fixture_shutdown(&s_fx);
+}
 
 static void inject_frozen_cmds(int32_t count) {
     s_fx.ctx->frozen_cmds.internalArray = s_test_cmds;
@@ -43,11 +53,17 @@ static void inject_frozen_cmds(int32_t count) {
     s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
 }
 
-/* WALK-09 / D-52-20: after a walk that emits a RECT, the walker's per-walk
- * draw-call delta probe is > 0 (at least the walker-exit flush ticked the
- * gfx draw-call counter) AND nt_stats_format_lines surfaces the
- * "ui_draw_calls" line (proving the value was routed into nt_stats). */
-static void test_ui_draw_calls_counter_set(void) {
+/* Canonical metrics-bridge pattern: walk -> read getter -> publish into
+ * nt_stats. After this, nt_stats_format_lines must show the value. */
+static void publish_ui_metrics_to_stats(const nt_ui_context_t *ctx) {
+    nt_stats_count("ui_draw_calls", (uint64_t)nt_ui_get_last_walk_draw_calls(ctx));
+    nt_stats_count("ui_element_count", (uint64_t)nt_ui_get_last_walk_element_count(ctx));
+}
+
+/* WALK-09 (getter): after a walk that emits a RECT, the public draw-call
+ * getter reports >= 1 (the walker-exit flush issues at least one GL
+ * draw call). */
+static void test_get_last_walk_draw_calls_after_rect(void) {
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
     c->boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 100.0F, .height = 100.0F};
@@ -57,27 +73,12 @@ static void test_ui_draw_calls_counter_set(void) {
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    /* Per-walk delta probe: at least the walker-exit flush ticked one draw call. */
-    const uint32_t delta = nt_ui_test_last_walk_draw_call_delta(s_fx.ctx);
-    TEST_ASSERT_GREATER_THAN_UINT32(0U, delta);
-
-    /* nt_stats wiring: the counter must surface in format_lines. */
-    char buf[512];
-    uint32_t n = nt_stats_format_lines(buf, sizeof buf);
-    TEST_ASSERT_GREATER_THAN_UINT32(0U, n);
-    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(buf, "ui_draw_calls:"), "nt_stats must contain ui_draw_calls counter after walk");
-
-    /* The delta value must match what nt_stats holds -- verify via
-     * substring of the formatted counter line. */
-    char expected[64];
-    (void)snprintf(expected, sizeof expected, "ui_draw_calls: %u", (unsigned)delta);
-    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(buf, expected), "ui_draw_calls value in nt_stats must match per-walk delta probe");
+    TEST_ASSERT_GREATER_THAN_UINT32(0U, nt_ui_get_last_walk_draw_calls(s_fx.ctx));
 }
 
-/* WALK-09 / D-52-20: ui_element_count equals frozen_cmds.length and is
- * routed into nt_stats. */
-static void test_ui_element_count_counter_set(void) {
-    /* 3 RECT commands -> walker iterates 3 elements. */
+/* WALK-09 (getter): element count equals frozen_cmds.length exactly
+ * (synthetic injected array, no Clay wrapper elements). */
+static void test_get_last_walk_element_count_matches_frozen_cmds(void) {
     for (int i = 0; i < 3; ++i) {
         Clay_RenderCommand *c = &s_test_cmds[i];
         c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
@@ -89,20 +90,37 @@ static void test_ui_element_count_counter_set(void) {
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    /* Element count probe matches frozen_cmds.length exactly (no Clay
-     * wrapper elements -- frozen_cmds is the injected synthetic array). */
-    TEST_ASSERT_EQUAL_UINT32(3U, nt_ui_test_last_walk_element_count(s_fx.ctx));
-
-    /* nt_stats wiring. */
-    char buf[512];
-    (void)nt_stats_format_lines(buf, sizeof buf);
-    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(buf, "ui_element_count: 3"), "nt_stats ui_element_count must equal frozen_cmds.length");
+    TEST_ASSERT_EQUAL_UINT32(3U, nt_ui_get_last_walk_element_count(s_fx.ctx));
 }
 
-/* WALK-09 / D-52-20: counters are SET per walk, not accumulated. Walk twice
- * with different command counts -- the second walk's counter must reflect
- * the second declaration. */
-static void test_counters_reset_per_walk(void) {
+/* WALK-09 (bridge): app forwards getter values into nt_stats; both
+ * counters appear in nt_stats_format_lines with the expected values. */
+static void test_metrics_bridge_publishes_to_nt_stats(void) {
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    c->boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 50.0F, .height = 50.0F};
+    c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255.0F, .g = 255.0F, .b = 255.0F, .a = 255.0F};
+    inject_frozen_cmds(1);
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &target);
+    publish_ui_metrics_to_stats(s_fx.ctx);
+
+    const uint32_t draw_calls = nt_ui_get_last_walk_draw_calls(s_fx.ctx);
+
+    char buf[512];
+    const uint32_t n = nt_stats_format_lines(buf, sizeof buf);
+    TEST_ASSERT_GREATER_THAN_UINT32(0U, n);
+
+    char expected_draw[64];
+    (void)snprintf(expected_draw, sizeof expected_draw, "ui_draw_calls: %u", (unsigned)draw_calls);
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(buf, expected_draw), "bridge: ui_draw_calls value in nt_stats must match getter output");
+    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(buf, "ui_element_count: 1"), "bridge: ui_element_count must equal frozen_cmds.length");
+}
+
+/* WALK-09: counters are SET per walk (not accumulated). Walk twice with
+ * different command counts -- second getter call reflects second walk. */
+static void test_getters_reflect_latest_walk_only(void) {
     /* First walk: 2 RECT commands. */
     for (int i = 0; i < 2; ++i) {
         Clay_RenderCommand *c = &s_test_cmds[i];
@@ -114,29 +132,20 @@ static void test_counters_reset_per_walk(void) {
 
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
+    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_element_count(s_fx.ctx));
 
-    const uint32_t count1 = nt_ui_test_last_walk_element_count(s_fx.ctx);
-    TEST_ASSERT_EQUAL_UINT32(2U, count1);
-
-    /* Second walk: empty command array. */
+    /* Second walk: empty array. Getter must reflect THIS walk, not the
+     * accumulated total. */
     inject_frozen_cmds(0);
     nt_ui_walk(s_fx.ctx, &target);
-
-    const uint32_t count2 = nt_ui_test_last_walk_element_count(s_fx.ctx);
-    TEST_ASSERT_EQUAL_UINT32(0U, count2);
-    TEST_ASSERT_NOT_EQUAL_MESSAGE(count1, count2, "second walk's element count must reflect the second declaration, not accumulate");
-
-    /* nt_stats also reflects the second walk's value, not the first. */
-    char buf[512];
-    (void)nt_stats_format_lines(buf, sizeof buf);
-    TEST_ASSERT_NOT_NULL_MESSAGE(strstr(buf, "ui_element_count: 0"), "nt_stats ui_element_count must reflect second walk (=0), not first (=2)");
-    TEST_ASSERT_NULL_MESSAGE(strstr(buf, "ui_element_count: 2"), "old (first-walk) value must be overwritten in nt_stats");
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_element_count(s_fx.ctx));
 }
 
 int main(void) {
     UNITY_BEGIN();
-    RUN_TEST(test_ui_draw_calls_counter_set);
-    RUN_TEST(test_ui_element_count_counter_set);
-    RUN_TEST(test_counters_reset_per_walk);
+    RUN_TEST(test_get_last_walk_draw_calls_after_rect);
+    RUN_TEST(test_get_last_walk_element_count_matches_frozen_cmds);
+    RUN_TEST(test_metrics_bridge_publishes_to_nt_stats);
+    RUN_TEST(test_getters_reflect_latest_walk_only);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_stats.c
+++ b/tests/unit/test_nt_ui_stats.c
@@ -119,13 +119,13 @@ void setUp(void) {
     s_sprite_material = make_test_material();
     s_text_material = make_test_material();
 
-    nt_ui_set_atlas_white_region(s_atlas.handle, s_atlas.white_region_idx);
-    nt_ui_set_sprite_material(s_sprite_material);
-    nt_ui_set_text_material(s_text_material);
-    nt_ui_set_custom_handler(NULL, NULL);
-
     s_ctx = nt_ui_create_context(s_arena, sizeof s_arena);
     TEST_ASSERT_NOT_NULL(s_ctx);
+
+    nt_ui_set_atlas_white_region(s_ctx, s_atlas.handle, s_atlas.white_region_idx);
+    nt_ui_set_sprite_material(s_ctx, s_sprite_material);
+    nt_ui_set_text_material(s_ctx, s_text_material);
+    nt_ui_set_custom_handler(s_ctx, NULL, NULL);
 }
 
 void tearDown(void) {
@@ -133,7 +133,6 @@ void tearDown(void) {
         nt_ui_destroy_context(s_ctx);
         s_ctx = NULL;
     }
-    nt_ui_test_reset_walker_globals();
     minimal_ui_atlas_destroy(&s_atlas);
 
     nt_stats_shutdown();
@@ -171,7 +170,7 @@ static void test_ui_draw_calls_counter_set(void) {
     nt_ui_walk(s_ctx, &target);
 
     /* Per-walk delta probe: at least the walker-exit flush ticked one draw call. */
-    const uint32_t delta = nt_ui_test_last_walk_draw_call_delta();
+    const uint32_t delta = nt_ui_test_last_walk_draw_call_delta(s_ctx);
     TEST_ASSERT_GREATER_THAN_UINT32(0u, delta);
 
     /* nt_stats wiring: the counter must surface in format_lines. */
@@ -204,7 +203,7 @@ static void test_ui_element_count_counter_set(void) {
 
     /* Element count probe matches frozen_cmds.length exactly (no Clay
      * wrapper elements -- frozen_cmds is the injected synthetic array). */
-    TEST_ASSERT_EQUAL_UINT32(3u, nt_ui_test_last_walk_element_count());
+    TEST_ASSERT_EQUAL_UINT32(3u, nt_ui_test_last_walk_element_count(s_ctx));
 
     /* nt_stats wiring. */
     char buf[512];
@@ -228,14 +227,14 @@ static void test_counters_reset_per_walk(void) {
     nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
     nt_ui_walk(s_ctx, &target);
 
-    const uint32_t count1 = nt_ui_test_last_walk_element_count();
+    const uint32_t count1 = nt_ui_test_last_walk_element_count(s_ctx);
     TEST_ASSERT_EQUAL_UINT32(2u, count1);
 
     /* Second walk: empty command array. */
     inject_frozen_cmds(0);
     nt_ui_walk(s_ctx, &target);
 
-    const uint32_t count2 = nt_ui_test_last_walk_element_count();
+    const uint32_t count2 = nt_ui_test_last_walk_element_count(s_ctx);
     TEST_ASSERT_EQUAL_UINT32(0u, count2);
     TEST_ASSERT_NOT_EQUAL_MESSAGE(count1, count2, "second walk's element count must reflect the second declaration, not accumulate");
 

--- a/tests/unit/test_nt_ui_stats.c
+++ b/tests/unit/test_nt_ui_stats.c
@@ -23,7 +23,7 @@
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8U];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
 static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 8

--- a/tests/unit/test_nt_ui_stats.c
+++ b/tests/unit/test_nt_ui_stats.c
@@ -23,7 +23,7 @@
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8U];
 static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 8
@@ -50,21 +50,21 @@ static void inject_frozen_cmds(int32_t count) {
 static void test_ui_draw_calls_counter_set(void) {
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
-    c->boundingBox = (Clay_BoundingBox){.x = 0.0f, .y = 0.0f, .width = 100.0f, .height = 100.0f};
-    c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255.0f, .g = 0.0f, .b = 0.0f, .a = 255.0f};
+    c->boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 100.0F, .height = 100.0F};
+    c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255.0F, .g = 0.0F, .b = 0.0F, .a = 255.0F};
     inject_frozen_cmds(1);
 
-    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
     /* Per-walk delta probe: at least the walker-exit flush ticked one draw call. */
     const uint32_t delta = nt_ui_test_last_walk_draw_call_delta(s_fx.ctx);
-    TEST_ASSERT_GREATER_THAN_UINT32(0u, delta);
+    TEST_ASSERT_GREATER_THAN_UINT32(0U, delta);
 
     /* nt_stats wiring: the counter must surface in format_lines. */
     char buf[512];
     uint32_t n = nt_stats_format_lines(buf, sizeof buf);
-    TEST_ASSERT_GREATER_THAN_UINT32(0u, n);
+    TEST_ASSERT_GREATER_THAN_UINT32(0U, n);
     TEST_ASSERT_NOT_NULL_MESSAGE(strstr(buf, "ui_draw_calls:"), "nt_stats must contain ui_draw_calls counter after walk");
 
     /* The delta value must match what nt_stats holds -- verify via
@@ -81,17 +81,17 @@ static void test_ui_element_count_counter_set(void) {
     for (int i = 0; i < 3; ++i) {
         Clay_RenderCommand *c = &s_test_cmds[i];
         c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
-        c->boundingBox = (Clay_BoundingBox){.x = (float)(i * 20), .y = 0.0f, .width = 10.0f, .height = 10.0f};
-        c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 0.0f, .g = 255.0f, .b = 0.0f, .a = 255.0f};
+        c->boundingBox = (Clay_BoundingBox){.x = (float)(i * 20), .y = 0.0F, .width = 10.0F, .height = 10.0F};
+        c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 0.0F, .g = 255.0F, .b = 0.0F, .a = 255.0F};
     }
     inject_frozen_cmds(3);
 
-    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
     /* Element count probe matches frozen_cmds.length exactly (no Clay
      * wrapper elements -- frozen_cmds is the injected synthetic array). */
-    TEST_ASSERT_EQUAL_UINT32(3u, nt_ui_test_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(3U, nt_ui_test_last_walk_element_count(s_fx.ctx));
 
     /* nt_stats wiring. */
     char buf[512];
@@ -107,23 +107,23 @@ static void test_counters_reset_per_walk(void) {
     for (int i = 0; i < 2; ++i) {
         Clay_RenderCommand *c = &s_test_cmds[i];
         c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
-        c->boundingBox = (Clay_BoundingBox){.x = 0.0f, .y = 0.0f, .width = 10.0f, .height = 10.0f};
-        c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255.0f, .g = 255.0f, .b = 255.0f, .a = 255.0f};
+        c->boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 10.0F, .height = 10.0F};
+        c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255.0F, .g = 255.0F, .b = 255.0F, .a = 255.0F};
     }
     inject_frozen_cmds(2);
 
-    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
     const uint32_t count1 = nt_ui_test_last_walk_element_count(s_fx.ctx);
-    TEST_ASSERT_EQUAL_UINT32(2u, count1);
+    TEST_ASSERT_EQUAL_UINT32(2U, count1);
 
     /* Second walk: empty command array. */
     inject_frozen_cmds(0);
     nt_ui_walk(s_fx.ctx, &target);
 
     const uint32_t count2 = nt_ui_test_last_walk_element_count(s_fx.ctx);
-    TEST_ASSERT_EQUAL_UINT32(0u, count2);
+    TEST_ASSERT_EQUAL_UINT32(0U, count2);
     TEST_ASSERT_NOT_EQUAL_MESSAGE(count1, count2, "second walk's element count must reflect the second declaration, not accumulate");
 
     /* nt_stats also reflects the second walk's value, not the first. */

--- a/tests/unit/test_nt_ui_walker_batching.c
+++ b/tests/unit/test_nt_ui_walker_batching.c
@@ -30,12 +30,18 @@ static void inject_frozen_cmds(int32_t count) {
     s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
 }
 
+/* Static-lifetime layer descriptors (compound literal pointer must outlive
+ * the walk; file-scope static is the safest for tests). */
+static const nt_ui_element_data_t k_layer_sprite = {.layer = 0U};
+static const nt_ui_element_data_t k_layer_text = {.layer = 1U};
+
 static void make_rect(int idx, int16_t z, float x) {
     Clay_RenderCommand *c = &s_test_cmds[idx];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
     c->zIndex = z;
     c->boundingBox = (Clay_BoundingBox){.x = x, .y = 0, .width = 10, .height = 10};
     c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255, .g = 0, .b = 0, .a = 255};
+    c->userData = (void *)&k_layer_sprite;
 }
 
 static void make_text(int idx, int16_t z, float x) {
@@ -47,6 +53,7 @@ static void make_text(int idx, int16_t z, float x) {
     c->renderData.text.textColor = (Clay_Color){.r = 255, .g = 255, .b = 255, .a = 255};
     c->renderData.text.fontId = 0;
     c->renderData.text.fontSize = 14;
+    c->userData = (void *)&k_layer_text;
 }
 
 static int s_custom_calls;
@@ -60,8 +67,9 @@ static void custom_cb(const void *cmd, void *user) {
     ++s_custom_calls;
 }
 
-/* Interleaved RTRTRT @ z=0 collapses to 1 sprite dc. Test font
- * unregistered so emit_text early-returns; text-side untested here. */
+/* Interleaved RTRTRT @ z=0 with RECTs on layer 0 + TEXTs on layer 1
+ * collapses to 1 sprite dc -- layer sort emits all RECTs first (single
+ * sprite batch), then TEXTs flush sprite once on first emit_text entry. */
 static void test_same_z_rect_text_batches(void) {
     make_rect(0, 0, 0);
     make_text(1, 0, 20);
@@ -130,11 +138,73 @@ static void test_multi_z_preserves_painter_order(void) {
     TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_draw_calls(s_fx.ctx));
 }
 
+/* NULL userData defaults to layer 0 -- unlayered count exposes how many
+ * segmentable commands fell through to the default layer. */
+static void test_unlayered_count_tracks_null_userdata(void) {
+    /* 3 commands without userData (NULL) + 0 with explicit data.
+     * Use the bare commandType setup so userData stays NULL. */
+    Clay_RenderCommand *c0 = &s_test_cmds[0];
+    c0->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    c0->zIndex = 0;
+    c0->boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 10, .height = 10};
+    c0->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255, .g = 0, .b = 0, .a = 255};
+    c0->userData = NULL;
+    Clay_RenderCommand *c1 = &s_test_cmds[1];
+    c1->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    c1->zIndex = 0;
+    c1->boundingBox = (Clay_BoundingBox){.x = 20, .y = 0, .width = 10, .height = 10};
+    c1->renderData.rectangle.backgroundColor = (Clay_Color){.r = 0, .g = 255, .b = 0, .a = 255};
+    c1->userData = NULL;
+    Clay_RenderCommand *c2 = &s_test_cmds[2];
+    c2->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    c2->zIndex = 0;
+    c2->boundingBox = (Clay_BoundingBox){.x = 40, .y = 0, .width = 10, .height = 10};
+    c2->renderData.rectangle.backgroundColor = (Clay_Color){.r = 0, .g = 0, .b = 255, .a = 255};
+    c2->userData = (void *)&k_layer_sprite; /* explicit layer 0 */
+    inject_frozen_cmds(3);
+
+    nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    /* 2 of 3 commands were NULL-userData. */
+    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_test_last_walk_unlayered_count(s_fx.ctx));
+}
+
+/* Layer 1 cmd declared FIRST but renders AFTER layer 0 cmd declared SECOND. */
+static void test_layer_sort_overrides_declaration_order(void) {
+    Clay_RenderCommand *c0 = &s_test_cmds[0];
+    c0->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    c0->zIndex = 0;
+    c0->boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 10, .height = 10};
+    c0->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255, .g = 0, .b = 0, .a = 255};
+    c0->userData = (void *)&k_layer_text; /* layer 1, declared first */
+
+    Clay_RenderCommand *c1 = &s_test_cmds[1];
+    c1->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    c1->zIndex = 0;
+    c1->boundingBox = (Clay_BoundingBox){.x = 20, .y = 0, .width = 10, .height = 10};
+    c1->renderData.rectangle.backgroundColor = (Clay_Color){.r = 0, .g = 255, .b = 0, .a = 255};
+    c1->userData = (void *)&k_layer_sprite; /* layer 0, declared second */
+    inject_frozen_cmds(2);
+
+    nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    /* Layer 0 emits FIRST (declared second), layer 1 emits SECOND (declared first).
+     * The last_emit captures the most recent emit -- which must be layer 1's rect (x=0). */
+    float pos[3];
+    nt_sprite_renderer_test_last_emit_position(0U, pos);
+    /* emit_screen_rect's transform places vertex 0 at exactly the rect's (x, y). */
+    TEST_ASSERT_EQUAL_INT32(0, (int32_t)pos[0]);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_same_z_rect_text_batches);
     RUN_TEST(test_scissor_is_hard_barrier);
     RUN_TEST(test_custom_is_hard_barrier);
     RUN_TEST(test_multi_z_preserves_painter_order);
+    RUN_TEST(test_unlayered_count_tracks_null_userdata);
+    RUN_TEST(test_layer_sort_overrides_declaration_order);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_walker_batching.c
+++ b/tests/unit/test_nt_ui_walker_batching.c
@@ -60,13 +60,23 @@ static void custom_cb(const void *cmd, void *user) {
     ++s_custom_calls;
 }
 
-/* Same-z interleaved RECT/TEXT collapses to one sprite + one text draw
- * call instead of one per transition. Sequence RTRTRT (3 of each) at
- * z=0 used to produce 3 sprite flushes (one per TEXT, draining the
- * preceding RECT alone) + 1 text flush at exit = 4 draw calls. With
- * segment batching: Pass 1 stages all 3 RECTs together; first TEXT in
- * Pass 2 triggers a single sprite flush (1 draw call), then all 3
- * TEXTs stage; walker-exit text flush emits 1 draw call. Total 2. */
+/* Sprite-side proof: same-z interleaved RECT/TEXT no longer splits the
+ * sprite batch on every RECT->TEXT transition.
+ *
+ * Sequence: RTRTRT (3 of each) at z=0. The fixture does not register
+ * a font, so emit_text early-returns after its prologue sprite flush;
+ * the text-renderer side contributes 0 draw calls. What we can prove
+ * via draw_call_count is that the SPRITE batch survived the
+ * interleaving:
+ *   -- Old walker: each TEXT drained the preceding RECT alone (1 dc
+ *      per TEXT * 3 = 3 sprite dc).
+ *   -- New walker (segment batching): Pass 1 stages all 3 RECTs
+ *      together; first TEXT in Pass 2 triggers one sprite flush (1
+ *      dc). All subsequent TEXTs flush an already-empty sprite stage.
+ *      Total sprite dc = 1.
+ * Proving the TEXT side batches symmetrically would require setting
+ * up a real font + registered resource (see test_nt_ui_measure_cb for
+ * the harness), out of scope for this batching unit. */
 static void test_same_z_rect_text_batches(void) {
     make_rect(0, 0, 0);
     make_text(1, 0, 20);
@@ -79,10 +89,6 @@ static void test_same_z_rect_text_batches(void) {
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    /* Note: test font isn't registered (UI_WALKER_FX_BIND_ALL doesn't
-     * include a font). emit_text early-returns after the prologue sprite
-     * flush -- so the text-renderer side contributes 0 draw calls.
-     * Sprite batch drains in one call. */
     TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_draw_calls(s_fx.ctx));
 }
 

--- a/tests/unit/test_nt_ui_walker_batching.c
+++ b/tests/unit/test_nt_ui_walker_batching.c
@@ -30,8 +30,7 @@ static void inject_frozen_cmds(int32_t count) {
     s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
 }
 
-/* Static-lifetime layer descriptors (compound literal pointer must outlive
- * the walk; file-scope static is the safest for tests). */
+/* File-scope so layer data outlives walk (compound literal would scope out). */
 static const nt_ui_element_data_t k_layer_sprite = {.layer = 0U};
 static const nt_ui_element_data_t k_layer_text = {.layer = 1U};
 
@@ -60,16 +59,13 @@ static int s_custom_calls;
 static void custom_cb(const void *cmd, void *user) {
     (void)cmd;
     (void)user;
-    /* When the walker invokes a custom callback, sprite_renderer must be
-     * flushed first -- callback may bind its own pipeline. Verify staging
-     * is empty at the moment of entry. */
+    /* Callback may bind its own pipeline -- sprite staging must be empty. */
     TEST_ASSERT_EQUAL_UINT32(0U, nt_sprite_renderer_test_vertex_count());
     ++s_custom_calls;
 }
 
-/* Interleaved RTRTRT @ z=0 with RECTs on layer 0 + TEXTs on layer 1
- * collapses to 1 sprite dc -- layer sort emits all RECTs first (single
- * sprite batch), then TEXTs flush sprite once on first emit_text entry. */
+/* RECTs on layer 0 + TEXTs on layer 1: layer sort collapses interleaved
+ * RTRTRT to 1 sprite dc (sprites batch, single sprite flush on first TEXT). */
 static void test_same_z_rect_text_batches(void) {
     make_rect(0, 0, 0);
     make_text(1, 0, 20);
@@ -141,8 +137,7 @@ static void test_multi_z_preserves_painter_order(void) {
 /* NULL userData defaults to layer 0 -- unlayered count exposes how many
  * segmentable commands fell through to the default layer. */
 static void test_unlayered_count_tracks_null_userdata(void) {
-    /* 3 commands without userData (NULL) + 0 with explicit data.
-     * Use the bare commandType setup so userData stays NULL. */
+    /* Bare setup so userData stays NULL on the first two. */
     Clay_RenderCommand *c0 = &s_test_cmds[0];
     c0->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
     c0->zIndex = 0;
@@ -166,17 +161,14 @@ static void test_unlayered_count_tracks_null_userdata(void) {
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    /* 2 of 3 commands were NULL-userData. */
     TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_test_last_walk_unlayered_count(s_fx.ctx));
 }
 
-/* Sparse layers (0 and 200) must work correctly. Old iterate-per-layer
- * implementation would scan 200 empty buckets; counting sort is O(N + 256)
- * regardless of layer spread. */
+/* Sparse layers (0 and 200): bitmask scan skips empty buckets. */
 static void test_layer_sort_sparse_layers(void) {
     static const nt_ui_element_data_t k_layer_low = {.layer = 0U};
     static const nt_ui_element_data_t k_layer_high = {.layer = 200U};
-    /* Layer 200 declared first, layer 0 second -- after sort layer 0 renders first. */
+    /* Declared in reverse order; layer 0 must still render first. */
     Clay_RenderCommand *c0 = &s_test_cmds[0];
     c0->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
     c0->zIndex = 0;
@@ -195,37 +187,35 @@ static void test_layer_sort_sparse_layers(void) {
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    /* Last emit must be layer 200 (declared first but renders last) at x=0. */
+    /* Last emit must be layer 200's rect at x=0. */
     float pos[3];
     nt_sprite_renderer_test_last_emit_position(0U, pos);
     TEST_ASSERT_EQUAL_INT32(0, (int32_t)pos[0]);
 }
 
-/* Layer 1 cmd declared FIRST but renders AFTER layer 0 cmd declared SECOND. */
+/* Layer wins over declaration order: layer 0 declared second renders first. */
 static void test_layer_sort_overrides_declaration_order(void) {
     Clay_RenderCommand *c0 = &s_test_cmds[0];
     c0->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
     c0->zIndex = 0;
     c0->boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 10, .height = 10};
     c0->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255, .g = 0, .b = 0, .a = 255};
-    c0->userData = (void *)&k_layer_text; /* layer 1, declared first */
+    c0->userData = (void *)&k_layer_text;
 
     Clay_RenderCommand *c1 = &s_test_cmds[1];
     c1->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
     c1->zIndex = 0;
     c1->boundingBox = (Clay_BoundingBox){.x = 20, .y = 0, .width = 10, .height = 10};
     c1->renderData.rectangle.backgroundColor = (Clay_Color){.r = 0, .g = 255, .b = 0, .a = 255};
-    c1->userData = (void *)&k_layer_sprite; /* layer 0, declared second */
+    c1->userData = (void *)&k_layer_sprite;
     inject_frozen_cmds(2);
 
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    /* Layer 0 emits FIRST (declared second), layer 1 emits SECOND (declared first).
-     * The last_emit captures the most recent emit -- which must be layer 1's rect (x=0). */
+    /* Layer 1 (declared first) renders LAST: last emit is its rect at x=0. */
     float pos[3];
     nt_sprite_renderer_test_last_emit_position(0U, pos);
-    /* emit_screen_rect's transform places vertex 0 at exactly the rect's (x, y). */
     TEST_ASSERT_EQUAL_INT32(0, (int32_t)pos[0]);
 }
 

--- a/tests/unit/test_nt_ui_walker_batching.c
+++ b/tests/unit/test_nt_ui_walker_batching.c
@@ -170,6 +170,37 @@ static void test_unlayered_count_tracks_null_userdata(void) {
     TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_test_last_walk_unlayered_count(s_fx.ctx));
 }
 
+/* Sparse layers (0 and 200) must work correctly. Old iterate-per-layer
+ * implementation would scan 200 empty buckets; counting sort is O(N + 256)
+ * regardless of layer spread. */
+static void test_layer_sort_sparse_layers(void) {
+    static const nt_ui_element_data_t k_layer_low = {.layer = 0U};
+    static const nt_ui_element_data_t k_layer_high = {.layer = 200U};
+    /* Layer 200 declared first, layer 0 second -- after sort layer 0 renders first. */
+    Clay_RenderCommand *c0 = &s_test_cmds[0];
+    c0->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    c0->zIndex = 0;
+    c0->boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 10, .height = 10};
+    c0->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255, .g = 0, .b = 0, .a = 255};
+    c0->userData = (void *)&k_layer_high;
+
+    Clay_RenderCommand *c1 = &s_test_cmds[1];
+    c1->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    c1->zIndex = 0;
+    c1->boundingBox = (Clay_BoundingBox){.x = 20, .y = 0, .width = 10, .height = 10};
+    c1->renderData.rectangle.backgroundColor = (Clay_Color){.r = 0, .g = 255, .b = 0, .a = 255};
+    c1->userData = (void *)&k_layer_low;
+    inject_frozen_cmds(2);
+
+    nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    /* Last emit must be layer 200 (declared first but renders last) at x=0. */
+    float pos[3];
+    nt_sprite_renderer_test_last_emit_position(0U, pos);
+    TEST_ASSERT_EQUAL_INT32(0, (int32_t)pos[0]);
+}
+
 /* Layer 1 cmd declared FIRST but renders AFTER layer 0 cmd declared SECOND. */
 static void test_layer_sort_overrides_declaration_order(void) {
     Clay_RenderCommand *c0 = &s_test_cmds[0];
@@ -206,5 +237,6 @@ int main(void) {
     RUN_TEST(test_multi_z_preserves_painter_order);
     RUN_TEST(test_unlayered_count_tracks_null_userdata);
     RUN_TEST(test_layer_sort_overrides_declaration_order);
+    RUN_TEST(test_layer_sort_sparse_layers);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_walker_batching.c
+++ b/tests/unit/test_nt_ui_walker_batching.c
@@ -60,23 +60,8 @@ static void custom_cb(const void *cmd, void *user) {
     ++s_custom_calls;
 }
 
-/* Sprite-side proof: same-z interleaved RECT/TEXT no longer splits the
- * sprite batch on every RECT->TEXT transition.
- *
- * Sequence: RTRTRT (3 of each) at z=0. The fixture does not register
- * a font, so emit_text early-returns after its prologue sprite flush;
- * the text-renderer side contributes 0 draw calls. What we can prove
- * via draw_call_count is that the SPRITE batch survived the
- * interleaving:
- *   -- Old walker: each TEXT drained the preceding RECT alone (1 dc
- *      per TEXT * 3 = 3 sprite dc).
- *   -- New walker (segment batching): Pass 1 stages all 3 RECTs
- *      together; first TEXT in Pass 2 triggers one sprite flush (1
- *      dc). All subsequent TEXTs flush an already-empty sprite stage.
- *      Total sprite dc = 1.
- * Proving the TEXT side batches symmetrically would require setting
- * up a real font + registered resource (see test_nt_ui_measure_cb for
- * the harness), out of scope for this batching unit. */
+/* Interleaved RTRTRT @ z=0 collapses to 1 sprite dc. Test font
+ * unregistered so emit_text early-returns; text-side untested here. */
 static void test_same_z_rect_text_batches(void) {
     make_rect(0, 0, 0);
     make_text(1, 0, 20);
@@ -92,11 +77,7 @@ static void test_same_z_rect_text_batches(void) {
     TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_draw_calls(s_fx.ctx));
 }
 
-/* SCISSOR_START / SCISSOR_END are hard barriers -- the walker never
- * reorders commands across them. Sequence RECT-SCISSOR_START-RECT-
- * SCISSOR_END-RECT (all z=0) MUST produce 3 separate sprite draw calls,
- * one per scissor segment, because each scissor transition force-flushes
- * the renderer to preserve clip scope. */
+/* Each scissor transition force-flushes to preserve clip scope. */
 static void test_scissor_is_hard_barrier(void) {
     make_rect(0, 0, 0);
     s_test_cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
@@ -114,15 +95,10 @@ static void test_scissor_is_hard_barrier(void) {
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    /* RECT[0] flushed by scissor_push, RECT[2] flushed by scissor_pop,
-     * RECT[4] flushed by walker exit. 3 separate draw calls. */
     TEST_ASSERT_EQUAL_UINT32(calls_before + 3U, nt_sprite_renderer_test_draw_call_count());
 }
 
-/* CUSTOM is a hard barrier with the additional contract that the
- * callback sees clean renderer state. Sequence RECT-CUSTOM-RECT must
- * flush the first RECT before the callback runs (asserted inside the
- * callback) and emit the second RECT into a fresh batch afterwards. */
+/* CUSTOM callback sees clean renderer state (assert inside cb). */
 static void test_custom_is_hard_barrier(void) {
     s_custom_calls = 0;
     nt_ui_set_custom_handler(s_fx.ctx, custom_cb, NULL);
@@ -138,21 +114,10 @@ static void test_custom_is_hard_barrier(void) {
     nt_ui_walk(s_fx.ctx, &target);
 
     TEST_ASSERT_EQUAL_INT(1, s_custom_calls);
-    /* RECT[0] flushed at CUSTOM entry, RECT[2] flushed at walker exit. */
     TEST_ASSERT_EQUAL_UINT32(calls_before + 2U, nt_sprite_renderer_test_draw_call_count());
 }
 
-/* Different zIndex layers must never merge -- painter order across z is
- * a hard contract (game code relies on it for stacking). RECT@z=0,
- * RECT@z=5 at separate z must emit as two segments. With segmentation
- * by zIndex, sprite_renderer auto-batches both into one draw call only
- * because they share material/page; the segments are emitted in
- * ascending-z order, which IS painter order, so the merge is correct.
- * But if we extend the sequence with a TEXT@z=2 BETWEEN them, the TEXT
- * MUST be emitted between the two RECTs (else painter order broken).
- * That forces a sprite flush at the TEXT transition -- so the total
- * draw-call delta is 1 sprite (RECT@z=0 alone, flushed when TEXT@z=2
- * arrives) + RECT@z=5 batched at exit = 2. */
+/* z=0 RECT, z=2 TEXT, z=5 RECT -- TEXT between forces sprite flush. */
 static void test_multi_z_preserves_painter_order(void) {
     make_rect(0, 0, 0);
     make_text(1, 2, 20);
@@ -162,8 +127,6 @@ static void test_multi_z_preserves_painter_order(void) {
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    /* 2 sprite draw calls (z=0 RECT, then z=5 RECT after TEXT). Text
-     * font unregistered, contributes 0. */
     TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_draw_calls(s_fx.ctx));
 }
 

--- a/tests/unit/test_nt_ui_walker_batching.c
+++ b/tests/unit/test_nt_ui_walker_batching.c
@@ -1,0 +1,171 @@
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "clay.h"
+#include "renderers/nt_sprite_renderer.h"
+#include "test_helpers/ui_walker_fixture.h"
+#include "ui/nt_ui.h"
+#include "ui/nt_ui_internal.h"
+#include "unity.h"
+
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
+static ui_walker_fixture_t s_fx;
+
+#define MAX_TEST_CMDS 16
+static Clay_RenderCommand s_test_cmds[MAX_TEST_CMDS];
+static const char s_text[] = "X";
+
+void setUp(void) {
+    memset(s_test_cmds, 0, sizeof s_test_cmds);
+    ui_walker_fixture_init(&s_fx, s_arena, sizeof s_arena, UI_WALKER_FX_BIND_ALL);
+}
+
+void tearDown(void) { ui_walker_fixture_shutdown(&s_fx); }
+
+static void inject_frozen_cmds(int32_t count) {
+    s_fx.ctx->frozen_cmds.internalArray = s_test_cmds;
+    s_fx.ctx->frozen_cmds.length = count;
+    s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
+}
+
+static void make_rect(int idx, int16_t z, float x) {
+    Clay_RenderCommand *c = &s_test_cmds[idx];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    c->zIndex = z;
+    c->boundingBox = (Clay_BoundingBox){.x = x, .y = 0, .width = 10, .height = 10};
+    c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255, .g = 0, .b = 0, .a = 255};
+}
+
+static void make_text(int idx, int16_t z, float x) {
+    Clay_RenderCommand *c = &s_test_cmds[idx];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_TEXT;
+    c->zIndex = z;
+    c->boundingBox = (Clay_BoundingBox){.x = x, .y = 0, .width = 10, .height = 10};
+    c->renderData.text.stringContents = (Clay_StringSlice){.length = 1, .chars = s_text, .baseChars = s_text};
+    c->renderData.text.textColor = (Clay_Color){.r = 255, .g = 255, .b = 255, .a = 255};
+    c->renderData.text.fontId = 0;
+    c->renderData.text.fontSize = 14;
+}
+
+static int s_custom_calls;
+static void custom_cb(const void *cmd, void *user) {
+    (void)cmd;
+    (void)user;
+    /* When the walker invokes a custom callback, sprite_renderer must be
+     * flushed first -- callback may bind its own pipeline. Verify staging
+     * is empty at the moment of entry. */
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_sprite_renderer_test_vertex_count());
+    ++s_custom_calls;
+}
+
+/* Same-z interleaved RECT/TEXT collapses to one sprite + one text draw
+ * call instead of one per transition. Sequence RTRTRT (3 of each) at
+ * z=0 used to produce 3 sprite flushes (one per TEXT, draining the
+ * preceding RECT alone) + 1 text flush at exit = 4 draw calls. With
+ * segment batching: Pass 1 stages all 3 RECTs together; first TEXT in
+ * Pass 2 triggers a single sprite flush (1 draw call), then all 3
+ * TEXTs stage; walker-exit text flush emits 1 draw call. Total 2. */
+static void test_same_z_rect_text_batches(void) {
+    make_rect(0, 0, 0);
+    make_text(1, 0, 20);
+    make_rect(2, 0, 40);
+    make_text(3, 0, 60);
+    make_rect(4, 0, 80);
+    make_text(5, 0, 100);
+    inject_frozen_cmds(6);
+
+    nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    /* Note: test font isn't registered (UI_WALKER_FX_BIND_ALL doesn't
+     * include a font). emit_text early-returns after the prologue sprite
+     * flush -- so the text-renderer side contributes 0 draw calls.
+     * Sprite batch drains in one call. */
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_draw_calls(s_fx.ctx));
+}
+
+/* SCISSOR_START / SCISSOR_END are hard barriers -- the walker never
+ * reorders commands across them. Sequence RECT-SCISSOR_START-RECT-
+ * SCISSOR_END-RECT (all z=0) MUST produce 3 separate sprite draw calls,
+ * one per scissor segment, because each scissor transition force-flushes
+ * the renderer to preserve clip scope. */
+static void test_scissor_is_hard_barrier(void) {
+    make_rect(0, 0, 0);
+    s_test_cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
+    s_test_cmds[1].zIndex = 0;
+    s_test_cmds[1].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 800, .height = 600};
+    s_test_cmds[1].renderData.clip.horizontal = true;
+    s_test_cmds[1].renderData.clip.vertical = true;
+    make_rect(2, 0, 20);
+    s_test_cmds[3].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
+    s_test_cmds[3].zIndex = 0;
+    make_rect(4, 0, 40);
+    inject_frozen_cmds(5);
+
+    const uint32_t calls_before = nt_sprite_renderer_test_draw_call_count();
+    nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    /* RECT[0] flushed by scissor_push, RECT[2] flushed by scissor_pop,
+     * RECT[4] flushed by walker exit. 3 separate draw calls. */
+    TEST_ASSERT_EQUAL_UINT32(calls_before + 3U, nt_sprite_renderer_test_draw_call_count());
+}
+
+/* CUSTOM is a hard barrier with the additional contract that the
+ * callback sees clean renderer state. Sequence RECT-CUSTOM-RECT must
+ * flush the first RECT before the callback runs (asserted inside the
+ * callback) and emit the second RECT into a fresh batch afterwards. */
+static void test_custom_is_hard_barrier(void) {
+    s_custom_calls = 0;
+    nt_ui_set_custom_handler(s_fx.ctx, custom_cb, NULL);
+
+    make_rect(0, 0, 0);
+    s_test_cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_CUSTOM;
+    s_test_cmds[1].zIndex = 0;
+    make_rect(2, 0, 20);
+    inject_frozen_cmds(3);
+
+    const uint32_t calls_before = nt_sprite_renderer_test_draw_call_count();
+    nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    TEST_ASSERT_EQUAL_INT(1, s_custom_calls);
+    /* RECT[0] flushed at CUSTOM entry, RECT[2] flushed at walker exit. */
+    TEST_ASSERT_EQUAL_UINT32(calls_before + 2U, nt_sprite_renderer_test_draw_call_count());
+}
+
+/* Different zIndex layers must never merge -- painter order across z is
+ * a hard contract (game code relies on it for stacking). RECT@z=0,
+ * RECT@z=5 at separate z must emit as two segments. With segmentation
+ * by zIndex, sprite_renderer auto-batches both into one draw call only
+ * because they share material/page; the segments are emitted in
+ * ascending-z order, which IS painter order, so the merge is correct.
+ * But if we extend the sequence with a TEXT@z=2 BETWEEN them, the TEXT
+ * MUST be emitted between the two RECTs (else painter order broken).
+ * That forces a sprite flush at the TEXT transition -- so the total
+ * draw-call delta is 1 sprite (RECT@z=0 alone, flushed when TEXT@z=2
+ * arrives) + RECT@z=5 batched at exit = 2. */
+static void test_multi_z_preserves_painter_order(void) {
+    make_rect(0, 0, 0);
+    make_text(1, 2, 20);
+    make_rect(2, 5, 40);
+    inject_frozen_cmds(3);
+
+    nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    /* 2 sprite draw calls (z=0 RECT, then z=5 RECT after TEXT). Text
+     * font unregistered, contributes 0. */
+    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_draw_calls(s_fx.ctx));
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_same_z_rect_text_batches);
+    RUN_TEST(test_scissor_is_hard_barrier);
+    RUN_TEST(test_custom_is_hard_barrier);
+    RUN_TEST(test_multi_z_preserves_painter_order);
+    return UNITY_END();
+}

--- a/tests/unit/test_nt_ui_walker_batching.c
+++ b/tests/unit/test_nt_ui_walker_batching.c
@@ -10,7 +10,7 @@
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_TEST_ARENA_SIZE];
 static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 16

--- a/tests/unit/test_nt_ui_walker_custom.c
+++ b/tests/unit/test_nt_ui_walker_custom.c
@@ -16,7 +16,7 @@
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8U];
 static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 4

--- a/tests/unit/test_nt_ui_walker_custom.c
+++ b/tests/unit/test_nt_ui_walker_custom.c
@@ -1,0 +1,26 @@
+/* tests/unit/test_nt_ui_walker_custom.c — Plan 52-00 stub
+ *
+ * Covers WALK-05 (CUSTOM → registered handler with opaque clay_cmd ptr).
+ * Wave 0 ships TEST_IGNORE bodies; Plan 52-04 fills with real assertions.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* WALK-05 / D-52-09: registered custom handler is invoked with (cmd, userdata) */
+static void test_custom_handler_invoked(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+/* WALK-05 / D-52-09: NULL custom handler → silent skip (no warning, no assert) */
+static void test_null_custom_handler_silent_skip(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_custom_handler_invoked);
+    RUN_TEST(test_null_custom_handler_silent_skip);
+    return UNITY_END();
+}

--- a/tests/unit/test_nt_ui_walker_custom.c
+++ b/tests/unit/test_nt_ui_walker_custom.c
@@ -10,7 +10,7 @@
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_TEST_ARENA_SIZE];
 static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 4

--- a/tests/unit/test_nt_ui_walker_custom.c
+++ b/tests/unit/test_nt_ui_walker_custom.c
@@ -123,13 +123,13 @@ void setUp(void) {
     s_sprite_material = make_test_material();
     s_text_material = make_test_material();
 
-    nt_ui_set_atlas_white_region(s_atlas.handle, s_atlas.white_region_idx);
-    nt_ui_set_sprite_material(s_sprite_material);
-    nt_ui_set_text_material(s_text_material);
-    nt_ui_set_custom_handler(NULL, NULL);
-
     s_ctx = nt_ui_create_context(s_arena, sizeof s_arena);
     TEST_ASSERT_NOT_NULL(s_ctx);
+
+    nt_ui_set_atlas_white_region(s_ctx, s_atlas.handle, s_atlas.white_region_idx);
+    nt_ui_set_sprite_material(s_ctx, s_sprite_material);
+    nt_ui_set_text_material(s_ctx, s_text_material);
+    nt_ui_set_custom_handler(s_ctx, NULL, NULL);
 }
 
 void tearDown(void) {
@@ -137,7 +137,6 @@ void tearDown(void) {
         nt_ui_destroy_context(s_ctx);
         s_ctx = NULL;
     }
-    nt_ui_test_reset_walker_globals();
     minimal_ui_atlas_destroy(&s_atlas);
     nt_stats_shutdown();
     nt_sprite_renderer_shutdown();
@@ -161,7 +160,7 @@ static void inject_frozen_cmds(int32_t count) {
 /* WALK-05: registered handler is called with (clay_cmd, userdata). */
 static void test_custom_handler_invoked(void) {
     int sentinel = 42;
-    nt_ui_set_custom_handler(test_custom_handler, &sentinel);
+    nt_ui_set_custom_handler(s_ctx, test_custom_handler, &sentinel);
 
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_CUSTOM;
@@ -182,7 +181,7 @@ static void test_custom_handler_invoked(void) {
 
 /* WALK-05 / D-52-09: NULL handler = silent skip (no crash, no warning). */
 static void test_null_custom_handler_silent_skip(void) {
-    nt_ui_set_custom_handler(NULL, NULL);
+    nt_ui_set_custom_handler(s_ctx, NULL, NULL);
 
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_CUSTOM;

--- a/tests/unit/test_nt_ui_walker_custom.c
+++ b/tests/unit/test_nt_ui_walker_custom.c
@@ -25,6 +25,7 @@
 #include "renderers/nt_sprite_renderer.h"
 #include "renderers/nt_text_renderer.h"
 #include "resource/nt_resource.h"
+#include "stats/nt_stats.h"
 #include "test_helpers/nt_assert_trap.h"
 #include "test_helpers/ui_atlas.h"
 #include "ui/nt_ui.h"
@@ -113,6 +114,11 @@ void setUp(void) {
     nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
     nt_text_renderer_init();
 
+    /* nt_stats_init required: Plan 52-05 wired nt_stats_count("ui_draw_calls", ...)
+     * + nt_stats_count("ui_element_count", ...) at nt_ui_walk exit. Without init,
+     * nt_stats_count's NT_ASSERT(s_stats.initialized) trips on every walk. */
+    nt_stats_init(NULL);
+
     s_atlas = minimal_ui_atlas_create();
     s_sprite_material = make_test_material();
     s_text_material = make_test_material();
@@ -133,6 +139,7 @@ void tearDown(void) {
     }
     nt_ui_test_reset_walker_globals();
     minimal_ui_atlas_destroy(&s_atlas);
+    nt_stats_shutdown();
     nt_sprite_renderer_shutdown();
     nt_text_renderer_shutdown();
     nt_gfx_end_pass();

--- a/tests/unit/test_nt_ui_walker_custom.c
+++ b/tests/unit/test_nt_ui_walker_custom.c
@@ -1,22 +1,193 @@
-/* tests/unit/test_nt_ui_walker_custom.c — Plan 52-00 stub
+/* tests/unit/test_nt_ui_walker_custom.c -- Plan 52-04
  *
- * Covers WALK-05 (CUSTOM → registered handler with opaque clay_cmd ptr).
- * Wave 0 ships TEST_IGNORE bodies; Plan 52-04 fills with real assertions.
+ * Covers WALK-05 / D-52-09: CUSTOM command -> registered handler called
+ * with (cmd, userdata); NULL handler is a silent skip.
  */
 
+#include <math.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
+/* clang-format off */
+#include "atlas/nt_atlas.h"
+#include "clay.h"
+#include "core/nt_assert.h"
+#include "font/nt_font.h"
+#include "graphics/nt_gfx.h"
+#include "hash/nt_hash.h"
+#include "input/nt_input.h"
+#include "material/nt_material.h"
+#include "nt_pack_format.h"
+#include "renderers/nt_sprite_renderer.h"
+#include "renderers/nt_text_renderer.h"
+#include "resource/nt_resource.h"
+#include "test_helpers/nt_assert_trap.h"
+#include "test_helpers/ui_atlas.h"
+#include "ui/nt_ui.h"
+#include "ui/nt_ui_internal.h"
 #include "unity.h"
+/* clang-format on */
 
-void setUp(void) {}
-void tearDown(void) {}
+static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+static minimal_ui_atlas_t s_atlas;
+static nt_material_t s_sprite_material;
+static nt_material_t s_text_material;
+static nt_ui_context_t *s_ctx;
+static uint32_t s_vpack_counter;
 
-/* WALK-05 / D-52-09: registered custom handler is invoked with (cmd, userdata) */
-static void test_custom_handler_invoked(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+#define MAX_TEST_CMDS 4
+static Clay_RenderCommand s_test_cmds[MAX_TEST_CMDS];
 
-/* WALK-05 / D-52-09: NULL custom handler → silent skip (no warning, no assert) */
-static void test_null_custom_handler_silent_skip(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+/* Custom-handler observers. */
+static int s_custom_calls;
+static const void *s_custom_received_cmd;
+static void *s_custom_received_user;
+
+static void test_custom_handler(const void *clay_cmd, void *userdata) {
+    s_custom_calls++;
+    s_custom_received_cmd = clay_cmd;
+    s_custom_received_user = userdata;
+}
+
+static nt_material_t make_test_material(void) {
+    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "void main(){}", .label = "walker_vs"});
+    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "void main(){}", .label = "walker_fs"});
+
+    char pack_name[64];
+    char vs_name[64];
+    char fs_name[64];
+    (void)snprintf(pack_name, sizeof pack_name, "walker_mat_pack_%u", s_vpack_counter);
+    (void)snprintf(vs_name, sizeof vs_name, "walker_vs_%u", s_vpack_counter);
+    (void)snprintf(fs_name, sizeof fs_name, "walker_fs_%u", s_vpack_counter);
+    s_vpack_counter++;
+
+    nt_hash32_t pid = nt_hash32_str(pack_name);
+    nt_hash64_t vs_rid = nt_hash64_str(vs_name);
+    nt_hash64_t fs_rid = nt_hash64_str(fs_name);
+
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pid, 0));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, vs_rid, NT_ASSET_SHADER_CODE, vs.id));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, fs_rid, NT_ASSET_SHADER_CODE, fs.id));
+
+    nt_resource_t vs_res = nt_resource_request(vs_rid, NT_ASSET_SHADER_CODE);
+    nt_resource_t fs_res = nt_resource_request(fs_rid, NT_ASSET_SHADER_CODE);
+    nt_resource_step();
+
+    nt_material_create_desc_t desc;
+    memset(&desc, 0, sizeof desc);
+    desc.vs = vs_res;
+    desc.fs = fs_res;
+    desc.depth_test = false;
+    desc.depth_write = false;
+    desc.cull_mode = NT_CULL_NONE;
+    desc.color_mode = NT_COLOR_MODE_NONE;
+    desc.label = "walker_test_material";
+
+    nt_material_t mat = nt_material_create(&desc);
+    nt_material_step();
+    return mat;
+}
+
+void setUp(void) {
+    nt_test_assert_install();
+    s_vpack_counter = 0;
+    s_custom_calls = 0;
+    s_custom_received_cmd = NULL;
+    s_custom_received_user = NULL;
+    memset(s_test_cmds, 0, sizeof s_test_cmds);
+
+    nt_hash_init(&(nt_hash_desc_t){0});
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_pipelines = 16, .max_buffers = 64, .max_textures = 32, .max_meshes = 16});
+    nt_resource_init(&(nt_resource_desc_t){0});
+    nt_atlas_init();
+    nt_font_init(&(nt_font_desc_t){.max_fonts = 4});
+    nt_material_init(&(nt_material_desc_t){.max_materials = 32});
+
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+
+    nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
+    nt_text_renderer_init();
+
+    s_atlas = minimal_ui_atlas_create();
+    s_sprite_material = make_test_material();
+    s_text_material = make_test_material();
+
+    nt_ui_set_atlas_white_region(s_atlas.handle, s_atlas.white_region_idx);
+    nt_ui_set_sprite_material(s_sprite_material);
+    nt_ui_set_text_material(s_text_material);
+    nt_ui_set_custom_handler(NULL, NULL);
+
+    s_ctx = nt_ui_create_context(s_arena, sizeof s_arena);
+    TEST_ASSERT_NOT_NULL(s_ctx);
+}
+
+void tearDown(void) {
+    if (s_ctx != NULL) {
+        nt_ui_destroy_context(s_ctx);
+        s_ctx = NULL;
+    }
+    nt_ui_test_reset_walker_globals();
+    minimal_ui_atlas_destroy(&s_atlas);
+    nt_sprite_renderer_shutdown();
+    nt_text_renderer_shutdown();
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+    nt_material_shutdown();
+    nt_font_shutdown();
+    nt_atlas_test_reset();
+    nt_resource_shutdown();
+    nt_gfx_shutdown();
+    nt_hash_shutdown();
+}
+
+static void inject_frozen_cmds(int32_t count) {
+    s_ctx->frozen_cmds.internalArray = s_test_cmds;
+    s_ctx->frozen_cmds.length = count;
+    s_ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
+}
+
+/* WALK-05: registered handler is called with (clay_cmd, userdata). */
+static void test_custom_handler_invoked(void) {
+    int sentinel = 42;
+    nt_ui_set_custom_handler(test_custom_handler, &sentinel);
+
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_CUSTOM;
+    c->boundingBox = (Clay_BoundingBox){.x = 5, .y = 5, .width = 50, .height = 50};
+    c->renderData.custom.backgroundColor = (Clay_Color){0};
+    c->renderData.custom.customData = NULL;
+    inject_frozen_cmds(1);
+
+    nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
+    nt_ui_walk(s_ctx, &target);
+
+    TEST_ASSERT_EQUAL_INT(1, s_custom_calls);
+    /* D-52-09 Option A: handler receives clay_cmd as const void * (opaque),
+     * which is the same pointer that's in our cmds array slot 0. */
+    TEST_ASSERT_EQUAL_PTR(c, s_custom_received_cmd);
+    TEST_ASSERT_EQUAL_PTR(&sentinel, s_custom_received_user);
+}
+
+/* WALK-05 / D-52-09: NULL handler = silent skip (no crash, no warning). */
+static void test_null_custom_handler_silent_skip(void) {
+    nt_ui_set_custom_handler(NULL, NULL);
+
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_CUSTOM;
+    c->boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 10, .height = 10};
+    inject_frozen_cmds(1);
+
+    nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
+    /* Must NOT crash. */
+    nt_ui_walk(s_ctx, &target);
+
+    TEST_ASSERT_EQUAL_INT(0, s_custom_calls);
+}
 
 int main(void) {
     UNITY_BEGIN();

--- a/tests/unit/test_nt_ui_walker_custom.c
+++ b/tests/unit/test_nt_ui_walker_custom.c
@@ -16,7 +16,7 @@
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8U];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
 static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 4

--- a/tests/unit/test_nt_ui_walker_custom.c
+++ b/tests/unit/test_nt_ui_walker_custom.c
@@ -4,41 +4,20 @@
  * with (cmd, userdata); NULL handler is a silent skip.
  */
 
-#include <math.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
-/* clang-format off */
-#include "atlas/nt_atlas.h"
 #include "clay.h"
-#include "core/nt_assert.h"
-#include "font/nt_font.h"
-#include "graphics/nt_gfx.h"
-#include "hash/nt_hash.h"
-#include "input/nt_input.h"
-#include "material/nt_material.h"
-#include "nt_pack_format.h"
-#include "renderers/nt_sprite_renderer.h"
-#include "renderers/nt_text_renderer.h"
-#include "resource/nt_resource.h"
-#include "stats/nt_stats.h"
 #include "test_helpers/nt_assert_trap.h"
-#include "test_helpers/ui_atlas.h"
+#include "test_helpers/ui_walker_fixture.h"
 #include "ui/nt_ui.h"
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
-/* clang-format on */
 
 static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
-static minimal_ui_atlas_t s_atlas;
-static nt_material_t s_sprite_material;
-static nt_material_t s_text_material;
-static nt_ui_context_t *s_ctx;
-static uint32_t s_vpack_counter;
+static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 4
 static Clay_RenderCommand s_test_cmds[MAX_TEST_CMDS];
@@ -54,113 +33,28 @@ static void test_custom_handler(const void *clay_cmd, void *userdata) {
     s_custom_received_user = userdata;
 }
 
-static nt_material_t make_test_material(void) {
-    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "void main(){}", .label = "walker_vs"});
-    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "void main(){}", .label = "walker_fs"});
-
-    char pack_name[64];
-    char vs_name[64];
-    char fs_name[64];
-    (void)snprintf(pack_name, sizeof pack_name, "walker_mat_pack_%u", s_vpack_counter);
-    (void)snprintf(vs_name, sizeof vs_name, "walker_vs_%u", s_vpack_counter);
-    (void)snprintf(fs_name, sizeof fs_name, "walker_fs_%u", s_vpack_counter);
-    s_vpack_counter++;
-
-    nt_hash32_t pid = nt_hash32_str(pack_name);
-    nt_hash64_t vs_rid = nt_hash64_str(vs_name);
-    nt_hash64_t fs_rid = nt_hash64_str(fs_name);
-
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pid, 0));
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, vs_rid, NT_ASSET_SHADER_CODE, vs.id));
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, fs_rid, NT_ASSET_SHADER_CODE, fs.id));
-
-    nt_resource_t vs_res = nt_resource_request(vs_rid, NT_ASSET_SHADER_CODE);
-    nt_resource_t fs_res = nt_resource_request(fs_rid, NT_ASSET_SHADER_CODE);
-    nt_resource_step();
-
-    nt_material_create_desc_t desc;
-    memset(&desc, 0, sizeof desc);
-    desc.vs = vs_res;
-    desc.fs = fs_res;
-    desc.depth_test = false;
-    desc.depth_write = false;
-    desc.cull_mode = NT_CULL_NONE;
-    desc.color_mode = NT_COLOR_MODE_NONE;
-    desc.label = "walker_test_material";
-
-    nt_material_t mat = nt_material_create(&desc);
-    nt_material_step();
-    return mat;
-}
-
 void setUp(void) {
     nt_test_assert_install();
-    s_vpack_counter = 0;
     s_custom_calls = 0;
     s_custom_received_cmd = NULL;
     s_custom_received_user = NULL;
     memset(s_test_cmds, 0, sizeof s_test_cmds);
 
-    nt_hash_init(&(nt_hash_desc_t){0});
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_pipelines = 16, .max_buffers = 64, .max_textures = 32, .max_meshes = 16});
-    nt_resource_init(&(nt_resource_desc_t){0});
-    nt_atlas_init();
-    nt_font_init(&(nt_font_desc_t){.max_fonts = 4});
-    nt_material_init(&(nt_material_desc_t){.max_materials = 32});
-
-    nt_gfx_begin_frame();
-    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
-
-    nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
-    nt_text_renderer_init();
-
-    /* nt_stats_init required: Plan 52-05 wired nt_stats_count("ui_draw_calls", ...)
-     * + nt_stats_count("ui_element_count", ...) at nt_ui_walk exit. Without init,
-     * nt_stats_count's NT_ASSERT(s_stats.initialized) trips on every walk. */
-    nt_stats_init(NULL);
-
-    s_atlas = minimal_ui_atlas_create();
-    s_sprite_material = make_test_material();
-    s_text_material = make_test_material();
-
-    s_ctx = nt_ui_create_context(s_arena, sizeof s_arena);
-    TEST_ASSERT_NOT_NULL(s_ctx);
-
-    nt_ui_set_atlas_white_region(s_ctx, s_atlas.handle, s_atlas.white_region_idx);
-    nt_ui_set_sprite_material(s_ctx, s_sprite_material);
-    nt_ui_set_text_material(s_ctx, s_text_material);
-    nt_ui_set_custom_handler(s_ctx, NULL, NULL);
+    ui_walker_fixture_init(&s_fx, s_arena, sizeof s_arena, UI_WALKER_FX_BIND_ALL);
 }
 
-void tearDown(void) {
-    if (s_ctx != NULL) {
-        nt_ui_destroy_context(s_ctx);
-        s_ctx = NULL;
-    }
-    minimal_ui_atlas_destroy(&s_atlas);
-    nt_stats_shutdown();
-    nt_sprite_renderer_shutdown();
-    nt_text_renderer_shutdown();
-    nt_gfx_end_pass();
-    nt_gfx_end_frame();
-    nt_material_shutdown();
-    nt_font_shutdown();
-    nt_atlas_test_reset();
-    nt_resource_shutdown();
-    nt_gfx_shutdown();
-    nt_hash_shutdown();
-}
+void tearDown(void) { ui_walker_fixture_shutdown(&s_fx); }
 
 static void inject_frozen_cmds(int32_t count) {
-    s_ctx->frozen_cmds.internalArray = s_test_cmds;
-    s_ctx->frozen_cmds.length = count;
-    s_ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
+    s_fx.ctx->frozen_cmds.internalArray = s_test_cmds;
+    s_fx.ctx->frozen_cmds.length = count;
+    s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
 }
 
 /* WALK-05: registered handler is called with (clay_cmd, userdata). */
 static void test_custom_handler_invoked(void) {
     int sentinel = 42;
-    nt_ui_set_custom_handler(s_ctx, test_custom_handler, &sentinel);
+    nt_ui_set_custom_handler(s_fx.ctx, test_custom_handler, &sentinel);
 
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_CUSTOM;
@@ -170,7 +64,7 @@ static void test_custom_handler_invoked(void) {
     inject_frozen_cmds(1);
 
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
     TEST_ASSERT_EQUAL_INT(1, s_custom_calls);
     /* D-52-09 Option A: handler receives clay_cmd as const void * (opaque),
@@ -181,7 +75,7 @@ static void test_custom_handler_invoked(void) {
 
 /* WALK-05 / D-52-09: NULL handler = silent skip (no crash, no warning). */
 static void test_null_custom_handler_silent_skip(void) {
-    nt_ui_set_custom_handler(s_ctx, NULL, NULL);
+    nt_ui_set_custom_handler(s_fx.ctx, NULL, NULL);
 
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_CUSTOM;
@@ -190,7 +84,7 @@ static void test_null_custom_handler_silent_skip(void) {
 
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
     /* Must NOT crash. */
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
     TEST_ASSERT_EQUAL_INT(0, s_custom_calls);
 }

--- a/tests/unit/test_nt_ui_walker_custom.c
+++ b/tests/unit/test_nt_ui_walker_custom.c
@@ -1,9 +1,3 @@
-/* tests/unit/test_nt_ui_walker_custom.c -- Plan 52-04
- *
- * Covers WALK-05 / D-52-09: CUSTOM command -> registered handler called
- * with (cmd, userdata); NULL handler is a silent skip.
- */
-
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -51,7 +45,7 @@ static void inject_frozen_cmds(int32_t count) {
     s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
 }
 
-/* WALK-05: registered handler is called with (clay_cmd, userdata). */
+/* registered handler is called with (clay_cmd, userdata). */
 static void test_custom_handler_invoked(void) {
     int sentinel = 42;
     nt_ui_set_custom_handler(s_fx.ctx, test_custom_handler, &sentinel);
@@ -67,13 +61,13 @@ static void test_custom_handler_invoked(void) {
     nt_ui_walk(s_fx.ctx, &target);
 
     TEST_ASSERT_EQUAL_INT(1, s_custom_calls);
-    /* D-52-09 Option A: handler receives clay_cmd as const void * (opaque),
-     * which is the same pointer that's in our cmds array slot 0. */
+    /* Handler receives clay_cmd as opaque const void * -- same pointer
+     * as our cmds[0] slot. */
     TEST_ASSERT_EQUAL_PTR(c, s_custom_received_cmd);
     TEST_ASSERT_EQUAL_PTR(&sentinel, s_custom_received_user);
 }
 
-/* WALK-05 / D-52-09: NULL handler = silent skip (no crash, no warning). */
+/* NULL handler = silent skip (no crash, no warning). */
 static void test_null_custom_handler_silent_skip(void) {
     nt_ui_set_custom_handler(s_fx.ctx, NULL, NULL);
 

--- a/tests/unit/test_nt_ui_walker_dispatch.c
+++ b/tests/unit/test_nt_ui_walker_dispatch.c
@@ -141,7 +141,6 @@ static void test_dispatch_image(void) {
     s_image_payload.atlas = s_fx.atlas.handle;
     s_image_payload.region_index = s_fx.atlas.polygon_region_idx; /* 6-vert hull */
     s_image_payload.flip_bits = 0;
-    memset(s_image_payload.slice9_lrtb, 0, sizeof s_image_payload.slice9_lrtb);
 
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_IMAGE;
@@ -223,7 +222,6 @@ static void test_dispatch_image_tinted_packs_color(void) {
     s_image_payload.atlas = s_fx.atlas.handle;
     s_image_payload.region_index = s_fx.atlas.white_region_idx;
     s_image_payload.flip_bits = 0;
-    memset(s_image_payload.slice9_lrtb, 0, sizeof s_image_payload.slice9_lrtb);
 
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_IMAGE;

--- a/tests/unit/test_nt_ui_walker_dispatch.c
+++ b/tests/unit/test_nt_ui_walker_dispatch.c
@@ -102,14 +102,8 @@ static void test_dispatch_border_emits_4_rects(void) {
     TEST_ASSERT_EQUAL_UINT32(calls_before + 1U, nt_sprite_renderer_test_draw_call_count());
 }
 
-/* TEXT -> flush sprite (no-op when empty) + text renderer setters
- * + draw_n. We verify the text renderer's set_material call counter ticks. */
+/* No font registered -- emit_text early-returns; checks branch reachable. */
 static void test_dispatch_text(void) {
-    /* Note: This test doesn't register a font in s_fx.ctx -- emit_text's
-     * nt_font_valid early-return fires, so no glyphs are drawn. But the
-     * sprite-flush at the top of emit_text DOES happen, and the test
-     * confirms the walk completes without crashing (TEXT branch reachable).
-     * A separate flush test verifies the boundary semantics. */
     nt_text_renderer_test_reset_call_counters();
 
     Clay_RenderCommand *c = &s_test_cmds[0];
@@ -235,16 +229,10 @@ static void test_dispatch_image_tinted_packs_color(void) {
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    /* Probe the last vertex's color (4 channels, packed BGRA into uint32
-     * but stored per-channel in the vertex). We can only check vertex
-     * count here without exposing color probes -- the meaningful contract
-     * is that we DID emit (4 verts) and didn't take the silent no-op. */
     TEST_ASSERT_EQUAL_UINT32(4U, nt_sprite_renderer_test_last_emit_vertex_count());
 }
 
-/* IMAGE payload with a not-READY atlas handle must silently no-op
- * (no crash, no emit). Async-loading atlases are a legitimate runtime
- * state -- next frame will draw. */
+/* Not-READY atlas must silent no-op (async loading is legitimate). */
 static void test_dispatch_image_not_ready_silent(void) {
     nt_ui_image_payload_t bad = {.atlas = {.id = 0xDEADBEEFU}, .region_index = 0, .flip_bits = 0};
     Clay_RenderCommand *c = &s_test_cmds[0];

--- a/tests/unit/test_nt_ui_walker_dispatch.c
+++ b/tests/unit/test_nt_ui_walker_dispatch.c
@@ -1,38 +1,337 @@
-/* tests/unit/test_nt_ui_walker_dispatch.c — Plan 52-00 stub
+/* tests/unit/test_nt_ui_walker_dispatch.c -- Plan 52-04
  *
- * Covers WALK-01 (all 7 cmd types dispatch correctly) and WALK-04 (BORDER
- * emits 4 thin RECT quads with all 4 widths non-zero). Wave 0 ships
- * TEST_IGNORE bodies; Plan 52-04 fills with real assertions.
+ * Covers WALK-01 (all 8 Clay command types dispatch to the right backend)
+ * and WALK-04 (BORDER with all 4 widths non-zero emits exactly 4 thin
+ * rects). Synthetic Clay_RenderCommand arrays are injected directly into
+ * ctx->frozen_cmds (visible via nt_ui_internal.h) -- this is the
+ * walker-only path, bypassing Clay's declaration machinery.
  */
 
+/* System headers before Unity to avoid noreturn / __declspec conflict on MSVC */
+#include <math.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
+/* clang-format off */
+#include "atlas/nt_atlas.h"
+#include "clay.h"
+#include "core/nt_assert.h"
+#include "font/nt_font.h"
+#include "graphics/nt_gfx.h"
+#include "hash/nt_hash.h"
+#include "input/nt_input.h"
+#include "material/nt_material.h"
+#include "nt_crc32.h"
+#include "nt_pack_format.h"
+#include "renderers/nt_sprite_renderer.h"
+#include "renderers/nt_text_renderer.h"
+#include "resource/nt_resource.h"
+#include "test_helpers/nt_assert_trap.h"
+#include "test_helpers/ui_atlas.h"
+#include "ui/nt_ui.h"
+#include "ui/nt_ui_internal.h"
 #include "unity.h"
+/* clang-format on */
 
-void setUp(void) {}
-void tearDown(void) {}
+/* ---- Shared test fixtures ---- */
 
-/* WALK-01: RECTANGLE → sprite renderer emit_region (white region) */
-static void test_dispatch_rectangle(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+static minimal_ui_atlas_t s_atlas;
+static nt_material_t s_sprite_material;
+static nt_material_t s_text_material;
+static nt_ui_context_t *s_ctx;
+static uint32_t s_vpack_counter;
 
-/* WALK-04: BORDER with all 4 widths non-zero emits exactly 4 thin rects */
-static void test_dispatch_border_emits_4_rects(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+/* Static command arrays for synthetic frozen_cmds injection. */
+#define MAX_TEST_CMDS 32
+static Clay_RenderCommand s_test_cmds[MAX_TEST_CMDS];
 
-/* WALK-01: TEXT → flushes sprite, sets font+material, calls nt_text_renderer_draw_n */
-static void test_dispatch_text(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+/* Image payload backing storage. */
+static nt_ui_image_payload_t s_image_payload;
 
-/* WALK-01: IMAGE → reads nt_ui_image_payload_t, emit_region on payload atlas */
-static void test_dispatch_image(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+/* Custom-handler flag + receiver. */
+static bool s_custom_called;
+static const void *s_custom_received_cmd;
+static void *s_custom_received_user;
 
-/* WALK-01: SCISSOR_START / SCISSOR_END → flush + push/pop walker stack + gfx scissor */
-static void test_dispatch_scissor_start_end(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+static void test_custom_handler(const void *clay_cmd, void *userdata) {
+    s_custom_called = true;
+    s_custom_received_cmd = clay_cmd;
+    s_custom_received_user = userdata;
+}
 
-/* WALK-01: CUSTOM → flush + invoke g_nt_ui_custom_fn (registered handler) */
-static void test_dispatch_custom(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+/* ---- Build a minimal test material via virtual-pack-registered shaders ---- */
 
-/* WALK-01: NONE → silent skip (no assert, no warning) */
-static void test_dispatch_none_silent_skip(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+static nt_material_t make_test_material(void) {
+    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "void main(){}", .label = "walker_vs"});
+    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "void main(){}", .label = "walker_fs"});
+
+    char pack_name[64];
+    char vs_name[64];
+    char fs_name[64];
+    (void)snprintf(pack_name, sizeof pack_name, "walker_mat_pack_%u", s_vpack_counter);
+    (void)snprintf(vs_name, sizeof vs_name, "walker_vs_%u", s_vpack_counter);
+    (void)snprintf(fs_name, sizeof fs_name, "walker_fs_%u", s_vpack_counter);
+    s_vpack_counter++;
+
+    nt_hash32_t pid = nt_hash32_str(pack_name);
+    nt_hash64_t vs_rid = nt_hash64_str(vs_name);
+    nt_hash64_t fs_rid = nt_hash64_str(fs_name);
+
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pid, 0));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, vs_rid, NT_ASSET_SHADER_CODE, vs.id));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, fs_rid, NT_ASSET_SHADER_CODE, fs.id));
+
+    nt_resource_t vs_res = nt_resource_request(vs_rid, NT_ASSET_SHADER_CODE);
+    nt_resource_t fs_res = nt_resource_request(fs_rid, NT_ASSET_SHADER_CODE);
+    nt_resource_step();
+
+    nt_material_create_desc_t desc;
+    memset(&desc, 0, sizeof desc);
+    desc.vs = vs_res;
+    desc.fs = fs_res;
+    desc.depth_test = false;
+    desc.depth_write = false;
+    desc.cull_mode = NT_CULL_NONE;
+    desc.color_mode = NT_COLOR_MODE_NONE;
+    desc.label = "walker_test_material";
+
+    nt_material_t mat = nt_material_create(&desc);
+    nt_material_step();
+    return mat;
+}
+
+/* ---- Common setUp / tearDown ---- */
+
+void setUp(void) {
+    nt_test_assert_install();
+    s_vpack_counter = 0;
+    s_custom_called = false;
+    s_custom_received_cmd = NULL;
+    s_custom_received_user = NULL;
+    memset(s_test_cmds, 0, sizeof s_test_cmds);
+    memset(&s_image_payload, 0, sizeof s_image_payload);
+
+    nt_hash_init(&(nt_hash_desc_t){0});
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_pipelines = 16, .max_buffers = 64, .max_textures = 32, .max_meshes = 16});
+    nt_resource_init(&(nt_resource_desc_t){0});
+    nt_atlas_init();
+    nt_font_init(&(nt_font_desc_t){.max_fonts = 4});
+    nt_material_init(&(nt_material_desc_t){.max_materials = 32});
+
+    /* Begin a frame/pass so flush's draw_indexed doesn't trip the stub backend
+     * "no active pass" guard (mirrors test_sprite_renderer setUp). */
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+
+    nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
+    nt_text_renderer_init();
+
+    s_atlas = minimal_ui_atlas_create();
+    s_sprite_material = make_test_material();
+    s_text_material = make_test_material();
+
+    nt_ui_set_atlas_white_region(s_atlas.handle, s_atlas.white_region_idx);
+    nt_ui_set_sprite_material(s_sprite_material);
+    nt_ui_set_text_material(s_text_material);
+    nt_ui_set_custom_handler(NULL, NULL);
+
+    s_ctx = nt_ui_create_context(s_arena, sizeof s_arena);
+    TEST_ASSERT_NOT_NULL(s_ctx);
+}
+
+void tearDown(void) {
+    if (s_ctx != NULL) {
+        nt_ui_destroy_context(s_ctx);
+        s_ctx = NULL;
+    }
+    nt_ui_test_reset_walker_globals();
+    minimal_ui_atlas_destroy(&s_atlas);
+
+    nt_sprite_renderer_shutdown();
+    nt_text_renderer_shutdown();
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    nt_material_shutdown();
+    nt_font_shutdown();
+    nt_atlas_test_reset();
+    nt_resource_shutdown();
+    nt_gfx_shutdown();
+    nt_hash_shutdown();
+}
+
+/* Inject a synthetic frozen_cmds array into the ctx so the walker iterates
+ * a known-shape command list. Bypasses Clay declaration machinery. */
+static void inject_frozen_cmds(int32_t count) {
+    s_ctx->frozen_cmds.internalArray = s_test_cmds;
+    s_ctx->frozen_cmds.length = count;
+    s_ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
+}
+
+/* ---- Tests ---- */
+
+/* WALK-01: RECTANGLE -> sprite renderer emit_region (4 verts for white quad) */
+static void test_dispatch_rectangle(void) {
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    c->boundingBox = (Clay_BoundingBox){.x = 10.0f, .y = 20.0f, .width = 100.0f, .height = 50.0f};
+    c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255.0f, .g = 0.0f, .b = 0.0f, .a = 255.0f};
+    inject_frozen_cmds(1);
+
+    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_walk(s_ctx, &target);
+
+    /* White region is 4 verts/6 indices -- emit_region preserves it. */
+    TEST_ASSERT_EQUAL_UINT32(4u, nt_sprite_renderer_test_last_emit_vertex_count());
+    TEST_ASSERT_EQUAL_UINT32(6u, nt_sprite_renderer_test_last_emit_index_count());
+    /* Walker element count delta matches frozen_cmds.length. */
+    TEST_ASSERT_EQUAL_UINT32(1u, nt_ui_test_last_walk_element_count());
+}
+
+/* WALK-04: BORDER with all 4 widths non-zero -- exactly 4 last_emit calls
+ * happen (top, bottom, left, right), all into the white region. Verify the
+ * LAST emit was still a white 4-vert quad. */
+static void test_dispatch_border_emits_4_rects(void) {
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_BORDER;
+    c->boundingBox = (Clay_BoundingBox){.x = 0.0f, .y = 0.0f, .width = 200.0f, .height = 100.0f};
+    c->renderData.border.color = (Clay_Color){.r = 0.0f, .g = 255.0f, .b = 0.0f, .a = 255.0f};
+    c->renderData.border.width = (Clay_BorderWidth){.left = 2, .right = 2, .top = 2, .bottom = 2, .betweenChildren = 0};
+    inject_frozen_cmds(1);
+
+    /* Snapshot draw-call counter before walk. emit_border calls
+     * emit_screen_rect 4 times against the same sprite material + atlas;
+     * they all batch into one cmd that flushes at walk exit. */
+    const uint32_t calls_before = nt_sprite_renderer_test_draw_call_count();
+
+    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_walk(s_ctx, &target);
+
+    /* Last emit is still a 4-vert white quad. */
+    TEST_ASSERT_EQUAL_UINT32(4u, nt_sprite_renderer_test_last_emit_vertex_count());
+    /* All 4 sides batch into one cmd; walker exit flush adds exactly 1 draw call. */
+    TEST_ASSERT_EQUAL_UINT32(calls_before + 1u, nt_sprite_renderer_test_draw_call_count());
+}
+
+/* WALK-01: TEXT -> flush sprite (no-op when empty) + text renderer setters
+ * + draw_n. We verify the text renderer's set_material call counter ticks. */
+static void test_dispatch_text(void) {
+    /* Note: This test doesn't register a font in s_ctx -- emit_text's
+     * nt_font_valid early-return fires, so no glyphs are drawn. But the
+     * sprite-flush at the top of emit_text DOES happen, and the test
+     * confirms the walk completes without crashing (TEXT branch reachable).
+     * A separate flush test verifies the boundary semantics. */
+    nt_text_renderer_test_reset_call_counters();
+
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_TEXT;
+    c->boundingBox = (Clay_BoundingBox){.x = 50.0f, .y = 60.0f, .width = 100.0f, .height = 20.0f};
+    static const char *kText = "AB";
+    c->renderData.text.stringContents = (Clay_StringSlice){.length = 2, .chars = kText, .baseChars = kText};
+    c->renderData.text.textColor = (Clay_Color){.r = 255.0f, .g = 255.0f, .b = 255.0f, .a = 255.0f};
+    c->renderData.text.fontId = 0;
+    c->renderData.text.fontSize = 14;
+    c->renderData.text.letterSpacing = 0;
+    c->renderData.text.lineHeight = 0;
+    inject_frozen_cmds(1);
+
+    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_walk(s_ctx, &target);
+
+    /* font_id=0 has no font set in the per-ctx registry; emit_text exits
+     * before calling set_font/set_material. The walker just needs to not
+     * crash on the TEXT case. */
+    TEST_ASSERT_EQUAL_UINT32(0u, nt_text_renderer_test_set_material_calls());
+    TEST_ASSERT_EQUAL_UINT32(0u, nt_text_renderer_test_set_font_calls());
+    /* Walker element count still ticks. */
+    TEST_ASSERT_EQUAL_UINT32(1u, nt_ui_test_last_walk_element_count());
+}
+
+/* WALK-01: IMAGE -> reads nt_ui_image_payload_t and emits one region. */
+static void test_dispatch_image(void) {
+    s_image_payload.atlas = s_atlas.handle;
+    s_image_payload.region_index = s_atlas.polygon_region_idx; /* 6-vert hull */
+    s_image_payload.flip_bits = 0;
+    memset(s_image_payload.slice9_lrtb, 0, sizeof s_image_payload.slice9_lrtb);
+
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_IMAGE;
+    c->boundingBox = (Clay_BoundingBox){.x = 100.0f, .y = 100.0f, .width = 64.0f, .height = 64.0f};
+    c->renderData.image.backgroundColor = (Clay_Color){0}; /* untinted */
+    c->renderData.image.imageData = &s_image_payload;
+    inject_frozen_cmds(1);
+
+    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_walk(s_ctx, &target);
+
+    /* Polygon hull preservation: emit_image must NOT collapse to 4-vert quad. */
+    TEST_ASSERT_EQUAL_UINT32(6u, nt_sprite_renderer_test_last_emit_vertex_count());
+    TEST_ASSERT_EQUAL_UINT32(12u, nt_sprite_renderer_test_last_emit_index_count());
+}
+
+/* WALK-01 / WALK-02 / WALK-03: SCISSOR_START + SCISSOR_END are dispatched
+ * and the walker exits with scissor disabled. */
+static void test_dispatch_scissor_start_end(void) {
+    Clay_RenderCommand *cs = &s_test_cmds[0];
+    cs->commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
+    cs->boundingBox = (Clay_BoundingBox){.x = 50.0f, .y = 50.0f, .width = 200.0f, .height = 200.0f};
+    cs->renderData.clip.horizontal = true;
+    cs->renderData.clip.vertical = true;
+
+    Clay_RenderCommand *ce = &s_test_cmds[1];
+    ce->commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
+
+    inject_frozen_cmds(2);
+
+    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_walk(s_ctx, &target);
+
+    /* Walker MUST disable scissor at exit (CP-04). */
+    TEST_ASSERT_FALSE(nt_gfx_test_scissor_enabled());
+    TEST_ASSERT_EQUAL_UINT32(2u, nt_ui_test_last_walk_element_count());
+}
+
+/* WALK-05: CUSTOM -> registered handler called with (cmd, userdata). */
+static void test_dispatch_custom(void) {
+    int sentinel = 42;
+    nt_ui_set_custom_handler(test_custom_handler, &sentinel);
+
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_CUSTOM;
+    c->boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 10, .height = 10};
+    c->renderData.custom.backgroundColor = (Clay_Color){0};
+    c->renderData.custom.customData = NULL;
+    inject_frozen_cmds(1);
+
+    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_walk(s_ctx, &target);
+
+    TEST_ASSERT_TRUE(s_custom_called);
+    TEST_ASSERT_EQUAL_PTR(c, s_custom_received_cmd);
+    TEST_ASSERT_EQUAL_PTR(&sentinel, s_custom_received_user);
+}
+
+/* WALK-01: NONE -> silent skip (no crash, no emit). */
+static void test_dispatch_none_silent_skip(void) {
+    /* Walk an empty command array -- frozen_cmds.length = 0. */
+    inject_frozen_cmds(0);
+
+    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_walk(s_ctx, &target);
+
+    TEST_ASSERT_EQUAL_UINT32(0u, nt_ui_test_last_walk_element_count());
+
+    /* Also test an explicit NONE command -- still no crash, still no emit. */
+    s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_NONE;
+    inject_frozen_cmds(1);
+    nt_ui_walk(s_ctx, &target);
+    TEST_ASSERT_EQUAL_UINT32(1u, nt_ui_test_last_walk_element_count());
+}
 
 int main(void) {
     UNITY_BEGIN();

--- a/tests/unit/test_nt_ui_walker_dispatch.c
+++ b/tests/unit/test_nt_ui_walker_dispatch.c
@@ -15,7 +15,7 @@
 
 /* ---- Test-local state ---- */
 
-alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_TEST_ARENA_SIZE];
 static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 32
@@ -357,6 +357,27 @@ static void test_dispatch_border_width_exceeds_radius(void) {
     TEST_ASSERT_GREATER_THAN_UINT32(0U, nt_sprite_renderer_test_last_emit_vertex_count());
 }
 
+/* Mixed corners (some sharp, some rounded) in one BORDER. Locks current
+ * vertex count: 2 sharp pairs (2 verts each) + 2 rounded pairs (2*(SEG+1)
+ * verts each) = 2*2 + 2*2*(SEG+1) = 4 + 28 = 32 verts at SEG=6.
+ * Catches structural regressions in emit_corner_strip_pairs / strip wrap. */
+static void test_dispatch_border_mixed_radii(void) {
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_BORDER;
+    c->boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 100.0F, .height = 60.0F};
+    c->renderData.border.color = (Clay_Color){.r = 0.0F, .g = 255.0F, .b = 0.0F, .a = 255.0F};
+    c->renderData.border.width = (Clay_BorderWidth){.left = 2, .right = 2, .top = 2, .bottom = 2, .betweenChildren = 0};
+    c->renderData.border.cornerRadius = (Clay_CornerRadius){.topLeft = 10.0F, .topRight = 0.0F, .bottomLeft = 0.0F, .bottomRight = 10.0F};
+    inject_frozen_cmds(1);
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    /* SEG=6 (private to nt_ui.c): 2 sharp corners give 2 pairs = 4 verts.
+     * 2 rounded corners give 2*(6+1) = 14 pairs = 28 verts. Total 32. */
+    TEST_ASSERT_EQUAL_UINT32(32U, nt_sprite_renderer_test_last_emit_vertex_count());
+}
+
 /* Rounded IMAGE asserts -- rounded edges must be baked into the atlas. */
 static void test_dispatch_image_nonzero_radius_asserts(void) {
     s_image_payload.atlas = s_fx.atlas.handle;
@@ -402,6 +423,7 @@ int main(void) {
     RUN_TEST(test_dispatch_border_rounded_emits_strip);
     RUN_TEST(test_dispatch_border_rounded_partial_widths);
     RUN_TEST(test_dispatch_border_width_exceeds_radius);
+    RUN_TEST(test_dispatch_border_mixed_radii);
     RUN_TEST(test_dispatch_rect_asymmetric_radii_no_over_clamp);
     RUN_TEST(test_dispatch_rounded_rect_uv_is_centroid_not_corner);
     RUN_TEST(test_dispatch_image_nonzero_radius_asserts);

--- a/tests/unit/test_nt_ui_walker_dispatch.c
+++ b/tests/unit/test_nt_ui_walker_dispatch.c
@@ -83,7 +83,7 @@ static void test_dispatch_rectangle(void) {
     TEST_ASSERT_EQUAL_UINT32(4U, nt_sprite_renderer_test_last_emit_vertex_count());
     TEST_ASSERT_EQUAL_UINT32(6U, nt_sprite_renderer_test_last_emit_index_count());
     /* Walker element count delta matches frozen_cmds.length. */
-    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_test_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_element_count(s_fx.ctx));
 }
 
 /* WALK-04: BORDER with all 4 widths non-zero -- exactly 4 last_emit calls
@@ -142,7 +142,7 @@ static void test_dispatch_text(void) {
     TEST_ASSERT_EQUAL_UINT32(0U, nt_text_renderer_test_set_material_calls());
     TEST_ASSERT_EQUAL_UINT32(0U, nt_text_renderer_test_set_font_calls());
     /* Walker element count still ticks. */
-    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_test_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_element_count(s_fx.ctx));
 }
 
 /* WALK-01: IMAGE -> reads nt_ui_image_payload_t and emits one region. */
@@ -186,7 +186,7 @@ static void test_dispatch_scissor_start_end(void) {
 
     /* Walker MUST disable scissor at exit (CP-04). */
     TEST_ASSERT_FALSE(nt_gfx_test_scissor_enabled());
-    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_test_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_element_count(s_fx.ctx));
 }
 
 /* WALK-05: CUSTOM -> registered handler called with (cmd, userdata). */
@@ -217,13 +217,13 @@ static void test_dispatch_none_silent_skip(void) {
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_test_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_element_count(s_fx.ctx));
 
     /* Also test an explicit NONE command -- still no crash, still no emit. */
     s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_NONE;
     inject_frozen_cmds(1);
     nt_ui_walk(s_fx.ctx, &target);
-    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_test_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_element_count(s_fx.ctx));
 }
 
 int main(void) {

--- a/tests/unit/test_nt_ui_walker_dispatch.c
+++ b/tests/unit/test_nt_ui_walker_dispatch.c
@@ -217,6 +217,33 @@ static void test_dispatch_none_silent_skip(void) {
     TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_element_count(s_fx.ctx));
 }
 
+/* IMAGE with non-default backgroundColor must pack the tint (not fall
+ * through the all-zero "default untinted" shortcut). */
+static void test_dispatch_image_tinted_packs_color(void) {
+    s_image_payload.atlas = s_fx.atlas.handle;
+    s_image_payload.region_index = s_fx.atlas.white_region_idx;
+    s_image_payload.flip_bits = 0;
+    memset(s_image_payload.slice9_lrtb, 0, sizeof s_image_payload.slice9_lrtb);
+
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_IMAGE;
+    c->boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 32, .height = 32};
+    /* Half-alpha black -- not (0,0,0,0), so must NOT take the untinted
+     * shortcut. Packed: r=0, g=0, b=0, a=128 -> 0x80000000 in 0xAABBGGRR. */
+    c->renderData.image.backgroundColor = (Clay_Color){.r = 0.0F, .g = 0.0F, .b = 0.0F, .a = 128.0F};
+    c->renderData.image.imageData = &s_image_payload;
+    inject_frozen_cmds(1);
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    /* Probe the last vertex's color (4 channels, packed BGRA into uint32
+     * but stored per-channel in the vertex). We can only check vertex
+     * count here without exposing color probes -- the meaningful contract
+     * is that we DID emit (4 verts) and didn't take the silent no-op. */
+    TEST_ASSERT_EQUAL_UINT32(4U, nt_sprite_renderer_test_last_emit_vertex_count());
+}
+
 /* IMAGE payload with a not-READY atlas handle must silently no-op
  * (no crash, no emit). Async-loading atlases are a legitimate runtime
  * state -- next frame will draw. */
@@ -247,6 +274,7 @@ int main(void) {
     RUN_TEST(test_dispatch_scissor_start_end);
     RUN_TEST(test_dispatch_custom);
     RUN_TEST(test_dispatch_none_silent_skip);
+    RUN_TEST(test_dispatch_image_tinted_packs_color);
     RUN_TEST(test_dispatch_image_not_ready_silent);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_walker_dispatch.c
+++ b/tests/unit/test_nt_ui_walker_dispatch.c
@@ -24,7 +24,7 @@
 
 /* ---- Test-local state ---- */
 
-static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8U];
 static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 32
@@ -72,18 +72,18 @@ static void inject_frozen_cmds(int32_t count) {
 static void test_dispatch_rectangle(void) {
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
-    c->boundingBox = (Clay_BoundingBox){.x = 10.0f, .y = 20.0f, .width = 100.0f, .height = 50.0f};
-    c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255.0f, .g = 0.0f, .b = 0.0f, .a = 255.0f};
+    c->boundingBox = (Clay_BoundingBox){.x = 10.0F, .y = 20.0F, .width = 100.0F, .height = 50.0F};
+    c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255.0F, .g = 0.0F, .b = 0.0F, .a = 255.0F};
     inject_frozen_cmds(1);
 
-    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
     /* White region is 4 verts/6 indices -- emit_region preserves it. */
-    TEST_ASSERT_EQUAL_UINT32(4u, nt_sprite_renderer_test_last_emit_vertex_count());
-    TEST_ASSERT_EQUAL_UINT32(6u, nt_sprite_renderer_test_last_emit_index_count());
+    TEST_ASSERT_EQUAL_UINT32(4U, nt_sprite_renderer_test_last_emit_vertex_count());
+    TEST_ASSERT_EQUAL_UINT32(6U, nt_sprite_renderer_test_last_emit_index_count());
     /* Walker element count delta matches frozen_cmds.length. */
-    TEST_ASSERT_EQUAL_UINT32(1u, nt_ui_test_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_test_last_walk_element_count(s_fx.ctx));
 }
 
 /* WALK-04: BORDER with all 4 widths non-zero -- exactly 4 last_emit calls
@@ -92,8 +92,8 @@ static void test_dispatch_rectangle(void) {
 static void test_dispatch_border_emits_4_rects(void) {
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_BORDER;
-    c->boundingBox = (Clay_BoundingBox){.x = 0.0f, .y = 0.0f, .width = 200.0f, .height = 100.0f};
-    c->renderData.border.color = (Clay_Color){.r = 0.0f, .g = 255.0f, .b = 0.0f, .a = 255.0f};
+    c->boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 200.0F, .height = 100.0F};
+    c->renderData.border.color = (Clay_Color){.r = 0.0F, .g = 255.0F, .b = 0.0F, .a = 255.0F};
     c->renderData.border.width = (Clay_BorderWidth){.left = 2, .right = 2, .top = 2, .bottom = 2, .betweenChildren = 0};
     inject_frozen_cmds(1);
 
@@ -102,13 +102,13 @@ static void test_dispatch_border_emits_4_rects(void) {
      * they all batch into one cmd that flushes at walk exit. */
     const uint32_t calls_before = nt_sprite_renderer_test_draw_call_count();
 
-    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
     /* Last emit is still a 4-vert white quad. */
-    TEST_ASSERT_EQUAL_UINT32(4u, nt_sprite_renderer_test_last_emit_vertex_count());
+    TEST_ASSERT_EQUAL_UINT32(4U, nt_sprite_renderer_test_last_emit_vertex_count());
     /* All 4 sides batch into one cmd; walker exit flush adds exactly 1 draw call. */
-    TEST_ASSERT_EQUAL_UINT32(calls_before + 1u, nt_sprite_renderer_test_draw_call_count());
+    TEST_ASSERT_EQUAL_UINT32(calls_before + 1U, nt_sprite_renderer_test_draw_call_count());
 }
 
 /* WALK-01: TEXT -> flush sprite (no-op when empty) + text renderer setters
@@ -123,26 +123,26 @@ static void test_dispatch_text(void) {
 
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_TEXT;
-    c->boundingBox = (Clay_BoundingBox){.x = 50.0f, .y = 60.0f, .width = 100.0f, .height = 20.0f};
+    c->boundingBox = (Clay_BoundingBox){.x = 50.0F, .y = 60.0F, .width = 100.0F, .height = 20.0F};
     static const char *kText = "AB";
     c->renderData.text.stringContents = (Clay_StringSlice){.length = 2, .chars = kText, .baseChars = kText};
-    c->renderData.text.textColor = (Clay_Color){.r = 255.0f, .g = 255.0f, .b = 255.0f, .a = 255.0f};
+    c->renderData.text.textColor = (Clay_Color){.r = 255.0F, .g = 255.0F, .b = 255.0F, .a = 255.0F};
     c->renderData.text.fontId = 0;
     c->renderData.text.fontSize = 14;
     c->renderData.text.letterSpacing = 0;
     c->renderData.text.lineHeight = 0;
     inject_frozen_cmds(1);
 
-    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
     /* font_id=0 has no font set in the per-ctx registry; emit_text exits
      * before calling set_font/set_material. The walker just needs to not
      * crash on the TEXT case. */
-    TEST_ASSERT_EQUAL_UINT32(0u, nt_text_renderer_test_set_material_calls());
-    TEST_ASSERT_EQUAL_UINT32(0u, nt_text_renderer_test_set_font_calls());
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_text_renderer_test_set_material_calls());
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_text_renderer_test_set_font_calls());
     /* Walker element count still ticks. */
-    TEST_ASSERT_EQUAL_UINT32(1u, nt_ui_test_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_test_last_walk_element_count(s_fx.ctx));
 }
 
 /* WALK-01: IMAGE -> reads nt_ui_image_payload_t and emits one region. */
@@ -154,17 +154,17 @@ static void test_dispatch_image(void) {
 
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_IMAGE;
-    c->boundingBox = (Clay_BoundingBox){.x = 100.0f, .y = 100.0f, .width = 64.0f, .height = 64.0f};
+    c->boundingBox = (Clay_BoundingBox){.x = 100.0F, .y = 100.0F, .width = 64.0F, .height = 64.0F};
     c->renderData.image.backgroundColor = (Clay_Color){0}; /* untinted */
     c->renderData.image.imageData = &s_image_payload;
     inject_frozen_cmds(1);
 
-    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
     /* Polygon hull preservation: emit_image must NOT collapse to 4-vert quad. */
-    TEST_ASSERT_EQUAL_UINT32(6u, nt_sprite_renderer_test_last_emit_vertex_count());
-    TEST_ASSERT_EQUAL_UINT32(12u, nt_sprite_renderer_test_last_emit_index_count());
+    TEST_ASSERT_EQUAL_UINT32(6U, nt_sprite_renderer_test_last_emit_vertex_count());
+    TEST_ASSERT_EQUAL_UINT32(12U, nt_sprite_renderer_test_last_emit_index_count());
 }
 
 /* WALK-01 / WALK-02 / WALK-03: SCISSOR_START + SCISSOR_END are dispatched
@@ -172,7 +172,7 @@ static void test_dispatch_image(void) {
 static void test_dispatch_scissor_start_end(void) {
     Clay_RenderCommand *cs = &s_test_cmds[0];
     cs->commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
-    cs->boundingBox = (Clay_BoundingBox){.x = 50.0f, .y = 50.0f, .width = 200.0f, .height = 200.0f};
+    cs->boundingBox = (Clay_BoundingBox){.x = 50.0F, .y = 50.0F, .width = 200.0F, .height = 200.0F};
     cs->renderData.clip.horizontal = true;
     cs->renderData.clip.vertical = true;
 
@@ -181,12 +181,12 @@ static void test_dispatch_scissor_start_end(void) {
 
     inject_frozen_cmds(2);
 
-    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
     /* Walker MUST disable scissor at exit (CP-04). */
     TEST_ASSERT_FALSE(nt_gfx_test_scissor_enabled());
-    TEST_ASSERT_EQUAL_UINT32(2u, nt_ui_test_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_test_last_walk_element_count(s_fx.ctx));
 }
 
 /* WALK-05: CUSTOM -> registered handler called with (cmd, userdata). */
@@ -201,7 +201,7 @@ static void test_dispatch_custom(void) {
     c->renderData.custom.customData = NULL;
     inject_frozen_cmds(1);
 
-    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
     TEST_ASSERT_TRUE(s_custom_called);
@@ -214,16 +214,16 @@ static void test_dispatch_none_silent_skip(void) {
     /* Walk an empty command array -- frozen_cmds.length = 0. */
     inject_frozen_cmds(0);
 
-    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    TEST_ASSERT_EQUAL_UINT32(0u, nt_ui_test_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_test_last_walk_element_count(s_fx.ctx));
 
     /* Also test an explicit NONE command -- still no crash, still no emit. */
     s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_NONE;
     inject_frozen_cmds(1);
     nt_ui_walk(s_fx.ctx, &target);
-    TEST_ASSERT_EQUAL_UINT32(1u, nt_ui_test_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_test_last_walk_element_count(s_fx.ctx));
 }
 
 int main(void) {

--- a/tests/unit/test_nt_ui_walker_dispatch.c
+++ b/tests/unit/test_nt_ui_walker_dispatch.c
@@ -217,6 +217,27 @@ static void test_dispatch_none_silent_skip(void) {
     TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_element_count(s_fx.ctx));
 }
 
+/* IMAGE payload with a not-READY atlas handle must silently no-op
+ * (no crash, no emit). Async-loading atlases are a legitimate runtime
+ * state -- next frame will draw. */
+static void test_dispatch_image_not_ready_silent(void) {
+    nt_ui_image_payload_t bad = {.atlas = {.id = 0xDEADBEEFU}, .region_index = 0, .flip_bits = 0};
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_IMAGE;
+    c->boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 64, .height = 64};
+    c->renderData.image.backgroundColor = (Clay_Color){0};
+    c->renderData.image.imageData = &bad;
+    inject_frozen_cmds(1);
+
+    const uint32_t calls_before = nt_sprite_renderer_test_draw_call_count();
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    /* The IMAGE emit was skipped; no draw call from this command. */
+    TEST_ASSERT_EQUAL_UINT32(calls_before, nt_sprite_renderer_test_draw_call_count());
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_dispatch_rectangle);
@@ -226,5 +247,6 @@ int main(void) {
     RUN_TEST(test_dispatch_scissor_start_end);
     RUN_TEST(test_dispatch_custom);
     RUN_TEST(test_dispatch_none_silent_skip);
+    RUN_TEST(test_dispatch_image_not_ready_silent);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_walker_dispatch.c
+++ b/tests/unit/test_nt_ui_walker_dispatch.c
@@ -1,0 +1,47 @@
+/* tests/unit/test_nt_ui_walker_dispatch.c — Plan 52-00 stub
+ *
+ * Covers WALK-01 (all 7 cmd types dispatch correctly) and WALK-04 (BORDER
+ * emits 4 thin RECT quads with all 4 widths non-zero). Wave 0 ships
+ * TEST_IGNORE bodies; Plan 52-04 fills with real assertions.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* WALK-01: RECTANGLE → sprite renderer emit_region (white region) */
+static void test_dispatch_rectangle(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+/* WALK-04: BORDER with all 4 widths non-zero emits exactly 4 thin rects */
+static void test_dispatch_border_emits_4_rects(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+/* WALK-01: TEXT → flushes sprite, sets font+material, calls nt_text_renderer_draw_n */
+static void test_dispatch_text(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+/* WALK-01: IMAGE → reads nt_ui_image_payload_t, emit_region on payload atlas */
+static void test_dispatch_image(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+/* WALK-01: SCISSOR_START / SCISSOR_END → flush + push/pop walker stack + gfx scissor */
+static void test_dispatch_scissor_start_end(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+/* WALK-01: CUSTOM → flush + invoke g_nt_ui_custom_fn (registered handler) */
+static void test_dispatch_custom(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+/* WALK-01: NONE → silent skip (no assert, no warning) */
+static void test_dispatch_none_silent_skip(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_dispatch_rectangle);
+    RUN_TEST(test_dispatch_border_emits_4_rects);
+    RUN_TEST(test_dispatch_text);
+    RUN_TEST(test_dispatch_image);
+    RUN_TEST(test_dispatch_scissor_start_end);
+    RUN_TEST(test_dispatch_custom);
+    RUN_TEST(test_dispatch_none_silent_skip);
+    return UNITY_END();
+}

--- a/tests/unit/test_nt_ui_walker_dispatch.c
+++ b/tests/unit/test_nt_ui_walker_dispatch.c
@@ -312,6 +312,38 @@ static void test_dispatch_rounded_rect_uv_is_centroid_not_corner(void) {
     TEST_ASSERT_EQUAL_UINT16(0x7FFFU, uv0[1]);
 }
 
+/* CSS3 border-radius proportional scaling: asymmetric radii where the SUM
+ * along a side fits the dimension must NOT be over-clamped. Before the
+ * CSS3 fix this case was clamped by half_h to {30,30,10,10} -- after the
+ * fix it stays {40,40,10,10} (sums 80 across w=200 and 50 across h=60
+ * both fit, factor=1.0). Vertex count and bbox are observable. */
+static void test_dispatch_rect_asymmetric_radii_no_over_clamp(void) {
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    c->boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 200.0F, .height = 60.0F};
+    c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255.0F, .g = 0.0F, .b = 0.0F, .a = 255.0F};
+    c->renderData.rectangle.cornerRadius = (Clay_CornerRadius){.topLeft = 40.0F, .topRight = 40.0F, .bottomLeft = 10.0F, .bottomRight = 10.0F};
+    inject_frozen_cmds(1);
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    /* All four corners non-zero -> full tessellation (1 center + 4 * 7 = 29 verts). */
+    TEST_ASSERT_EQUAL_UINT32(29U, nt_sprite_renderer_test_last_emit_vertex_count());
+
+    /* TL arc entry at (0, top_y + tl) where tl should be 40 (NOT 30):
+     * vertex index 1 in fan (first boundary vert after center) is TL arc
+     * west point at (x, y+tl) per emit_rounded_rect ordering. Float-imprecise
+     * cosf(π) gives ~-1.0 (not exact), so allow ±1 tolerance. */
+    float pos[3];
+    nt_sprite_renderer_test_last_emit_position(1U, pos);
+    const int32_t px = (int32_t)pos[0];
+    const int32_t py = (int32_t)pos[1];
+    TEST_ASSERT_TRUE(px == 0 || px == -1);  /* near 0 within float epsilon */
+    TEST_ASSERT_GREATER_THAN_INT32(35, py); /* MUST be ~40, NOT 30 from old half-clamp */
+    TEST_ASSERT_LESS_OR_EQUAL_INT32(40, py);
+}
+
 /* BORDER with rounded corners and partial widths (e.g. only bottom border)
  * must not assert -- inner radius clamps to 0 on axes where width=0, giving
  * a degenerate strip segment for skipped sides. */
@@ -395,6 +427,7 @@ int main(void) {
     RUN_TEST(test_dispatch_border_rounded_emits_strip);
     RUN_TEST(test_dispatch_border_rounded_partial_widths);
     RUN_TEST(test_dispatch_border_width_exceeds_radius);
+    RUN_TEST(test_dispatch_rect_asymmetric_radii_no_over_clamp);
     RUN_TEST(test_dispatch_rounded_rect_uv_is_centroid_not_corner);
     RUN_TEST(test_dispatch_image_nonzero_radius_asserts);
     RUN_TEST(test_dispatch_text_unbound_font_asserts);

--- a/tests/unit/test_nt_ui_walker_dispatch.c
+++ b/tests/unit/test_nt_ui_walker_dispatch.c
@@ -102,32 +102,24 @@ static void test_dispatch_border_emits_4_rects(void) {
     TEST_ASSERT_EQUAL_UINT32(calls_before + 1U, nt_sprite_renderer_test_draw_call_count());
 }
 
-/* No font registered -- emit_text early-returns; checks branch reachable. */
-static void test_dispatch_text(void) {
-    nt_text_renderer_test_reset_call_counters();
-
+/* TEXT command with empty font slot is a contract violation -- emit_text
+ * asserts. Game must call nt_ui_set_font before declaring TEXT.
+ * Fixture binds slot 0 with a stub font, so use slot 1 (unbound). */
+static void test_dispatch_text_unbound_font_asserts(void) {
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_TEXT;
     c->boundingBox = (Clay_BoundingBox){.x = 50.0F, .y = 60.0F, .width = 100.0F, .height = 20.0F};
     static const char *kText = "AB";
     c->renderData.text.stringContents = (Clay_StringSlice){.length = 2, .chars = kText, .baseChars = kText};
     c->renderData.text.textColor = (Clay_Color){.r = 255.0F, .g = 255.0F, .b = 255.0F, .a = 255.0F};
-    c->renderData.text.fontId = 0;
+    c->renderData.text.fontId = 1; /* unbound slot in fixture */
     c->renderData.text.fontSize = 14;
     c->renderData.text.letterSpacing = 0;
     c->renderData.text.lineHeight = 0;
     inject_frozen_cmds(1);
 
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
-    nt_ui_walk(s_fx.ctx, &target);
-
-    /* font_id=0 has no font set in the per-ctx registry; emit_text exits
-     * before calling set_font/set_material. The walker just needs to not
-     * crash on the TEXT case. */
-    TEST_ASSERT_EQUAL_UINT32(0U, nt_text_renderer_test_set_material_calls());
-    TEST_ASSERT_EQUAL_UINT32(0U, nt_text_renderer_test_set_font_calls());
-    /* Walker element count still ticks. */
-    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_element_count(s_fx.ctx));
+    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }
 
 /* IMAGE -> reads nt_ui_image_payload_t and emits one region. */
@@ -232,6 +224,149 @@ static void test_dispatch_image_tinted_packs_color(void) {
     TEST_ASSERT_EQUAL_UINT32(4U, nt_sprite_renderer_test_last_emit_vertex_count());
 }
 
+/* RECT with non-zero cornerRadius takes the tessellated-fan path: emits
+ * 1 center vertex + 4 * (NT_UI_CORNER_SEGMENTS + 1) boundary verts when
+ * all four corners are rounded. NT_UI_CORNER_SEGMENTS is private to
+ * nt_ui.c, so this test compares against the flat-corner emit count
+ * instead of hardcoding it. */
+static void test_dispatch_rectangle_rounded_emits_fan(void) {
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    c->boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 100.0F, .height = 60.0F};
+    c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255.0F, .g = 255.0F, .b = 255.0F, .a = 255.0F};
+    c->renderData.rectangle.cornerRadius = (Clay_CornerRadius){.topLeft = 8.0F, .topRight = 8.0F, .bottomLeft = 8.0F, .bottomRight = 8.0F};
+    inject_frozen_cmds(1);
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    /* Tessellated fan must be strictly more verts than the 4-vert flat quad
+     * and strictly more indices than the 6-index flat quad. */
+    TEST_ASSERT_GREATER_THAN_UINT32(4U, nt_sprite_renderer_test_last_emit_vertex_count());
+    TEST_ASSERT_GREATER_THAN_UINT32(6U, nt_sprite_renderer_test_last_emit_index_count());
+}
+
+/* RECT with all-zero cornerRadius stays on the 4-vert fast path -- locking
+ * the existing emit_screen_rect optimization in place. */
+static void test_dispatch_rectangle_zero_radius_keeps_fast_path(void) {
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    c->boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 100.0F, .height = 60.0F};
+    c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255.0F, .g = 255.0F, .b = 255.0F, .a = 255.0F};
+    c->renderData.rectangle.cornerRadius = (Clay_CornerRadius){0};
+    inject_frozen_cmds(1);
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    TEST_ASSERT_EQUAL_UINT32(4U, nt_sprite_renderer_test_last_emit_vertex_count());
+    TEST_ASSERT_EQUAL_UINT32(6U, nt_sprite_renderer_test_last_emit_index_count());
+}
+
+/* BORDER with non-zero cornerRadius takes the ring-strip path:
+ * 4*(SEG+1)*2 verts when all four corners are rounded. */
+static void test_dispatch_border_rounded_emits_strip(void) {
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_BORDER;
+    c->boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 200.0F, .height = 100.0F};
+    c->renderData.border.color = (Clay_Color){.r = 0.0F, .g = 255.0F, .b = 0.0F, .a = 255.0F};
+    c->renderData.border.width = (Clay_BorderWidth){.left = 2, .right = 2, .top = 2, .bottom = 2, .betweenChildren = 0};
+    c->renderData.border.cornerRadius = (Clay_CornerRadius){.topLeft = 8.0F, .topRight = 8.0F, .bottomLeft = 8.0F, .bottomRight = 8.0F};
+    inject_frozen_cmds(1);
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    /* Ring strip emits significantly more than the 4-vert flat border fast path. */
+    TEST_ASSERT_GREATER_THAN_UINT32(4U, nt_sprite_renderer_test_last_emit_vertex_count());
+}
+
+/* emit_geometry samples the region's UV centroid, NOT vertex[0]'s corner UV.
+ * The fixture's white_region is a 4-vert quad with UV corners at
+ * (0,0), (0xFFFF,0), (0xFFFF,0xFFFF), (0,0xFFFF) -- mean = (0x7FFF, 0x7FFF).
+ * A texel-corner sample would bleed into adjacent atlas pixels under
+ * linear filtering; centroid keeps the sample firmly inside the white pixel. */
+static void test_dispatch_rounded_rect_uv_is_centroid_not_corner(void) {
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    c->boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 80.0F, .height = 40.0F};
+    c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255.0F, .g = 255.0F, .b = 255.0F, .a = 255.0F};
+    c->renderData.rectangle.cornerRadius = (Clay_CornerRadius){.topLeft = 6.0F, .topRight = 6.0F, .bottomLeft = 6.0F, .bottomRight = 6.0F};
+    inject_frozen_cmds(1);
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    /* Every emitted vertex must carry the SAME UV (solid-color shape).
+     * Spot-check vertex 0 and vertex 1; they share by contract. */
+    const uint32_t emitted = nt_sprite_renderer_test_last_emit_vertex_count();
+    TEST_ASSERT_GREATER_THAN_UINT32(2U, emitted);
+    uint16_t uv0[2];
+    uint16_t uv1[2];
+    nt_sprite_renderer_test_last_emit_texcoord(0U, uv0);
+    nt_sprite_renderer_test_last_emit_texcoord(1U, uv1);
+    TEST_ASSERT_EQUAL_UINT16(uv0[0], uv1[0]);
+    TEST_ASSERT_EQUAL_UINT16(uv0[1], uv1[1]);
+    /* Centroid of fixture white_region corner UVs: (0+0xFFFF+0xFFFF+0)/4 = 0x7FFF. */
+    TEST_ASSERT_EQUAL_UINT16(0x7FFFU, uv0[0]);
+    TEST_ASSERT_EQUAL_UINT16(0x7FFFU, uv0[1]);
+}
+
+/* BORDER with rounded corners and partial widths (e.g. only bottom border)
+ * must not assert -- inner radius clamps to 0 on axes where width=0, giving
+ * a degenerate strip segment for skipped sides. */
+static void test_dispatch_border_rounded_partial_widths(void) {
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_BORDER;
+    c->boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 100.0F, .height = 60.0F};
+    c->renderData.border.color = (Clay_Color){.r = 0.0F, .g = 0.0F, .b = 255.0F, .a = 255.0F};
+    /* Only bottom border, with rounded bottom corners. Top sides absent. */
+    c->renderData.border.width = (Clay_BorderWidth){.left = 0, .right = 0, .top = 0, .bottom = 2, .betweenChildren = 0};
+    c->renderData.border.cornerRadius = (Clay_CornerRadius){.bottomLeft = 6.0F, .bottomRight = 6.0F};
+    inject_frozen_cmds(1);
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &target); /* Must not crash, must not assert. */
+    /* Emits something (ring strip with degenerate parts). */
+    TEST_ASSERT_GREATER_THAN_UINT32(0U, nt_sprite_renderer_test_last_emit_vertex_count());
+}
+
+/* BORDER with width > radius clamps inner radius to 0 on the affected axis.
+ * Should not crash; result is "filled" corner without rounding. */
+static void test_dispatch_border_width_exceeds_radius(void) {
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_BORDER;
+    c->boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 100.0F, .height = 60.0F};
+    c->renderData.border.color = (Clay_Color){.r = 255.0F, .g = 255.0F, .b = 0.0F, .a = 255.0F};
+    /* Width 8 with radius 4 -- inner clamps to 0. */
+    c->renderData.border.width = (Clay_BorderWidth){.left = 8, .right = 8, .top = 8, .bottom = 8, .betweenChildren = 0};
+    c->renderData.border.cornerRadius = (Clay_CornerRadius){.topLeft = 4.0F, .topRight = 4.0F, .bottomLeft = 4.0F, .bottomRight = 4.0F};
+    inject_frozen_cmds(1);
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &target); /* Must not crash. */
+    TEST_ASSERT_GREATER_THAN_UINT32(0U, nt_sprite_renderer_test_last_emit_vertex_count());
+}
+
+/* IMAGE with any non-zero corner radius must assert -- rounded images are
+ * pre-baked into the atlas, not clipped at the walker. */
+static void test_dispatch_image_nonzero_radius_asserts(void) {
+    s_image_payload.atlas = s_fx.atlas.handle;
+    s_image_payload.region_index = s_fx.atlas.white_region_idx;
+    s_image_payload.flip_bits = 0;
+
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_IMAGE;
+    c->boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 32, .height = 32};
+    c->renderData.image.backgroundColor = (Clay_Color){0};
+    c->renderData.image.cornerRadius = (Clay_CornerRadius){.topLeft = 4.0F};
+    c->renderData.image.imageData = &s_image_payload;
+    inject_frozen_cmds(1);
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
+}
+
 /* Not-READY atlas must silent no-op (async loading is legitimate). */
 static void test_dispatch_image_not_ready_silent(void) {
     nt_ui_image_payload_t bad = {.atlas = {.id = 0xDEADBEEFU}, .region_index = 0, .flip_bits = 0};
@@ -254,8 +389,15 @@ static void test_dispatch_image_not_ready_silent(void) {
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_dispatch_rectangle);
+    RUN_TEST(test_dispatch_rectangle_zero_radius_keeps_fast_path);
+    RUN_TEST(test_dispatch_rectangle_rounded_emits_fan);
     RUN_TEST(test_dispatch_border_emits_4_rects);
-    RUN_TEST(test_dispatch_text);
+    RUN_TEST(test_dispatch_border_rounded_emits_strip);
+    RUN_TEST(test_dispatch_border_rounded_partial_widths);
+    RUN_TEST(test_dispatch_border_width_exceeds_radius);
+    RUN_TEST(test_dispatch_rounded_rect_uv_is_centroid_not_corner);
+    RUN_TEST(test_dispatch_image_nonzero_radius_asserts);
+    RUN_TEST(test_dispatch_text_unbound_font_asserts);
     RUN_TEST(test_dispatch_image);
     RUN_TEST(test_dispatch_scissor_start_end);
     RUN_TEST(test_dispatch_custom);

--- a/tests/unit/test_nt_ui_walker_dispatch.c
+++ b/tests/unit/test_nt_ui_walker_dispatch.c
@@ -24,7 +24,7 @@
 
 /* ---- Test-local state ---- */
 
-static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8U];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
 static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 32

--- a/tests/unit/test_nt_ui_walker_dispatch.c
+++ b/tests/unit/test_nt_ui_walker_dispatch.c
@@ -1,12 +1,3 @@
-/* tests/unit/test_nt_ui_walker_dispatch.c -- Plan 52-04
- *
- * Covers WALK-01 (all 8 Clay command types dispatch to the right backend)
- * and WALK-04 (BORDER with all 4 widths non-zero emits exactly 4 thin
- * rects). Synthetic Clay_RenderCommand arrays are injected directly into
- * ctx->frozen_cmds (visible via nt_ui_internal.h) -- this is the
- * walker-only path, bypassing Clay's declaration machinery.
- */
-
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -68,7 +59,7 @@ static void inject_frozen_cmds(int32_t count) {
 
 /* ---- Tests ---- */
 
-/* WALK-01: RECTANGLE -> sprite renderer emit_region (4 verts for white quad) */
+/* RECTANGLE -> sprite renderer emit_region (4 verts for white quad) */
 static void test_dispatch_rectangle(void) {
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
@@ -86,7 +77,7 @@ static void test_dispatch_rectangle(void) {
     TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_element_count(s_fx.ctx));
 }
 
-/* WALK-04: BORDER with all 4 widths non-zero -- exactly 4 last_emit calls
+/* BORDER with all 4 widths non-zero -- exactly 4 last_emit calls
  * happen (top, bottom, left, right), all into the white region. Verify the
  * LAST emit was still a white 4-vert quad. */
 static void test_dispatch_border_emits_4_rects(void) {
@@ -111,7 +102,7 @@ static void test_dispatch_border_emits_4_rects(void) {
     TEST_ASSERT_EQUAL_UINT32(calls_before + 1U, nt_sprite_renderer_test_draw_call_count());
 }
 
-/* WALK-01: TEXT -> flush sprite (no-op when empty) + text renderer setters
+/* TEXT -> flush sprite (no-op when empty) + text renderer setters
  * + draw_n. We verify the text renderer's set_material call counter ticks. */
 static void test_dispatch_text(void) {
     /* Note: This test doesn't register a font in s_fx.ctx -- emit_text's
@@ -145,7 +136,7 @@ static void test_dispatch_text(void) {
     TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_element_count(s_fx.ctx));
 }
 
-/* WALK-01: IMAGE -> reads nt_ui_image_payload_t and emits one region. */
+/* IMAGE -> reads nt_ui_image_payload_t and emits one region. */
 static void test_dispatch_image(void) {
     s_image_payload.atlas = s_fx.atlas.handle;
     s_image_payload.region_index = s_fx.atlas.polygon_region_idx; /* 6-vert hull */
@@ -167,7 +158,7 @@ static void test_dispatch_image(void) {
     TEST_ASSERT_EQUAL_UINT32(12U, nt_sprite_renderer_test_last_emit_index_count());
 }
 
-/* WALK-01 / WALK-02 / WALK-03: SCISSOR_START + SCISSOR_END are dispatched
+/* SCISSOR_START + SCISSOR_END are dispatched
  * and the walker exits with scissor disabled. */
 static void test_dispatch_scissor_start_end(void) {
     Clay_RenderCommand *cs = &s_test_cmds[0];
@@ -184,12 +175,12 @@ static void test_dispatch_scissor_start_end(void) {
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    /* Walker MUST disable scissor at exit (CP-04). */
+    /* Walker MUST disable scissor at exit. */
     TEST_ASSERT_FALSE(nt_gfx_test_scissor_enabled());
     TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_element_count(s_fx.ctx));
 }
 
-/* WALK-05: CUSTOM -> registered handler called with (cmd, userdata). */
+/* CUSTOM -> registered handler called with (cmd, userdata). */
 static void test_dispatch_custom(void) {
     int sentinel = 42;
     nt_ui_set_custom_handler(s_fx.ctx, test_custom_handler, &sentinel);
@@ -209,7 +200,7 @@ static void test_dispatch_custom(void) {
     TEST_ASSERT_EQUAL_PTR(&sentinel, s_custom_received_user);
 }
 
-/* WALK-01: NONE -> silent skip (no crash, no emit). */
+/* NONE -> silent skip (no crash, no emit). */
 static void test_dispatch_none_silent_skip(void) {
     /* Walk an empty command array -- frozen_cmds.length = 0. */
     inject_frozen_cmds(0);

--- a/tests/unit/test_nt_ui_walker_dispatch.c
+++ b/tests/unit/test_nt_ui_walker_dispatch.c
@@ -7,51 +7,29 @@
  * walker-only path, bypassing Clay's declaration machinery.
  */
 
-/* System headers before Unity to avoid noreturn / __declspec conflict on MSVC */
-#include <math.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
-/* clang-format off */
-#include "atlas/nt_atlas.h"
 #include "clay.h"
-#include "core/nt_assert.h"
-#include "font/nt_font.h"
 #include "graphics/nt_gfx.h"
-#include "hash/nt_hash.h"
-#include "input/nt_input.h"
-#include "material/nt_material.h"
-#include "nt_crc32.h"
-#include "nt_pack_format.h"
 #include "renderers/nt_sprite_renderer.h"
 #include "renderers/nt_text_renderer.h"
-#include "resource/nt_resource.h"
-#include "stats/nt_stats.h"
 #include "test_helpers/nt_assert_trap.h"
-#include "test_helpers/ui_atlas.h"
+#include "test_helpers/ui_walker_fixture.h"
 #include "ui/nt_ui.h"
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
-/* clang-format on */
 
-/* ---- Shared test fixtures ---- */
+/* ---- Test-local state ---- */
 
 static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
-static minimal_ui_atlas_t s_atlas;
-static nt_material_t s_sprite_material;
-static nt_material_t s_text_material;
-static nt_ui_context_t *s_ctx;
-static uint32_t s_vpack_counter;
+static ui_walker_fixture_t s_fx;
 
-/* Static command arrays for synthetic frozen_cmds injection. */
 #define MAX_TEST_CMDS 32
 static Clay_RenderCommand s_test_cmds[MAX_TEST_CMDS];
 
-/* Image payload backing storage. */
 static nt_ui_image_payload_t s_image_payload;
 
 /* Custom-handler flag + receiver. */
@@ -65,118 +43,27 @@ static void test_custom_handler(const void *clay_cmd, void *userdata) {
     s_custom_received_user = userdata;
 }
 
-/* ---- Build a minimal test material via virtual-pack-registered shaders ---- */
-
-static nt_material_t make_test_material(void) {
-    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "void main(){}", .label = "walker_vs"});
-    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "void main(){}", .label = "walker_fs"});
-
-    char pack_name[64];
-    char vs_name[64];
-    char fs_name[64];
-    (void)snprintf(pack_name, sizeof pack_name, "walker_mat_pack_%u", s_vpack_counter);
-    (void)snprintf(vs_name, sizeof vs_name, "walker_vs_%u", s_vpack_counter);
-    (void)snprintf(fs_name, sizeof fs_name, "walker_fs_%u", s_vpack_counter);
-    s_vpack_counter++;
-
-    nt_hash32_t pid = nt_hash32_str(pack_name);
-    nt_hash64_t vs_rid = nt_hash64_str(vs_name);
-    nt_hash64_t fs_rid = nt_hash64_str(fs_name);
-
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pid, 0));
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, vs_rid, NT_ASSET_SHADER_CODE, vs.id));
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, fs_rid, NT_ASSET_SHADER_CODE, fs.id));
-
-    nt_resource_t vs_res = nt_resource_request(vs_rid, NT_ASSET_SHADER_CODE);
-    nt_resource_t fs_res = nt_resource_request(fs_rid, NT_ASSET_SHADER_CODE);
-    nt_resource_step();
-
-    nt_material_create_desc_t desc;
-    memset(&desc, 0, sizeof desc);
-    desc.vs = vs_res;
-    desc.fs = fs_res;
-    desc.depth_test = false;
-    desc.depth_write = false;
-    desc.cull_mode = NT_CULL_NONE;
-    desc.color_mode = NT_COLOR_MODE_NONE;
-    desc.label = "walker_test_material";
-
-    nt_material_t mat = nt_material_create(&desc);
-    nt_material_step();
-    return mat;
-}
-
 /* ---- Common setUp / tearDown ---- */
 
 void setUp(void) {
     nt_test_assert_install();
-    s_vpack_counter = 0;
     s_custom_called = false;
     s_custom_received_cmd = NULL;
     s_custom_received_user = NULL;
     memset(s_test_cmds, 0, sizeof s_test_cmds);
     memset(&s_image_payload, 0, sizeof s_image_payload);
 
-    nt_hash_init(&(nt_hash_desc_t){0});
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_pipelines = 16, .max_buffers = 64, .max_textures = 32, .max_meshes = 16});
-    nt_resource_init(&(nt_resource_desc_t){0});
-    nt_atlas_init();
-    nt_font_init(&(nt_font_desc_t){.max_fonts = 4});
-    nt_material_init(&(nt_material_desc_t){.max_materials = 32});
-
-    /* Begin a frame/pass so flush's draw_indexed doesn't trip the stub backend
-     * "no active pass" guard (mirrors test_sprite_renderer setUp). */
-    nt_gfx_begin_frame();
-    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
-
-    nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
-    nt_text_renderer_init();
-
-    /* nt_stats_init required: Plan 52-05 wired nt_stats_count("ui_draw_calls", ...)
-     * + nt_stats_count("ui_element_count", ...) at nt_ui_walk exit. Without init,
-     * nt_stats_count's NT_ASSERT(s_stats.initialized) trips on every walk. */
-    nt_stats_init(NULL);
-
-    s_atlas = minimal_ui_atlas_create();
-    s_sprite_material = make_test_material();
-    s_text_material = make_test_material();
-
-    s_ctx = nt_ui_create_context(s_arena, sizeof s_arena);
-    TEST_ASSERT_NOT_NULL(s_ctx);
-
-    nt_ui_set_atlas_white_region(s_ctx, s_atlas.handle, s_atlas.white_region_idx);
-    nt_ui_set_sprite_material(s_ctx, s_sprite_material);
-    nt_ui_set_text_material(s_ctx, s_text_material);
-    nt_ui_set_custom_handler(s_ctx, NULL, NULL);
+    ui_walker_fixture_init(&s_fx, s_arena, sizeof s_arena, UI_WALKER_FX_BIND_ALL);
 }
 
-void tearDown(void) {
-    if (s_ctx != NULL) {
-        nt_ui_destroy_context(s_ctx);
-        s_ctx = NULL;
-    }
-    minimal_ui_atlas_destroy(&s_atlas);
-
-    nt_stats_shutdown();
-    nt_sprite_renderer_shutdown();
-    nt_text_renderer_shutdown();
-    nt_gfx_end_pass();
-    nt_gfx_end_frame();
-
-    nt_material_shutdown();
-    nt_font_shutdown();
-    nt_atlas_test_reset();
-    nt_resource_shutdown();
-    nt_gfx_shutdown();
-    nt_hash_shutdown();
-}
+void tearDown(void) { ui_walker_fixture_shutdown(&s_fx); }
 
 /* Inject a synthetic frozen_cmds array into the ctx so the walker iterates
  * a known-shape command list. Bypasses Clay declaration machinery. */
 static void inject_frozen_cmds(int32_t count) {
-    s_ctx->frozen_cmds.internalArray = s_test_cmds;
-    s_ctx->frozen_cmds.length = count;
-    s_ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
+    s_fx.ctx->frozen_cmds.internalArray = s_test_cmds;
+    s_fx.ctx->frozen_cmds.length = count;
+    s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
 }
 
 /* ---- Tests ---- */
@@ -190,13 +77,13 @@ static void test_dispatch_rectangle(void) {
     inject_frozen_cmds(1);
 
     nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
     /* White region is 4 verts/6 indices -- emit_region preserves it. */
     TEST_ASSERT_EQUAL_UINT32(4u, nt_sprite_renderer_test_last_emit_vertex_count());
     TEST_ASSERT_EQUAL_UINT32(6u, nt_sprite_renderer_test_last_emit_index_count());
     /* Walker element count delta matches frozen_cmds.length. */
-    TEST_ASSERT_EQUAL_UINT32(1u, nt_ui_test_last_walk_element_count(s_ctx));
+    TEST_ASSERT_EQUAL_UINT32(1u, nt_ui_test_last_walk_element_count(s_fx.ctx));
 }
 
 /* WALK-04: BORDER with all 4 widths non-zero -- exactly 4 last_emit calls
@@ -216,7 +103,7 @@ static void test_dispatch_border_emits_4_rects(void) {
     const uint32_t calls_before = nt_sprite_renderer_test_draw_call_count();
 
     nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
     /* Last emit is still a 4-vert white quad. */
     TEST_ASSERT_EQUAL_UINT32(4u, nt_sprite_renderer_test_last_emit_vertex_count());
@@ -227,7 +114,7 @@ static void test_dispatch_border_emits_4_rects(void) {
 /* WALK-01: TEXT -> flush sprite (no-op when empty) + text renderer setters
  * + draw_n. We verify the text renderer's set_material call counter ticks. */
 static void test_dispatch_text(void) {
-    /* Note: This test doesn't register a font in s_ctx -- emit_text's
+    /* Note: This test doesn't register a font in s_fx.ctx -- emit_text's
      * nt_font_valid early-return fires, so no glyphs are drawn. But the
      * sprite-flush at the top of emit_text DOES happen, and the test
      * confirms the walk completes without crashing (TEXT branch reachable).
@@ -247,7 +134,7 @@ static void test_dispatch_text(void) {
     inject_frozen_cmds(1);
 
     nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
     /* font_id=0 has no font set in the per-ctx registry; emit_text exits
      * before calling set_font/set_material. The walker just needs to not
@@ -255,13 +142,13 @@ static void test_dispatch_text(void) {
     TEST_ASSERT_EQUAL_UINT32(0u, nt_text_renderer_test_set_material_calls());
     TEST_ASSERT_EQUAL_UINT32(0u, nt_text_renderer_test_set_font_calls());
     /* Walker element count still ticks. */
-    TEST_ASSERT_EQUAL_UINT32(1u, nt_ui_test_last_walk_element_count(s_ctx));
+    TEST_ASSERT_EQUAL_UINT32(1u, nt_ui_test_last_walk_element_count(s_fx.ctx));
 }
 
 /* WALK-01: IMAGE -> reads nt_ui_image_payload_t and emits one region. */
 static void test_dispatch_image(void) {
-    s_image_payload.atlas = s_atlas.handle;
-    s_image_payload.region_index = s_atlas.polygon_region_idx; /* 6-vert hull */
+    s_image_payload.atlas = s_fx.atlas.handle;
+    s_image_payload.region_index = s_fx.atlas.polygon_region_idx; /* 6-vert hull */
     s_image_payload.flip_bits = 0;
     memset(s_image_payload.slice9_lrtb, 0, sizeof s_image_payload.slice9_lrtb);
 
@@ -273,7 +160,7 @@ static void test_dispatch_image(void) {
     inject_frozen_cmds(1);
 
     nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
     /* Polygon hull preservation: emit_image must NOT collapse to 4-vert quad. */
     TEST_ASSERT_EQUAL_UINT32(6u, nt_sprite_renderer_test_last_emit_vertex_count());
@@ -295,17 +182,17 @@ static void test_dispatch_scissor_start_end(void) {
     inject_frozen_cmds(2);
 
     nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
     /* Walker MUST disable scissor at exit (CP-04). */
     TEST_ASSERT_FALSE(nt_gfx_test_scissor_enabled());
-    TEST_ASSERT_EQUAL_UINT32(2u, nt_ui_test_last_walk_element_count(s_ctx));
+    TEST_ASSERT_EQUAL_UINT32(2u, nt_ui_test_last_walk_element_count(s_fx.ctx));
 }
 
 /* WALK-05: CUSTOM -> registered handler called with (cmd, userdata). */
 static void test_dispatch_custom(void) {
     int sentinel = 42;
-    nt_ui_set_custom_handler(s_ctx, test_custom_handler, &sentinel);
+    nt_ui_set_custom_handler(s_fx.ctx, test_custom_handler, &sentinel);
 
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_CUSTOM;
@@ -315,7 +202,7 @@ static void test_dispatch_custom(void) {
     inject_frozen_cmds(1);
 
     nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
     TEST_ASSERT_TRUE(s_custom_called);
     TEST_ASSERT_EQUAL_PTR(c, s_custom_received_cmd);
@@ -328,15 +215,15 @@ static void test_dispatch_none_silent_skip(void) {
     inject_frozen_cmds(0);
 
     nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
-    TEST_ASSERT_EQUAL_UINT32(0u, nt_ui_test_last_walk_element_count(s_ctx));
+    TEST_ASSERT_EQUAL_UINT32(0u, nt_ui_test_last_walk_element_count(s_fx.ctx));
 
     /* Also test an explicit NONE command -- still no crash, still no emit. */
     s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_NONE;
     inject_frozen_cmds(1);
-    nt_ui_walk(s_ctx, &target);
-    TEST_ASSERT_EQUAL_UINT32(1u, nt_ui_test_last_walk_element_count(s_ctx));
+    nt_ui_walk(s_fx.ctx, &target);
+    TEST_ASSERT_EQUAL_UINT32(1u, nt_ui_test_last_walk_element_count(s_fx.ctx));
 }
 
 int main(void) {

--- a/tests/unit/test_nt_ui_walker_dispatch.c
+++ b/tests/unit/test_nt_ui_walker_dispatch.c
@@ -30,6 +30,7 @@
 #include "renderers/nt_sprite_renderer.h"
 #include "renderers/nt_text_renderer.h"
 #include "resource/nt_resource.h"
+#include "stats/nt_stats.h"
 #include "test_helpers/nt_assert_trap.h"
 #include "test_helpers/ui_atlas.h"
 #include "ui/nt_ui.h"
@@ -131,6 +132,11 @@ void setUp(void) {
     nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
     nt_text_renderer_init();
 
+    /* nt_stats_init required: Plan 52-05 wired nt_stats_count("ui_draw_calls", ...)
+     * + nt_stats_count("ui_element_count", ...) at nt_ui_walk exit. Without init,
+     * nt_stats_count's NT_ASSERT(s_stats.initialized) trips on every walk. */
+    nt_stats_init(NULL);
+
     s_atlas = minimal_ui_atlas_create();
     s_sprite_material = make_test_material();
     s_text_material = make_test_material();
@@ -152,6 +158,7 @@ void tearDown(void) {
     nt_ui_test_reset_walker_globals();
     minimal_ui_atlas_destroy(&s_atlas);
 
+    nt_stats_shutdown();
     nt_sprite_renderer_shutdown();
     nt_text_renderer_shutdown();
     nt_gfx_end_pass();

--- a/tests/unit/test_nt_ui_walker_dispatch.c
+++ b/tests/unit/test_nt_ui_walker_dispatch.c
@@ -202,8 +202,7 @@ static void test_dispatch_none_silent_skip(void) {
     TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_element_count(s_fx.ctx));
 }
 
-/* IMAGE with non-default backgroundColor must pack the tint (not fall
- * through the all-zero "default untinted" shortcut). */
+/* Non-zero tint must NOT hit the "untinted" shortcut. */
 static void test_dispatch_image_tinted_packs_color(void) {
     s_image_payload.atlas = s_fx.atlas.handle;
     s_image_payload.region_index = s_fx.atlas.white_region_idx;
@@ -212,8 +211,7 @@ static void test_dispatch_image_tinted_packs_color(void) {
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_IMAGE;
     c->boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 32, .height = 32};
-    /* Half-alpha black -- not (0,0,0,0), so must NOT take the untinted
-     * shortcut. Packed: r=0, g=0, b=0, a=128 -> 0x80000000 in 0xAABBGGRR. */
+    /* Half-alpha black: packs to 0x80000000 in 0xAABBGGRR. */
     c->renderData.image.backgroundColor = (Clay_Color){.r = 0.0F, .g = 0.0F, .b = 0.0F, .a = 128.0F};
     c->renderData.image.imageData = &s_image_payload;
     inject_frozen_cmds(1);
@@ -224,11 +222,7 @@ static void test_dispatch_image_tinted_packs_color(void) {
     TEST_ASSERT_EQUAL_UINT32(4U, nt_sprite_renderer_test_last_emit_vertex_count());
 }
 
-/* RECT with non-zero cornerRadius takes the tessellated-fan path: emits
- * 1 center vertex + 4 * (NT_UI_CORNER_SEGMENTS + 1) boundary verts when
- * all four corners are rounded. NT_UI_CORNER_SEGMENTS is private to
- * nt_ui.c, so this test compares against the flat-corner emit count
- * instead of hardcoding it. */
+/* Rounded RECT goes through the tessellated-fan path (>4 verts). */
 static void test_dispatch_rectangle_rounded_emits_fan(void) {
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
@@ -240,14 +234,11 @@ static void test_dispatch_rectangle_rounded_emits_fan(void) {
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    /* Tessellated fan must be strictly more verts than the 4-vert flat quad
-     * and strictly more indices than the 6-index flat quad. */
     TEST_ASSERT_GREATER_THAN_UINT32(4U, nt_sprite_renderer_test_last_emit_vertex_count());
     TEST_ASSERT_GREATER_THAN_UINT32(6U, nt_sprite_renderer_test_last_emit_index_count());
 }
 
-/* RECT with all-zero cornerRadius stays on the 4-vert fast path -- locking
- * the existing emit_screen_rect optimization in place. */
+/* Zero cornerRadius keeps the 4-vert fast path. */
 static void test_dispatch_rectangle_zero_radius_keeps_fast_path(void) {
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
@@ -263,8 +254,7 @@ static void test_dispatch_rectangle_zero_radius_keeps_fast_path(void) {
     TEST_ASSERT_EQUAL_UINT32(6U, nt_sprite_renderer_test_last_emit_index_count());
 }
 
-/* BORDER with non-zero cornerRadius takes the ring-strip path:
- * 4*(SEG+1)*2 verts when all four corners are rounded. */
+/* Rounded BORDER goes through the ring-strip path (>4 verts). */
 static void test_dispatch_border_rounded_emits_strip(void) {
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_BORDER;
@@ -277,15 +267,12 @@ static void test_dispatch_border_rounded_emits_strip(void) {
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    /* Ring strip emits significantly more than the 4-vert flat border fast path. */
     TEST_ASSERT_GREATER_THAN_UINT32(4U, nt_sprite_renderer_test_last_emit_vertex_count());
 }
 
-/* emit_geometry samples the region's UV centroid, NOT vertex[0]'s corner UV.
- * The fixture's white_region is a 4-vert quad with UV corners at
- * (0,0), (0xFFFF,0), (0xFFFF,0xFFFF), (0,0xFFFF) -- mean = (0x7FFF, 0x7FFF).
- * A texel-corner sample would bleed into adjacent atlas pixels under
- * linear filtering; centroid keeps the sample firmly inside the white pixel. */
+/* emit_geometry samples the centroid (mean of 4 corner UVs) -- NOT vertex[0]'s
+ * UV which would land at a texel boundary and bleed under linear filtering.
+ * Fixture white_region UVs: (0,0)(FFFF,0)(FFFF,FFFF)(0,FFFF), mean = 0x7FFF. */
 static void test_dispatch_rounded_rect_uv_is_centroid_not_corner(void) {
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
@@ -312,11 +299,8 @@ static void test_dispatch_rounded_rect_uv_is_centroid_not_corner(void) {
     TEST_ASSERT_EQUAL_UINT16(0x7FFFU, uv0[1]);
 }
 
-/* CSS3 border-radius proportional scaling: asymmetric radii where the SUM
- * along a side fits the dimension must NOT be over-clamped. Before the
- * CSS3 fix this case was clamped by half_h to {30,30,10,10} -- after the
- * fix it stays {40,40,10,10} (sums 80 across w=200 and 50 across h=60
- * both fit, factor=1.0). Vertex count and bbox are observable. */
+/* CSS3 §5.5 keeps asymmetric radii {40,40,10,10} on 200x60 -- adjacent sums
+ * fit, factor=1, no over-clamp to {30,30,10,10}. */
 static void test_dispatch_rect_asymmetric_radii_no_over_clamp(void) {
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
@@ -328,25 +312,21 @@ static void test_dispatch_rect_asymmetric_radii_no_over_clamp(void) {
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    /* All four corners non-zero -> full tessellation (1 center + 4 * 7 = 29 verts). */
+    /* 1 center + 4 * 7 arc points = 29 verts. */
     TEST_ASSERT_EQUAL_UINT32(29U, nt_sprite_renderer_test_last_emit_vertex_count());
 
-    /* TL arc entry at (0, top_y + tl) where tl should be 40 (NOT 30):
-     * vertex index 1 in fan (first boundary vert after center) is TL arc
-     * west point at (x, y+tl) per emit_rounded_rect ordering. Float-imprecise
-     * cosf(π) gives ~-1.0 (not exact), so allow ±1 tolerance. */
+    /* TL arc west point at (x, y+tl). cosf(π) ≈ -1 -> ±1 tolerance. */
     float pos[3];
     nt_sprite_renderer_test_last_emit_position(1U, pos);
     const int32_t px = (int32_t)pos[0];
     const int32_t py = (int32_t)pos[1];
-    TEST_ASSERT_TRUE(px == 0 || px == -1);  /* near 0 within float epsilon */
-    TEST_ASSERT_GREATER_THAN_INT32(35, py); /* MUST be ~40, NOT 30 from old half-clamp */
+    TEST_ASSERT_TRUE(px == 0 || px == -1);
+    TEST_ASSERT_GREATER_THAN_INT32(35, py); /* ~40, NOT 30 from old half-clamp */
     TEST_ASSERT_LESS_OR_EQUAL_INT32(40, py);
 }
 
-/* BORDER with rounded corners and partial widths (e.g. only bottom border)
- * must not assert -- inner radius clamps to 0 on axes where width=0, giving
- * a degenerate strip segment for skipped sides. */
+/* Partial widths with rounded corners: inner radius clamps to 0 on zero-width
+ * axes, producing degenerate strip segments for the skipped sides. */
 static void test_dispatch_border_rounded_partial_widths(void) {
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_BORDER;
@@ -358,30 +338,26 @@ static void test_dispatch_border_rounded_partial_widths(void) {
     inject_frozen_cmds(1);
 
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
-    nt_ui_walk(s_fx.ctx, &target); /* Must not crash, must not assert. */
-    /* Emits something (ring strip with degenerate parts). */
+    nt_ui_walk(s_fx.ctx, &target);
     TEST_ASSERT_GREATER_THAN_UINT32(0U, nt_sprite_renderer_test_last_emit_vertex_count());
 }
 
-/* BORDER with width > radius clamps inner radius to 0 on the affected axis.
- * Should not crash; result is "filled" corner without rounding. */
+/* width > radius: inner radius clamps to 0 (corner "filled" inside). */
 static void test_dispatch_border_width_exceeds_radius(void) {
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_BORDER;
     c->boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 100.0F, .height = 60.0F};
     c->renderData.border.color = (Clay_Color){.r = 255.0F, .g = 255.0F, .b = 0.0F, .a = 255.0F};
-    /* Width 8 with radius 4 -- inner clamps to 0. */
     c->renderData.border.width = (Clay_BorderWidth){.left = 8, .right = 8, .top = 8, .bottom = 8, .betweenChildren = 0};
     c->renderData.border.cornerRadius = (Clay_CornerRadius){.topLeft = 4.0F, .topRight = 4.0F, .bottomLeft = 4.0F, .bottomRight = 4.0F};
     inject_frozen_cmds(1);
 
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
-    nt_ui_walk(s_fx.ctx, &target); /* Must not crash. */
+    nt_ui_walk(s_fx.ctx, &target);
     TEST_ASSERT_GREATER_THAN_UINT32(0U, nt_sprite_renderer_test_last_emit_vertex_count());
 }
 
-/* IMAGE with any non-zero corner radius must assert -- rounded images are
- * pre-baked into the atlas, not clipped at the walker. */
+/* Rounded IMAGE asserts -- rounded edges must be baked into the atlas. */
 static void test_dispatch_image_nonzero_radius_asserts(void) {
     s_image_payload.atlas = s_fx.atlas.handle;
     s_image_payload.region_index = s_fx.atlas.white_region_idx;
@@ -414,7 +390,6 @@ static void test_dispatch_image_not_ready_silent(void) {
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    /* The IMAGE emit was skipped; no draw call from this command. */
     TEST_ASSERT_EQUAL_UINT32(calls_before, nt_sprite_renderer_test_draw_call_count());
 }
 

--- a/tests/unit/test_nt_ui_walker_dispatch.c
+++ b/tests/unit/test_nt_ui_walker_dispatch.c
@@ -141,13 +141,13 @@ void setUp(void) {
     s_sprite_material = make_test_material();
     s_text_material = make_test_material();
 
-    nt_ui_set_atlas_white_region(s_atlas.handle, s_atlas.white_region_idx);
-    nt_ui_set_sprite_material(s_sprite_material);
-    nt_ui_set_text_material(s_text_material);
-    nt_ui_set_custom_handler(NULL, NULL);
-
     s_ctx = nt_ui_create_context(s_arena, sizeof s_arena);
     TEST_ASSERT_NOT_NULL(s_ctx);
+
+    nt_ui_set_atlas_white_region(s_ctx, s_atlas.handle, s_atlas.white_region_idx);
+    nt_ui_set_sprite_material(s_ctx, s_sprite_material);
+    nt_ui_set_text_material(s_ctx, s_text_material);
+    nt_ui_set_custom_handler(s_ctx, NULL, NULL);
 }
 
 void tearDown(void) {
@@ -155,7 +155,6 @@ void tearDown(void) {
         nt_ui_destroy_context(s_ctx);
         s_ctx = NULL;
     }
-    nt_ui_test_reset_walker_globals();
     minimal_ui_atlas_destroy(&s_atlas);
 
     nt_stats_shutdown();
@@ -197,7 +196,7 @@ static void test_dispatch_rectangle(void) {
     TEST_ASSERT_EQUAL_UINT32(4u, nt_sprite_renderer_test_last_emit_vertex_count());
     TEST_ASSERT_EQUAL_UINT32(6u, nt_sprite_renderer_test_last_emit_index_count());
     /* Walker element count delta matches frozen_cmds.length. */
-    TEST_ASSERT_EQUAL_UINT32(1u, nt_ui_test_last_walk_element_count());
+    TEST_ASSERT_EQUAL_UINT32(1u, nt_ui_test_last_walk_element_count(s_ctx));
 }
 
 /* WALK-04: BORDER with all 4 widths non-zero -- exactly 4 last_emit calls
@@ -256,7 +255,7 @@ static void test_dispatch_text(void) {
     TEST_ASSERT_EQUAL_UINT32(0u, nt_text_renderer_test_set_material_calls());
     TEST_ASSERT_EQUAL_UINT32(0u, nt_text_renderer_test_set_font_calls());
     /* Walker element count still ticks. */
-    TEST_ASSERT_EQUAL_UINT32(1u, nt_ui_test_last_walk_element_count());
+    TEST_ASSERT_EQUAL_UINT32(1u, nt_ui_test_last_walk_element_count(s_ctx));
 }
 
 /* WALK-01: IMAGE -> reads nt_ui_image_payload_t and emits one region. */
@@ -300,13 +299,13 @@ static void test_dispatch_scissor_start_end(void) {
 
     /* Walker MUST disable scissor at exit (CP-04). */
     TEST_ASSERT_FALSE(nt_gfx_test_scissor_enabled());
-    TEST_ASSERT_EQUAL_UINT32(2u, nt_ui_test_last_walk_element_count());
+    TEST_ASSERT_EQUAL_UINT32(2u, nt_ui_test_last_walk_element_count(s_ctx));
 }
 
 /* WALK-05: CUSTOM -> registered handler called with (cmd, userdata). */
 static void test_dispatch_custom(void) {
     int sentinel = 42;
-    nt_ui_set_custom_handler(test_custom_handler, &sentinel);
+    nt_ui_set_custom_handler(s_ctx, test_custom_handler, &sentinel);
 
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_CUSTOM;
@@ -331,13 +330,13 @@ static void test_dispatch_none_silent_skip(void) {
     nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
     nt_ui_walk(s_ctx, &target);
 
-    TEST_ASSERT_EQUAL_UINT32(0u, nt_ui_test_last_walk_element_count());
+    TEST_ASSERT_EQUAL_UINT32(0u, nt_ui_test_last_walk_element_count(s_ctx));
 
     /* Also test an explicit NONE command -- still no crash, still no emit. */
     s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_NONE;
     inject_frozen_cmds(1);
     nt_ui_walk(s_ctx, &target);
-    TEST_ASSERT_EQUAL_UINT32(1u, nt_ui_test_last_walk_element_count());
+    TEST_ASSERT_EQUAL_UINT32(1u, nt_ui_test_last_walk_element_count(s_ctx));
 }
 
 int main(void) {

--- a/tests/unit/test_nt_ui_walker_dispatch.c
+++ b/tests/unit/test_nt_ui_walker_dispatch.c
@@ -74,7 +74,7 @@ static void test_dispatch_rectangle(void) {
     TEST_ASSERT_EQUAL_UINT32(4U, nt_sprite_renderer_test_last_emit_vertex_count());
     TEST_ASSERT_EQUAL_UINT32(6U, nt_sprite_renderer_test_last_emit_index_count());
     /* Walker element count delta matches frozen_cmds.length. */
-    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_command_count(s_fx.ctx));
 }
 
 /* BORDER with all 4 widths non-zero -- exactly 4 last_emit calls
@@ -162,7 +162,7 @@ static void test_dispatch_scissor_start_end(void) {
 
     /* Walker MUST disable scissor at exit. */
     TEST_ASSERT_FALSE(nt_gfx_test_scissor_enabled());
-    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_command_count(s_fx.ctx));
 }
 
 /* CUSTOM -> registered handler called with (cmd, userdata). */
@@ -193,13 +193,13 @@ static void test_dispatch_none_silent_skip(void) {
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_command_count(s_fx.ctx));
 
     /* Also test an explicit NONE command -- still no crash, still no emit. */
     s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_NONE;
     inject_frozen_cmds(1);
     nt_ui_walk(s_fx.ctx, &target);
-    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_command_count(s_fx.ctx));
 }
 
 /* Non-zero tint must NOT hit the "untinted" shortcut. */

--- a/tests/unit/test_nt_ui_walker_flush.c
+++ b/tests/unit/test_nt_ui_walker_flush.c
@@ -26,6 +26,7 @@
 #include "renderers/nt_sprite_renderer.h"
 #include "renderers/nt_text_renderer.h"
 #include "resource/nt_resource.h"
+#include "stats/nt_stats.h"
 #include "test_helpers/nt_assert_trap.h"
 #include "test_helpers/ui_atlas.h"
 #include "ui/nt_ui.h"
@@ -100,6 +101,11 @@ void setUp(void) {
     nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
     nt_text_renderer_init();
 
+    /* nt_stats_init required: Plan 52-05 wired nt_stats_count("ui_draw_calls", ...)
+     * + nt_stats_count("ui_element_count", ...) at nt_ui_walk exit. Without init,
+     * nt_stats_count's NT_ASSERT(s_stats.initialized) trips on every walk. */
+    nt_stats_init(NULL);
+
     s_atlas = minimal_ui_atlas_create();
     s_sprite_material = make_test_material();
     s_text_material = make_test_material();
@@ -120,6 +126,7 @@ void tearDown(void) {
     }
     nt_ui_test_reset_walker_globals();
     minimal_ui_atlas_destroy(&s_atlas);
+    nt_stats_shutdown();
     nt_sprite_renderer_shutdown();
     nt_text_renderer_shutdown();
     nt_gfx_end_pass();

--- a/tests/unit/test_nt_ui_walker_flush.c
+++ b/tests/unit/test_nt_ui_walker_flush.c
@@ -1,0 +1,31 @@
+/* tests/unit/test_nt_ui_walker_flush.c — Plan 52-00 stub
+ *
+ * Covers WALK-06 (walker flushes both renderers at scissor/text/target
+ * boundaries and at walk exit). Wave 0 ships TEST_IGNORE bodies; Plan 52-04
+ * fills with real assertions.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* WALK-06 / D-52-18: walker exit flushes both sprite and text renderers */
+static void test_walker_exit_flushes_sprite_and_text(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+/* WALK-06: SCISSOR_START/END flushes both renderers before changing scissor state */
+static void test_flush_on_scissor_transition(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+/* WALK-06: RECT → TEXT transition flushes sprite before text path begins */
+static void test_flush_on_rect_to_text_transition(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_walker_exit_flushes_sprite_and_text);
+    RUN_TEST(test_flush_on_scissor_transition);
+    RUN_TEST(test_flush_on_rect_to_text_transition);
+    return UNITY_END();
+}

--- a/tests/unit/test_nt_ui_walker_flush.c
+++ b/tests/unit/test_nt_ui_walker_flush.c
@@ -1,26 +1,220 @@
-/* tests/unit/test_nt_ui_walker_flush.c — Plan 52-00 stub
+/* tests/unit/test_nt_ui_walker_flush.c -- Plan 52-04
  *
- * Covers WALK-06 (walker flushes both renderers at scissor/text/target
- * boundaries and at walk exit). Wave 0 ships TEST_IGNORE bodies; Plan 52-04
- * fills with real assertions.
+ * Covers WALK-06 / D-52-18: walker flushes both sprite + text renderers
+ * at scissor / text boundaries and at walk exit. Probes the renderer's
+ * test-access draw_call_count / vertex_count counters.
  */
 
+#include <math.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
+/* clang-format off */
+#include "atlas/nt_atlas.h"
+#include "clay.h"
+#include "core/nt_assert.h"
+#include "font/nt_font.h"
+#include "graphics/nt_gfx.h"
+#include "hash/nt_hash.h"
+#include "input/nt_input.h"
+#include "material/nt_material.h"
+#include "nt_pack_format.h"
+#include "renderers/nt_sprite_renderer.h"
+#include "renderers/nt_text_renderer.h"
+#include "resource/nt_resource.h"
+#include "test_helpers/nt_assert_trap.h"
+#include "test_helpers/ui_atlas.h"
+#include "ui/nt_ui.h"
+#include "ui/nt_ui_internal.h"
 #include "unity.h"
+/* clang-format on */
 
-void setUp(void) {}
-void tearDown(void) {}
+static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+static minimal_ui_atlas_t s_atlas;
+static nt_material_t s_sprite_material;
+static nt_material_t s_text_material;
+static nt_ui_context_t *s_ctx;
+static uint32_t s_vpack_counter;
 
-/* WALK-06 / D-52-18: walker exit flushes both sprite and text renderers */
-static void test_walker_exit_flushes_sprite_and_text(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+#define MAX_TEST_CMDS 8
+static Clay_RenderCommand s_test_cmds[MAX_TEST_CMDS];
 
-/* WALK-06: SCISSOR_START/END flushes both renderers before changing scissor state */
-static void test_flush_on_scissor_transition(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+static nt_material_t make_test_material(void) {
+    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "void main(){}", .label = "walker_vs"});
+    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "void main(){}", .label = "walker_fs"});
 
-/* WALK-06: RECT → TEXT transition flushes sprite before text path begins */
-static void test_flush_on_rect_to_text_transition(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+    char pack_name[64];
+    char vs_name[64];
+    char fs_name[64];
+    (void)snprintf(pack_name, sizeof pack_name, "walker_mat_pack_%u", s_vpack_counter);
+    (void)snprintf(vs_name, sizeof vs_name, "walker_vs_%u", s_vpack_counter);
+    (void)snprintf(fs_name, sizeof fs_name, "walker_fs_%u", s_vpack_counter);
+    s_vpack_counter++;
+
+    nt_hash32_t pid = nt_hash32_str(pack_name);
+    nt_hash64_t vs_rid = nt_hash64_str(vs_name);
+    nt_hash64_t fs_rid = nt_hash64_str(fs_name);
+
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pid, 0));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, vs_rid, NT_ASSET_SHADER_CODE, vs.id));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, fs_rid, NT_ASSET_SHADER_CODE, fs.id));
+
+    nt_resource_t vs_res = nt_resource_request(vs_rid, NT_ASSET_SHADER_CODE);
+    nt_resource_t fs_res = nt_resource_request(fs_rid, NT_ASSET_SHADER_CODE);
+    nt_resource_step();
+
+    nt_material_create_desc_t desc;
+    memset(&desc, 0, sizeof desc);
+    desc.vs = vs_res;
+    desc.fs = fs_res;
+    desc.depth_test = false;
+    desc.depth_write = false;
+    desc.cull_mode = NT_CULL_NONE;
+    desc.color_mode = NT_COLOR_MODE_NONE;
+    desc.label = "walker_test_material";
+
+    nt_material_t mat = nt_material_create(&desc);
+    nt_material_step();
+    return mat;
+}
+
+void setUp(void) {
+    nt_test_assert_install();
+    s_vpack_counter = 0;
+    memset(s_test_cmds, 0, sizeof s_test_cmds);
+
+    nt_hash_init(&(nt_hash_desc_t){0});
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_pipelines = 16, .max_buffers = 64, .max_textures = 32, .max_meshes = 16});
+    nt_resource_init(&(nt_resource_desc_t){0});
+    nt_atlas_init();
+    nt_font_init(&(nt_font_desc_t){.max_fonts = 4});
+    nt_material_init(&(nt_material_desc_t){.max_materials = 32});
+
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+
+    nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
+    nt_text_renderer_init();
+
+    s_atlas = minimal_ui_atlas_create();
+    s_sprite_material = make_test_material();
+    s_text_material = make_test_material();
+
+    nt_ui_set_atlas_white_region(s_atlas.handle, s_atlas.white_region_idx);
+    nt_ui_set_sprite_material(s_sprite_material);
+    nt_ui_set_text_material(s_text_material);
+    nt_ui_set_custom_handler(NULL, NULL);
+
+    s_ctx = nt_ui_create_context(s_arena, sizeof s_arena);
+    TEST_ASSERT_NOT_NULL(s_ctx);
+}
+
+void tearDown(void) {
+    if (s_ctx != NULL) {
+        nt_ui_destroy_context(s_ctx);
+        s_ctx = NULL;
+    }
+    nt_ui_test_reset_walker_globals();
+    minimal_ui_atlas_destroy(&s_atlas);
+    nt_sprite_renderer_shutdown();
+    nt_text_renderer_shutdown();
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+    nt_material_shutdown();
+    nt_font_shutdown();
+    nt_atlas_test_reset();
+    nt_resource_shutdown();
+    nt_gfx_shutdown();
+    nt_hash_shutdown();
+}
+
+static void inject_frozen_cmds(int32_t count) {
+    s_ctx->frozen_cmds.internalArray = s_test_cmds;
+    s_ctx->frozen_cmds.length = count;
+    s_ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
+}
+
+/* WALK-06: walker exit flushes both sprite and text renderers. After
+ * emitting 1 RECT into the sprite renderer's staging, the staging vertex
+ * count is non-zero. After nt_ui_walk returns, the walker's exit-flush
+ * MUST drain that staging back to 0. */
+static void test_walker_exit_flushes_sprite_and_text(void) {
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    c->boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 50, .height = 50};
+    c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 128, .g = 128, .b = 128, .a = 255};
+    inject_frozen_cmds(1);
+
+    nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
+    nt_ui_walk(s_ctx, &target);
+
+    /* After flush, staging vertex_count resets to 0. */
+    TEST_ASSERT_EQUAL_UINT32(0u, nt_sprite_renderer_test_vertex_count());
+    TEST_ASSERT_EQUAL_UINT32(0u, nt_text_renderer_test_vertex_count());
+}
+
+/* WALK-06: SCISSOR_START/END flushes both renderers before changing
+ * scissor state. Sequence: RECT (accumulates) -> SCISSOR_START (must
+ * flush sprite) -> RECT (accumulates again) -> SCISSOR_END (must flush
+ * sprite) -> walk-exit flush. */
+static void test_flush_on_scissor_transition(void) {
+    Clay_RenderCommand *cmds = s_test_cmds;
+    cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    cmds[0].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 10, .height = 10};
+    cmds[0].renderData.rectangle.backgroundColor = (Clay_Color){.r = 255, .g = 0, .b = 0, .a = 255};
+    cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
+    cmds[1].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 800, .height = 600};
+    cmds[1].renderData.clip.horizontal = true;
+    cmds[1].renderData.clip.vertical = true;
+    cmds[2].commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    cmds[2].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 10, .height = 10};
+    cmds[2].renderData.rectangle.backgroundColor = (Clay_Color){.r = 0, .g = 255, .b = 0, .a = 255};
+    cmds[3].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
+    inject_frozen_cmds(4);
+
+    const uint32_t calls_before = nt_sprite_renderer_test_draw_call_count();
+    nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
+    nt_ui_walk(s_ctx, &target);
+
+    /* scissor_push flushes the first RECT (1 draw call), then scissor_pop
+     * flushes the second RECT (1 more). The walker-exit flush adds 0 more
+     * because pop already drained staging. So delta == 2. */
+    TEST_ASSERT_EQUAL_UINT32(calls_before + 2u, nt_sprite_renderer_test_draw_call_count());
+}
+
+/* WALK-06: RECT -> TEXT transition flushes sprite renderer before text
+ * emit begins. We verify by checking that one draw call happened mid-
+ * walk (sprite flush at TEXT boundary), even though the test font is
+ * NOT registered (so the actual text path early-returns). The sprite
+ * flush is unconditional at the top of emit_text. */
+static void test_flush_on_rect_to_text_transition(void) {
+    Clay_RenderCommand *cmds = s_test_cmds;
+    cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    cmds[0].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 10, .height = 10};
+    cmds[0].renderData.rectangle.backgroundColor = (Clay_Color){.r = 255, .g = 255, .b = 255, .a = 255};
+
+    static const char *kText = "X";
+    cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_TEXT;
+    cmds[1].boundingBox = (Clay_BoundingBox){.x = 20, .y = 20, .width = 10, .height = 10};
+    cmds[1].renderData.text.stringContents = (Clay_StringSlice){.length = 1, .chars = kText, .baseChars = kText};
+    cmds[1].renderData.text.textColor = (Clay_Color){.r = 255, .g = 255, .b = 255, .a = 255};
+    cmds[1].renderData.text.fontId = 0;
+    cmds[1].renderData.text.fontSize = 14;
+    inject_frozen_cmds(2);
+
+    const uint32_t sprite_calls_before = nt_sprite_renderer_test_draw_call_count();
+    nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
+    nt_ui_walk(s_ctx, &target);
+
+    /* emit_text always flushes sprite at the top. That flush drains the
+     * RECT staging into one draw call. Walker-exit flush adds nothing
+     * (already drained). So delta == 1. */
+    TEST_ASSERT_EQUAL_UINT32(sprite_calls_before + 1u, nt_sprite_renderer_test_draw_call_count());
+}
 
 int main(void) {
     UNITY_BEGIN();

--- a/tests/unit/test_nt_ui_walker_flush.c
+++ b/tests/unit/test_nt_ui_walker_flush.c
@@ -20,7 +20,7 @@
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8U];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
 static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 8

--- a/tests/unit/test_nt_ui_walker_flush.c
+++ b/tests/unit/test_nt_ui_walker_flush.c
@@ -20,7 +20,7 @@
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8U];
 static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 8
@@ -55,8 +55,8 @@ static void test_walker_exit_flushes_sprite_and_text(void) {
     nt_ui_walk(s_fx.ctx, &target);
 
     /* After flush, staging vertex_count resets to 0. */
-    TEST_ASSERT_EQUAL_UINT32(0u, nt_sprite_renderer_test_vertex_count());
-    TEST_ASSERT_EQUAL_UINT32(0u, nt_text_renderer_test_vertex_count());
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_sprite_renderer_test_vertex_count());
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_text_renderer_test_vertex_count());
 }
 
 /* WALK-06: SCISSOR_START/END flushes both renderers before changing
@@ -85,7 +85,7 @@ static void test_flush_on_scissor_transition(void) {
     /* scissor_push flushes the first RECT (1 draw call), then scissor_pop
      * flushes the second RECT (1 more). The walker-exit flush adds 0 more
      * because pop already drained staging. So delta == 2. */
-    TEST_ASSERT_EQUAL_UINT32(calls_before + 2u, nt_sprite_renderer_test_draw_call_count());
+    TEST_ASSERT_EQUAL_UINT32(calls_before + 2U, nt_sprite_renderer_test_draw_call_count());
 }
 
 /* WALK-06: RECT -> TEXT transition flushes sprite renderer before text
@@ -115,7 +115,7 @@ static void test_flush_on_rect_to_text_transition(void) {
     /* emit_text always flushes sprite at the top. That flush drains the
      * RECT staging into one draw call. Walker-exit flush adds nothing
      * (already drained). So delta == 1. */
-    TEST_ASSERT_EQUAL_UINT32(sprite_calls_before + 1u, nt_sprite_renderer_test_draw_call_count());
+    TEST_ASSERT_EQUAL_UINT32(sprite_calls_before + 1U, nt_sprite_renderer_test_draw_call_count());
 }
 
 int main(void) {

--- a/tests/unit/test_nt_ui_walker_flush.c
+++ b/tests/unit/test_nt_ui_walker_flush.c
@@ -110,13 +110,13 @@ void setUp(void) {
     s_sprite_material = make_test_material();
     s_text_material = make_test_material();
 
-    nt_ui_set_atlas_white_region(s_atlas.handle, s_atlas.white_region_idx);
-    nt_ui_set_sprite_material(s_sprite_material);
-    nt_ui_set_text_material(s_text_material);
-    nt_ui_set_custom_handler(NULL, NULL);
-
     s_ctx = nt_ui_create_context(s_arena, sizeof s_arena);
     TEST_ASSERT_NOT_NULL(s_ctx);
+
+    nt_ui_set_atlas_white_region(s_ctx, s_atlas.handle, s_atlas.white_region_idx);
+    nt_ui_set_sprite_material(s_ctx, s_sprite_material);
+    nt_ui_set_text_material(s_ctx, s_text_material);
+    nt_ui_set_custom_handler(s_ctx, NULL, NULL);
 }
 
 void tearDown(void) {
@@ -124,7 +124,6 @@ void tearDown(void) {
         nt_ui_destroy_context(s_ctx);
         s_ctx = NULL;
     }
-    nt_ui_test_reset_walker_globals();
     minimal_ui_atlas_destroy(&s_atlas);
     nt_stats_shutdown();
     nt_sprite_renderer_shutdown();

--- a/tests/unit/test_nt_ui_walker_flush.c
+++ b/tests/unit/test_nt_ui_walker_flush.c
@@ -13,7 +13,7 @@
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_TEST_ARENA_SIZE];
 static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 8

--- a/tests/unit/test_nt_ui_walker_flush.c
+++ b/tests/unit/test_nt_ui_walker_flush.c
@@ -5,143 +5,39 @@
  * test-access draw_call_count / vertex_count counters.
  */
 
-#include <math.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
-/* clang-format off */
-#include "atlas/nt_atlas.h"
 #include "clay.h"
-#include "core/nt_assert.h"
-#include "font/nt_font.h"
 #include "graphics/nt_gfx.h"
-#include "hash/nt_hash.h"
-#include "input/nt_input.h"
-#include "material/nt_material.h"
-#include "nt_pack_format.h"
 #include "renderers/nt_sprite_renderer.h"
 #include "renderers/nt_text_renderer.h"
-#include "resource/nt_resource.h"
-#include "stats/nt_stats.h"
 #include "test_helpers/nt_assert_trap.h"
-#include "test_helpers/ui_atlas.h"
+#include "test_helpers/ui_walker_fixture.h"
 #include "ui/nt_ui.h"
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
-/* clang-format on */
 
 static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
-static minimal_ui_atlas_t s_atlas;
-static nt_material_t s_sprite_material;
-static nt_material_t s_text_material;
-static nt_ui_context_t *s_ctx;
-static uint32_t s_vpack_counter;
+static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 8
 static Clay_RenderCommand s_test_cmds[MAX_TEST_CMDS];
 
-static nt_material_t make_test_material(void) {
-    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "void main(){}", .label = "walker_vs"});
-    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "void main(){}", .label = "walker_fs"});
-
-    char pack_name[64];
-    char vs_name[64];
-    char fs_name[64];
-    (void)snprintf(pack_name, sizeof pack_name, "walker_mat_pack_%u", s_vpack_counter);
-    (void)snprintf(vs_name, sizeof vs_name, "walker_vs_%u", s_vpack_counter);
-    (void)snprintf(fs_name, sizeof fs_name, "walker_fs_%u", s_vpack_counter);
-    s_vpack_counter++;
-
-    nt_hash32_t pid = nt_hash32_str(pack_name);
-    nt_hash64_t vs_rid = nt_hash64_str(vs_name);
-    nt_hash64_t fs_rid = nt_hash64_str(fs_name);
-
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pid, 0));
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, vs_rid, NT_ASSET_SHADER_CODE, vs.id));
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, fs_rid, NT_ASSET_SHADER_CODE, fs.id));
-
-    nt_resource_t vs_res = nt_resource_request(vs_rid, NT_ASSET_SHADER_CODE);
-    nt_resource_t fs_res = nt_resource_request(fs_rid, NT_ASSET_SHADER_CODE);
-    nt_resource_step();
-
-    nt_material_create_desc_t desc;
-    memset(&desc, 0, sizeof desc);
-    desc.vs = vs_res;
-    desc.fs = fs_res;
-    desc.depth_test = false;
-    desc.depth_write = false;
-    desc.cull_mode = NT_CULL_NONE;
-    desc.color_mode = NT_COLOR_MODE_NONE;
-    desc.label = "walker_test_material";
-
-    nt_material_t mat = nt_material_create(&desc);
-    nt_material_step();
-    return mat;
-}
-
 void setUp(void) {
     nt_test_assert_install();
-    s_vpack_counter = 0;
     memset(s_test_cmds, 0, sizeof s_test_cmds);
-
-    nt_hash_init(&(nt_hash_desc_t){0});
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_pipelines = 16, .max_buffers = 64, .max_textures = 32, .max_meshes = 16});
-    nt_resource_init(&(nt_resource_desc_t){0});
-    nt_atlas_init();
-    nt_font_init(&(nt_font_desc_t){.max_fonts = 4});
-    nt_material_init(&(nt_material_desc_t){.max_materials = 32});
-
-    nt_gfx_begin_frame();
-    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
-
-    nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
-    nt_text_renderer_init();
-
-    /* nt_stats_init required: Plan 52-05 wired nt_stats_count("ui_draw_calls", ...)
-     * + nt_stats_count("ui_element_count", ...) at nt_ui_walk exit. Without init,
-     * nt_stats_count's NT_ASSERT(s_stats.initialized) trips on every walk. */
-    nt_stats_init(NULL);
-
-    s_atlas = minimal_ui_atlas_create();
-    s_sprite_material = make_test_material();
-    s_text_material = make_test_material();
-
-    s_ctx = nt_ui_create_context(s_arena, sizeof s_arena);
-    TEST_ASSERT_NOT_NULL(s_ctx);
-
-    nt_ui_set_atlas_white_region(s_ctx, s_atlas.handle, s_atlas.white_region_idx);
-    nt_ui_set_sprite_material(s_ctx, s_sprite_material);
-    nt_ui_set_text_material(s_ctx, s_text_material);
-    nt_ui_set_custom_handler(s_ctx, NULL, NULL);
+    ui_walker_fixture_init(&s_fx, s_arena, sizeof s_arena, UI_WALKER_FX_BIND_ALL);
 }
 
-void tearDown(void) {
-    if (s_ctx != NULL) {
-        nt_ui_destroy_context(s_ctx);
-        s_ctx = NULL;
-    }
-    minimal_ui_atlas_destroy(&s_atlas);
-    nt_stats_shutdown();
-    nt_sprite_renderer_shutdown();
-    nt_text_renderer_shutdown();
-    nt_gfx_end_pass();
-    nt_gfx_end_frame();
-    nt_material_shutdown();
-    nt_font_shutdown();
-    nt_atlas_test_reset();
-    nt_resource_shutdown();
-    nt_gfx_shutdown();
-    nt_hash_shutdown();
-}
+void tearDown(void) { ui_walker_fixture_shutdown(&s_fx); }
 
 static void inject_frozen_cmds(int32_t count) {
-    s_ctx->frozen_cmds.internalArray = s_test_cmds;
-    s_ctx->frozen_cmds.length = count;
-    s_ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
+    s_fx.ctx->frozen_cmds.internalArray = s_test_cmds;
+    s_fx.ctx->frozen_cmds.length = count;
+    s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
 }
 
 /* WALK-06: walker exit flushes both sprite and text renderers. After
@@ -156,7 +52,7 @@ static void test_walker_exit_flushes_sprite_and_text(void) {
     inject_frozen_cmds(1);
 
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
     /* After flush, staging vertex_count resets to 0. */
     TEST_ASSERT_EQUAL_UINT32(0u, nt_sprite_renderer_test_vertex_count());
@@ -184,7 +80,7 @@ static void test_flush_on_scissor_transition(void) {
 
     const uint32_t calls_before = nt_sprite_renderer_test_draw_call_count();
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
     /* scissor_push flushes the first RECT (1 draw call), then scissor_pop
      * flushes the second RECT (1 more). The walker-exit flush adds 0 more
@@ -214,7 +110,7 @@ static void test_flush_on_rect_to_text_transition(void) {
 
     const uint32_t sprite_calls_before = nt_sprite_renderer_test_draw_call_count();
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
     /* emit_text always flushes sprite at the top. That flush drains the
      * RECT staging into one draw call. Walker-exit flush adds nothing

--- a/tests/unit/test_nt_ui_walker_flush.c
+++ b/tests/unit/test_nt_ui_walker_flush.c
@@ -1,10 +1,3 @@
-/* tests/unit/test_nt_ui_walker_flush.c -- Plan 52-04
- *
- * Covers WALK-06 / D-52-18: walker flushes both sprite + text renderers
- * at scissor / text boundaries and at walk exit. Probes the renderer's
- * test-access draw_call_count / vertex_count counters.
- */
-
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -40,7 +33,7 @@ static void inject_frozen_cmds(int32_t count) {
     s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
 }
 
-/* WALK-06: walker exit flushes both sprite and text renderers. After
+/* walker exit flushes both sprite and text renderers. After
  * emitting 1 RECT into the sprite renderer's staging, the staging vertex
  * count is non-zero. After nt_ui_walk returns, the walker's exit-flush
  * MUST drain that staging back to 0. */
@@ -59,7 +52,7 @@ static void test_walker_exit_flushes_sprite_and_text(void) {
     TEST_ASSERT_EQUAL_UINT32(0U, nt_text_renderer_test_vertex_count());
 }
 
-/* WALK-06: SCISSOR_START/END flushes both renderers before changing
+/* SCISSOR_START/END flushes both renderers before changing
  * scissor state. Sequence: RECT (accumulates) -> SCISSOR_START (must
  * flush sprite) -> RECT (accumulates again) -> SCISSOR_END (must flush
  * sprite) -> walk-exit flush. */
@@ -88,7 +81,7 @@ static void test_flush_on_scissor_transition(void) {
     TEST_ASSERT_EQUAL_UINT32(calls_before + 2U, nt_sprite_renderer_test_draw_call_count());
 }
 
-/* WALK-06: RECT -> TEXT transition flushes sprite renderer before text
+/* RECT -> TEXT transition flushes sprite renderer before text
  * emit begins. We verify by checking that one draw call happened mid-
  * walk (sprite flush at TEXT boundary), even though the test font is
  * NOT registered (so the actual text path early-returns). The sprite

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -109,6 +109,31 @@ static void test_walk_without_text_material_asserts(void) {
     NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }
 
+/* walk on a freshly-created ctx (no begin/end) must assert -- frozen_cmds
+ * is zero-init'd; without the guard the walker is a silent no-op. */
+static void test_walk_without_end_asserts(void) {
+    /* Use a fresh arena+ctx outside the fixture so we don't inherit
+     * frozen_cmds from injection. */
+    alignas(NT_UI_ARENA_ALIGN) static uint8_t fresh_arena[NT_UI_DEFAULT_ARENA_SIZE];
+    nt_ui_context_t *fresh = nt_ui_create_context(fresh_arena, sizeof fresh_arena);
+    TEST_ASSERT_NOT_NULL(fresh);
+    nt_ui_set_atlas_white_region(fresh, s_fx.atlas.handle, s_fx.atlas.white_region_idx);
+    nt_ui_set_sprite_material(fresh, s_fx.sprite_material);
+    nt_ui_set_text_material(fresh, s_fx.text_material);
+    nt_ui_set_custom_handler(fresh, NULL, NULL);
+
+    nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
+    NT_TEST_EXPECT_ASSERT(nt_ui_walk(fresh, &target));
+    nt_ui_destroy_context(fresh);
+}
+
+/* viewport components must be non-negative (otherwise (int) cast is UB). */
+static void test_walk_negative_viewport_asserts(void) {
+    inject_frozen_cmds(0);
+    nt_ui_target_t target = {.viewport = {-1.0F, 0, 800, 600}};
+    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
+}
+
 /* Macro to set s_setup_bind BEFORE RUN_TEST invokes setUp -- Unity runs
  * setUp first, then the test function, so the mode flag must be written
  * by the caller of RUN_TEST, not from inside the test body. */
@@ -120,6 +145,10 @@ static void test_walk_without_text_material_asserts(void) {
 
 int main(void) {
     UNITY_BEGIN();
+    s_setup_bind = UI_WALKER_FX_BIND_ALL;
+    RUN_TEST(test_walk_without_end_asserts);
+    s_setup_bind = UI_WALKER_FX_BIND_ALL;
+    RUN_TEST(test_walk_negative_viewport_asserts);
     s_setup_bind = UI_WALKER_FX_BIND_ALL;
     RUN_TEST(test_second_walk_identical);
     s_setup_bind = UI_WALKER_FX_BIND_ALL;

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -1,0 +1,40 @@
+/* tests/unit/test_nt_ui_walker_readonly.c — Plan 52-00 stub
+ *
+ * Covers UI-06 (multi-walk read-only invariant) and UI-07 (viewport from
+ * target applied at walker entry) plus three death-tests for pre-walk
+ * asserts (D-52-06 atlas, D-52-19 sprite material, D-52-19 text material).
+ * Wave 0 ships TEST_IGNORE bodies; Plan 52-04 fills with real assertions.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* UI-06: two walks against same ctx + target produce identical probe state */
+static void test_second_walk_identical(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+/* UI-07: walker entry applies target->viewport via nt_gfx_set_viewport */
+static void test_viewport_applied(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+/* D-52-06: walk without atlas set → assert (death-test) */
+static void test_walk_without_atlas_asserts(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+/* D-52-19 (sprite material variant — Revision Issue 1): walk without sprite material asserts */
+static void test_walk_without_sprite_material_asserts(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+/* D-52-19: walk without text material set → assert (death-test) */
+static void test_walk_without_text_material_asserts(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_second_walk_identical);
+    RUN_TEST(test_viewport_applied);
+    RUN_TEST(test_walk_without_atlas_asserts);
+    RUN_TEST(test_walk_without_sprite_material_asserts);
+    RUN_TEST(test_walk_without_text_material_asserts);
+    return UNITY_END();
+}

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -87,13 +87,20 @@ static void test_viewport_applied(void) {
     TEST_ASSERT_EQUAL_INT(480, vp[3]);
 }
 
-/* walk without atlas set asserts. */
-static void test_walk_without_atlas_asserts(void) {
+/* walk without atlas bound is a silent no-op (async-loading policy --
+ * game can start the loop before atlas is ready). */
+static void test_walk_without_atlas_silent_noop(void) {
     /* Mode flag was set before Unity invoked setUp -- the atlas setter
      * was skipped, so ctx->atlas.id == 0. */
-    inject_frozen_cmds(0);
+    s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 10, .height = 10};
+    inject_frozen_cmds(1);
+    const uint32_t calls_before = nt_sprite_renderer_test_draw_call_count();
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
-    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
+    nt_ui_walk(s_fx.ctx, &target);
+    /* No draws, stats zeroed. */
+    TEST_ASSERT_EQUAL_UINT32(calls_before, nt_sprite_renderer_test_draw_call_count());
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_command_count(s_fx.ctx));
 }
 
 /* death-test: walk without sprite material asserts. */
@@ -215,7 +222,7 @@ int main(void) {
     /* Death-tests last so a partial bind doesn't leak into the happy-path
      * runs above. tearDown resets s_setup_bind to ALL each time, so each
      * death-test re-arms its own mode here. */
-    RUN_TEST_WITH_BIND(UI_WALKER_FX_BIND_ALL & ~UI_WALKER_FX_BIND_ATLAS, test_walk_without_atlas_asserts);
+    RUN_TEST_WITH_BIND(UI_WALKER_FX_BIND_ALL & ~UI_WALKER_FX_BIND_ATLAS, test_walk_without_atlas_silent_noop);
     RUN_TEST_WITH_BIND(UI_WALKER_FX_BIND_ALL & ~UI_WALKER_FX_BIND_SPRITE_MATERIAL, test_walk_without_sprite_material_asserts);
     RUN_TEST_WITH_BIND(UI_WALKER_FX_BIND_ALL & ~UI_WALKER_FX_BIND_TEXT_MATERIAL, test_walk_without_text_material_asserts);
     return UNITY_END();

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -62,18 +62,18 @@ static void test_second_walk_identical(void) {
 
     int vp1[4];
     nt_gfx_test_viewport_rect(vp1);
-    const uint32_t elements1 = nt_ui_test_last_walk_element_count(s_fx.ctx);
+    const uint32_t elements1 = nt_ui_get_last_walk_element_count(s_fx.ctx);
     /* Read but don't compare draw-call delta -- walking once already
      * incurs draw calls; a second walk will too, so the EXACT delta-
      * to-delta count is what we compare. */
-    const uint32_t delta1 = nt_ui_test_last_walk_draw_call_delta(s_fx.ctx);
+    const uint32_t delta1 = nt_ui_get_last_walk_draw_calls(s_fx.ctx);
 
     nt_ui_walk(s_fx.ctx, &target);
 
     int vp2[4];
     nt_gfx_test_viewport_rect(vp2);
-    const uint32_t elements2 = nt_ui_test_last_walk_element_count(s_fx.ctx);
-    const uint32_t delta2 = nt_ui_test_last_walk_draw_call_delta(s_fx.ctx);
+    const uint32_t elements2 = nt_ui_get_last_walk_element_count(s_fx.ctx);
+    const uint32_t delta2 = nt_ui_get_last_walk_draw_calls(s_fx.ctx);
 
     TEST_ASSERT_EQUAL_INT_ARRAY(vp1, vp2, 4);
     TEST_ASSERT_EQUAL_UINT32(elements1, elements2);

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -20,7 +20,7 @@
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8U];
 static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 8
@@ -84,7 +84,7 @@ static void test_second_walk_identical(void) {
 static void test_viewport_applied(void) {
     inject_frozen_cmds(0);
 
-    nt_ui_target_t target = {.viewport = {100.0f, 200.0f, 640.0f, 480.0f}};
+    nt_ui_target_t target = {.viewport = {100.0F, 200.0F, 640.0F, 480.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
     int vp[4];

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -12,7 +12,7 @@
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_TEST_ARENA_SIZE];
 static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 8
@@ -113,7 +113,7 @@ static void test_walk_without_text_material_asserts(void) {
 /* walk before begin/end must assert (frozen_cmds is zero-init). */
 static void test_walk_without_end_asserts(void) {
     /* Fresh ctx so we don't inherit injected frozen_cmds. */
-    alignas(NT_UI_ARENA_ALIGN) static uint8_t fresh_arena[NT_UI_DEFAULT_ARENA_SIZE];
+    alignas(NT_UI_ARENA_ALIGN) static uint8_t fresh_arena[NT_UI_TEST_ARENA_SIZE];
     const nt_ui_create_desc_t desc = nt_ui_create_desc_defaults();
     nt_ui_context_t *fresh = nt_ui_create_context(fresh_arena, sizeof fresh_arena, &desc);
     TEST_ASSERT_NOT_NULL(fresh);

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -1,40 +1,257 @@
-/* tests/unit/test_nt_ui_walker_readonly.c — Plan 52-00 stub
+/* tests/unit/test_nt_ui_walker_readonly.c -- Plan 52-04
  *
- * Covers UI-06 (multi-walk read-only invariant) and UI-07 (viewport from
- * target applied at walker entry) plus three death-tests for pre-walk
- * asserts (D-52-06 atlas, D-52-19 sprite material, D-52-19 text material).
- * Wave 0 ships TEST_IGNORE bodies; Plan 52-04 fills with real assertions.
+ * Covers UI-06 (two walks against same ctx+target produce identical state)
+ * and UI-07 (walker entry applies target->viewport via nt_gfx_set_viewport).
+ * Three death-tests for pre-walk asserts (D-52-06 atlas, D-52-19 sprite +
+ * text material). All death-tests use NT_TEST_EXPECT_ASSERT (Revision
+ * Issue 3) -- no TEST_IGNORE fallback.
  */
 
+#include <math.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
+/* clang-format off */
+#include "atlas/nt_atlas.h"
+#include "clay.h"
+#include "core/nt_assert.h"
+#include "font/nt_font.h"
+#include "graphics/nt_gfx.h"
+#include "hash/nt_hash.h"
+#include "input/nt_input.h"
+#include "material/nt_material.h"
+#include "nt_pack_format.h"
+#include "renderers/nt_sprite_renderer.h"
+#include "renderers/nt_text_renderer.h"
+#include "resource/nt_resource.h"
+#include "test_helpers/nt_assert_trap.h"
+#include "test_helpers/ui_atlas.h"
+#include "ui/nt_ui.h"
+#include "ui/nt_ui_internal.h"
 #include "unity.h"
+/* clang-format on */
 
-void setUp(void) {}
-void tearDown(void) {}
+static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+static minimal_ui_atlas_t s_atlas;
+static nt_material_t s_sprite_material;
+static nt_material_t s_text_material;
+static nt_ui_context_t *s_ctx;
+static uint32_t s_vpack_counter;
 
-/* UI-06: two walks against same ctx + target produce identical probe state */
-static void test_second_walk_identical(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+#define MAX_TEST_CMDS 8
+static Clay_RenderCommand s_test_cmds[MAX_TEST_CMDS];
 
-/* UI-07: walker entry applies target->viewport via nt_gfx_set_viewport */
-static void test_viewport_applied(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+/* setUp variants -- the death-tests need a partially-initialized walker
+ * (some setters omitted). The flag controls which setters setUp runs. */
+typedef enum {
+    SETUP_FULL = 0,
+    SETUP_NO_ATLAS,
+    SETUP_NO_SPRITE_MATERIAL,
+    SETUP_NO_TEXT_MATERIAL,
+} setup_mode_t;
+static setup_mode_t s_setup_mode = SETUP_FULL;
 
-/* D-52-06: walk without atlas set → assert (death-test) */
-static void test_walk_without_atlas_asserts(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+static nt_material_t make_test_material(void) {
+    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "void main(){}", .label = "walker_vs"});
+    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "void main(){}", .label = "walker_fs"});
 
-/* D-52-19 (sprite material variant — Revision Issue 1): walk without sprite material asserts */
-static void test_walk_without_sprite_material_asserts(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+    char pack_name[64];
+    char vs_name[64];
+    char fs_name[64];
+    (void)snprintf(pack_name, sizeof pack_name, "walker_mat_pack_%u", s_vpack_counter);
+    (void)snprintf(vs_name, sizeof vs_name, "walker_vs_%u", s_vpack_counter);
+    (void)snprintf(fs_name, sizeof fs_name, "walker_fs_%u", s_vpack_counter);
+    s_vpack_counter++;
 
-/* D-52-19: walk without text material set → assert (death-test) */
-static void test_walk_without_text_material_asserts(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+    nt_hash32_t pid = nt_hash32_str(pack_name);
+    nt_hash64_t vs_rid = nt_hash64_str(vs_name);
+    nt_hash64_t fs_rid = nt_hash64_str(fs_name);
+
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pid, 0));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, vs_rid, NT_ASSET_SHADER_CODE, vs.id));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, fs_rid, NT_ASSET_SHADER_CODE, fs.id));
+
+    nt_resource_t vs_res = nt_resource_request(vs_rid, NT_ASSET_SHADER_CODE);
+    nt_resource_t fs_res = nt_resource_request(fs_rid, NT_ASSET_SHADER_CODE);
+    nt_resource_step();
+
+    nt_material_create_desc_t desc;
+    memset(&desc, 0, sizeof desc);
+    desc.vs = vs_res;
+    desc.fs = fs_res;
+    desc.depth_test = false;
+    desc.depth_write = false;
+    desc.cull_mode = NT_CULL_NONE;
+    desc.color_mode = NT_COLOR_MODE_NONE;
+    desc.label = "walker_test_material";
+
+    nt_material_t mat = nt_material_create(&desc);
+    nt_material_step();
+    return mat;
+}
+
+void setUp(void) {
+    nt_test_assert_install();
+    s_vpack_counter = 0;
+    memset(s_test_cmds, 0, sizeof s_test_cmds);
+
+    nt_hash_init(&(nt_hash_desc_t){0});
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_pipelines = 16, .max_buffers = 64, .max_textures = 32, .max_meshes = 16});
+    nt_resource_init(&(nt_resource_desc_t){0});
+    nt_atlas_init();
+    nt_font_init(&(nt_font_desc_t){.max_fonts = 4});
+    nt_material_init(&(nt_material_desc_t){.max_materials = 32});
+
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+
+    nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
+    nt_text_renderer_init();
+
+    s_atlas = minimal_ui_atlas_create();
+    s_sprite_material = make_test_material();
+    s_text_material = make_test_material();
+
+    /* Per-test walker setter selection. Clears first so death-tests start
+     * from a known-empty state. */
+    nt_ui_test_reset_walker_globals();
+    if (s_setup_mode != SETUP_NO_ATLAS) {
+        nt_ui_set_atlas_white_region(s_atlas.handle, s_atlas.white_region_idx);
+    }
+    if (s_setup_mode != SETUP_NO_SPRITE_MATERIAL) {
+        nt_ui_set_sprite_material(s_sprite_material);
+    }
+    if (s_setup_mode != SETUP_NO_TEXT_MATERIAL) {
+        nt_ui_set_text_material(s_text_material);
+    }
+    nt_ui_set_custom_handler(NULL, NULL);
+
+    s_ctx = nt_ui_create_context(s_arena, sizeof s_arena);
+    TEST_ASSERT_NOT_NULL(s_ctx);
+
+    /* Reset mode to FULL for the next test -- per-test setup applies a
+     * sentinel BEFORE Unity runs setUp via the run_with_mode wrappers below. */
+}
+
+void tearDown(void) {
+    if (s_ctx != NULL) {
+        nt_ui_destroy_context(s_ctx);
+        s_ctx = NULL;
+    }
+    nt_ui_test_reset_walker_globals();
+    minimal_ui_atlas_destroy(&s_atlas);
+    nt_sprite_renderer_shutdown();
+    nt_text_renderer_shutdown();
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+    nt_material_shutdown();
+    nt_font_shutdown();
+    nt_atlas_test_reset();
+    nt_resource_shutdown();
+    nt_gfx_shutdown();
+    nt_hash_shutdown();
+    s_setup_mode = SETUP_FULL;
+}
+
+static void inject_frozen_cmds(int32_t count) {
+    s_ctx->frozen_cmds.internalArray = s_test_cmds;
+    s_ctx->frozen_cmds.length = count;
+    s_ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
+}
+
+/* UI-06: two walks against same ctx+target produce identical probe state. */
+static void test_second_walk_identical(void) {
+    Clay_RenderCommand *c = &s_test_cmds[0];
+    c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    c->boundingBox = (Clay_BoundingBox){.x = 10, .y = 20, .width = 30, .height = 40};
+    c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 200, .g = 200, .b = 200, .a = 255};
+    inject_frozen_cmds(1);
+
+    nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
+    nt_ui_walk(s_ctx, &target);
+
+    int vp1[4];
+    nt_gfx_test_viewport_rect(vp1);
+    const uint32_t elements1 = nt_ui_test_last_walk_element_count();
+    /* Read but don't compare draw-call delta -- walking once already
+     * incurs draw calls; a second walk will too, so the EXACT delta-
+     * to-delta count is what we compare. */
+    const uint32_t delta1 = nt_ui_test_last_walk_draw_call_delta();
+
+    nt_ui_walk(s_ctx, &target);
+
+    int vp2[4];
+    nt_gfx_test_viewport_rect(vp2);
+    const uint32_t elements2 = nt_ui_test_last_walk_element_count();
+    const uint32_t delta2 = nt_ui_test_last_walk_draw_call_delta();
+
+    TEST_ASSERT_EQUAL_INT_ARRAY(vp1, vp2, 4);
+    TEST_ASSERT_EQUAL_UINT32(elements1, elements2);
+    TEST_ASSERT_EQUAL_UINT32(delta1, delta2);
+}
+
+/* UI-07: walker entry applies target->viewport via nt_gfx_set_viewport. */
+static void test_viewport_applied(void) {
+    inject_frozen_cmds(0);
+
+    nt_ui_target_t target = {.viewport = {100.0f, 200.0f, 640.0f, 480.0f}};
+    nt_ui_walk(s_ctx, &target);
+
+    int vp[4];
+    nt_gfx_test_viewport_rect(vp);
+    TEST_ASSERT_EQUAL_INT(100, vp[0]);
+    TEST_ASSERT_EQUAL_INT(200, vp[1]);
+    TEST_ASSERT_EQUAL_INT(640, vp[2]);
+    TEST_ASSERT_EQUAL_INT(480, vp[3]);
+}
+
+/* D-52-06 death-test: walk without atlas set asserts. */
+static void test_walk_without_atlas_asserts(void) {
+    /* Mode flag was set before Unity invoked setUp -- the atlas setter
+     * was skipped, so g_nt_ui_atlas.id == 0. */
+    inject_frozen_cmds(0);
+    nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
+    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_ctx, &target));
+}
+
+/* D-52-19 / Revision Issue 1 death-test: walk without sprite material asserts. */
+static void test_walk_without_sprite_material_asserts(void) {
+    inject_frozen_cmds(0);
+    nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
+    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_ctx, &target));
+}
+
+/* D-52-19 death-test: walk without text material asserts. */
+static void test_walk_without_text_material_asserts(void) {
+    inject_frozen_cmds(0);
+    nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
+    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_ctx, &target));
+}
+
+/* Macro to set s_setup_mode BEFORE RUN_TEST invokes setUp -- Unity runs
+ * setUp first, then the test function, so the mode flag must be written
+ * by the caller of RUN_TEST, not from inside the test body. */
+#define RUN_TEST_WITH_MODE(mode, fn)                                                                                                                                                                   \
+    do {                                                                                                                                                                                               \
+        s_setup_mode = (mode);                                                                                                                                                                         \
+        RUN_TEST(fn);                                                                                                                                                                                  \
+    } while (0)
 
 int main(void) {
     UNITY_BEGIN();
+    s_setup_mode = SETUP_FULL;
     RUN_TEST(test_second_walk_identical);
+    s_setup_mode = SETUP_FULL;
     RUN_TEST(test_viewport_applied);
-    RUN_TEST(test_walk_without_atlas_asserts);
-    RUN_TEST(test_walk_without_sprite_material_asserts);
-    RUN_TEST(test_walk_without_text_material_asserts);
+    /* Death-tests last so a partial-init setUp doesn't leak into the
+     * happy-path runs above. tearDown resets s_setup_mode to FULL each
+     * time, so each death-test re-arms its own mode here. */
+    RUN_TEST_WITH_MODE(SETUP_NO_ATLAS, test_walk_without_atlas_asserts);
+    RUN_TEST_WITH_MODE(SETUP_NO_SPRITE_MATERIAL, test_walk_without_sprite_material_asserts);
+    RUN_TEST_WITH_MODE(SETUP_NO_TEXT_MATERIAL, test_walk_without_text_material_asserts);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -20,7 +20,7 @@
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8U];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
 static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 8

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -7,166 +7,46 @@
  * Issue 3) -- no TEST_IGNORE fallback.
  */
 
-#include <math.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
-/* clang-format off */
-#include "atlas/nt_atlas.h"
 #include "clay.h"
-#include "core/nt_assert.h"
-#include "font/nt_font.h"
 #include "graphics/nt_gfx.h"
-#include "hash/nt_hash.h"
-#include "input/nt_input.h"
-#include "material/nt_material.h"
-#include "nt_pack_format.h"
-#include "renderers/nt_sprite_renderer.h"
-#include "renderers/nt_text_renderer.h"
-#include "resource/nt_resource.h"
-#include "stats/nt_stats.h"
 #include "test_helpers/nt_assert_trap.h"
-#include "test_helpers/ui_atlas.h"
+#include "test_helpers/ui_walker_fixture.h"
 #include "ui/nt_ui.h"
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
-/* clang-format on */
 
 static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
-static minimal_ui_atlas_t s_atlas;
-static nt_material_t s_sprite_material;
-static nt_material_t s_text_material;
-static nt_ui_context_t *s_ctx;
-static uint32_t s_vpack_counter;
+static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 8
 static Clay_RenderCommand s_test_cmds[MAX_TEST_CMDS];
 
-/* setUp variants -- the death-tests need a partially-initialized walker
- * (some setters omitted). The flag controls which setters setUp runs. */
-typedef enum {
-    SETUP_FULL = 0,
-    SETUP_NO_ATLAS,
-    SETUP_NO_SPRITE_MATERIAL,
-    SETUP_NO_TEXT_MATERIAL,
-} setup_mode_t;
-static setup_mode_t s_setup_mode = SETUP_FULL;
-
-static nt_material_t make_test_material(void) {
-    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "void main(){}", .label = "walker_vs"});
-    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "void main(){}", .label = "walker_fs"});
-
-    char pack_name[64];
-    char vs_name[64];
-    char fs_name[64];
-    (void)snprintf(pack_name, sizeof pack_name, "walker_mat_pack_%u", s_vpack_counter);
-    (void)snprintf(vs_name, sizeof vs_name, "walker_vs_%u", s_vpack_counter);
-    (void)snprintf(fs_name, sizeof fs_name, "walker_fs_%u", s_vpack_counter);
-    s_vpack_counter++;
-
-    nt_hash32_t pid = nt_hash32_str(pack_name);
-    nt_hash64_t vs_rid = nt_hash64_str(vs_name);
-    nt_hash64_t fs_rid = nt_hash64_str(fs_name);
-
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pid, 0));
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, vs_rid, NT_ASSET_SHADER_CODE, vs.id));
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, fs_rid, NT_ASSET_SHADER_CODE, fs.id));
-
-    nt_resource_t vs_res = nt_resource_request(vs_rid, NT_ASSET_SHADER_CODE);
-    nt_resource_t fs_res = nt_resource_request(fs_rid, NT_ASSET_SHADER_CODE);
-    nt_resource_step();
-
-    nt_material_create_desc_t desc;
-    memset(&desc, 0, sizeof desc);
-    desc.vs = vs_res;
-    desc.fs = fs_res;
-    desc.depth_test = false;
-    desc.depth_write = false;
-    desc.cull_mode = NT_CULL_NONE;
-    desc.color_mode = NT_COLOR_MODE_NONE;
-    desc.label = "walker_test_material";
-
-    nt_material_t mat = nt_material_create(&desc);
-    nt_material_step();
-    return mat;
-}
+/* Death-tests need a partially-bound walker (one of atlas / sprite material /
+ * text material omitted). The next setUp reads this and forwards it to
+ * ui_walker_fixture_init's bind mask. */
+static ui_walker_fx_bind_t s_setup_bind = UI_WALKER_FX_BIND_ALL;
 
 void setUp(void) {
     nt_test_assert_install();
-    s_vpack_counter = 0;
     memset(s_test_cmds, 0, sizeof s_test_cmds);
-
-    nt_hash_init(&(nt_hash_desc_t){0});
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_pipelines = 16, .max_buffers = 64, .max_textures = 32, .max_meshes = 16});
-    nt_resource_init(&(nt_resource_desc_t){0});
-    nt_atlas_init();
-    nt_font_init(&(nt_font_desc_t){.max_fonts = 4});
-    nt_material_init(&(nt_material_desc_t){.max_materials = 32});
-
-    nt_gfx_begin_frame();
-    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
-
-    nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
-    nt_text_renderer_init();
-
-    /* nt_stats_init required: Plan 52-05 wired nt_stats_count("ui_draw_calls", ...)
-     * + nt_stats_count("ui_element_count", ...) at nt_ui_walk exit. Without init,
-     * nt_stats_count's NT_ASSERT(s_stats.initialized) trips on every walk. */
-    nt_stats_init(NULL);
-
-    s_atlas = minimal_ui_atlas_create();
-    s_sprite_material = make_test_material();
-    s_text_material = make_test_material();
-
-    s_ctx = nt_ui_create_context(s_arena, sizeof s_arena);
-    TEST_ASSERT_NOT_NULL(s_ctx);
-
-    /* Per-test walker setter selection. A fresh context has all walker fields
-     * zero-initialised, so death-tests just skip the setter for the field
-     * whose absence they expect the walker to assert on. */
-    if (s_setup_mode != SETUP_NO_ATLAS) {
-        nt_ui_set_atlas_white_region(s_ctx, s_atlas.handle, s_atlas.white_region_idx);
-    }
-    if (s_setup_mode != SETUP_NO_SPRITE_MATERIAL) {
-        nt_ui_set_sprite_material(s_ctx, s_sprite_material);
-    }
-    if (s_setup_mode != SETUP_NO_TEXT_MATERIAL) {
-        nt_ui_set_text_material(s_ctx, s_text_material);
-    }
-    nt_ui_set_custom_handler(s_ctx, NULL, NULL);
-
-    /* Reset mode to FULL for the next test -- per-test setup applies a
-     * sentinel BEFORE Unity runs setUp via the run_with_mode wrappers below. */
+    ui_walker_fixture_init(&s_fx, s_arena, sizeof s_arena, s_setup_bind);
 }
 
 void tearDown(void) {
-    if (s_ctx != NULL) {
-        nt_ui_destroy_context(s_ctx);
-        s_ctx = NULL;
-    }
-    minimal_ui_atlas_destroy(&s_atlas);
-    nt_stats_shutdown();
-    nt_sprite_renderer_shutdown();
-    nt_text_renderer_shutdown();
-    nt_gfx_end_pass();
-    nt_gfx_end_frame();
-    nt_material_shutdown();
-    nt_font_shutdown();
-    nt_atlas_test_reset();
-    nt_resource_shutdown();
-    nt_gfx_shutdown();
-    nt_hash_shutdown();
-    s_setup_mode = SETUP_FULL;
+    ui_walker_fixture_shutdown(&s_fx);
+    /* Reset to all-bound; per-test mode is re-armed via RUN_TEST_WITH_BIND. */
+    s_setup_bind = UI_WALKER_FX_BIND_ALL;
 }
 
 static void inject_frozen_cmds(int32_t count) {
-    s_ctx->frozen_cmds.internalArray = s_test_cmds;
-    s_ctx->frozen_cmds.length = count;
-    s_ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
+    s_fx.ctx->frozen_cmds.internalArray = s_test_cmds;
+    s_fx.ctx->frozen_cmds.length = count;
+    s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
 }
 
 /* UI-06: two walks against same ctx+target produce identical probe state. */
@@ -178,22 +58,22 @@ static void test_second_walk_identical(void) {
     inject_frozen_cmds(1);
 
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
     int vp1[4];
     nt_gfx_test_viewport_rect(vp1);
-    const uint32_t elements1 = nt_ui_test_last_walk_element_count(s_ctx);
+    const uint32_t elements1 = nt_ui_test_last_walk_element_count(s_fx.ctx);
     /* Read but don't compare draw-call delta -- walking once already
      * incurs draw calls; a second walk will too, so the EXACT delta-
      * to-delta count is what we compare. */
-    const uint32_t delta1 = nt_ui_test_last_walk_draw_call_delta(s_ctx);
+    const uint32_t delta1 = nt_ui_test_last_walk_draw_call_delta(s_fx.ctx);
 
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
     int vp2[4];
     nt_gfx_test_viewport_rect(vp2);
-    const uint32_t elements2 = nt_ui_test_last_walk_element_count(s_ctx);
-    const uint32_t delta2 = nt_ui_test_last_walk_draw_call_delta(s_ctx);
+    const uint32_t elements2 = nt_ui_test_last_walk_element_count(s_fx.ctx);
+    const uint32_t delta2 = nt_ui_test_last_walk_draw_call_delta(s_fx.ctx);
 
     TEST_ASSERT_EQUAL_INT_ARRAY(vp1, vp2, 4);
     TEST_ASSERT_EQUAL_UINT32(elements1, elements2);
@@ -205,7 +85,7 @@ static void test_viewport_applied(void) {
     inject_frozen_cmds(0);
 
     nt_ui_target_t target = {.viewport = {100.0f, 200.0f, 640.0f, 480.0f}};
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
     int vp[4];
     nt_gfx_test_viewport_rect(vp);
@@ -221,43 +101,43 @@ static void test_walk_without_atlas_asserts(void) {
      * was skipped, so g_nt_ui_atlas.id == 0. */
     inject_frozen_cmds(0);
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
-    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_ctx, &target));
+    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }
 
 /* D-52-19 / Revision Issue 1 death-test: walk without sprite material asserts. */
 static void test_walk_without_sprite_material_asserts(void) {
     inject_frozen_cmds(0);
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
-    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_ctx, &target));
+    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }
 
 /* D-52-19 death-test: walk without text material asserts. */
 static void test_walk_without_text_material_asserts(void) {
     inject_frozen_cmds(0);
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
-    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_ctx, &target));
+    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }
 
-/* Macro to set s_setup_mode BEFORE RUN_TEST invokes setUp -- Unity runs
+/* Macro to set s_setup_bind BEFORE RUN_TEST invokes setUp -- Unity runs
  * setUp first, then the test function, so the mode flag must be written
  * by the caller of RUN_TEST, not from inside the test body. */
-#define RUN_TEST_WITH_MODE(mode, fn)                                                                                                                                                                   \
+#define RUN_TEST_WITH_BIND(bind, fn)                                                                                                                                                                   \
     do {                                                                                                                                                                                               \
-        s_setup_mode = (mode);                                                                                                                                                                         \
+        s_setup_bind = (bind);                                                                                                                                                                         \
         RUN_TEST(fn);                                                                                                                                                                                  \
     } while (0)
 
 int main(void) {
     UNITY_BEGIN();
-    s_setup_mode = SETUP_FULL;
+    s_setup_bind = UI_WALKER_FX_BIND_ALL;
     RUN_TEST(test_second_walk_identical);
-    s_setup_mode = SETUP_FULL;
+    s_setup_bind = UI_WALKER_FX_BIND_ALL;
     RUN_TEST(test_viewport_applied);
-    /* Death-tests last so a partial-init setUp doesn't leak into the
-     * happy-path runs above. tearDown resets s_setup_mode to FULL each
-     * time, so each death-test re-arms its own mode here. */
-    RUN_TEST_WITH_MODE(SETUP_NO_ATLAS, test_walk_without_atlas_asserts);
-    RUN_TEST_WITH_MODE(SETUP_NO_SPRITE_MATERIAL, test_walk_without_sprite_material_asserts);
-    RUN_TEST_WITH_MODE(SETUP_NO_TEXT_MATERIAL, test_walk_without_text_material_asserts);
+    /* Death-tests last so a partial bind doesn't leak into the happy-path
+     * runs above. tearDown resets s_setup_bind to ALL each time, so each
+     * death-test re-arms its own mode here. */
+    RUN_TEST_WITH_BIND(UI_WALKER_FX_BIND_ALL & ~UI_WALKER_FX_BIND_ATLAS, test_walk_without_atlas_asserts);
+    RUN_TEST_WITH_BIND(UI_WALKER_FX_BIND_ALL & ~UI_WALKER_FX_BIND_SPRITE_MATERIAL, test_walk_without_sprite_material_asserts);
+    RUN_TEST_WITH_BIND(UI_WALKER_FX_BIND_ALL & ~UI_WALKER_FX_BIND_TEXT_MATERIAL, test_walk_without_text_material_asserts);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -110,11 +110,9 @@ static void test_walk_without_text_material_asserts(void) {
     NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }
 
-/* walk on a freshly-created ctx (no begin/end) must assert -- frozen_cmds
- * is zero-init'd; without the guard the walker is a silent no-op. */
+/* walk before begin/end must assert (frozen_cmds is zero-init). */
 static void test_walk_without_end_asserts(void) {
-    /* Use a fresh arena+ctx outside the fixture so we don't inherit
-     * frozen_cmds from injection. */
+    /* Fresh ctx so we don't inherit injected frozen_cmds. */
     alignas(NT_UI_ARENA_ALIGN) static uint8_t fresh_arena[NT_UI_DEFAULT_ARENA_SIZE];
     const nt_ui_create_desc_t desc = nt_ui_create_desc_defaults();
     nt_ui_context_t *fresh = nt_ui_create_context(fresh_arena, sizeof fresh_arena, &desc);
@@ -129,16 +127,14 @@ static void test_walk_without_end_asserts(void) {
     nt_ui_destroy_context(fresh);
 }
 
-/* viewport origin must be non-negative (otherwise (int) cast is UB). */
+/* Negative origin is a caller bug ((int) cast would be UB). */
 static void test_walk_negative_viewport_origin_asserts(void) {
     inject_frozen_cmds(0);
     nt_ui_target_t target = {.viewport = {-1.0F, 0, 800, 600}};
     NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }
 
-/* viewport w/h < 0 is a caller bug -- assert by fail-early policy.
- * Symmetric with origin assert above; zero is the only legitimate
- * "small" value (handled by separate silent no-op path). */
+/* Negative w/h is a caller bug; zero is the legitimate "small" value. */
 static void test_walk_negative_viewport_size_asserts(void) {
     inject_frozen_cmds(0);
     nt_ui_target_t neg_w = {.viewport = {0, 0, -1.0F, 600}};
@@ -147,27 +143,21 @@ static void test_walk_negative_viewport_size_asserts(void) {
     NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &neg_h));
 }
 
-/* Zero-size viewport (minimized window / mobile orientation transition) is
- * a legitimate runtime state -- walker must silent no-op, not assert, AND
- * must reset per-walk stats so caller doesn't read stale values from the
- * previous non-empty walk. */
+/* Zero viewport is legitimate (minimized tab); walker silent no-ops. */
 static void test_walk_zero_viewport_silent_noop(void) {
     inject_frozen_cmds(0);
     const uint32_t calls_before = nt_sprite_renderer_test_draw_call_count();
     nt_ui_target_t zero_w = {.viewport = {0.0F, 0.0F, 0.0F, 600.0F}};
-    nt_ui_walk(s_fx.ctx, &zero_w); /* Must not crash. */
+    nt_ui_walk(s_fx.ctx, &zero_w);
     nt_ui_target_t zero_h = {.viewport = {0.0F, 0.0F, 800.0F, 0.0F}};
     nt_ui_walk(s_fx.ctx, &zero_h);
     nt_ui_target_t zero_both = {.viewport = {0.0F, 0.0F, 0.0F, 0.0F}};
     nt_ui_walk(s_fx.ctx, &zero_both);
-    /* No draw calls emitted from any of the three. */
     TEST_ASSERT_EQUAL_UINT32(calls_before, nt_sprite_renderer_test_draw_call_count());
 }
 
-/* Zero-viewport walk after a non-empty walk must overwrite the stats with 0,
- * not leave stale element_count from the previous frame. */
+/* Zero-viewport walk must overwrite stats (not leave stale prior frame). */
 static void test_walk_zero_viewport_resets_stats(void) {
-    /* First: a normal walk with some commands so stats become non-zero. */
     s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
     s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 10, .height = 10};
     s_test_cmds[0].renderData.rectangle.backgroundColor = (Clay_Color){.r = 255, .g = 0, .b = 0, .a = 255};
@@ -176,17 +166,13 @@ static void test_walk_zero_viewport_resets_stats(void) {
     nt_ui_walk(s_fx.ctx, &normal);
     TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_element_count(s_fx.ctx));
 
-    /* Second: minimized window simulated by zero viewport. */
     nt_ui_target_t zero = {.viewport = {0, 0, 0.0F, 0.0F}};
     nt_ui_walk(s_fx.ctx, &zero);
-    /* Stats MUST be reset; caller-visible value must be 0, not the stale 1. */
     TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_element_count(s_fx.ctx));
     TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_draw_calls(s_fx.ctx));
 }
 
-/* Macro to set s_setup_bind BEFORE RUN_TEST invokes setUp -- Unity runs
- * setUp first, then the test function, so the mode flag must be written
- * by the caller of RUN_TEST, not from inside the test body. */
+/* Set s_setup_bind BEFORE RUN_TEST: setUp fires first, must see the flag. */
 #define RUN_TEST_WITH_BIND(bind, fn)                                                                                                                                                                   \
     do {                                                                                                                                                                                               \
         s_setup_bind = (bind);                                                                                                                                                                         \

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -172,6 +172,21 @@ static void test_walk_zero_viewport_resets_stats(void) {
     TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_draw_calls(s_fx.ctx));
 }
 
+/* Zero-viewport walk must disable scissor (clean GL state on entry/exit,
+ * symmetric with the non-zero path). */
+static void test_walk_zero_viewport_disables_scissor(void) {
+    /* Enable scissor before walking; walker must reset regardless of viewport. */
+    nt_gfx_set_scissor(10, 10, 50, 50);
+    nt_gfx_set_scissor_enabled(true);
+    TEST_ASSERT_TRUE(nt_gfx_test_scissor_enabled());
+
+    inject_frozen_cmds(0);
+    nt_ui_target_t zero = {.viewport = {0, 0, 0.0F, 0.0F}};
+    nt_ui_walk(s_fx.ctx, &zero);
+
+    TEST_ASSERT_FALSE(nt_gfx_test_scissor_enabled());
+}
+
 /* Set s_setup_bind BEFORE RUN_TEST: setUp fires first, must see the flag. */
 #define RUN_TEST_WITH_BIND(bind, fn)                                                                                                                                                                   \
     do {                                                                                                                                                                                               \
@@ -191,6 +206,8 @@ int main(void) {
     RUN_TEST(test_walk_zero_viewport_silent_noop);
     s_setup_bind = UI_WALKER_FX_BIND_ALL;
     RUN_TEST(test_walk_zero_viewport_resets_stats);
+    s_setup_bind = UI_WALKER_FX_BIND_ALL;
+    RUN_TEST(test_walk_zero_viewport_disables_scissor);
     s_setup_bind = UI_WALKER_FX_BIND_ALL;
     RUN_TEST(test_second_walk_identical);
     s_setup_bind = UI_WALKER_FX_BIND_ALL;

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -5,6 +5,7 @@
 
 #include "clay.h"
 #include "graphics/nt_gfx.h"
+#include "renderers/nt_sprite_renderer.h"
 #include "test_helpers/nt_assert_trap.h"
 #include "test_helpers/ui_walker_fixture.h"
 #include "ui/nt_ui.h"
@@ -115,7 +116,8 @@ static void test_walk_without_end_asserts(void) {
     /* Use a fresh arena+ctx outside the fixture so we don't inherit
      * frozen_cmds from injection. */
     alignas(NT_UI_ARENA_ALIGN) static uint8_t fresh_arena[NT_UI_DEFAULT_ARENA_SIZE];
-    nt_ui_context_t *fresh = nt_ui_create_context(fresh_arena, sizeof fresh_arena);
+    const nt_ui_create_desc_t desc = nt_ui_create_desc_defaults();
+    nt_ui_context_t *fresh = nt_ui_create_context(fresh_arena, sizeof fresh_arena, &desc);
     TEST_ASSERT_NOT_NULL(fresh);
     nt_ui_set_atlas_white_region(fresh, s_fx.atlas.handle, s_fx.atlas.white_region_idx);
     nt_ui_set_sprite_material(fresh, s_fx.sprite_material);
@@ -134,6 +136,21 @@ static void test_walk_negative_viewport_asserts(void) {
     NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }
 
+/* Zero-size viewport (minimized window / mobile orientation transition) is
+ * a legitimate runtime state -- walker must silent no-op, not assert. */
+static void test_walk_zero_viewport_silent_noop(void) {
+    inject_frozen_cmds(0);
+    const uint32_t calls_before = nt_sprite_renderer_test_draw_call_count();
+    nt_ui_target_t zero_w = {.viewport = {0.0F, 0.0F, 0.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &zero_w); /* Must not crash. */
+    nt_ui_target_t zero_h = {.viewport = {0.0F, 0.0F, 800.0F, 0.0F}};
+    nt_ui_walk(s_fx.ctx, &zero_h);
+    nt_ui_target_t zero_both = {.viewport = {0.0F, 0.0F, 0.0F, 0.0F}};
+    nt_ui_walk(s_fx.ctx, &zero_both);
+    /* No draw calls emitted from any of the three. */
+    TEST_ASSERT_EQUAL_UINT32(calls_before, nt_sprite_renderer_test_draw_call_count());
+}
+
 /* Macro to set s_setup_bind BEFORE RUN_TEST invokes setUp -- Unity runs
  * setUp first, then the test function, so the mode flag must be written
  * by the caller of RUN_TEST, not from inside the test body. */
@@ -149,6 +166,8 @@ int main(void) {
     RUN_TEST(test_walk_without_end_asserts);
     s_setup_bind = UI_WALKER_FX_BIND_ALL;
     RUN_TEST(test_walk_negative_viewport_asserts);
+    s_setup_bind = UI_WALKER_FX_BIND_ALL;
+    RUN_TEST(test_walk_zero_viewport_silent_noop);
     s_setup_bind = UI_WALKER_FX_BIND_ALL;
     RUN_TEST(test_second_walk_identical);
     s_setup_bind = UI_WALKER_FX_BIND_ALL;

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -129,15 +129,28 @@ static void test_walk_without_end_asserts(void) {
     nt_ui_destroy_context(fresh);
 }
 
-/* viewport components must be non-negative (otherwise (int) cast is UB). */
-static void test_walk_negative_viewport_asserts(void) {
+/* viewport origin must be non-negative (otherwise (int) cast is UB). */
+static void test_walk_negative_viewport_origin_asserts(void) {
     inject_frozen_cmds(0);
     nt_ui_target_t target = {.viewport = {-1.0F, 0, 800, 600}};
     NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }
 
+/* viewport w/h < 0 is a caller bug -- assert by fail-early policy.
+ * Symmetric with origin assert above; zero is the only legitimate
+ * "small" value (handled by separate silent no-op path). */
+static void test_walk_negative_viewport_size_asserts(void) {
+    inject_frozen_cmds(0);
+    nt_ui_target_t neg_w = {.viewport = {0, 0, -1.0F, 600}};
+    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &neg_w));
+    nt_ui_target_t neg_h = {.viewport = {0, 0, 800, -1.0F}};
+    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &neg_h));
+}
+
 /* Zero-size viewport (minimized window / mobile orientation transition) is
- * a legitimate runtime state -- walker must silent no-op, not assert. */
+ * a legitimate runtime state -- walker must silent no-op, not assert, AND
+ * must reset per-walk stats so caller doesn't read stale values from the
+ * previous non-empty walk. */
 static void test_walk_zero_viewport_silent_noop(void) {
     inject_frozen_cmds(0);
     const uint32_t calls_before = nt_sprite_renderer_test_draw_call_count();
@@ -149,6 +162,26 @@ static void test_walk_zero_viewport_silent_noop(void) {
     nt_ui_walk(s_fx.ctx, &zero_both);
     /* No draw calls emitted from any of the three. */
     TEST_ASSERT_EQUAL_UINT32(calls_before, nt_sprite_renderer_test_draw_call_count());
+}
+
+/* Zero-viewport walk after a non-empty walk must overwrite the stats with 0,
+ * not leave stale element_count from the previous frame. */
+static void test_walk_zero_viewport_resets_stats(void) {
+    /* First: a normal walk with some commands so stats become non-zero. */
+    s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+    s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 10, .height = 10};
+    s_test_cmds[0].renderData.rectangle.backgroundColor = (Clay_Color){.r = 255, .g = 0, .b = 0, .a = 255};
+    inject_frozen_cmds(1);
+    nt_ui_target_t normal = {.viewport = {0, 0, 800, 600}};
+    nt_ui_walk(s_fx.ctx, &normal);
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_element_count(s_fx.ctx));
+
+    /* Second: minimized window simulated by zero viewport. */
+    nt_ui_target_t zero = {.viewport = {0, 0, 0.0F, 0.0F}};
+    nt_ui_walk(s_fx.ctx, &zero);
+    /* Stats MUST be reset; caller-visible value must be 0, not the stale 1. */
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_draw_calls(s_fx.ctx));
 }
 
 /* Macro to set s_setup_bind BEFORE RUN_TEST invokes setUp -- Unity runs
@@ -165,9 +198,13 @@ int main(void) {
     s_setup_bind = UI_WALKER_FX_BIND_ALL;
     RUN_TEST(test_walk_without_end_asserts);
     s_setup_bind = UI_WALKER_FX_BIND_ALL;
-    RUN_TEST(test_walk_negative_viewport_asserts);
+    RUN_TEST(test_walk_negative_viewport_origin_asserts);
+    s_setup_bind = UI_WALKER_FX_BIND_ALL;
+    RUN_TEST(test_walk_negative_viewport_size_asserts);
     s_setup_bind = UI_WALKER_FX_BIND_ALL;
     RUN_TEST(test_walk_zero_viewport_silent_noop);
+    s_setup_bind = UI_WALKER_FX_BIND_ALL;
+    RUN_TEST(test_walk_zero_viewport_resets_stats);
     s_setup_bind = UI_WALKER_FX_BIND_ALL;
     RUN_TEST(test_second_walk_identical);
     s_setup_bind = UI_WALKER_FX_BIND_ALL;

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -28,6 +28,7 @@
 #include "renderers/nt_sprite_renderer.h"
 #include "renderers/nt_text_renderer.h"
 #include "resource/nt_resource.h"
+#include "stats/nt_stats.h"
 #include "test_helpers/nt_assert_trap.h"
 #include "test_helpers/ui_atlas.h"
 #include "ui/nt_ui.h"
@@ -112,6 +113,11 @@ void setUp(void) {
     nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
     nt_text_renderer_init();
 
+    /* nt_stats_init required: Plan 52-05 wired nt_stats_count("ui_draw_calls", ...)
+     * + nt_stats_count("ui_element_count", ...) at nt_ui_walk exit. Without init,
+     * nt_stats_count's NT_ASSERT(s_stats.initialized) trips on every walk. */
+    nt_stats_init(NULL);
+
     s_atlas = minimal_ui_atlas_create();
     s_sprite_material = make_test_material();
     s_text_material = make_test_material();
@@ -144,6 +150,7 @@ void tearDown(void) {
     }
     nt_ui_test_reset_walker_globals();
     minimal_ui_atlas_destroy(&s_atlas);
+    nt_stats_shutdown();
     nt_sprite_renderer_shutdown();
     nt_text_renderer_shutdown();
     nt_gfx_end_pass();

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -89,7 +89,7 @@ static void test_viewport_applied(void) {
 /* walk without atlas set asserts. */
 static void test_walk_without_atlas_asserts(void) {
     /* Mode flag was set before Unity invoked setUp -- the atlas setter
-     * was skipped, so g_nt_ui_atlas.id == 0. */
+     * was skipped, so ctx->atlas.id == 0. */
     inject_frozen_cmds(0);
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
     NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -111,9 +111,19 @@ static void test_walk_without_sprite_material_asserts(void) {
     NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }
 
-/* D-52-19 death-test: walk without text material asserts. */
+/* D-52-19 death-test: walk that EMITS A TEXT COMMAND without text_material
+ * set asserts inside emit_text. (text_material is asserted lazily so a
+ * pure-RECT UI doesn't require the setter.) */
 static void test_walk_without_text_material_asserts(void) {
-    inject_frozen_cmds(0);
+    static const char *kText = "X";
+    s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_TEXT;
+    s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 10, .height = 10};
+    s_test_cmds[0].renderData.text.stringContents = (Clay_StringSlice){.length = 1, .chars = kText, .baseChars = kText};
+    s_test_cmds[0].renderData.text.textColor = (Clay_Color){.r = 255, .g = 255, .b = 255, .a = 255};
+    s_test_cmds[0].renderData.text.fontId = 0;
+    s_test_cmds[0].renderData.text.fontSize = 14;
+    inject_frozen_cmds(1);
+
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
     NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -111,19 +111,9 @@ static void test_walk_without_sprite_material_asserts(void) {
     NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }
 
-/* D-52-19 death-test: walk that EMITS A TEXT COMMAND without text_material
- * set asserts inside emit_text. (text_material is asserted lazily so a
- * pure-RECT UI doesn't require the setter.) */
+/* D-52-19 death-test: walk without text material asserts at walker entry. */
 static void test_walk_without_text_material_asserts(void) {
-    static const char *kText = "X";
-    s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_TEXT;
-    s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 10, .height = 10};
-    s_test_cmds[0].renderData.text.stringContents = (Clay_StringSlice){.length = 1, .chars = kText, .baseChars = kText};
-    s_test_cmds[0].renderData.text.textColor = (Clay_Color){.r = 255, .g = 255, .b = 255, .a = 255};
-    s_test_cmds[0].renderData.text.fontId = 0;
-    s_test_cmds[0].renderData.text.fontSize = 14;
-    inject_frozen_cmds(1);
-
+    inject_frozen_cmds(0);
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
     NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -122,22 +122,22 @@ void setUp(void) {
     s_sprite_material = make_test_material();
     s_text_material = make_test_material();
 
-    /* Per-test walker setter selection. Clears first so death-tests start
-     * from a known-empty state. */
-    nt_ui_test_reset_walker_globals();
-    if (s_setup_mode != SETUP_NO_ATLAS) {
-        nt_ui_set_atlas_white_region(s_atlas.handle, s_atlas.white_region_idx);
-    }
-    if (s_setup_mode != SETUP_NO_SPRITE_MATERIAL) {
-        nt_ui_set_sprite_material(s_sprite_material);
-    }
-    if (s_setup_mode != SETUP_NO_TEXT_MATERIAL) {
-        nt_ui_set_text_material(s_text_material);
-    }
-    nt_ui_set_custom_handler(NULL, NULL);
-
     s_ctx = nt_ui_create_context(s_arena, sizeof s_arena);
     TEST_ASSERT_NOT_NULL(s_ctx);
+
+    /* Per-test walker setter selection. A fresh context has all walker fields
+     * zero-initialised, so death-tests just skip the setter for the field
+     * whose absence they expect the walker to assert on. */
+    if (s_setup_mode != SETUP_NO_ATLAS) {
+        nt_ui_set_atlas_white_region(s_ctx, s_atlas.handle, s_atlas.white_region_idx);
+    }
+    if (s_setup_mode != SETUP_NO_SPRITE_MATERIAL) {
+        nt_ui_set_sprite_material(s_ctx, s_sprite_material);
+    }
+    if (s_setup_mode != SETUP_NO_TEXT_MATERIAL) {
+        nt_ui_set_text_material(s_ctx, s_text_material);
+    }
+    nt_ui_set_custom_handler(s_ctx, NULL, NULL);
 
     /* Reset mode to FULL for the next test -- per-test setup applies a
      * sentinel BEFORE Unity runs setUp via the run_with_mode wrappers below. */
@@ -148,7 +148,6 @@ void tearDown(void) {
         nt_ui_destroy_context(s_ctx);
         s_ctx = NULL;
     }
-    nt_ui_test_reset_walker_globals();
     minimal_ui_atlas_destroy(&s_atlas);
     nt_stats_shutdown();
     nt_sprite_renderer_shutdown();
@@ -183,18 +182,18 @@ static void test_second_walk_identical(void) {
 
     int vp1[4];
     nt_gfx_test_viewport_rect(vp1);
-    const uint32_t elements1 = nt_ui_test_last_walk_element_count();
+    const uint32_t elements1 = nt_ui_test_last_walk_element_count(s_ctx);
     /* Read but don't compare draw-call delta -- walking once already
      * incurs draw calls; a second walk will too, so the EXACT delta-
      * to-delta count is what we compare. */
-    const uint32_t delta1 = nt_ui_test_last_walk_draw_call_delta();
+    const uint32_t delta1 = nt_ui_test_last_walk_draw_call_delta(s_ctx);
 
     nt_ui_walk(s_ctx, &target);
 
     int vp2[4];
     nt_gfx_test_viewport_rect(vp2);
-    const uint32_t elements2 = nt_ui_test_last_walk_element_count();
-    const uint32_t delta2 = nt_ui_test_last_walk_draw_call_delta();
+    const uint32_t elements2 = nt_ui_test_last_walk_element_count(s_ctx);
+    const uint32_t delta2 = nt_ui_test_last_walk_draw_call_delta(s_ctx);
 
     TEST_ASSERT_EQUAL_INT_ARRAY(vp1, vp2, 4);
     TEST_ASSERT_EQUAL_UINT32(elements1, elements2);

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -1,12 +1,3 @@
-/* tests/unit/test_nt_ui_walker_readonly.c -- Plan 52-04
- *
- * Covers UI-06 (two walks against same ctx+target produce identical state)
- * and UI-07 (walker entry applies target->viewport via nt_gfx_set_viewport).
- * Three death-tests for pre-walk asserts (D-52-06 atlas, D-52-19 sprite +
- * text material). All death-tests use NT_TEST_EXPECT_ASSERT (Revision
- * Issue 3) -- no TEST_IGNORE fallback.
- */
-
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -49,7 +40,7 @@ static void inject_frozen_cmds(int32_t count) {
     s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
 }
 
-/* UI-06: two walks against same ctx+target produce identical probe state. */
+/* two walks against same ctx+target produce identical probe state. */
 static void test_second_walk_identical(void) {
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
@@ -80,7 +71,7 @@ static void test_second_walk_identical(void) {
     TEST_ASSERT_EQUAL_UINT32(delta1, delta2);
 }
 
-/* UI-07: walker entry applies target->viewport via nt_gfx_set_viewport. */
+/* walker entry applies target->viewport via nt_gfx_set_viewport. */
 static void test_viewport_applied(void) {
     inject_frozen_cmds(0);
 
@@ -95,7 +86,7 @@ static void test_viewport_applied(void) {
     TEST_ASSERT_EQUAL_INT(480, vp[3]);
 }
 
-/* D-52-06 death-test: walk without atlas set asserts. */
+/* walk without atlas set asserts. */
 static void test_walk_without_atlas_asserts(void) {
     /* Mode flag was set before Unity invoked setUp -- the atlas setter
      * was skipped, so g_nt_ui_atlas.id == 0. */
@@ -104,14 +95,14 @@ static void test_walk_without_atlas_asserts(void) {
     NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }
 
-/* D-52-19 / Revision Issue 1 death-test: walk without sprite material asserts. */
+/* death-test: walk without sprite material asserts. */
 static void test_walk_without_sprite_material_asserts(void) {
     inject_frozen_cmds(0);
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
     NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }
 
-/* D-52-19 death-test: walk without text material asserts at walker entry. */
+/* walk without text material asserts at walker entry. */
 static void test_walk_without_text_material_asserts(void) {
     inject_frozen_cmds(0);
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -54,7 +54,7 @@ static void test_second_walk_identical(void) {
 
     int vp1[4];
     nt_gfx_test_viewport_rect(vp1);
-    const uint32_t elements1 = nt_ui_get_last_walk_element_count(s_fx.ctx);
+    const uint32_t elements1 = nt_ui_get_last_walk_command_count(s_fx.ctx);
     /* Read but don't compare draw-call delta -- walking once already
      * incurs draw calls; a second walk will too, so the EXACT delta-
      * to-delta count is what we compare. */
@@ -64,7 +64,7 @@ static void test_second_walk_identical(void) {
 
     int vp2[4];
     nt_gfx_test_viewport_rect(vp2);
-    const uint32_t elements2 = nt_ui_get_last_walk_element_count(s_fx.ctx);
+    const uint32_t elements2 = nt_ui_get_last_walk_command_count(s_fx.ctx);
     const uint32_t delta2 = nt_ui_get_last_walk_draw_calls(s_fx.ctx);
 
     TEST_ASSERT_EQUAL_INT_ARRAY(vp1, vp2, 4);
@@ -164,11 +164,11 @@ static void test_walk_zero_viewport_resets_stats(void) {
     inject_frozen_cmds(1);
     nt_ui_target_t normal = {.viewport = {0, 0, 800, 600}};
     nt_ui_walk(s_fx.ctx, &normal);
-    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_command_count(s_fx.ctx));
 
     nt_ui_target_t zero = {.viewport = {0, 0, 0.0F, 0.0F}};
     nt_ui_walk(s_fx.ctx, &zero);
-    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_element_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_command_count(s_fx.ctx));
     TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_draw_calls(s_fx.ctx));
 }
 

--- a/tests/unit/test_nt_ui_walker_scissor.c
+++ b/tests/unit/test_nt_ui_walker_scissor.c
@@ -1,6 +1,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "clay.h"
@@ -51,49 +52,25 @@ static void test_scissor_depth_8_ok(void) {
     TEST_ASSERT_FALSE(nt_gfx_test_scissor_enabled());
 }
 
-/* Per-ctx max_scissor_depth (VLA size) -- depth=4 here, push #5 overflows. */
-static void test_scissor_depth_custom_via_desc(void) {
-    alignas(NT_UI_ARENA_ALIGN) static uint8_t s_custom_arena[NT_UI_TEST_ARENA_SIZE];
-    const nt_ui_create_desc_t custom_desc = {
-        .max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT,
-        .max_scissor_depth = 4U,
-    };
-    nt_ui_context_t *custom_ctx = nt_ui_create_context(s_custom_arena, sizeof s_custom_arena, &custom_desc);
-    TEST_ASSERT_NOT_NULL(custom_ctx);
-    nt_ui_set_atlas_white_region(custom_ctx, s_fx.atlas.handle, s_fx.atlas.white_region_idx);
-    nt_ui_set_sprite_material(custom_ctx, s_fx.sprite_material);
-    nt_ui_set_text_material(custom_ctx, s_fx.text_material);
-
-    Clay_RenderCommand local_cmds[5];
-    memset(local_cmds, 0, sizeof local_cmds);
-    for (int32_t i = 0; i < 5; ++i) {
-        local_cmds[i].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
-        local_cmds[i].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 800, .height = 600};
-        local_cmds[i].renderData.clip.horizontal = true;
-        local_cmds[i].renderData.clip.vertical = true;
+/* Hard cap NT_UI_WALKER_SCISSOR_DEPTH_CAP push asserts on overflow. */
+static void test_scissor_depth_cap_asserts(void) {
+    /* MAX_TEST_CMDS may be smaller than CAP+1; use a heap array sized to CAP+1. */
+    const int32_t over = NT_UI_WALKER_SCISSOR_DEPTH_CAP + 1;
+    Clay_RenderCommand *cmds = (Clay_RenderCommand *)calloc((size_t)over, sizeof(Clay_RenderCommand));
+    TEST_ASSERT_NOT_NULL(cmds);
+    for (int32_t i = 0; i < over; ++i) {
+        cmds[i].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
+        cmds[i].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 800, .height = 600};
+        cmds[i].renderData.clip.horizontal = true;
+        cmds[i].renderData.clip.vertical = true;
     }
-    custom_ctx->frozen_cmds.internalArray = local_cmds;
-    custom_ctx->frozen_cmds.length = 5;
-    custom_ctx->frozen_cmds.capacity = 5;
-
-    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
-    NT_TEST_EXPECT_ASSERT(nt_ui_walk(custom_ctx, &target));
-
-    nt_ui_destroy_context(custom_ctx);
-}
-
-/* 9 nested SCISSOR_START must assert (depth overflow). */
-static void test_scissor_depth_9_asserts(void) {
-    for (int32_t i = 0; i < 9; ++i) {
-        s_test_cmds[i].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
-        s_test_cmds[i].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 800, .height = 600};
-        s_test_cmds[i].renderData.clip.horizontal = true;
-        s_test_cmds[i].renderData.clip.vertical = true;
-    }
-    inject_frozen_cmds(9);
+    s_fx.ctx->frozen_cmds.internalArray = cmds;
+    s_fx.ctx->frozen_cmds.length = over;
+    s_fx.ctx->frozen_cmds.capacity = over;
 
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
+    free(cmds);
 }
 
 /* 2 SCISSOR_START + 1 SCISSOR_END leaves depth > 0
@@ -279,8 +256,7 @@ static void test_scissor_neither_axis_asserts(void) {
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_scissor_depth_8_ok);
-    RUN_TEST(test_scissor_depth_9_asserts);
-    RUN_TEST(test_scissor_depth_custom_via_desc);
+    RUN_TEST(test_scissor_depth_cap_asserts);
     RUN_TEST(test_scissor_unbalanced_asserts_at_exit);
     RUN_TEST(test_scissor_y_flip_top_left_to_gl_bottom_left);
     RUN_TEST(test_scissor_intersection_nested);

--- a/tests/unit/test_nt_ui_walker_scissor.c
+++ b/tests/unit/test_nt_ui_walker_scissor.c
@@ -1,0 +1,43 @@
+/* tests/unit/test_nt_ui_walker_scissor.c — Plan 52-00 stub
+ *
+ * Covers WALK-02 (walker-local scissor stack ≤8 + balanced exit assert) and
+ * WALK-03 (Y-flip top-left → GL bottom-left + intersection at push). Wave 0
+ * ships TEST_IGNORE bodies; Plan 52-04 fills with real assertions.
+ */
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "unity.h"
+
+void setUp(void) {}
+void tearDown(void) {}
+
+/* WALK-02: 8 nested scissors pushed and popped successfully */
+static void test_scissor_depth_8_ok(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+/* WALK-02: 9th nested scissor asserts (overflow) — death-test */
+static void test_scissor_depth_9_asserts(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+/* WALK-02: unbalanced stack (more SCISSOR_START than END) asserts at walker exit */
+static void test_scissor_unbalanced_asserts_at_exit(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+/* WALK-03: Clay top-left scissor rect translates to GL bottom-left rect */
+static void test_scissor_y_flip_top_left_to_gl_bottom_left(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+/* WALK-03: nested SCISSOR_START intersects with stack top, not replaces */
+static void test_scissor_intersection_nested(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+/* WALK-03 / D-52-17: walker exit disables scissor (nt_gfx_set_scissor_enabled(false)) */
+static void test_walker_exit_disables_scissor(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_scissor_depth_8_ok);
+    RUN_TEST(test_scissor_depth_9_asserts);
+    RUN_TEST(test_scissor_unbalanced_asserts_at_exit);
+    RUN_TEST(test_scissor_y_flip_top_left_to_gl_bottom_left);
+    RUN_TEST(test_scissor_intersection_nested);
+    RUN_TEST(test_walker_exit_disables_scissor);
+    return UNITY_END();
+}

--- a/tests/unit/test_nt_ui_walker_scissor.c
+++ b/tests/unit/test_nt_ui_walker_scissor.c
@@ -26,6 +26,7 @@
 #include "renderers/nt_sprite_renderer.h"
 #include "renderers/nt_text_renderer.h"
 #include "resource/nt_resource.h"
+#include "stats/nt_stats.h"
 #include "test_helpers/nt_assert_trap.h"
 #include "test_helpers/ui_atlas.h"
 #include "ui/nt_ui.h"
@@ -100,6 +101,11 @@ void setUp(void) {
     nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
     nt_text_renderer_init();
 
+    /* nt_stats_init required: Plan 52-05 wired nt_stats_count("ui_draw_calls", ...)
+     * + nt_stats_count("ui_element_count", ...) at nt_ui_walk exit. Without init,
+     * nt_stats_count's NT_ASSERT(s_stats.initialized) trips on every walk. */
+    nt_stats_init(NULL);
+
     s_atlas = minimal_ui_atlas_create();
     s_sprite_material = make_test_material();
     s_text_material = make_test_material();
@@ -120,6 +126,7 @@ void tearDown(void) {
     }
     nt_ui_test_reset_walker_globals();
     minimal_ui_atlas_destroy(&s_atlas);
+    nt_stats_shutdown();
     nt_sprite_renderer_shutdown();
     nt_text_renderer_shutdown();
     nt_gfx_end_pass();

--- a/tests/unit/test_nt_ui_walker_scissor.c
+++ b/tests/unit/test_nt_ui_walker_scissor.c
@@ -174,6 +174,40 @@ static void test_walker_exit_disables_scissor(void) {
     TEST_ASSERT_FALSE(nt_gfx_test_scissor_enabled());
 }
 
+/* WALK-03 / D-52-17: Clay's bounding box is target-local. With a non-zero
+ * viewport offset (split-screen pane, sub-FBO render-target), the GL scissor
+ * MUST add viewport.x to x and use a Y-flip relative to viewport.y, not the
+ * raw framebuffer height. Without this, a split-screen pane's clip rectangle
+ * lands on the wrong physical pixels (clipping the wrong pane). */
+static void test_scissor_respects_viewport_offset(void) {
+    /* Local scissor at (10, 10) within a 400x300 viewport that itself
+     * starts at framebuffer offset (100, 50). */
+    s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
+    s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 10.0f, .y = 10.0f, .width = 100.0f, .height = 100.0f};
+    s_test_cmds[0].renderData.clip.horizontal = true;
+    s_test_cmds[0].renderData.clip.vertical = true;
+    s_test_cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
+    inject_frozen_cmds(2);
+
+    nt_ui_target_t target = {.viewport = {100.0f, 50.0f, 400.0f, 300.0f}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    int rect[4];
+    nt_gfx_test_scissor_rect(rect);
+
+    /* Expected (GL coords, bottom-left origin):
+     *   x_gl = viewport.x + local_x          = 100 + 10           = 110
+     *   y_gl = viewport.y + viewport.h - local_y - local_h
+     *        = 50 + 300 - 10 - 100                                = 240
+     *   w    = local_w                                            = 100
+     *   h    = local_h                                            = 100
+     */
+    TEST_ASSERT_EQUAL_INT_MESSAGE(110, rect[0], "scissor x must include viewport offset");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(240, rect[1], "scissor y must Y-flip within viewport, not framebuffer");
+    TEST_ASSERT_EQUAL_INT(100, rect[2]);
+    TEST_ASSERT_EQUAL_INT(100, rect[3]);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_scissor_depth_8_ok);
@@ -182,5 +216,6 @@ int main(void) {
     RUN_TEST(test_scissor_y_flip_top_left_to_gl_bottom_left);
     RUN_TEST(test_scissor_intersection_nested);
     RUN_TEST(test_walker_exit_disables_scissor);
+    RUN_TEST(test_scissor_respects_viewport_offset);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_walker_scissor.c
+++ b/tests/unit/test_nt_ui_walker_scissor.c
@@ -262,8 +262,9 @@ static void test_scissor_vertical_only(void) {
     TEST_ASSERT_EQUAL_INT(50, rect[3]);
 }
 
-/* Neither axis clipped -> scissor covers the full viewport. */
-static void test_scissor_neither_axis(void) {
+/* Both axes unclipped is a contract violation (no-op scissor with wasted
+ * flushes); walker asserts so the misconfig surfaces in dev. */
+static void test_scissor_neither_axis_asserts(void) {
     s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
     s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 50.0F, .y = 100.0F, .width = 200.0F, .height = 50.0F};
     s_test_cmds[0].renderData.clip.horizontal = false;
@@ -272,14 +273,7 @@ static void test_scissor_neither_axis(void) {
     inject_frozen_cmds(2);
 
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
-    nt_ui_walk(s_fx.ctx, &target);
-
-    int rect[4];
-    nt_gfx_test_scissor_rect(rect);
-    TEST_ASSERT_EQUAL_INT(0, rect[0]);
-    TEST_ASSERT_EQUAL_INT(0, rect[1]);
-    TEST_ASSERT_EQUAL_INT(800, rect[2]);
-    TEST_ASSERT_EQUAL_INT(600, rect[3]);
+    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }
 
 int main(void) {
@@ -294,6 +288,6 @@ int main(void) {
     RUN_TEST(test_scissor_respects_viewport_offset);
     RUN_TEST(test_scissor_horizontal_only);
     RUN_TEST(test_scissor_vertical_only);
-    RUN_TEST(test_scissor_neither_axis);
+    RUN_TEST(test_scissor_neither_axis_asserts);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_walker_scissor.c
+++ b/tests/unit/test_nt_ui_walker_scissor.c
@@ -11,7 +11,7 @@
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_TEST_ARENA_SIZE];
 static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 32
@@ -53,7 +53,7 @@ static void test_scissor_depth_8_ok(void) {
 
 /* Per-ctx max_scissor_depth (VLA size) -- depth=4 here, push #5 overflows. */
 static void test_scissor_depth_custom_via_desc(void) {
-    alignas(NT_UI_ARENA_ALIGN) static uint8_t s_custom_arena[NT_UI_DEFAULT_ARENA_SIZE];
+    alignas(NT_UI_ARENA_ALIGN) static uint8_t s_custom_arena[NT_UI_TEST_ARENA_SIZE];
     const nt_ui_create_desc_t custom_desc = {
         .max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT,
         .max_scissor_depth = 4U,

--- a/tests/unit/test_nt_ui_walker_scissor.c
+++ b/tests/unit/test_nt_ui_walker_scissor.c
@@ -1,10 +1,3 @@
-/* tests/unit/test_nt_ui_walker_scissor.c -- Plan 52-04
- *
- * Covers WALK-02 (walker-local scissor stack depth 8 + balanced exit
- * assert) and WALK-03 (Y-flip top-left -> GL bottom-left + intersection
- * at push). Death-tests use NT_TEST_EXPECT_ASSERT (Revision Issue 3).
- */
-
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
@@ -38,7 +31,7 @@ static void inject_frozen_cmds(int32_t count) {
     s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
 }
 
-/* WALK-02: 8 nested SCISSOR_START / 8 SCISSOR_END must succeed (depth 8
+/* 8 nested SCISSOR_START / 8 SCISSOR_END must succeed (depth 8
  * is at the limit but not over). */
 static void test_scissor_depth_8_ok(void) {
     for (int32_t i = 0; i < 8; ++i) {
@@ -58,8 +51,7 @@ static void test_scissor_depth_8_ok(void) {
     TEST_ASSERT_FALSE(nt_gfx_test_scissor_enabled());
 }
 
-/* WALK-02 death-test: 9 nested SCISSOR_START must assert (depth overflow).
- * Wrapped in NT_TEST_EXPECT_ASSERT (Revision Issue 3). */
+/* 9 nested SCISSOR_START must assert (depth overflow). */
 static void test_scissor_depth_9_asserts(void) {
     for (int32_t i = 0; i < 9; ++i) {
         s_test_cmds[i].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
@@ -73,7 +65,7 @@ static void test_scissor_depth_9_asserts(void) {
     NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }
 
-/* WALK-02 death-test: 2 SCISSOR_START + 1 SCISSOR_END leaves depth > 0
+/* 2 SCISSOR_START + 1 SCISSOR_END leaves depth > 0
  * at walk exit -> the final NT_ASSERT(depth == 0) must fire. */
 static void test_scissor_unbalanced_asserts_at_exit(void) {
     s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
@@ -87,7 +79,7 @@ static void test_scissor_unbalanced_asserts_at_exit(void) {
     NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }
 
-/* WALK-03: Clay scissor (x=100, y=100, w=200, h=200) inside an 800x600 viewport
+/* Clay scissor (x=100, y=100, w=200, h=200) inside an 800x600 viewport
  * must produce GL scissor at (100, 600 - 100 - 200 = 300, 200, 200). The
  * scissor is disabled at walk exit; we observe the LAST set_scissor rect via
  * the gfx test probe, which retains the most-recent values regardless of
@@ -112,7 +104,7 @@ static void test_scissor_y_flip_top_left_to_gl_bottom_left(void) {
     TEST_ASSERT_EQUAL_INT(200, rect[3]);
 }
 
-/* WALK-03 / D-52-17: nested SCISSOR_START intersects with stack top.
+/* nested SCISSOR_START intersects with stack top.
  * Outer (0..100, 0..100), inner (50..200, 50..200) -> intersection
  * (50..100, 50..100) i.e. (x=50, y=50, w=50, h=50) in Clay's top-left
  * space. After Y-flip in a 600-tall fb: y_gl = 600 - 50 - 50 = 500. */
@@ -160,7 +152,7 @@ static void test_scissor_intersection_nested(void) {
     TEST_ASSERT_EQUAL_INT(100, rect[3]);
 }
 
-/* WALK-03 / D-52-17: walker exit always disables scissor, even if scissor
+/* walker exit always disables scissor, even if scissor
  * was enabled mid-walk. */
 static void test_walker_exit_disables_scissor(void) {
     s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
@@ -174,7 +166,7 @@ static void test_walker_exit_disables_scissor(void) {
     TEST_ASSERT_FALSE(nt_gfx_test_scissor_enabled());
 }
 
-/* WALK-03 / D-52-17: Clay's bounding box is target-local. With a non-zero
+/* Clay's bounding box is target-local. With a non-zero
  * viewport offset (split-screen pane, sub-FBO render-target), the GL scissor
  * MUST add viewport.x to x and use a Y-flip relative to viewport.y, not the
  * raw framebuffer height. Without this, a split-screen pane's clip rectangle

--- a/tests/unit/test_nt_ui_walker_scissor.c
+++ b/tests/unit/test_nt_ui_walker_scissor.c
@@ -108,15 +108,7 @@ static void test_scissor_y_flip_top_left_to_gl_bottom_left(void) {
     TEST_ASSERT_EQUAL_INT(200, rect[3]);
 }
 
-/* Nested scissor must intersect with parent, not replace. Outer = (0..100,
- * 0..100), inner = (50..200, 50..200) -> intersection = (50..100, 50..100).
- *
- * We inspect the LAST nt_gfx_set_scissor call to see the rect that survived
- * intersection. scissor_pop re-applies parent on each pop, so we close inner
- * first (which re-applies outer) and assert against the outer rect; the
- * intersect arithmetic still happens on push, just isn't directly observable
- * via the test probe -- the test then validates the push-time intersect math
- * indirectly by relying on the outer pop. */
+/* Nested scissor intersects, not replaces. */
 static void test_scissor_intersection_nested(void) {
     s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
     s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 100.0F, .height = 100.0F};

--- a/tests/unit/test_nt_ui_walker_scissor.c
+++ b/tests/unit/test_nt_ui_walker_scissor.c
@@ -104,46 +104,34 @@ static void test_scissor_y_flip_top_left_to_gl_bottom_left(void) {
     TEST_ASSERT_EQUAL_INT(200, rect[3]);
 }
 
-/* nested SCISSOR_START intersects with stack top.
- * Outer (0..100, 0..100), inner (50..200, 50..200) -> intersection
- * (50..100, 50..100) i.e. (x=50, y=50, w=50, h=50) in Clay's top-left
- * space. After Y-flip in a 600-tall fb: y_gl = 600 - 50 - 50 = 500. */
+/* Nested scissor must intersect with parent, not replace. Outer = (0..100,
+ * 0..100), inner = (50..200, 50..200) -> intersection = (50..100, 50..100).
+ *
+ * We inspect the LAST nt_gfx_set_scissor call to see the rect that survived
+ * intersection. scissor_pop re-applies parent on each pop, so we close inner
+ * first (which re-applies outer) and assert against the outer rect; the
+ * intersect arithmetic still happens on push, just isn't directly observable
+ * via the test probe -- the test then validates the push-time intersect math
+ * indirectly by relying on the outer pop. */
 static void test_scissor_intersection_nested(void) {
-    /* Outer */
     s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
     s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 100.0F, .height = 100.0F};
-    /* Inner -- pre-intersect rect would have been (50,50,150,150) (extending
-     * to 200,200), but intersection with outer clips it to (50,50,50,50). */
+    s_test_cmds[0].renderData.clip.horizontal = true;
+    s_test_cmds[0].renderData.clip.vertical = true;
     s_test_cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
     s_test_cmds[1].boundingBox = (Clay_BoundingBox){.x = 50.0F, .y = 50.0F, .width = 150.0F, .height = 150.0F};
-    /* Pop inner (we want to inspect the LAST scissor call which was the
-     * inner push, but to balance the stack we still need the END. After
-     * the END, scissor_pop re-applies the outer rect -- which masks the
-     * inner's value. So we close with only the outer END here. Wait: that
-     * leaves a depth-1 stack at exit, asserting on `depth == 0`. We must
-     * close both. Workaround: end inner BEFORE walker would re-apply -- not
-     * possible; the rect-replay is built-in. Solution: snapshot via an
-     * intermediate RECT between inner-push and outer-pop. We instead test
-     * the intersection by capturing the rect via nt_gfx probes mid-walk
-     * through the FINAL inner push -- but the walker exits before we can
-     * peek. Therefore: pop in REVERSE order (close inner first, then outer),
-     * and verify the FIRST inner intersection happened by checking the
-     * outer rect from the FINAL scissor_pop (depth==1) call. Outer is
-     * (0, 0, 100, 100) -- after pop of inner the walker re-applies that. */
-    s_test_cmds[2].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END; /* close inner */
-    s_test_cmds[3].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END; /* close outer */
+    s_test_cmds[1].renderData.clip.horizontal = true;
+    s_test_cmds[1].renderData.clip.vertical = true;
+    s_test_cmds[2].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
+    s_test_cmds[3].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
     inject_frozen_cmds(4);
 
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    /* After scissor_pop of inner, scissor_pop re-applies outer (0, 0, 100, 100).
-     * That's the second-to-last set_scissor call. The actual LAST call is
-     * nt_gfx_set_scissor_enabled(false) at walk exit, which does NOT
-     * overwrite the rect. So nt_gfx_test_scissor_rect still reads back
-     * the OUTER rect after pop-inner (the LAST set_scissor call).
-     *
-     * Outer in GL bottom-left: y_gl = 600 - 0 - 100 = 500. */
+    /* After pop-inner re-applies outer, walker exit only disables scissor
+     * (does not overwrite the rect probe). So we read the outer rect:
+     *   (0, 0, 100, 100) in Clay top-left -> Y-flip: y_gl = 600 - 100 = 500. */
     int rect[4];
     nt_gfx_test_scissor_rect(rect);
     TEST_ASSERT_EQUAL_INT(0, rect[0]);
@@ -200,6 +188,71 @@ static void test_scissor_respects_viewport_offset(void) {
     TEST_ASSERT_EQUAL_INT(100, rect[3]);
 }
 
+/* clip.horizontal=true, clip.vertical=false: only x is clipped. y/h
+ * should span the full viewport. */
+static void test_scissor_horizontal_only(void) {
+    s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
+    s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 50.0F, .y = 100.0F, .width = 200.0F, .height = 50.0F};
+    s_test_cmds[0].renderData.clip.horizontal = true;
+    s_test_cmds[0].renderData.clip.vertical = false;
+    s_test_cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
+    inject_frozen_cmds(2);
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    int rect[4];
+    nt_gfx_test_scissor_rect(rect);
+    /* x = 50, w = 200 (clipped). y = 0, h = 600 (unclipped -> full viewport).
+     * GL Y-flip: y_gl = 0 + 600 - 0 - 600 = 0. */
+    TEST_ASSERT_EQUAL_INT_MESSAGE(50, rect[0], "x must be clipped");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(0, rect[1], "y must span full viewport (Y-flip of 0..600)");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(200, rect[2], "w must be clipped");
+    TEST_ASSERT_EQUAL_INT_MESSAGE(600, rect[3], "h must span full viewport");
+}
+
+/* clip.horizontal=false, clip.vertical=true: only y is clipped. */
+static void test_scissor_vertical_only(void) {
+    s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
+    s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 50.0F, .y = 100.0F, .width = 200.0F, .height = 50.0F};
+    s_test_cmds[0].renderData.clip.horizontal = false;
+    s_test_cmds[0].renderData.clip.vertical = true;
+    s_test_cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
+    inject_frozen_cmds(2);
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    int rect[4];
+    nt_gfx_test_scissor_rect(rect);
+    /* x = 0, w = 800 (unclipped). y = 100, h = 50 (clipped).
+     * GL Y-flip: y_gl = 600 - 100 - 50 = 450. */
+    TEST_ASSERT_EQUAL_INT(0, rect[0]);
+    TEST_ASSERT_EQUAL_INT(450, rect[1]);
+    TEST_ASSERT_EQUAL_INT(800, rect[2]);
+    TEST_ASSERT_EQUAL_INT(50, rect[3]);
+}
+
+/* Neither axis clipped -> scissor covers the full viewport. */
+static void test_scissor_neither_axis(void) {
+    s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
+    s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 50.0F, .y = 100.0F, .width = 200.0F, .height = 50.0F};
+    s_test_cmds[0].renderData.clip.horizontal = false;
+    s_test_cmds[0].renderData.clip.vertical = false;
+    s_test_cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
+    inject_frozen_cmds(2);
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    int rect[4];
+    nt_gfx_test_scissor_rect(rect);
+    TEST_ASSERT_EQUAL_INT(0, rect[0]);
+    TEST_ASSERT_EQUAL_INT(0, rect[1]);
+    TEST_ASSERT_EQUAL_INT(800, rect[2]);
+    TEST_ASSERT_EQUAL_INT(600, rect[3]);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_scissor_depth_8_ok);
@@ -209,5 +262,8 @@ int main(void) {
     RUN_TEST(test_scissor_intersection_nested);
     RUN_TEST(test_walker_exit_disables_scissor);
     RUN_TEST(test_scissor_respects_viewport_offset);
+    RUN_TEST(test_scissor_horizontal_only);
+    RUN_TEST(test_scissor_vertical_only);
+    RUN_TEST(test_scissor_neither_axis);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_walker_scissor.c
+++ b/tests/unit/test_nt_ui_walker_scissor.c
@@ -18,7 +18,7 @@
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8U];
 static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 32
@@ -52,7 +52,7 @@ static void test_scissor_depth_8_ok(void) {
     }
     inject_frozen_cmds(16);
 
-    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
     TEST_ASSERT_FALSE(nt_gfx_test_scissor_enabled());
@@ -69,7 +69,7 @@ static void test_scissor_depth_9_asserts(void) {
     }
     inject_frozen_cmds(9);
 
-    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }
 
@@ -83,7 +83,7 @@ static void test_scissor_unbalanced_asserts_at_exit(void) {
     s_test_cmds[2].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
     inject_frozen_cmds(3);
 
-    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }
 
@@ -94,13 +94,13 @@ static void test_scissor_unbalanced_asserts_at_exit(void) {
  * the enabled flag. */
 static void test_scissor_y_flip_top_left_to_gl_bottom_left(void) {
     s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
-    s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 100.0f, .y = 100.0f, .width = 200.0f, .height = 200.0f};
+    s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 100.0F, .y = 100.0F, .width = 200.0F, .height = 200.0F};
     s_test_cmds[0].renderData.clip.horizontal = true;
     s_test_cmds[0].renderData.clip.vertical = true;
     s_test_cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
     inject_frozen_cmds(2);
 
-    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
     int rect[4];
@@ -119,11 +119,11 @@ static void test_scissor_y_flip_top_left_to_gl_bottom_left(void) {
 static void test_scissor_intersection_nested(void) {
     /* Outer */
     s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
-    s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 0.0f, .y = 0.0f, .width = 100.0f, .height = 100.0f};
+    s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 100.0F, .height = 100.0F};
     /* Inner -- pre-intersect rect would have been (50,50,150,150) (extending
      * to 200,200), but intersection with outer clips it to (50,50,50,50). */
     s_test_cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
-    s_test_cmds[1].boundingBox = (Clay_BoundingBox){.x = 50.0f, .y = 50.0f, .width = 150.0f, .height = 150.0f};
+    s_test_cmds[1].boundingBox = (Clay_BoundingBox){.x = 50.0F, .y = 50.0F, .width = 150.0F, .height = 150.0F};
     /* Pop inner (we want to inspect the LAST scissor call which was the
      * inner push, but to balance the stack we still need the END. After
      * the END, scissor_pop re-applies the outer rect -- which masks the
@@ -142,7 +142,7 @@ static void test_scissor_intersection_nested(void) {
     s_test_cmds[3].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END; /* close outer */
     inject_frozen_cmds(4);
 
-    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
     /* After scissor_pop of inner, scissor_pop re-applies outer (0, 0, 100, 100).
@@ -168,7 +168,7 @@ static void test_walker_exit_disables_scissor(void) {
     s_test_cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
     inject_frozen_cmds(2);
 
-    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
     TEST_ASSERT_FALSE(nt_gfx_test_scissor_enabled());
@@ -183,13 +183,13 @@ static void test_scissor_respects_viewport_offset(void) {
     /* Local scissor at (10, 10) within a 400x300 viewport that itself
      * starts at framebuffer offset (100, 50). */
     s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
-    s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 10.0f, .y = 10.0f, .width = 100.0f, .height = 100.0f};
+    s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 10.0F, .y = 10.0F, .width = 100.0F, .height = 100.0F};
     s_test_cmds[0].renderData.clip.horizontal = true;
     s_test_cmds[0].renderData.clip.vertical = true;
     s_test_cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
     inject_frozen_cmds(2);
 
-    nt_ui_target_t target = {.viewport = {100.0f, 50.0f, 400.0f, 300.0f}};
+    nt_ui_target_t target = {.viewport = {100.0F, 50.0F, 400.0F, 300.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
     int rect[4];

--- a/tests/unit/test_nt_ui_walker_scissor.c
+++ b/tests/unit/test_nt_ui_walker_scissor.c
@@ -18,7 +18,7 @@
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
-static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8U];
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_DEFAULT_ARENA_SIZE];
 static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 32

--- a/tests/unit/test_nt_ui_walker_scissor.c
+++ b/tests/unit/test_nt_ui_walker_scissor.c
@@ -51,6 +51,41 @@ static void test_scissor_depth_8_ok(void) {
     TEST_ASSERT_FALSE(nt_gfx_test_scissor_enabled());
 }
 
+/* Custom max_scissor_depth via desc: walker stack VLA-sizes to ctx config.
+ * Build a separate ctx with depth=4; pushing 4 scissors must succeed but
+ * pushing a 5th must overflow the per-ctx limit even though the global
+ * #define default is 8. */
+static void test_scissor_depth_custom_via_desc(void) {
+    alignas(NT_UI_ARENA_ALIGN) static uint8_t s_custom_arena[NT_UI_DEFAULT_ARENA_SIZE];
+    const nt_ui_create_desc_t custom_desc = {
+        .max_elements = NT_UI_DEFAULT_MAX_ELEMENT_COUNT,
+        .max_scissor_depth = 4U,
+    };
+    nt_ui_context_t *custom_ctx = nt_ui_create_context(s_custom_arena, sizeof s_custom_arena, &custom_desc);
+    TEST_ASSERT_NOT_NULL(custom_ctx);
+    nt_ui_set_atlas_white_region(custom_ctx, s_fx.atlas.handle, s_fx.atlas.white_region_idx);
+    nt_ui_set_sprite_material(custom_ctx, s_fx.sprite_material);
+    nt_ui_set_text_material(custom_ctx, s_fx.text_material);
+
+    /* Push 5 scissors -> overflow on the 5th. */
+    Clay_RenderCommand local_cmds[5];
+    memset(local_cmds, 0, sizeof local_cmds);
+    for (int32_t i = 0; i < 5; ++i) {
+        local_cmds[i].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
+        local_cmds[i].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 800, .height = 600};
+        local_cmds[i].renderData.clip.horizontal = true;
+        local_cmds[i].renderData.clip.vertical = true;
+    }
+    custom_ctx->frozen_cmds.internalArray = local_cmds;
+    custom_ctx->frozen_cmds.length = 5;
+    custom_ctx->frozen_cmds.capacity = 5;
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    NT_TEST_EXPECT_ASSERT(nt_ui_walk(custom_ctx, &target));
+
+    nt_ui_destroy_context(custom_ctx);
+}
+
 /* 9 nested SCISSOR_START must assert (depth overflow). */
 static void test_scissor_depth_9_asserts(void) {
     for (int32_t i = 0; i < 9; ++i) {
@@ -255,6 +290,7 @@ int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_scissor_depth_8_ok);
     RUN_TEST(test_scissor_depth_9_asserts);
+    RUN_TEST(test_scissor_depth_custom_via_desc);
     RUN_TEST(test_scissor_unbalanced_asserts_at_exit);
     RUN_TEST(test_scissor_y_flip_top_left_to_gl_bottom_left);
     RUN_TEST(test_scissor_intersection_nested);

--- a/tests/unit/test_nt_ui_walker_scissor.c
+++ b/tests/unit/test_nt_ui_walker_scissor.c
@@ -51,10 +51,7 @@ static void test_scissor_depth_8_ok(void) {
     TEST_ASSERT_FALSE(nt_gfx_test_scissor_enabled());
 }
 
-/* Custom max_scissor_depth via desc: walker stack VLA-sizes to ctx config.
- * Build a separate ctx with depth=4; pushing 4 scissors must succeed but
- * pushing a 5th must overflow the per-ctx limit even though the global
- * #define default is 8. */
+/* Per-ctx max_scissor_depth (VLA size) -- depth=4 here, push #5 overflows. */
 static void test_scissor_depth_custom_via_desc(void) {
     alignas(NT_UI_ARENA_ALIGN) static uint8_t s_custom_arena[NT_UI_DEFAULT_ARENA_SIZE];
     const nt_ui_create_desc_t custom_desc = {
@@ -67,7 +64,6 @@ static void test_scissor_depth_custom_via_desc(void) {
     nt_ui_set_sprite_material(custom_ctx, s_fx.sprite_material);
     nt_ui_set_text_material(custom_ctx, s_fx.text_material);
 
-    /* Push 5 scissors -> overflow on the 5th. */
     Clay_RenderCommand local_cmds[5];
     memset(local_cmds, 0, sizeof local_cmds);
     for (int32_t i = 0; i < 5; ++i) {

--- a/tests/unit/test_nt_ui_walker_scissor.c
+++ b/tests/unit/test_nt_ui_walker_scissor.c
@@ -70,8 +70,12 @@ static void test_scissor_depth_9_asserts(void) {
 static void test_scissor_unbalanced_asserts_at_exit(void) {
     s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
     s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 800, .height = 600};
+    s_test_cmds[0].renderData.clip.horizontal = true;
+    s_test_cmds[0].renderData.clip.vertical = true;
     s_test_cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
     s_test_cmds[1].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 800, .height = 600};
+    s_test_cmds[1].renderData.clip.horizontal = true;
+    s_test_cmds[1].renderData.clip.vertical = true;
     s_test_cmds[2].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
     inject_frozen_cmds(3);
 
@@ -145,6 +149,8 @@ static void test_scissor_intersection_nested(void) {
 static void test_walker_exit_disables_scissor(void) {
     s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
     s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 10, .y = 10, .width = 100, .height = 100};
+    s_test_cmds[0].renderData.clip.horizontal = true;
+    s_test_cmds[0].renderData.clip.vertical = true;
     s_test_cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
     inject_frozen_cmds(2);
 

--- a/tests/unit/test_nt_ui_walker_scissor.c
+++ b/tests/unit/test_nt_ui_walker_scissor.c
@@ -1,35 +1,278 @@
-/* tests/unit/test_nt_ui_walker_scissor.c — Plan 52-00 stub
+/* tests/unit/test_nt_ui_walker_scissor.c -- Plan 52-04
  *
- * Covers WALK-02 (walker-local scissor stack ≤8 + balanced exit assert) and
- * WALK-03 (Y-flip top-left → GL bottom-left + intersection at push). Wave 0
- * ships TEST_IGNORE bodies; Plan 52-04 fills with real assertions.
+ * Covers WALK-02 (walker-local scissor stack depth 8 + balanced exit
+ * assert) and WALK-03 (Y-flip top-left -> GL bottom-left + intersection
+ * at push). Death-tests use NT_TEST_EXPECT_ASSERT (Revision Issue 3).
  */
 
+#include <math.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
 
+/* clang-format off */
+#include "atlas/nt_atlas.h"
+#include "clay.h"
+#include "core/nt_assert.h"
+#include "font/nt_font.h"
+#include "graphics/nt_gfx.h"
+#include "hash/nt_hash.h"
+#include "input/nt_input.h"
+#include "material/nt_material.h"
+#include "nt_pack_format.h"
+#include "renderers/nt_sprite_renderer.h"
+#include "renderers/nt_text_renderer.h"
+#include "resource/nt_resource.h"
+#include "test_helpers/nt_assert_trap.h"
+#include "test_helpers/ui_atlas.h"
+#include "ui/nt_ui.h"
+#include "ui/nt_ui_internal.h"
 #include "unity.h"
+/* clang-format on */
 
-void setUp(void) {}
-void tearDown(void) {}
+static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
+static minimal_ui_atlas_t s_atlas;
+static nt_material_t s_sprite_material;
+static nt_material_t s_text_material;
+static nt_ui_context_t *s_ctx;
+static uint32_t s_vpack_counter;
 
-/* WALK-02: 8 nested scissors pushed and popped successfully */
-static void test_scissor_depth_8_ok(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+#define MAX_TEST_CMDS 32
+static Clay_RenderCommand s_test_cmds[MAX_TEST_CMDS];
 
-/* WALK-02: 9th nested scissor asserts (overflow) — death-test */
-static void test_scissor_depth_9_asserts(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+static nt_material_t make_test_material(void) {
+    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "void main(){}", .label = "walker_vs"});
+    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "void main(){}", .label = "walker_fs"});
 
-/* WALK-02: unbalanced stack (more SCISSOR_START than END) asserts at walker exit */
-static void test_scissor_unbalanced_asserts_at_exit(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+    char pack_name[64];
+    char vs_name[64];
+    char fs_name[64];
+    (void)snprintf(pack_name, sizeof pack_name, "walker_mat_pack_%u", s_vpack_counter);
+    (void)snprintf(vs_name, sizeof vs_name, "walker_vs_%u", s_vpack_counter);
+    (void)snprintf(fs_name, sizeof fs_name, "walker_fs_%u", s_vpack_counter);
+    s_vpack_counter++;
 
-/* WALK-03: Clay top-left scissor rect translates to GL bottom-left rect */
-static void test_scissor_y_flip_top_left_to_gl_bottom_left(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+    nt_hash32_t pid = nt_hash32_str(pack_name);
+    nt_hash64_t vs_rid = nt_hash64_str(vs_name);
+    nt_hash64_t fs_rid = nt_hash64_str(fs_name);
 
-/* WALK-03: nested SCISSOR_START intersects with stack top, not replaces */
-static void test_scissor_intersection_nested(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pid, 0));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, vs_rid, NT_ASSET_SHADER_CODE, vs.id));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, fs_rid, NT_ASSET_SHADER_CODE, fs.id));
 
-/* WALK-03 / D-52-17: walker exit disables scissor (nt_gfx_set_scissor_enabled(false)) */
-static void test_walker_exit_disables_scissor(void) { TEST_IGNORE_MESSAGE("Wave 0 stub — filled by plan 52-04"); }
+    nt_resource_t vs_res = nt_resource_request(vs_rid, NT_ASSET_SHADER_CODE);
+    nt_resource_t fs_res = nt_resource_request(fs_rid, NT_ASSET_SHADER_CODE);
+    nt_resource_step();
+
+    nt_material_create_desc_t desc;
+    memset(&desc, 0, sizeof desc);
+    desc.vs = vs_res;
+    desc.fs = fs_res;
+    desc.depth_test = false;
+    desc.depth_write = false;
+    desc.cull_mode = NT_CULL_NONE;
+    desc.color_mode = NT_COLOR_MODE_NONE;
+    desc.label = "walker_test_material";
+
+    nt_material_t mat = nt_material_create(&desc);
+    nt_material_step();
+    return mat;
+}
+
+void setUp(void) {
+    nt_test_assert_install();
+    s_vpack_counter = 0;
+    memset(s_test_cmds, 0, sizeof s_test_cmds);
+
+    nt_hash_init(&(nt_hash_desc_t){0});
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_pipelines = 16, .max_buffers = 64, .max_textures = 32, .max_meshes = 16});
+    nt_resource_init(&(nt_resource_desc_t){0});
+    nt_atlas_init();
+    nt_font_init(&(nt_font_desc_t){.max_fonts = 4});
+    nt_material_init(&(nt_material_desc_t){.max_materials = 32});
+
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+
+    nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
+    nt_text_renderer_init();
+
+    s_atlas = minimal_ui_atlas_create();
+    s_sprite_material = make_test_material();
+    s_text_material = make_test_material();
+
+    nt_ui_set_atlas_white_region(s_atlas.handle, s_atlas.white_region_idx);
+    nt_ui_set_sprite_material(s_sprite_material);
+    nt_ui_set_text_material(s_text_material);
+    nt_ui_set_custom_handler(NULL, NULL);
+
+    s_ctx = nt_ui_create_context(s_arena, sizeof s_arena);
+    TEST_ASSERT_NOT_NULL(s_ctx);
+}
+
+void tearDown(void) {
+    if (s_ctx != NULL) {
+        nt_ui_destroy_context(s_ctx);
+        s_ctx = NULL;
+    }
+    nt_ui_test_reset_walker_globals();
+    minimal_ui_atlas_destroy(&s_atlas);
+    nt_sprite_renderer_shutdown();
+    nt_text_renderer_shutdown();
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+    nt_material_shutdown();
+    nt_font_shutdown();
+    nt_atlas_test_reset();
+    nt_resource_shutdown();
+    nt_gfx_shutdown();
+    nt_hash_shutdown();
+}
+
+static void inject_frozen_cmds(int32_t count) {
+    s_ctx->frozen_cmds.internalArray = s_test_cmds;
+    s_ctx->frozen_cmds.length = count;
+    s_ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
+}
+
+/* WALK-02: 8 nested SCISSOR_START / 8 SCISSOR_END must succeed (depth 8
+ * is at the limit but not over). */
+static void test_scissor_depth_8_ok(void) {
+    for (int32_t i = 0; i < 8; ++i) {
+        s_test_cmds[i].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
+        s_test_cmds[i].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 800, .height = 600};
+        s_test_cmds[i].renderData.clip.horizontal = true;
+        s_test_cmds[i].renderData.clip.vertical = true;
+    }
+    for (int32_t i = 8; i < 16; ++i) {
+        s_test_cmds[i].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
+    }
+    inject_frozen_cmds(16);
+
+    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_walk(s_ctx, &target);
+
+    TEST_ASSERT_FALSE(nt_gfx_test_scissor_enabled());
+}
+
+/* WALK-02 death-test: 9 nested SCISSOR_START must assert (depth overflow).
+ * Wrapped in NT_TEST_EXPECT_ASSERT (Revision Issue 3). */
+static void test_scissor_depth_9_asserts(void) {
+    for (int32_t i = 0; i < 9; ++i) {
+        s_test_cmds[i].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
+        s_test_cmds[i].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 800, .height = 600};
+        s_test_cmds[i].renderData.clip.horizontal = true;
+        s_test_cmds[i].renderData.clip.vertical = true;
+    }
+    inject_frozen_cmds(9);
+
+    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_ctx, &target));
+}
+
+/* WALK-02 death-test: 2 SCISSOR_START + 1 SCISSOR_END leaves depth > 0
+ * at walk exit -> the final NT_ASSERT(depth == 0) must fire. */
+static void test_scissor_unbalanced_asserts_at_exit(void) {
+    s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
+    s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 800, .height = 600};
+    s_test_cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
+    s_test_cmds[1].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 800, .height = 600};
+    s_test_cmds[2].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
+    inject_frozen_cmds(3);
+
+    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_ctx, &target));
+}
+
+/* WALK-03: Clay scissor (x=100, y=100, w=200, h=200) inside an 800x600 viewport
+ * must produce GL scissor at (100, 600 - 100 - 200 = 300, 200, 200). The
+ * scissor is disabled at walk exit; we observe the LAST set_scissor rect via
+ * the gfx test probe, which retains the most-recent values regardless of
+ * the enabled flag. */
+static void test_scissor_y_flip_top_left_to_gl_bottom_left(void) {
+    s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
+    s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 100.0f, .y = 100.0f, .width = 200.0f, .height = 200.0f};
+    s_test_cmds[0].renderData.clip.horizontal = true;
+    s_test_cmds[0].renderData.clip.vertical = true;
+    s_test_cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
+    inject_frozen_cmds(2);
+
+    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_walk(s_ctx, &target);
+
+    int rect[4];
+    nt_gfx_test_scissor_rect(rect);
+    /* GL bottom-left form: y_gl = fb_h - y - h = 600 - 100 - 200 = 300. */
+    TEST_ASSERT_EQUAL_INT(100, rect[0]);
+    TEST_ASSERT_EQUAL_INT(300, rect[1]);
+    TEST_ASSERT_EQUAL_INT(200, rect[2]);
+    TEST_ASSERT_EQUAL_INT(200, rect[3]);
+}
+
+/* WALK-03 / D-52-17: nested SCISSOR_START intersects with stack top.
+ * Outer (0..100, 0..100), inner (50..200, 50..200) -> intersection
+ * (50..100, 50..100) i.e. (x=50, y=50, w=50, h=50) in Clay's top-left
+ * space. After Y-flip in a 600-tall fb: y_gl = 600 - 50 - 50 = 500. */
+static void test_scissor_intersection_nested(void) {
+    /* Outer */
+    s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
+    s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 0.0f, .y = 0.0f, .width = 100.0f, .height = 100.0f};
+    /* Inner -- pre-intersect rect would have been (50,50,150,150) (extending
+     * to 200,200), but intersection with outer clips it to (50,50,50,50). */
+    s_test_cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
+    s_test_cmds[1].boundingBox = (Clay_BoundingBox){.x = 50.0f, .y = 50.0f, .width = 150.0f, .height = 150.0f};
+    /* Pop inner (we want to inspect the LAST scissor call which was the
+     * inner push, but to balance the stack we still need the END. After
+     * the END, scissor_pop re-applies the outer rect -- which masks the
+     * inner's value. So we close with only the outer END here. Wait: that
+     * leaves a depth-1 stack at exit, asserting on `depth == 0`. We must
+     * close both. Workaround: end inner BEFORE walker would re-apply -- not
+     * possible; the rect-replay is built-in. Solution: snapshot via an
+     * intermediate RECT between inner-push and outer-pop. We instead test
+     * the intersection by capturing the rect via nt_gfx probes mid-walk
+     * through the FINAL inner push -- but the walker exits before we can
+     * peek. Therefore: pop in REVERSE order (close inner first, then outer),
+     * and verify the FIRST inner intersection happened by checking the
+     * outer rect from the FINAL scissor_pop (depth==1) call. Outer is
+     * (0, 0, 100, 100) -- after pop of inner the walker re-applies that. */
+    s_test_cmds[2].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END; /* close inner */
+    s_test_cmds[3].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END; /* close outer */
+    inject_frozen_cmds(4);
+
+    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_walk(s_ctx, &target);
+
+    /* After scissor_pop of inner, scissor_pop re-applies outer (0, 0, 100, 100).
+     * That's the second-to-last set_scissor call. The actual LAST call is
+     * nt_gfx_set_scissor_enabled(false) at walk exit, which does NOT
+     * overwrite the rect. So nt_gfx_test_scissor_rect still reads back
+     * the OUTER rect after pop-inner (the LAST set_scissor call).
+     *
+     * Outer in GL bottom-left: y_gl = 600 - 0 - 100 = 500. */
+    int rect[4];
+    nt_gfx_test_scissor_rect(rect);
+    TEST_ASSERT_EQUAL_INT(0, rect[0]);
+    TEST_ASSERT_EQUAL_INT(500, rect[1]);
+    TEST_ASSERT_EQUAL_INT(100, rect[2]);
+    TEST_ASSERT_EQUAL_INT(100, rect[3]);
+}
+
+/* WALK-03 / D-52-17: walker exit always disables scissor, even if scissor
+ * was enabled mid-walk. */
+static void test_walker_exit_disables_scissor(void) {
+    s_test_cmds[0].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
+    s_test_cmds[0].boundingBox = (Clay_BoundingBox){.x = 10, .y = 10, .width = 100, .height = 100};
+    s_test_cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
+    inject_frozen_cmds(2);
+
+    nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
+    nt_ui_walk(s_ctx, &target);
+
+    TEST_ASSERT_FALSE(nt_gfx_test_scissor_enabled());
+}
 
 int main(void) {
     UNITY_BEGIN();

--- a/tests/unit/test_nt_ui_walker_scissor.c
+++ b/tests/unit/test_nt_ui_walker_scissor.c
@@ -110,13 +110,13 @@ void setUp(void) {
     s_sprite_material = make_test_material();
     s_text_material = make_test_material();
 
-    nt_ui_set_atlas_white_region(s_atlas.handle, s_atlas.white_region_idx);
-    nt_ui_set_sprite_material(s_sprite_material);
-    nt_ui_set_text_material(s_text_material);
-    nt_ui_set_custom_handler(NULL, NULL);
-
     s_ctx = nt_ui_create_context(s_arena, sizeof s_arena);
     TEST_ASSERT_NOT_NULL(s_ctx);
+
+    nt_ui_set_atlas_white_region(s_ctx, s_atlas.handle, s_atlas.white_region_idx);
+    nt_ui_set_sprite_material(s_ctx, s_sprite_material);
+    nt_ui_set_text_material(s_ctx, s_text_material);
+    nt_ui_set_custom_handler(s_ctx, NULL, NULL);
 }
 
 void tearDown(void) {
@@ -124,7 +124,6 @@ void tearDown(void) {
         nt_ui_destroy_context(s_ctx);
         s_ctx = NULL;
     }
-    nt_ui_test_reset_walker_globals();
     minimal_ui_atlas_destroy(&s_atlas);
     nt_stats_shutdown();
     nt_sprite_renderer_shutdown();

--- a/tests/unit/test_nt_ui_walker_scissor.c
+++ b/tests/unit/test_nt_ui_walker_scissor.c
@@ -5,143 +5,37 @@
  * at push). Death-tests use NT_TEST_EXPECT_ASSERT (Revision Issue 3).
  */
 
-#include <math.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
-#include <stdlib.h>
 #include <string.h>
 
-/* clang-format off */
-#include "atlas/nt_atlas.h"
 #include "clay.h"
-#include "core/nt_assert.h"
-#include "font/nt_font.h"
 #include "graphics/nt_gfx.h"
-#include "hash/nt_hash.h"
-#include "input/nt_input.h"
-#include "material/nt_material.h"
-#include "nt_pack_format.h"
-#include "renderers/nt_sprite_renderer.h"
-#include "renderers/nt_text_renderer.h"
-#include "resource/nt_resource.h"
-#include "stats/nt_stats.h"
 #include "test_helpers/nt_assert_trap.h"
-#include "test_helpers/ui_atlas.h"
+#include "test_helpers/ui_walker_fixture.h"
 #include "ui/nt_ui.h"
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
-/* clang-format on */
 
 static uint64_t s_arena[NT_UI_DEFAULT_ARENA_SIZE / 8u];
-static minimal_ui_atlas_t s_atlas;
-static nt_material_t s_sprite_material;
-static nt_material_t s_text_material;
-static nt_ui_context_t *s_ctx;
-static uint32_t s_vpack_counter;
+static ui_walker_fixture_t s_fx;
 
 #define MAX_TEST_CMDS 32
 static Clay_RenderCommand s_test_cmds[MAX_TEST_CMDS];
 
-static nt_material_t make_test_material(void) {
-    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "void main(){}", .label = "walker_vs"});
-    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "void main(){}", .label = "walker_fs"});
-
-    char pack_name[64];
-    char vs_name[64];
-    char fs_name[64];
-    (void)snprintf(pack_name, sizeof pack_name, "walker_mat_pack_%u", s_vpack_counter);
-    (void)snprintf(vs_name, sizeof vs_name, "walker_vs_%u", s_vpack_counter);
-    (void)snprintf(fs_name, sizeof fs_name, "walker_fs_%u", s_vpack_counter);
-    s_vpack_counter++;
-
-    nt_hash32_t pid = nt_hash32_str(pack_name);
-    nt_hash64_t vs_rid = nt_hash64_str(vs_name);
-    nt_hash64_t fs_rid = nt_hash64_str(fs_name);
-
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pid, 0));
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, vs_rid, NT_ASSET_SHADER_CODE, vs.id));
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, fs_rid, NT_ASSET_SHADER_CODE, fs.id));
-
-    nt_resource_t vs_res = nt_resource_request(vs_rid, NT_ASSET_SHADER_CODE);
-    nt_resource_t fs_res = nt_resource_request(fs_rid, NT_ASSET_SHADER_CODE);
-    nt_resource_step();
-
-    nt_material_create_desc_t desc;
-    memset(&desc, 0, sizeof desc);
-    desc.vs = vs_res;
-    desc.fs = fs_res;
-    desc.depth_test = false;
-    desc.depth_write = false;
-    desc.cull_mode = NT_CULL_NONE;
-    desc.color_mode = NT_COLOR_MODE_NONE;
-    desc.label = "walker_test_material";
-
-    nt_material_t mat = nt_material_create(&desc);
-    nt_material_step();
-    return mat;
-}
-
 void setUp(void) {
     nt_test_assert_install();
-    s_vpack_counter = 0;
     memset(s_test_cmds, 0, sizeof s_test_cmds);
-
-    nt_hash_init(&(nt_hash_desc_t){0});
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_pipelines = 16, .max_buffers = 64, .max_textures = 32, .max_meshes = 16});
-    nt_resource_init(&(nt_resource_desc_t){0});
-    nt_atlas_init();
-    nt_font_init(&(nt_font_desc_t){.max_fonts = 4});
-    nt_material_init(&(nt_material_desc_t){.max_materials = 32});
-
-    nt_gfx_begin_frame();
-    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
-
-    nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
-    nt_text_renderer_init();
-
-    /* nt_stats_init required: Plan 52-05 wired nt_stats_count("ui_draw_calls", ...)
-     * + nt_stats_count("ui_element_count", ...) at nt_ui_walk exit. Without init,
-     * nt_stats_count's NT_ASSERT(s_stats.initialized) trips on every walk. */
-    nt_stats_init(NULL);
-
-    s_atlas = minimal_ui_atlas_create();
-    s_sprite_material = make_test_material();
-    s_text_material = make_test_material();
-
-    s_ctx = nt_ui_create_context(s_arena, sizeof s_arena);
-    TEST_ASSERT_NOT_NULL(s_ctx);
-
-    nt_ui_set_atlas_white_region(s_ctx, s_atlas.handle, s_atlas.white_region_idx);
-    nt_ui_set_sprite_material(s_ctx, s_sprite_material);
-    nt_ui_set_text_material(s_ctx, s_text_material);
-    nt_ui_set_custom_handler(s_ctx, NULL, NULL);
+    ui_walker_fixture_init(&s_fx, s_arena, sizeof s_arena, UI_WALKER_FX_BIND_ALL);
 }
 
-void tearDown(void) {
-    if (s_ctx != NULL) {
-        nt_ui_destroy_context(s_ctx);
-        s_ctx = NULL;
-    }
-    minimal_ui_atlas_destroy(&s_atlas);
-    nt_stats_shutdown();
-    nt_sprite_renderer_shutdown();
-    nt_text_renderer_shutdown();
-    nt_gfx_end_pass();
-    nt_gfx_end_frame();
-    nt_material_shutdown();
-    nt_font_shutdown();
-    nt_atlas_test_reset();
-    nt_resource_shutdown();
-    nt_gfx_shutdown();
-    nt_hash_shutdown();
-}
+void tearDown(void) { ui_walker_fixture_shutdown(&s_fx); }
 
 static void inject_frozen_cmds(int32_t count) {
-    s_ctx->frozen_cmds.internalArray = s_test_cmds;
-    s_ctx->frozen_cmds.length = count;
-    s_ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
+    s_fx.ctx->frozen_cmds.internalArray = s_test_cmds;
+    s_fx.ctx->frozen_cmds.length = count;
+    s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
 }
 
 /* WALK-02: 8 nested SCISSOR_START / 8 SCISSOR_END must succeed (depth 8
@@ -159,7 +53,7 @@ static void test_scissor_depth_8_ok(void) {
     inject_frozen_cmds(16);
 
     nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
     TEST_ASSERT_FALSE(nt_gfx_test_scissor_enabled());
 }
@@ -176,7 +70,7 @@ static void test_scissor_depth_9_asserts(void) {
     inject_frozen_cmds(9);
 
     nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
-    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_ctx, &target));
+    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }
 
 /* WALK-02 death-test: 2 SCISSOR_START + 1 SCISSOR_END leaves depth > 0
@@ -190,7 +84,7 @@ static void test_scissor_unbalanced_asserts_at_exit(void) {
     inject_frozen_cmds(3);
 
     nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
-    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_ctx, &target));
+    NT_TEST_EXPECT_ASSERT(nt_ui_walk(s_fx.ctx, &target));
 }
 
 /* WALK-03: Clay scissor (x=100, y=100, w=200, h=200) inside an 800x600 viewport
@@ -207,7 +101,7 @@ static void test_scissor_y_flip_top_left_to_gl_bottom_left(void) {
     inject_frozen_cmds(2);
 
     nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
     int rect[4];
     nt_gfx_test_scissor_rect(rect);
@@ -249,7 +143,7 @@ static void test_scissor_intersection_nested(void) {
     inject_frozen_cmds(4);
 
     nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
     /* After scissor_pop of inner, scissor_pop re-applies outer (0, 0, 100, 100).
      * That's the second-to-last set_scissor call. The actual LAST call is
@@ -275,7 +169,7 @@ static void test_walker_exit_disables_scissor(void) {
     inject_frozen_cmds(2);
 
     nt_ui_target_t target = {.viewport = {0.0f, 0.0f, 800.0f, 600.0f}};
-    nt_ui_walk(s_ctx, &target);
+    nt_ui_walk(s_fx.ctx, &target);
 
     TEST_ASSERT_FALSE(nt_gfx_test_scissor_enabled());
 }

--- a/tests/unit/test_shape.c
+++ b/tests/unit/test_shape.c
@@ -1,4 +1,4 @@
-/* NT_SHAPE_RENDERER_TEST_ACCESS defined via CMake target_compile_definitions */
+/* NT_TEST_ACCESS defined via CMake target_compile_definitions */
 #include "graphics/nt_gfx.h"
 #include "renderers/nt_shape_renderer.h"
 #include "unity.h"

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -6,7 +6,7 @@
 #include <string.h>
 
 /* clang-format off */
-/* NT_SPRITE_RENDERER_TEST_ACCESS / NT_ATLAS_TEST_ACCESS provided via CMake */
+/* NT_TEST_ACCESS / NT_TEST_ACCESS provided via CMake */
 #include "atlas/nt_atlas.h"
 #include "drawable_comp/nt_drawable_comp.h"
 #include "entity/nt_entity.h"

--- a/tests/unit/test_stats.c
+++ b/tests/unit/test_stats.c
@@ -233,13 +233,15 @@ static void test_stats_draw_pitfall9_explicit_set_calls(void) {
     const float identity[16] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
     const float white[4] = {1, 1, 1, 1};
 
-    nt_stats_draw(mat, font, identity, 16.0F, white);
+    /* draw_n asserts on font.id==0 (contract: caller must set_font first).
+     * Setters fire BEFORE the assert, so counters survive the longjmp. */
+    EXPECT_ASSERT(nt_stats_draw(mat, font, identity, 16.0F, white));
     TEST_ASSERT_EQUAL_UINT32(1U, nt_text_renderer_test_set_material_calls());
     TEST_ASSERT_EQUAL_UINT32(1U, nt_text_renderer_test_set_font_calls());
 
     /* Second call with SAME material/font: still increments because the
      * caller (nt_stats_draw) ALWAYS calls both setters explicitly. */
-    nt_stats_draw(mat, font, identity, 16.0F, white);
+    EXPECT_ASSERT(nt_stats_draw(mat, font, identity, 16.0F, white));
     TEST_ASSERT_EQUAL_UINT32(2U, nt_text_renderer_test_set_material_calls());
     TEST_ASSERT_EQUAL_UINT32(2U, nt_text_renderer_test_set_font_calls());
 

--- a/tests/unit/test_stats.c
+++ b/tests/unit/test_stats.c
@@ -233,17 +233,17 @@ static void test_stats_draw_pitfall9_explicit_set_calls(void) {
     const float identity[16] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
     const float white[4] = {1, 1, 1, 1};
 
-    /* draw_n asserts on font.id==0 (contract: caller must set_font first).
-     * Setters fire BEFORE the assert, so counters survive the longjmp. */
+    /* set_material now fail-fast asserts on invalid handle BEFORE the
+     * same-handle early-return, so {0} mat trips the assert in
+     * set_material (counter incremented first), and set_font is never
+     * reached. The counter delta still proves nt_stats_draw doesn't cache. */
     EXPECT_ASSERT(nt_stats_draw(mat, font, identity, 16.0F, white));
     TEST_ASSERT_EQUAL_UINT32(1U, nt_text_renderer_test_set_material_calls());
-    TEST_ASSERT_EQUAL_UINT32(1U, nt_text_renderer_test_set_font_calls());
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_text_renderer_test_set_font_calls());
 
-    /* Second call with SAME material/font: still increments because the
-     * caller (nt_stats_draw) ALWAYS calls both setters explicitly. */
     EXPECT_ASSERT(nt_stats_draw(mat, font, identity, 16.0F, white));
     TEST_ASSERT_EQUAL_UINT32(2U, nt_text_renderer_test_set_material_calls());
-    TEST_ASSERT_EQUAL_UINT32(2U, nt_text_renderer_test_set_font_calls());
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_text_renderer_test_set_font_calls());
 
     nt_stats_shutdown();
 }

--- a/tests/unit/test_text_renderer.c
+++ b/tests/unit/test_text_renderer.c
@@ -174,7 +174,7 @@ void tearDown(void) {
 /* ---- Test 1: UTF-8 decode ASCII (TEXT-03) ---- */
 
 void test_utf8_decode_ascii(void) {
-    nt_text_renderer_draw("ABC", s_identity, 32.0F, s_white);
+    nt_text_renderer_draw("ABC", s_identity, 32.0F, s_white, 0.0F);
     TEST_ASSERT_EQUAL_UINT32(3, nt_text_renderer_test_glyph_count());
 }
 
@@ -183,7 +183,7 @@ void test_utf8_decode_ascii(void) {
 void test_utf8_decode_cyrillic(void) {
     /* "При" in Russian = 3 codepoints, 6 bytes */
     /* These are non-ASCII, so they won't be in our test font -> tofu glyphs */
-    nt_text_renderer_draw("\xd0\x9f\xd1\x80\xd0\xb8", s_identity, 32.0F, s_white);
+    nt_text_renderer_draw("\xd0\x9f\xd1\x80\xd0\xb8", s_identity, 32.0F, s_white, 0.0F);
     /* Tofu glyphs still produce quads (has visible bbox) */
     TEST_ASSERT_EQUAL_UINT32(3, nt_text_renderer_test_glyph_count());
 }
@@ -192,7 +192,7 @@ void test_utf8_decode_cyrillic(void) {
 
 void test_utf8_decode_cjk(void) {
     /* "你好" = 2 codepoints, 6 bytes */
-    nt_text_renderer_draw("\xe4\xbd\xa0\xe5\xa5\xbd", s_identity, 32.0F, s_white);
+    nt_text_renderer_draw("\xe4\xbd\xa0\xe5\xa5\xbd", s_identity, 32.0F, s_white, 0.0F);
     TEST_ASSERT_EQUAL_UINT32(2, nt_text_renderer_test_glyph_count());
 }
 
@@ -200,7 +200,7 @@ void test_utf8_decode_cjk(void) {
 
 void test_measure_returns_nonzero(void) {
     /* "ABC" -> all in test font with advance=500, units_per_em=1000 */
-    nt_text_size_t sz = nt_font_measure(s_font, "ABC", 32.0F);
+    nt_text_size_t sz = nt_font_measure(s_font, "ABC", 32.0F, 0.0F);
     TEST_ASSERT_TRUE(sz.width > 0.0F);
     TEST_ASSERT_TRUE(sz.height > 0.0F);
 }
@@ -208,7 +208,7 @@ void test_measure_returns_nonzero(void) {
 /* ---- Test 5: Measure empty string (TEXT-02 edge) ---- */
 
 void test_measure_empty_string(void) {
-    nt_text_size_t sz = nt_font_measure(s_font, "", 32.0F);
+    nt_text_size_t sz = nt_font_measure(s_font, "", 32.0F, 0.0F);
     TEST_ASSERT_TRUE(sz.width == 0.0F);
     TEST_ASSERT_TRUE(sz.height == 0.0F);
 }
@@ -216,7 +216,7 @@ void test_measure_empty_string(void) {
 /* ---- Test 6: Measure NULL string (TEXT-02 edge) ---- */
 
 void test_measure_null_string(void) {
-    nt_text_size_t sz = nt_font_measure(s_font, NULL, 32.0F);
+    nt_text_size_t sz = nt_font_measure(s_font, NULL, 32.0F, 0.0F);
     TEST_ASSERT_TRUE(sz.width == 0.0F);
     TEST_ASSERT_TRUE(sz.height == 0.0F);
 }
@@ -224,7 +224,7 @@ void test_measure_null_string(void) {
 /* ---- Test 7: Vertex stride is 68 bytes (TEXT-01) ---- */
 
 void test_vertex_stride_68(void) {
-    nt_text_renderer_draw("A", s_identity, 32.0F, s_white);
+    nt_text_renderer_draw("A", s_identity, 32.0F, s_white, 0.0F);
     TEST_ASSERT_EQUAL_UINT32(1, nt_text_renderer_test_glyph_count());
 
     /* 4 vertices for one glyph, at 68 bytes stride */
@@ -239,7 +239,7 @@ void test_vertex_stride_68(void) {
 /* ---- Test 8: 4 vertices per glyph (TEXT-01) ---- */
 
 void test_vertex_count_4_per_glyph(void) {
-    nt_text_renderer_draw("AB", s_identity, 32.0F, s_white);
+    nt_text_renderer_draw("AB", s_identity, 32.0F, s_white, 0.0F);
     /* 2 visible glyphs -> 8 vertices */
     TEST_ASSERT_EQUAL_UINT32(8, nt_text_renderer_test_vertex_count());
 }
@@ -247,7 +247,7 @@ void test_vertex_count_4_per_glyph(void) {
 /* ---- Test 9: Flush resets counts (TEXT-05) ---- */
 
 void test_flush_resets_counts(void) {
-    nt_text_renderer_draw("A", s_identity, 32.0F, s_white);
+    nt_text_renderer_draw("A", s_identity, 32.0F, s_white, 0.0F);
     TEST_ASSERT_GREATER_THAN(0U, nt_text_renderer_test_glyph_count());
 
     nt_text_renderer_flush();
@@ -258,15 +258,15 @@ void test_flush_resets_counts(void) {
 /* ---- Test 10: Measure width increases with more chars (TEXT-04) ---- */
 
 void test_measure_width_increases(void) {
-    nt_text_size_t sz_a = nt_font_measure(s_font, "A", 32.0F);
-    nt_text_size_t sz_ab = nt_font_measure(s_font, "AB", 32.0F);
+    nt_text_size_t sz_a = nt_font_measure(s_font, "A", 32.0F, 0.0F);
+    nt_text_size_t sz_ab = nt_font_measure(s_font, "AB", 32.0F, 0.0F);
     TEST_ASSERT_TRUE(sz_ab.width > sz_a.width);
 }
 
 /* ---- Test 11: Newlines reset x and advance y ---- */
 
 void test_draw_newline_advances_to_next_line(void) {
-    nt_text_renderer_draw("A\nB", s_identity, 32.0F, s_white);
+    nt_text_renderer_draw("A\nB", s_identity, 32.0F, s_white, 0.0F);
     TEST_ASSERT_EQUAL_UINT32(2, nt_text_renderer_test_glyph_count());
 
     const uint8_t *verts = (const uint8_t *)nt_text_renderer_test_vertices();
@@ -289,7 +289,7 @@ void test_draw_newline_advances_to_next_line(void) {
 
 void test_draw_n_matches_draw(void) {
     /* Capture vertex stream from existing _draw on NUL-terminated "AB" */
-    nt_text_renderer_draw("AB", s_identity, 32.0F, s_white);
+    nt_text_renderer_draw("AB", s_identity, 32.0F, s_white, 0.0F);
     const uint32_t draw_vcount = nt_text_renderer_test_vertex_count();
     const uint32_t draw_gcount = nt_text_renderer_test_glyph_count();
     TEST_ASSERT_EQUAL_UINT32(8U, draw_vcount); /* 2 visible glyphs × 4 verts */
@@ -306,7 +306,7 @@ void test_draw_n_matches_draw(void) {
     TEST_ASSERT_EQUAL_UINT32(0U, nt_text_renderer_test_vertex_count());
 
     /* Call length-aware variant with matching length */
-    nt_text_renderer_draw_n("AB", 2U, s_identity, 32.0F, s_white);
+    nt_text_renderer_draw_n("AB", 2U, s_identity, 32.0F, s_white, 0.0F);
     const uint32_t draw_n_vcount = nt_text_renderer_test_vertex_count();
     const uint32_t draw_n_gcount = nt_text_renderer_test_glyph_count();
 
@@ -315,11 +315,34 @@ void test_draw_n_matches_draw(void) {
     TEST_ASSERT_EQUAL_MEMORY(buf_draw, nt_text_renderer_test_vertices(), bytes_to_copy);
 }
 
+/* ---- Test 13b: letter_spacing shifts subsequent glyphs by spacing pixels ---- */
+
+void test_draw_n_letter_spacing_advances_pen(void) {
+    /* Baseline: AB with zero spacing -- second glyph's first vertex x at advance(A). */
+    nt_text_renderer_draw_n("AB", 2U, s_identity, 32.0F, s_white, 0.0F);
+    TEST_ASSERT_EQUAL_UINT32(8U, nt_text_renderer_test_vertex_count());
+    const uint8_t *vraw = (const uint8_t *)nt_text_renderer_test_vertices();
+    float base_b_x = 0.0F;
+    memcpy(&base_b_x, vraw + ((size_t)4U * 68U), sizeof(float));
+
+    nt_text_renderer_flush();
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_text_renderer_test_vertex_count());
+
+    /* Same call with spacing=7: B's first vertex shifts by exactly 7 px. */
+    nt_text_renderer_draw_n("AB", 2U, s_identity, 32.0F, s_white, 7.0F);
+    const uint8_t *vspaced = (const uint8_t *)nt_text_renderer_test_vertices();
+    float spaced_b_x = 0.0F;
+    memcpy(&spaced_b_x, vspaced + ((size_t)4U * 68U), sizeof(float));
+
+    /* UNITY_EXCLUDE_FLOAT in this build: int-truncate to compare. */
+    TEST_ASSERT_EQUAL_INT32((int32_t)(base_b_x + 7.0F), (int32_t)spaced_b_x);
+}
+
 /* ---- Test 13: TEXT-01b — poisoned byte at utf8[len] does NOT contribute (no over-read) ---- */
 
 void test_draw_n_does_not_over_read(void) {
     /* Reference: _draw on the clean "AB" string */
-    nt_text_renderer_draw("AB", s_identity, 32.0F, s_white);
+    nt_text_renderer_draw("AB", s_identity, 32.0F, s_white, 0.0F);
     const uint32_t ref_vcount = nt_text_renderer_test_vertex_count();
     TEST_ASSERT_EQUAL_UINT32(8U, ref_vcount);
 
@@ -335,7 +358,7 @@ void test_draw_n_does_not_over_read(void) {
      * bugprone-not-null-terminated-result (matches test_font.c precedent). */
     const char buf[8] = {'A', 'B', 'X', 'X', 'X', 'X', 'X', 'X'};
 
-    nt_text_renderer_draw_n(buf, 2U, s_identity, 32.0F, s_white);
+    nt_text_renderer_draw_n(buf, 2U, s_identity, 32.0F, s_white, 0.0F);
     const uint32_t bounded_vcount = nt_text_renderer_test_vertex_count();
 
     TEST_ASSERT_EQUAL_UINT32(ref_vcount, bounded_vcount);
@@ -353,7 +376,7 @@ static void bench_draw_short_warm(void) {
     const int n_calls = 1000;
     const uint64_t t0 = nt_time_nanos();
     for (int i = 0; i < n_calls; i++) {
-        nt_text_renderer_draw_n("ABC", 3U, s_identity, 32.0F, s_white);
+        nt_text_renderer_draw_n("ABC", 3U, s_identity, 32.0F, s_white, 0.0F);
         nt_text_renderer_flush(); /* exclude buffer-overflow path from timing */
     }
     const uint64_t t1 = nt_time_nanos();
@@ -373,7 +396,7 @@ static void bench_draw_mixed_ui(void) {
 
     /* Warm up the glyph cache once. */
     for (int i = 0; i < label_count; i++) {
-        nt_text_renderer_draw_n(labels[i], lens[i], s_identity, 32.0F, s_white);
+        nt_text_renderer_draw_n(labels[i], lens[i], s_identity, 32.0F, s_white, 0.0F);
     }
     nt_text_renderer_flush();
 
@@ -382,7 +405,7 @@ static void bench_draw_mixed_ui(void) {
     const uint64_t t0 = nt_time_nanos();
     for (int f = 0; f < frames; f++) {
         for (int i = 0; i < label_count; i++) {
-            nt_text_renderer_draw_n(labels[i], lens[i], s_identity, 32.0F, s_white);
+            nt_text_renderer_draw_n(labels[i], lens[i], s_identity, 32.0F, s_white, 0.0F);
             total_calls++;
         }
         nt_text_renderer_flush();
@@ -410,6 +433,7 @@ int main(void) {
     RUN_TEST(test_measure_width_increases);
     RUN_TEST(test_draw_newline_advances_to_next_line);
     RUN_TEST(test_draw_n_matches_draw);
+    RUN_TEST(test_draw_n_letter_spacing_advances_pen);
     RUN_TEST(test_draw_n_does_not_over_read);
     RUN_TEST(bench_draw_short_warm);
     RUN_TEST(bench_draw_mixed_ui);

--- a/tests/unit/test_text_renderer.c
+++ b/tests/unit/test_text_renderer.c
@@ -174,7 +174,7 @@ void tearDown(void) {
 /* ---- Test 1: UTF-8 decode ASCII (TEXT-03) ---- */
 
 void test_utf8_decode_ascii(void) {
-    nt_text_renderer_draw("ABC", s_identity, 32.0F, s_white, 0.0F);
+    nt_text_renderer_draw("ABC", s_identity, 32.0F, s_white, 0.0F, 0.0F);
     TEST_ASSERT_EQUAL_UINT32(3, nt_text_renderer_test_glyph_count());
 }
 
@@ -183,7 +183,7 @@ void test_utf8_decode_ascii(void) {
 void test_utf8_decode_cyrillic(void) {
     /* "При" in Russian = 3 codepoints, 6 bytes */
     /* These are non-ASCII, so they won't be in our test font -> tofu glyphs */
-    nt_text_renderer_draw("\xd0\x9f\xd1\x80\xd0\xb8", s_identity, 32.0F, s_white, 0.0F);
+    nt_text_renderer_draw("\xd0\x9f\xd1\x80\xd0\xb8", s_identity, 32.0F, s_white, 0.0F, 0.0F);
     /* Tofu glyphs still produce quads (has visible bbox) */
     TEST_ASSERT_EQUAL_UINT32(3, nt_text_renderer_test_glyph_count());
 }
@@ -192,7 +192,7 @@ void test_utf8_decode_cyrillic(void) {
 
 void test_utf8_decode_cjk(void) {
     /* "你好" = 2 codepoints, 6 bytes */
-    nt_text_renderer_draw("\xe4\xbd\xa0\xe5\xa5\xbd", s_identity, 32.0F, s_white, 0.0F);
+    nt_text_renderer_draw("\xe4\xbd\xa0\xe5\xa5\xbd", s_identity, 32.0F, s_white, 0.0F, 0.0F);
     TEST_ASSERT_EQUAL_UINT32(2, nt_text_renderer_test_glyph_count());
 }
 
@@ -224,7 +224,7 @@ void test_measure_null_string(void) {
 /* ---- Test 7: Vertex stride is 68 bytes (TEXT-01) ---- */
 
 void test_vertex_stride_68(void) {
-    nt_text_renderer_draw("A", s_identity, 32.0F, s_white, 0.0F);
+    nt_text_renderer_draw("A", s_identity, 32.0F, s_white, 0.0F, 0.0F);
     TEST_ASSERT_EQUAL_UINT32(1, nt_text_renderer_test_glyph_count());
 
     /* 4 vertices for one glyph, at 68 bytes stride */
@@ -239,7 +239,7 @@ void test_vertex_stride_68(void) {
 /* ---- Test 8: 4 vertices per glyph (TEXT-01) ---- */
 
 void test_vertex_count_4_per_glyph(void) {
-    nt_text_renderer_draw("AB", s_identity, 32.0F, s_white, 0.0F);
+    nt_text_renderer_draw("AB", s_identity, 32.0F, s_white, 0.0F, 0.0F);
     /* 2 visible glyphs -> 8 vertices */
     TEST_ASSERT_EQUAL_UINT32(8, nt_text_renderer_test_vertex_count());
 }
@@ -247,7 +247,7 @@ void test_vertex_count_4_per_glyph(void) {
 /* ---- Test 9: Flush resets counts (TEXT-05) ---- */
 
 void test_flush_resets_counts(void) {
-    nt_text_renderer_draw("A", s_identity, 32.0F, s_white, 0.0F);
+    nt_text_renderer_draw("A", s_identity, 32.0F, s_white, 0.0F, 0.0F);
     TEST_ASSERT_GREATER_THAN(0U, nt_text_renderer_test_glyph_count());
 
     nt_text_renderer_flush();
@@ -266,7 +266,7 @@ void test_measure_width_increases(void) {
 /* ---- Test 11: Newlines reset x and advance y ---- */
 
 void test_draw_newline_advances_to_next_line(void) {
-    nt_text_renderer_draw("A\nB", s_identity, 32.0F, s_white, 0.0F);
+    nt_text_renderer_draw("A\nB", s_identity, 32.0F, s_white, 0.0F, 0.0F);
     TEST_ASSERT_EQUAL_UINT32(2, nt_text_renderer_test_glyph_count());
 
     const uint8_t *verts = (const uint8_t *)nt_text_renderer_test_vertices();
@@ -289,7 +289,7 @@ void test_draw_newline_advances_to_next_line(void) {
 
 void test_draw_n_matches_draw(void) {
     /* Capture vertex stream from existing _draw on NUL-terminated "AB" */
-    nt_text_renderer_draw("AB", s_identity, 32.0F, s_white, 0.0F);
+    nt_text_renderer_draw("AB", s_identity, 32.0F, s_white, 0.0F, 0.0F);
     const uint32_t draw_vcount = nt_text_renderer_test_vertex_count();
     const uint32_t draw_gcount = nt_text_renderer_test_glyph_count();
     TEST_ASSERT_EQUAL_UINT32(8U, draw_vcount); /* 2 visible glyphs × 4 verts */
@@ -306,7 +306,7 @@ void test_draw_n_matches_draw(void) {
     TEST_ASSERT_EQUAL_UINT32(0U, nt_text_renderer_test_vertex_count());
 
     /* Call length-aware variant with matching length */
-    nt_text_renderer_draw_n("AB", 2U, s_identity, 32.0F, s_white, 0.0F);
+    nt_text_renderer_draw_n("AB", 2U, s_identity, 32.0F, s_white, 0.0F, 0.0F);
     const uint32_t draw_n_vcount = nt_text_renderer_test_vertex_count();
     const uint32_t draw_n_gcount = nt_text_renderer_test_glyph_count();
 
@@ -319,7 +319,7 @@ void test_draw_n_matches_draw(void) {
 
 void test_draw_n_letter_spacing_advances_pen(void) {
     /* Baseline: AB with zero spacing -- second glyph's first vertex x at advance(A). */
-    nt_text_renderer_draw_n("AB", 2U, s_identity, 32.0F, s_white, 0.0F);
+    nt_text_renderer_draw_n("AB", 2U, s_identity, 32.0F, s_white, 0.0F, 0.0F);
     TEST_ASSERT_EQUAL_UINT32(8U, nt_text_renderer_test_vertex_count());
     const uint8_t *vraw = (const uint8_t *)nt_text_renderer_test_vertices();
     float base_b_x = 0.0F;
@@ -329,7 +329,7 @@ void test_draw_n_letter_spacing_advances_pen(void) {
     TEST_ASSERT_EQUAL_UINT32(0U, nt_text_renderer_test_vertex_count());
 
     /* Same call with spacing=7: B's first vertex shifts by exactly 7 px. */
-    nt_text_renderer_draw_n("AB", 2U, s_identity, 32.0F, s_white, 7.0F);
+    nt_text_renderer_draw_n("AB", 2U, s_identity, 32.0F, s_white, 7.0F, 0.0F);
     const uint8_t *vspaced = (const uint8_t *)nt_text_renderer_test_vertices();
     float spaced_b_x = 0.0F;
     memcpy(&spaced_b_x, vspaced + ((size_t)4U * 68U), sizeof(float));
@@ -338,11 +338,34 @@ void test_draw_n_letter_spacing_advances_pen(void) {
     TEST_ASSERT_EQUAL_INT32((int32_t)(base_b_x + 7.0F), (int32_t)spaced_b_x);
 }
 
+/* ---- line_leading shifts subsequent lines by leading px on \n ---- */
+
+void test_draw_n_line_leading_advances_pen_y(void) {
+    /* Baseline: "A\nB" with zero leading -- B at y = -natural_line_advance. */
+    nt_text_renderer_draw_n("A\nB", 3U, s_identity, 32.0F, s_white, 0.0F, 0.0F);
+    TEST_ASSERT_EQUAL_UINT32(8U, nt_text_renderer_test_vertex_count());
+    const uint8_t *vraw = (const uint8_t *)nt_text_renderer_test_vertices();
+    /* vertex 0 = A's first corner, vertex 4 = B's first corner. y is float[1]. */
+    float base_b_y = 0.0F;
+    memcpy(&base_b_y, vraw + ((size_t)4U * 68U) + sizeof(float), sizeof(float));
+
+    nt_text_renderer_flush();
+
+    /* Same call with leading=10: B shifts by 10 more px downward. */
+    nt_text_renderer_draw_n("A\nB", 3U, s_identity, 32.0F, s_white, 0.0F, 10.0F);
+    const uint8_t *vleading = (const uint8_t *)nt_text_renderer_test_vertices();
+    float leading_b_y = 0.0F;
+    memcpy(&leading_b_y, vleading + ((size_t)4U * 68U) + sizeof(float), sizeof(float));
+
+    /* B drew lower by exactly 10px (pen_y decreases by line_advance, which got +10). */
+    TEST_ASSERT_EQUAL_INT32((int32_t)(base_b_y - 10.0F), (int32_t)leading_b_y);
+}
+
 /* ---- Test 13: TEXT-01b — poisoned byte at utf8[len] does NOT contribute (no over-read) ---- */
 
 void test_draw_n_does_not_over_read(void) {
     /* Reference: _draw on the clean "AB" string */
-    nt_text_renderer_draw("AB", s_identity, 32.0F, s_white, 0.0F);
+    nt_text_renderer_draw("AB", s_identity, 32.0F, s_white, 0.0F, 0.0F);
     const uint32_t ref_vcount = nt_text_renderer_test_vertex_count();
     TEST_ASSERT_EQUAL_UINT32(8U, ref_vcount);
 
@@ -358,7 +381,7 @@ void test_draw_n_does_not_over_read(void) {
      * bugprone-not-null-terminated-result (matches test_font.c precedent). */
     const char buf[8] = {'A', 'B', 'X', 'X', 'X', 'X', 'X', 'X'};
 
-    nt_text_renderer_draw_n(buf, 2U, s_identity, 32.0F, s_white, 0.0F);
+    nt_text_renderer_draw_n(buf, 2U, s_identity, 32.0F, s_white, 0.0F, 0.0F);
     const uint32_t bounded_vcount = nt_text_renderer_test_vertex_count();
 
     TEST_ASSERT_EQUAL_UINT32(ref_vcount, bounded_vcount);
@@ -376,7 +399,7 @@ static void bench_draw_short_warm(void) {
     const int n_calls = 1000;
     const uint64_t t0 = nt_time_nanos();
     for (int i = 0; i < n_calls; i++) {
-        nt_text_renderer_draw_n("ABC", 3U, s_identity, 32.0F, s_white, 0.0F);
+        nt_text_renderer_draw_n("ABC", 3U, s_identity, 32.0F, s_white, 0.0F, 0.0F);
         nt_text_renderer_flush(); /* exclude buffer-overflow path from timing */
     }
     const uint64_t t1 = nt_time_nanos();
@@ -396,7 +419,7 @@ static void bench_draw_mixed_ui(void) {
 
     /* Warm up the glyph cache once. */
     for (int i = 0; i < label_count; i++) {
-        nt_text_renderer_draw_n(labels[i], lens[i], s_identity, 32.0F, s_white, 0.0F);
+        nt_text_renderer_draw_n(labels[i], lens[i], s_identity, 32.0F, s_white, 0.0F, 0.0F);
     }
     nt_text_renderer_flush();
 
@@ -405,7 +428,7 @@ static void bench_draw_mixed_ui(void) {
     const uint64_t t0 = nt_time_nanos();
     for (int f = 0; f < frames; f++) {
         for (int i = 0; i < label_count; i++) {
-            nt_text_renderer_draw_n(labels[i], lens[i], s_identity, 32.0F, s_white, 0.0F);
+            nt_text_renderer_draw_n(labels[i], lens[i], s_identity, 32.0F, s_white, 0.0F, 0.0F);
             total_calls++;
         }
         nt_text_renderer_flush();
@@ -434,6 +457,7 @@ int main(void) {
     RUN_TEST(test_draw_newline_advances_to_next_line);
     RUN_TEST(test_draw_n_matches_draw);
     RUN_TEST(test_draw_n_letter_spacing_advances_pen);
+    RUN_TEST(test_draw_n_line_leading_advances_pen_y);
     RUN_TEST(test_draw_n_does_not_over_read);
     RUN_TEST(bench_draw_short_warm);
     RUN_TEST(bench_draw_mixed_ui);


### PR DESCRIPTION
Closes #180.

## Summary

- Ships the **nt_ui module skeleton + walker MVP** — multi-context lifecycle (caller-owned arena, Clay-bound), `begin/end/walk` split, Clay measure callback + pointer state wiring, walker dispatch for all 8 Clay command types with depth-8 scissor stack, `ui_draw_calls` + `ui_element_count` stats counters surfaced through `nt_stats`.
- Adds **non-ECS public emit surface to nt_sprite_renderer** (Drift 4): `nt_sprite_renderer_set_material(mat)` + `nt_sprite_renderer_emit_region(...)`. ECS hot path (`emit_one`) and walker share one canonical `emit_region_resolved` body via `always_inline` — bunnymark FPS empirically unchanged.
- **Covers 17 requirements:** CLAY-03, CLAY-04, UI-01..08, WALK-01..06, WALK-09.

## Post-review cleanup (9 commits on top of the original phase deliverable)

Self-review of the initial implementation surfaced one architectural debt and a handful of correctness items. All fixed in this PR before merge:

| # | Change |
|---|---|
| 1 | Walker state moved from module globals → per-context (`nt_ui_context_t`). Unblocks Phase 53 themes from inheriting hidden global state. **Breaking change to setters** — they now take `ctx` as first arg. |
| 2 | Clay invariant violations now `NT_ASSERT` (fatal), not `NT_LOG_WARN`. Per AGENTS.md "fail early". |
| 3 | `emit_image` asserts payload atlas is non-zero and READY. |
| 4 | Walker scissor uses `floor/ceil` instead of `(int)` truncate — no more 1px clipping on subpixel UI. |
| 5 | Walker draw-call delta — `NT_ASSERT(calls_after >= calls_at_entry)` against underflow. |
| 6 | `clamp_u8` helper for color packing; drop lazy `Clay_SetMeasureTextFunction` flag; drop defensive `if (g_inframe_ctx == ctx)` in destroy. |
| 7 | slice9 warn-once hidden static removed; falls through silently to plain quad (Phase 54 fills the path). |
| 8 | Walker test fixture extracted (`tests/unit/test_helpers/ui_walker_fixture.{c,h}`) — **441 lines net deletion** across 6 test files. |
| 9 | Engine-subsystem init dependencies documented in nt_ui.h header. |

## Test plan

- [x] native-debug build clean
- [x] native-release build clean
- [x] wasm-debug build clean
- [x] ctest 46/46 green (34 existing + 12 new from Phase 52)
- [x] clang-format --dry-run --Werror clean on all modified .c/.h
- [x] scripts/tidy.sh clean (128 files including new helper)
- [x] **Bunnymark SD/HD FPS unchanged** post-refactor (D-52-02 perf gate empirically confirmed)
- [ ] CI green across full preset matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)