### PR TITLE
Phase 55: UI Walk Stats & CPU Timing

### DIFF
--- a/engine/ui/CMakeLists.txt
+++ b/engine/ui/CMakeLists.txt
@@ -85,6 +85,7 @@ target_link_libraries(nt_ui
         nt_sprite_renderer
         nt_text_renderer
         nt_atlas
+        nt_time
 )
 
 # nt_log is PRIVATE-linked by nt_add_module via the LOG_DOMAIN injection.

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -1053,11 +1053,11 @@ static inline uint32_t apply_opacity(uint32_t color_packed, float opacity) {
 
 /* Phase 55: per-walk counters passed to dispatch helpers. */
 typedef struct {
-    uint32_t rect_count;
-    uint32_t image_count;
-    uint32_t text_count;
-    uint32_t border_count;
-    uint32_t scissor_count;
+    uint32_t rect_command_count;
+    uint32_t image_command_count;
+    uint32_t text_command_count;
+    uint32_t border_command_count;
+    uint32_t scissor_command_count;
     uint32_t max_scissor_depth;
     uint32_t transform_pushes;
     uint32_t opacity_pushes;
@@ -1181,7 +1181,7 @@ static void dispatch_command(const nt_ui_context_t *ctx, const Clay_RenderComman
     case CLAY_RENDER_COMMAND_TYPE_NONE:
         return;
     case CLAY_RENDER_COMMAND_TYPE_RECTANGLE: {
-        counters->rect_count++;
+        counters->rect_command_count++;
         prep_sprite_dispatch(ctx, sprite_pipeline_dirty);
         const Clay_RectangleRenderData *r = &c->renderData.rectangle;
         uint32_t col = nt_color_pack_clay(r->backgroundColor);
@@ -1196,7 +1196,7 @@ static void dispatch_command(const nt_ui_context_t *ctx, const Clay_RenderComman
         return;
     }
     case CLAY_RENDER_COMMAND_TYPE_BORDER: {
-        counters->border_count++;
+        counters->border_command_count++;
         prep_sprite_dispatch(ctx, sprite_pipeline_dirty);
         Clay_RenderCommand local = *c;
         local.boundingBox = (Clay_BoundingBox){.x = sbb.x, .y = world_y, .width = sbb.width, .height = sbb.height};
@@ -1215,7 +1215,7 @@ static void dispatch_command(const nt_ui_context_t *ctx, const Clay_RenderComman
         return;
     }
     case CLAY_RENDER_COMMAND_TYPE_TEXT: {
-        counters->text_count++;
+        counters->text_command_count++;
         /* Drain sprite before switching to text pipeline; mark for lazy rebind. */
         nt_sprite_renderer_flush();
         *sprite_pipeline_dirty = true;
@@ -1226,7 +1226,7 @@ static void dispatch_command(const nt_ui_context_t *ctx, const Clay_RenderComman
         return;
     }
     case CLAY_RENDER_COMMAND_TYPE_IMAGE: {
-        counters->image_count++;
+        counters->image_command_count++;
         prep_sprite_dispatch(ctx, sprite_pipeline_dirty);
         Clay_RenderCommand local = *c;
         local.boundingBox = (Clay_BoundingBox){.x = sbb.x, .y = world_y, .width = sbb.width, .height = sbb.height};
@@ -1245,7 +1245,7 @@ static void dispatch_command(const nt_ui_context_t *ctx, const Clay_RenderComman
         return;
     }
     case CLAY_RENDER_COMMAND_TYPE_SCISSOR_START: {
-        counters->scissor_count++;
+        counters->scissor_command_count++;
         Clay_RenderCommand local = *c;
         if (ws->accum_rotation != 0.0F) {
             /* AABB of rotated scissor rect in Clay Y-down space */
@@ -1326,11 +1326,11 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
         ctx->last_walk_draw_call_delta = 0;
         ctx->last_walk_command_count = 0;
         ctx->last_walk_ms = 0.0F;
-        ctx->last_walk_rect_count = 0;
-        ctx->last_walk_image_count = 0;
-        ctx->last_walk_text_count = 0;
-        ctx->last_walk_border_count = 0;
-        ctx->last_walk_scissor_count = 0;
+        ctx->last_walk_rect_command_count = 0;
+        ctx->last_walk_image_command_count = 0;
+        ctx->last_walk_text_command_count = 0;
+        ctx->last_walk_border_command_count = 0;
+        ctx->last_walk_scissor_command_count = 0;
         ctx->last_walk_max_scissor_depth = 0;
         ctx->last_walk_transform_pushes = 0;
         ctx->last_walk_opacity_pushes = 0;
@@ -1351,11 +1351,11 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
         ctx->last_walk_draw_call_delta = 0;
         ctx->last_walk_command_count = 0;
         ctx->last_walk_ms = 0.0F;
-        ctx->last_walk_rect_count = 0;
-        ctx->last_walk_image_count = 0;
-        ctx->last_walk_text_count = 0;
-        ctx->last_walk_border_count = 0;
-        ctx->last_walk_scissor_count = 0;
+        ctx->last_walk_rect_command_count = 0;
+        ctx->last_walk_image_command_count = 0;
+        ctx->last_walk_text_command_count = 0;
+        ctx->last_walk_border_command_count = 0;
+        ctx->last_walk_scissor_command_count = 0;
         ctx->last_walk_max_scissor_depth = 0;
         ctx->last_walk_transform_pushes = 0;
         ctx->last_walk_opacity_pushes = 0;
@@ -1588,11 +1588,11 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(calls_after >= calls_at_entry && "nt_ui_walk: frame draw-call counter went backwards");
     ctx->last_walk_draw_call_delta = calls_after - calls_at_entry;
     ctx->last_walk_command_count = (uint32_t)arr->length;
-    ctx->last_walk_rect_count = counters.rect_count;
-    ctx->last_walk_image_count = counters.image_count;
-    ctx->last_walk_text_count = counters.text_count;
-    ctx->last_walk_border_count = counters.border_count;
-    ctx->last_walk_scissor_count = counters.scissor_count;
+    ctx->last_walk_rect_command_count = counters.rect_command_count;
+    ctx->last_walk_image_command_count = counters.image_command_count;
+    ctx->last_walk_text_command_count = counters.text_command_count;
+    ctx->last_walk_border_command_count = counters.border_command_count;
+    ctx->last_walk_scissor_command_count = counters.scissor_command_count;
     ctx->last_walk_max_scissor_depth = counters.max_scissor_depth;
     ctx->last_walk_transform_pushes = counters.transform_pushes;
     ctx->last_walk_opacity_pushes = counters.opacity_pushes;
@@ -1719,29 +1719,29 @@ float nt_ui_get_last_walk_ms(const nt_ui_context_t *ctx) {
     return ctx->last_walk_ms;
 }
 
-uint32_t nt_ui_get_last_walk_rect_count(const nt_ui_context_t *ctx) {
-    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_rect_count: ctx must be non-NULL");
-    return ctx->last_walk_rect_count;
+uint32_t nt_ui_get_last_walk_rect_command_count(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_rect_command_count: ctx must be non-NULL");
+    return ctx->last_walk_rect_command_count;
 }
 
-uint32_t nt_ui_get_last_walk_image_count(const nt_ui_context_t *ctx) {
-    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_image_count: ctx must be non-NULL");
-    return ctx->last_walk_image_count;
+uint32_t nt_ui_get_last_walk_image_command_count(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_image_command_count: ctx must be non-NULL");
+    return ctx->last_walk_image_command_count;
 }
 
-uint32_t nt_ui_get_last_walk_text_count(const nt_ui_context_t *ctx) {
-    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_text_count: ctx must be non-NULL");
-    return ctx->last_walk_text_count;
+uint32_t nt_ui_get_last_walk_text_command_count(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_text_command_count: ctx must be non-NULL");
+    return ctx->last_walk_text_command_count;
 }
 
-uint32_t nt_ui_get_last_walk_border_count(const nt_ui_context_t *ctx) {
-    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_border_count: ctx must be non-NULL");
-    return ctx->last_walk_border_count;
+uint32_t nt_ui_get_last_walk_border_command_count(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_border_command_count: ctx must be non-NULL");
+    return ctx->last_walk_border_command_count;
 }
 
-uint32_t nt_ui_get_last_walk_scissor_count(const nt_ui_context_t *ctx) {
-    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_scissor_count: ctx must be non-NULL");
-    return ctx->last_walk_scissor_count;
+uint32_t nt_ui_get_last_walk_scissor_command_count(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_scissor_command_count: ctx must be non-NULL");
+    return ctx->last_walk_scissor_command_count;
 }
 
 uint32_t nt_ui_get_last_walk_max_scissor_depth(const nt_ui_context_t *ctx) {

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -266,7 +266,9 @@ void nt_ui_end(nt_ui_context_t *ctx) {
     NT_ASSERT(ctx->in_frame && "nt_ui_end: ctx is not in_frame (begin was not called)");
     NT_ASSERT(ctx == g_nt_ui_inframe_ctx && "nt_ui_end: ctx mismatch with module in-frame ctx");
 
+    const double layout_t0 = nt_time_now();
     ctx->frozen_cmds = Clay_EndLayout();
+    ctx->last_layout_ms = (float)((nt_time_now() - layout_t0) * 1000.0);
 
     /* Markers keep layout-element indices (before_clay_idx). The walker
      * matches directly via nt_layout_index on each render command — no
@@ -1049,11 +1051,24 @@ static inline uint32_t apply_opacity(uint32_t color_packed, float opacity) {
     return (color_packed & 0x00FFFFFFU) | (a << 24);
 }
 
+/* Phase 55: per-walk counters passed to dispatch helpers. */
+typedef struct {
+    uint32_t rect_count;
+    uint32_t image_count;
+    uint32_t text_count;
+    uint32_t border_count;
+    uint32_t scissor_count;
+    uint32_t max_scissor_depth;
+    uint32_t transform_pushes;
+    uint32_t opacity_pushes;
+} nt_ui_walk_counters_t;
+
 /* Process a single side-channel marker into walker state. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-static void process_marker(const nt_ui_marker_t *marker, nt_ui_walker_state_t *ws) {
+static void process_marker(const nt_ui_marker_t *marker, nt_ui_walker_state_t *ws, nt_ui_walk_counters_t *counters) {
     switch (marker->type) {
     case NT_UI_MARKER_PUSH_TRANSFORM: {
+        counters->transform_pushes++;
         NT_ASSERT(ws->transform_depth < NT_UI_TRANSFORM_STACK_DEPTH_CAP && "transform stack overflow");
         const int d = ws->transform_depth;
         ws->transform_stack[d] = marker->transform;
@@ -1082,6 +1097,7 @@ static void process_marker(const nt_ui_marker_t *marker, nt_ui_walker_state_t *w
         walker_recompute_transform(ws);
         return;
     case NT_UI_MARKER_PUSH_OPACITY:
+        counters->opacity_pushes++;
         NT_ASSERT(ws->opacity_depth < NT_UI_OPACITY_STACK_DEPTH_CAP && "opacity stack overflow");
         ws->opacity_stack[ws->opacity_depth++] = marker->opacity;
         ws->accum_opacity *= marker->opacity;
@@ -1143,7 +1159,7 @@ static inline void prep_sprite_dispatch(const nt_ui_context_t *ctx, bool *sprite
  * scissor_push flip. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void dispatch_command(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, scissor_rect_t *scissor_stack, int *depth, const nt_ui_target_t *target, bool *sprite_pipeline_dirty,
-                             nt_ui_walker_state_t *ws) {
+                             nt_ui_walker_state_t *ws, nt_ui_walk_counters_t *counters) {
     const float vy = target->viewport[1];
     const float vh = target->viewport[3];
 
@@ -1165,6 +1181,7 @@ static void dispatch_command(const nt_ui_context_t *ctx, const Clay_RenderComman
     case CLAY_RENDER_COMMAND_TYPE_NONE:
         return;
     case CLAY_RENDER_COMMAND_TYPE_RECTANGLE: {
+        counters->rect_count++;
         prep_sprite_dispatch(ctx, sprite_pipeline_dirty);
         const Clay_RectangleRenderData *r = &c->renderData.rectangle;
         uint32_t col = nt_color_pack_clay(r->backgroundColor);
@@ -1179,6 +1196,7 @@ static void dispatch_command(const nt_ui_context_t *ctx, const Clay_RenderComman
         return;
     }
     case CLAY_RENDER_COMMAND_TYPE_BORDER: {
+        counters->border_count++;
         prep_sprite_dispatch(ctx, sprite_pipeline_dirty);
         Clay_RenderCommand local = *c;
         local.boundingBox = (Clay_BoundingBox){.x = sbb.x, .y = world_y, .width = sbb.width, .height = sbb.height};
@@ -1197,6 +1215,7 @@ static void dispatch_command(const nt_ui_context_t *ctx, const Clay_RenderComman
         return;
     }
     case CLAY_RENDER_COMMAND_TYPE_TEXT: {
+        counters->text_count++;
         /* Drain sprite before switching to text pipeline; mark for lazy rebind. */
         nt_sprite_renderer_flush();
         *sprite_pipeline_dirty = true;
@@ -1207,6 +1226,7 @@ static void dispatch_command(const nt_ui_context_t *ctx, const Clay_RenderComman
         return;
     }
     case CLAY_RENDER_COMMAND_TYPE_IMAGE: {
+        counters->image_count++;
         prep_sprite_dispatch(ctx, sprite_pipeline_dirty);
         Clay_RenderCommand local = *c;
         local.boundingBox = (Clay_BoundingBox){.x = sbb.x, .y = world_y, .width = sbb.width, .height = sbb.height};
@@ -1225,6 +1245,7 @@ static void dispatch_command(const nt_ui_context_t *ctx, const Clay_RenderComman
         return;
     }
     case CLAY_RENDER_COMMAND_TYPE_SCISSOR_START: {
+        counters->scissor_count++;
         Clay_RenderCommand local = *c;
         if (ws->accum_rotation != 0.0F) {
             /* AABB of rotated scissor rect in Clay Y-down space */
@@ -1264,6 +1285,9 @@ static void dispatch_command(const nt_ui_context_t *ctx, const Clay_RenderComman
             local.boundingBox = sbb;
         }
         scissor_push(&local, scissor_stack, depth, target, sprite_pipeline_dirty);
+        if ((uint32_t)*depth > counters->max_scissor_depth) {
+            counters->max_scissor_depth = (uint32_t)*depth;
+        }
         return;
     }
     case CLAY_RENDER_COMMAND_TYPE_SCISSOR_END:
@@ -1301,6 +1325,15 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     if (target->viewport[2] == 0.0F || target->viewport[3] == 0.0F || (scaled && target->fb_size[1] == 0.0F)) {
         ctx->last_walk_draw_call_delta = 0;
         ctx->last_walk_command_count = 0;
+        ctx->last_walk_ms = 0.0F;
+        ctx->last_walk_rect_count = 0;
+        ctx->last_walk_image_count = 0;
+        ctx->last_walk_text_count = 0;
+        ctx->last_walk_border_count = 0;
+        ctx->last_walk_scissor_count = 0;
+        ctx->last_walk_max_scissor_depth = 0;
+        ctx->last_walk_transform_pushes = 0;
+        ctx->last_walk_opacity_pushes = 0;
 #ifdef NT_TEST_ACCESS
         ctx->test_last_walk_unlayered_count = 0;
 #endif
@@ -1317,17 +1350,30 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     if (ctx->atlas.id == 0 || !nt_resource_is_ready(ctx->atlas)) {
         ctx->last_walk_draw_call_delta = 0;
         ctx->last_walk_command_count = 0;
+        ctx->last_walk_ms = 0.0F;
+        ctx->last_walk_rect_count = 0;
+        ctx->last_walk_image_count = 0;
+        ctx->last_walk_text_count = 0;
+        ctx->last_walk_border_count = 0;
+        ctx->last_walk_scissor_count = 0;
+        ctx->last_walk_max_scissor_depth = 0;
+        ctx->last_walk_transform_pushes = 0;
+        ctx->last_walk_opacity_pushes = 0;
 #ifdef NT_TEST_ACCESS
         ctx->test_last_walk_unlayered_count = 0;
 #endif
         return;
     }
 
+    const double walk_t0 = nt_time_now();
+
     scissor_rect_t scissor_stack[NT_UI_WALKER_SCISSOR_DEPTH_CAP];
     int depth = 0;
 
     nt_ui_walker_state_t ws;
     walker_state_init(&ws);
+
+    nt_ui_walk_counters_t counters = {0};
 
     /* AFTER entry flush so per-walk delta excludes caller's drained geometry. */
     const uint32_t calls_at_entry = nt_gfx_get_frame_draw_calls();
@@ -1362,7 +1408,7 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
         if (!is_segmentable(c->commandType)) {
             /* Match markers by nt_layout_index — no remap needed. */
             while (mcur < ctx->marker_count && (int32_t)ctx->markers[mcur].before_clay_idx <= c->nt_layout_index) {
-                process_marker(&ctx->markers[mcur], &ws);
+                process_marker(&ctx->markers[mcur], &ws, &counters);
                 ++mcur;
             }
             /* Resolve pending centers from non-segmentable commands too (SCISSOR_START has valid bbox). */
@@ -1378,7 +1424,7 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
                 ws.pending_center_count = 0;
                 walker_recompute_transform(&ws);
             }
-            dispatch_command(ctx, c, scissor_stack, &depth, target, &sprite_pipeline_dirty, &ws);
+            dispatch_command(ctx, c, scissor_stack, &depth, target, &sprite_pipeline_dirty, &ws, &counters);
             ++i;
             continue;
         }
@@ -1430,7 +1476,7 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
                 const Clay_RenderCommand *cc = &arr->internalArray[i + orig_idx];
                 /* Match markers by nt_layout_index — sorted order restores declaration sequence. */
                 while (mcur < ctx->marker_count && (int32_t)ctx->markers[mcur].before_clay_idx <= cc->nt_layout_index) {
-                    process_marker(&ctx->markers[mcur], &ws);
+                    process_marker(&ctx->markers[mcur], &ws, &counters);
                     ++mcur;
                 }
                 /* Resolve ALL pending centers from first command with valid bbox.
@@ -1514,7 +1560,7 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
                             ws.accum_rotation = baked[bi].rotation;
                             ws.accum_opacity = baked[bi].opacity;
                         }
-                        dispatch_command(ctx, cc, scissor_stack, &depth, target, &sprite_pipeline_dirty, &ws);
+                        dispatch_command(ctx, cc, scissor_stack, &depth, target, &sprite_pipeline_dirty, &ws, &counters);
                     }
                 }
             }
@@ -1526,7 +1572,7 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
 
     /* Drain remaining markers (pops at end of frame). */
     while (mcur < ctx->marker_count) {
-        process_marker(&ctx->markers[mcur], &ws);
+        process_marker(&ctx->markers[mcur], &ws, &counters);
         ++mcur;
     }
 
@@ -1542,6 +1588,15 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
     NT_ASSERT(calls_after >= calls_at_entry && "nt_ui_walk: frame draw-call counter went backwards");
     ctx->last_walk_draw_call_delta = calls_after - calls_at_entry;
     ctx->last_walk_command_count = (uint32_t)arr->length;
+    ctx->last_walk_rect_count = counters.rect_count;
+    ctx->last_walk_image_count = counters.image_count;
+    ctx->last_walk_text_count = counters.text_count;
+    ctx->last_walk_border_count = counters.border_count;
+    ctx->last_walk_scissor_count = counters.scissor_count;
+    ctx->last_walk_max_scissor_depth = counters.max_scissor_depth;
+    ctx->last_walk_transform_pushes = counters.transform_pushes;
+    ctx->last_walk_opacity_pushes = counters.opacity_pushes;
+    ctx->last_walk_ms = (float)((nt_time_now() - walk_t0) * 1000.0);
 #ifdef NT_TEST_ACCESS
     ctx->test_last_walk_unlayered_count = unlayered_count;
 #endif

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -6,6 +6,7 @@
 #include "material/nt_material.h"
 #include "renderers/nt_sprite_renderer.h"
 #include "renderers/nt_text_renderer.h"
+#include "time/nt_time.h"
 
 /* This is the single CLAY_IMPLEMENTATION TU. CMake parses deps/clay/VERSION
  * into CLAY_PINNED_*; the assert below catches version drift. */
@@ -1651,6 +1652,56 @@ uint32_t nt_ui_get_last_walk_draw_calls(const nt_ui_context_t *ctx) {
 uint32_t nt_ui_get_last_walk_command_count(const nt_ui_context_t *ctx) {
     NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_command_count: ctx must be non-NULL");
     return ctx->last_walk_command_count;
+}
+
+float nt_ui_get_last_layout_ms(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_get_last_layout_ms: ctx must be non-NULL");
+    return ctx->last_layout_ms;
+}
+
+float nt_ui_get_last_walk_ms(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_ms: ctx must be non-NULL");
+    return ctx->last_walk_ms;
+}
+
+uint32_t nt_ui_get_last_walk_rect_count(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_rect_count: ctx must be non-NULL");
+    return ctx->last_walk_rect_count;
+}
+
+uint32_t nt_ui_get_last_walk_image_count(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_image_count: ctx must be non-NULL");
+    return ctx->last_walk_image_count;
+}
+
+uint32_t nt_ui_get_last_walk_text_count(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_text_count: ctx must be non-NULL");
+    return ctx->last_walk_text_count;
+}
+
+uint32_t nt_ui_get_last_walk_border_count(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_border_count: ctx must be non-NULL");
+    return ctx->last_walk_border_count;
+}
+
+uint32_t nt_ui_get_last_walk_scissor_count(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_scissor_count: ctx must be non-NULL");
+    return ctx->last_walk_scissor_count;
+}
+
+uint32_t nt_ui_get_last_walk_max_scissor_depth(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_max_scissor_depth: ctx must be non-NULL");
+    return ctx->last_walk_max_scissor_depth;
+}
+
+uint32_t nt_ui_get_last_walk_transform_pushes(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_transform_pushes: ctx must be non-NULL");
+    return ctx->last_walk_transform_pushes;
+}
+
+uint32_t nt_ui_get_last_walk_opacity_pushes(const nt_ui_context_t *ctx) {
+    NT_ASSERT(ctx != NULL && "nt_ui_get_last_walk_opacity_pushes: ctx must be non-NULL");
+    return ctx->last_walk_opacity_pushes;
 }
 // #endregion
 

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -266,6 +266,7 @@ void nt_ui_end(nt_ui_context_t *ctx) {
     NT_ASSERT(ctx->in_frame && "nt_ui_end: ctx is not in_frame (begin was not called)");
     NT_ASSERT(ctx == g_nt_ui_inframe_ctx && "nt_ui_end: ctx mismatch with module in-frame ctx");
 
+    /* layout_ms times the Clay layout solve (EndLayout), not the begin->end span. */
     const double layout_t0 = nt_time_now();
     ctx->frozen_cmds = Clay_EndLayout();
     ctx->last_layout_ms = (float)((nt_time_now() - layout_t0) * 1000.0);
@@ -1365,6 +1366,9 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {
         return;
     }
 
+    /* Timed from here -- after the entry flush -- so walk_ms covers the UI walk's
+     * own dispatch, not draining the caller's pending geometry (same scope as
+     * last_walk_draw_call_delta below). */
     const double walk_t0 = nt_time_now();
 
     scissor_rect_t scissor_stack[NT_UI_WALKER_SCISSOR_DEPTH_CAP];

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -150,8 +150,11 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
 uint32_t nt_ui_get_last_walk_draw_calls(const nt_ui_context_t *ctx);
 /* Total Clay commands incl. SCISSOR/CUSTOM/NONE (non-drawing barriers). */
 uint32_t nt_ui_get_last_walk_command_count(const nt_ui_context_t *ctx);
-/* Phase 55: CPU timing (ms). layout runs in nt_ui_end; walk in nt_ui_walk. */
+/* Phase 55 CPU timing (ms); both reset to 0 on early-out walks. */
+/* layout_ms = the Clay_EndLayout solve only, not the whole begin->end span. */
 float nt_ui_get_last_layout_ms(const nt_ui_context_t *ctx);
+/* walk_ms = walk dispatch, timed from AFTER the entry flush -- excludes
+ * draining the caller's pending geometry (same scope as draw_calls). */
 float nt_ui_get_last_walk_ms(const nt_ui_context_t *ctx);
 /* Phase 55: per-type render-command counts, counted at dispatch (pre-emit, not
  * pixels drawn -- use draw_calls for GPU cost). Reset each walk. */

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -150,6 +150,19 @@ void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
 uint32_t nt_ui_get_last_walk_draw_calls(const nt_ui_context_t *ctx);
 /* Total Clay commands incl. SCISSOR/CUSTOM/NONE (non-drawing barriers). */
 uint32_t nt_ui_get_last_walk_command_count(const nt_ui_context_t *ctx);
+/* Phase 55: CPU timing (ms). layout runs in nt_ui_end; walk in nt_ui_walk. */
+float nt_ui_get_last_layout_ms(const nt_ui_context_t *ctx);
+float nt_ui_get_last_walk_ms(const nt_ui_context_t *ctx);
+/* Phase 55: per-type element counters. Reset each walk. */
+uint32_t nt_ui_get_last_walk_rect_count(const nt_ui_context_t *ctx);
+uint32_t nt_ui_get_last_walk_image_count(const nt_ui_context_t *ctx);
+uint32_t nt_ui_get_last_walk_text_count(const nt_ui_context_t *ctx);
+uint32_t nt_ui_get_last_walk_border_count(const nt_ui_context_t *ctx);
+/* Phase 55: scissor/marker counters. Reset each walk. */
+uint32_t nt_ui_get_last_walk_scissor_count(const nt_ui_context_t *ctx);
+uint32_t nt_ui_get_last_walk_max_scissor_depth(const nt_ui_context_t *ctx);
+uint32_t nt_ui_get_last_walk_transform_pushes(const nt_ui_context_t *ctx);
+uint32_t nt_ui_get_last_walk_opacity_pushes(const nt_ui_context_t *ctx);
 
 // #region transform_opacity_api
 /* Render-time transform -- no layout effect (D-54-09). */

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -153,13 +153,14 @@ uint32_t nt_ui_get_last_walk_command_count(const nt_ui_context_t *ctx);
 /* Phase 55: CPU timing (ms). layout runs in nt_ui_end; walk in nt_ui_walk. */
 float nt_ui_get_last_layout_ms(const nt_ui_context_t *ctx);
 float nt_ui_get_last_walk_ms(const nt_ui_context_t *ctx);
-/* Phase 55: per-type element counters. Reset each walk. */
-uint32_t nt_ui_get_last_walk_rect_count(const nt_ui_context_t *ctx);
-uint32_t nt_ui_get_last_walk_image_count(const nt_ui_context_t *ctx);
-uint32_t nt_ui_get_last_walk_text_count(const nt_ui_context_t *ctx);
-uint32_t nt_ui_get_last_walk_border_count(const nt_ui_context_t *ctx);
-/* Phase 55: scissor/marker counters. Reset each walk. */
-uint32_t nt_ui_get_last_walk_scissor_count(const nt_ui_context_t *ctx);
+/* Phase 55: per-type render-command counts, counted at dispatch (pre-emit, not
+ * pixels drawn -- use draw_calls for GPU cost). Reset each walk. */
+uint32_t nt_ui_get_last_walk_rect_command_count(const nt_ui_context_t *ctx);
+uint32_t nt_ui_get_last_walk_image_command_count(const nt_ui_context_t *ctx);
+uint32_t nt_ui_get_last_walk_text_command_count(const nt_ui_context_t *ctx);
+uint32_t nt_ui_get_last_walk_border_command_count(const nt_ui_context_t *ctx);
+/* Phase 55: scissor command count + marker push counts. Reset each walk. */
+uint32_t nt_ui_get_last_walk_scissor_command_count(const nt_ui_context_t *ctx);
 uint32_t nt_ui_get_last_walk_max_scissor_depth(const nt_ui_context_t *ctx);
 uint32_t nt_ui_get_last_walk_transform_pushes(const nt_ui_context_t *ctx);
 uint32_t nt_ui_get_last_walk_opacity_pushes(const nt_ui_context_t *ctx);

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -45,6 +45,19 @@ struct nt_ui_context {
     /* Per-walk metrics. Walker writes; nt_ui_get_last_walk_* reads. */
     uint32_t last_walk_draw_call_delta;
     uint32_t last_walk_command_count;
+    /* Phase 55: CPU timing (D-55-01, D-55-02) */
+    float last_layout_ms;
+    float last_walk_ms;
+    /* Phase 55: per-type element counters (D-55-03) */
+    uint32_t last_walk_rect_count;
+    uint32_t last_walk_image_count;
+    uint32_t last_walk_text_count;
+    uint32_t last_walk_border_count;
+    /* Phase 55: scissor/marker counters (D-55-05, D-55-06) */
+    uint32_t last_walk_scissor_count;
+    uint32_t last_walk_max_scissor_depth;
+    uint32_t last_walk_transform_pushes;
+    uint32_t last_walk_opacity_pushes;
 #ifdef NT_TEST_ACCESS
     uint32_t test_last_walk_unlayered_count;
 #endif

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -48,13 +48,13 @@ struct nt_ui_context {
     /* Phase 55: CPU timing (D-55-01, D-55-02) */
     float last_layout_ms;
     float last_walk_ms;
-    /* Phase 55: per-type element counters (D-55-03) */
-    uint32_t last_walk_rect_count;
-    uint32_t last_walk_image_count;
-    uint32_t last_walk_text_count;
-    uint32_t last_walk_border_count;
-    /* Phase 55: scissor/marker counters (D-55-05, D-55-06) */
-    uint32_t last_walk_scissor_count;
+    /* Phase 55: per-type render-command counts, counted pre-emit (D-55-03). */
+    uint32_t last_walk_rect_command_count;
+    uint32_t last_walk_image_command_count;
+    uint32_t last_walk_text_command_count;
+    uint32_t last_walk_border_command_count;
+    /* Phase 55: scissor command count + marker push counts (D-55-05, D-55-06) */
+    uint32_t last_walk_scissor_command_count;
     uint32_t last_walk_max_scissor_depth;
     uint32_t last_walk_transform_pushes;
     uint32_t last_walk_opacity_pushes;

--- a/examples/slice9_demo/main.c
+++ b/examples/slice9_demo/main.c
@@ -447,6 +447,9 @@ static void frame(void) {
             glm_translate(stats_model, (vec3){10.0F, scale.logical_h - 20.0F, 0.0F});
             const float stats_color[4] = {0.8F, 0.9F, 0.8F, 1.0F};
             nt_stats_draw(s_text_material, s_font, (const float *)stats_model, 14.0F, stats_color);
+            /* nt_stats_draw only stages text; flush before end_pass so the
+             * overlay lands in THIS frame, not the next walk's flush. */
+            nt_text_renderer_flush();
         }
         // #endregion
     }

--- a/examples/slice9_demo/main.c
+++ b/examples/slice9_demo/main.c
@@ -365,6 +365,8 @@ static void frame(void) {
     uniforms.near_far[1] = 1.0F;
 
     nt_gfx_begin_frame();
+    /* nt_stats reads frame total via segment named "frame" by convention. */
+    nt_gfx_begin_segment("frame");
     if (g_nt_gfx.context_restored) {
         nt_resource_invalidate(NT_ASSET_SHADER_CODE);
         nt_resource_invalidate(NT_ASSET_TEXTURE);
@@ -424,9 +426,7 @@ static void frame(void) {
         nt_ui_end(s_ctx);
 
         nt_ui_target_t target = nt_ui_scale_make_target(&scale);
-        nt_gfx_begin_segment("frame");
         nt_ui_walk(s_ctx, &target);
-        nt_gfx_end_segment();
 
         // #region metrics bridge
         nt_stats_count("ui_draw_calls", (uint64_t)nt_ui_get_last_walk_draw_calls(s_ctx));
@@ -452,6 +452,7 @@ static void frame(void) {
     }
 
     nt_gfx_end_pass();
+    nt_gfx_end_segment();
     nt_gfx_end_frame();
     nt_stats_frame_end();
 

--- a/examples/slice9_demo/main.c
+++ b/examples/slice9_demo/main.c
@@ -424,7 +424,31 @@ static void frame(void) {
         nt_ui_end(s_ctx);
 
         nt_ui_target_t target = nt_ui_scale_make_target(&scale);
+        nt_gfx_begin_segment("frame");
         nt_ui_walk(s_ctx, &target);
+        nt_gfx_end_segment();
+
+        // #region metrics bridge
+        nt_stats_count("ui_draw_calls", (uint64_t)nt_ui_get_last_walk_draw_calls(s_ctx));
+        nt_stats_count("ui_commands", (uint64_t)nt_ui_get_last_walk_command_count(s_ctx));
+        nt_stats_count("ui_rects", (uint64_t)nt_ui_get_last_walk_rect_count(s_ctx));
+        nt_stats_count("ui_images", (uint64_t)nt_ui_get_last_walk_image_count(s_ctx));
+        nt_stats_count("ui_texts", (uint64_t)nt_ui_get_last_walk_text_count(s_ctx));
+        nt_stats_count("ui_borders", (uint64_t)nt_ui_get_last_walk_border_count(s_ctx));
+        nt_stats_count("ui_scissors", (uint64_t)nt_ui_get_last_walk_scissor_count(s_ctx));
+        nt_stats_count("ui_layout_us", (uint64_t)(nt_ui_get_last_layout_ms(s_ctx) * 1000.0F));
+        nt_stats_count("ui_walk_us", (uint64_t)(nt_ui_get_last_walk_ms(s_ctx) * 1000.0F));
+        // #endregion
+
+        // #region stats overlay
+        {
+            mat4 stats_model;
+            glm_mat4_identity(stats_model);
+            glm_translate(stats_model, (vec3){10.0F, scale.logical_h - 20.0F, 0.0F});
+            const float stats_color[4] = {0.8F, 0.9F, 0.8F, 1.0F};
+            nt_stats_draw(s_text_material, s_font, (const float *)stats_model, 14.0F, stats_color);
+        }
+        // #endregion
     }
 
     nt_gfx_end_pass();

--- a/examples/slice9_demo/main.c
+++ b/examples/slice9_demo/main.c
@@ -431,11 +431,11 @@ static void frame(void) {
         // #region metrics bridge
         nt_stats_count("ui_draw_calls", (uint64_t)nt_ui_get_last_walk_draw_calls(s_ctx));
         nt_stats_count("ui_commands", (uint64_t)nt_ui_get_last_walk_command_count(s_ctx));
-        nt_stats_count("ui_rects", (uint64_t)nt_ui_get_last_walk_rect_count(s_ctx));
-        nt_stats_count("ui_images", (uint64_t)nt_ui_get_last_walk_image_count(s_ctx));
-        nt_stats_count("ui_texts", (uint64_t)nt_ui_get_last_walk_text_count(s_ctx));
-        nt_stats_count("ui_borders", (uint64_t)nt_ui_get_last_walk_border_count(s_ctx));
-        nt_stats_count("ui_scissors", (uint64_t)nt_ui_get_last_walk_scissor_count(s_ctx));
+        nt_stats_count("ui_rect_cmds", (uint64_t)nt_ui_get_last_walk_rect_command_count(s_ctx));
+        nt_stats_count("ui_image_cmds", (uint64_t)nt_ui_get_last_walk_image_command_count(s_ctx));
+        nt_stats_count("ui_text_cmds", (uint64_t)nt_ui_get_last_walk_text_command_count(s_ctx));
+        nt_stats_count("ui_border_cmds", (uint64_t)nt_ui_get_last_walk_border_command_count(s_ctx));
+        nt_stats_count("ui_scissor_cmds", (uint64_t)nt_ui_get_last_walk_scissor_command_count(s_ctx));
         nt_stats_count("ui_layout_us", (uint64_t)(nt_ui_get_last_layout_ms(s_ctx) * 1000.0F));
         nt_stats_count("ui_walk_us", (uint64_t)(nt_ui_get_last_walk_ms(s_ctx) * 1000.0F));
         // #endregion

--- a/tests/unit/test_nt_ui_begin_end.c
+++ b/tests/unit/test_nt_ui_begin_end.c
@@ -101,6 +101,24 @@ static void test_end_without_begin_asserts(void) {
     nt_ui_destroy_context(a);
 }
 
+/* nt_ui_end times Clay_EndLayout into last_layout_ms. A real begin/end cycle
+ * must leave a non-negative value (monotonic clock) -- catches a sign error or
+ * uninitialized-field regression in the timing math that a fixture which never
+ * runs nt_ui_end cannot. */
+static void test_end_sets_layout_ms(void) {
+    nt_ui_context_t *a = nt_ui_create_context(s_arena_a, sizeof s_arena_a, &s_ui_desc);
+    TEST_ASSERT_NOT_NULL(a);
+
+    nt_pointer_t mouse;
+    memset(&mouse, 0, sizeof mouse);
+
+    nt_ui_begin(a, 800.0F, 600.0F, 0.0F, &mouse);
+    nt_ui_end(a);
+    TEST_ASSERT_TRUE(nt_ui_get_last_layout_ms(a) >= 0.0F);
+
+    nt_ui_destroy_context(a);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_begin_sets_current_ctx);
@@ -108,5 +126,6 @@ int main(void) {
     RUN_TEST(test_end_clears_in_frame);
     RUN_TEST(test_end_clears_clay_current);
     RUN_TEST(test_end_without_begin_asserts);
+    RUN_TEST(test_end_sets_layout_ms);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_begin_end.c
+++ b/tests/unit/test_nt_ui_begin_end.c
@@ -101,8 +101,9 @@ static void test_end_without_begin_asserts(void) {
     nt_ui_destroy_context(a);
 }
 
-/* nt_ui_end times Clay_EndLayout into last_layout_ms. A real begin/end cycle
- * must leave a non-negative value (monotonic clock) -- catches a sign error or
+/* nt_ui_end times Clay_EndLayout into last_layout_ms. Scope: the Clay layout
+ * solve only, not the whole begin->end span. A real begin/end cycle must leave
+ * a non-negative value (monotonic clock) -- catches a sign error or
  * uninitialized-field regression in the timing math that a fixture which never
  * runs nt_ui_end cannot. */
 static void test_end_sets_layout_ms(void) {

--- a/tests/unit/test_nt_ui_begin_end.c
+++ b/tests/unit/test_nt_ui_begin_end.c
@@ -112,6 +112,9 @@ static void test_end_sets_layout_ms(void) {
     nt_pointer_t mouse;
     memset(&mouse, 0, sizeof mouse);
 
+    /* Sentinel: a removed/forgotten write leaves -1.0F and trips the assert;
+     * a real write in nt_ui_end replaces it with a non-negative ms value. */
+    a->last_layout_ms = -1.0F;
     nt_ui_begin(a, 800.0F, 600.0F, 0.0F, &mouse);
     nt_ui_end(a);
     TEST_ASSERT_TRUE(nt_ui_get_last_layout_ms(a) >= 0.0F);

--- a/tests/unit/test_nt_ui_stats.c
+++ b/tests/unit/test_nt_ui_stats.c
@@ -248,15 +248,13 @@ static void test_counters_reset_each_walk(void) {
     TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_border_count(s_fx.ctx));
 }
 
-/* layout_ms is written by nt_ui_end; verify ctx field is non-negative. */
-static void test_layout_ms_nonnegative(void) {
-    /* ctx was set up by fixture; last_layout_ms should be 0.0F (no end called
-     * in this test cycle) or >= 0 if fixture ran begin/end. Either way, >= 0. */
-    TEST_ASSERT_TRUE(nt_ui_get_last_layout_ms(s_fx.ctx) >= 0.0F);
-}
-
-/* walk_ms is non-negative after a walk with commands. */
-static void test_walk_ms_nonzero_with_commands(void) {
+/* walk_ms is written every walk: non-negative after a real walk (monotonic
+ * clock), and reset to 0.0F on the zero-viewport early-return path. The reset
+ * is the deterministic half -- it fails loudly if a future edit forgets to
+ * zero walk_ms in that early-return. (layout_ms is owned by nt_ui_end, which
+ * the walker fixture never calls, so its timing is covered in
+ * test_nt_ui_begin_end.c where a real begin/end cycle runs.) */
+static void test_walk_ms_set_then_reset_on_early_return(void) {
     for (int i = 0; i < 3; ++i) {
         Clay_RenderCommand *c = &s_test_cmds[i];
         c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
@@ -267,8 +265,14 @@ static void test_walk_ms_nonzero_with_commands(void) {
 
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
-
     TEST_ASSERT_TRUE(nt_ui_get_last_walk_ms(s_fx.ctx) >= 0.0F);
+
+    /* Zero-width viewport hits the early return, which must zero walk_ms.
+     * Value is non-negative, so "not positive" pins it to exactly 0 without a
+     * float-equality compare. */
+    nt_ui_target_t zero_target = {.viewport = {0.0F, 0.0F, 0.0F, 0.0F}};
+    nt_ui_walk(s_fx.ctx, &zero_target);
+    TEST_ASSERT_FALSE(nt_ui_get_last_walk_ms(s_fx.ctx) > 0.0F);
 }
 // #endregion
 
@@ -282,7 +286,6 @@ int main(void) {
     RUN_TEST(test_per_type_mixed_commands);
     RUN_TEST(test_scissor_count_and_depth);
     RUN_TEST(test_counters_reset_each_walk);
-    RUN_TEST(test_layout_ms_nonnegative);
-    RUN_TEST(test_walk_ms_nonzero_with_commands);
+    RUN_TEST(test_walk_ms_set_then_reset_on_early_return);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_stats.c
+++ b/tests/unit/test_nt_ui_stats.c
@@ -251,9 +251,11 @@ static void test_counters_reset_each_walk(void) {
 /* walk_ms is written every walk: non-negative after a real walk (monotonic
  * clock), and reset to 0.0F on the zero-viewport early-return path. The reset
  * is the deterministic half -- it fails loudly if a future edit forgets to
- * zero walk_ms in that early-return. (layout_ms is owned by nt_ui_end, which
- * the walker fixture never calls, so its timing is covered in
- * test_nt_ui_begin_end.c where a real begin/end cycle runs.) */
+ * zero walk_ms in that early-return. Scope: walk_ms times dispatch only; the
+ * entry flush runs before the timer starts, so it is excluded (same scope as
+ * the draw-call delta). (layout_ms is owned by nt_ui_end, which the walker
+ * fixture never calls, so its timing is covered in test_nt_ui_begin_end.c
+ * where a real begin/end cycle runs.) */
 static void test_walk_ms_set_then_reset_on_early_return(void) {
     for (int i = 0; i < 3; ++i) {
         Clay_RenderCommand *c = &s_test_cmds[i];

--- a/tests/unit/test_nt_ui_stats.c
+++ b/tests/unit/test_nt_ui_stats.c
@@ -129,8 +129,8 @@ static void test_getters_reflect_latest_walk_only(void) {
 }
 
 // #region phase55_counter_tests
-/* 3 RECTANGLE commands -> rect_count == 3, others 0. */
-static void test_per_type_rect_count(void) {
+/* 3 RECTANGLE commands -> rect_command_count == 3, others 0. */
+static void test_per_type_rect_command_count(void) {
     for (int i = 0; i < 3; ++i) {
         Clay_RenderCommand *c = &s_test_cmds[i];
         c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
@@ -142,10 +142,10 @@ static void test_per_type_rect_count(void) {
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    TEST_ASSERT_EQUAL_UINT32(3U, nt_ui_get_last_walk_rect_count(s_fx.ctx));
-    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_image_count(s_fx.ctx));
-    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_text_count(s_fx.ctx));
-    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_border_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(3U, nt_ui_get_last_walk_rect_command_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_image_command_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_text_command_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_border_command_count(s_fx.ctx));
 }
 
 /* 1 RECT + 1 TEXT + 1 BORDER + 1 RECT -> rect=2, text=1, border=1, image=0. */
@@ -187,14 +187,14 @@ static void test_per_type_mixed_commands(void) {
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_rect_count(s_fx.ctx));
-    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_image_count(s_fx.ctx));
-    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_text_count(s_fx.ctx));
-    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_border_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_rect_command_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_image_command_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_text_command_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_border_command_count(s_fx.ctx));
 }
 
-/* SCISSOR_START + RECT + SCISSOR_END -> scissor_count=1, max_depth=1. */
-static void test_scissor_count_and_depth(void) {
+/* SCISSOR_START + RECT + SCISSOR_END -> scissor_command_count=1, max_depth=1. */
+static void test_scissor_command_count_and_depth(void) {
     /* cmd 0: SCISSOR_START */
     {
         Clay_RenderCommand *c = &s_test_cmds[0];
@@ -220,9 +220,9 @@ static void test_scissor_count_and_depth(void) {
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
 
-    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_scissor_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_scissor_command_count(s_fx.ctx));
     TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_max_scissor_depth(s_fx.ctx));
-    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_rect_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_rect_command_count(s_fx.ctx));
 }
 
 /* Walk with 2 RECTs, assert rect=2. Walk again with 0 cmds, assert all 0. */
@@ -237,15 +237,15 @@ static void test_counters_reset_each_walk(void) {
 
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
-    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_rect_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_rect_command_count(s_fx.ctx));
 
     /* Second walk: empty. All per-type counters must be zero. */
     inject_frozen_cmds(0);
     nt_ui_walk(s_fx.ctx, &target);
-    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_rect_count(s_fx.ctx));
-    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_image_count(s_fx.ctx));
-    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_text_count(s_fx.ctx));
-    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_border_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_rect_command_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_image_command_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_text_command_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_border_command_count(s_fx.ctx));
 }
 
 /* walk_ms is written every walk: non-negative after a real walk (monotonic
@@ -284,9 +284,9 @@ int main(void) {
     RUN_TEST(test_get_last_walk_command_count_matches_frozen_cmds);
     RUN_TEST(test_metrics_bridge_publishes_to_nt_stats);
     RUN_TEST(test_getters_reflect_latest_walk_only);
-    RUN_TEST(test_per_type_rect_count);
+    RUN_TEST(test_per_type_rect_command_count);
     RUN_TEST(test_per_type_mixed_commands);
-    RUN_TEST(test_scissor_count_and_depth);
+    RUN_TEST(test_scissor_command_count_and_depth);
     RUN_TEST(test_counters_reset_each_walk);
     RUN_TEST(test_walk_ms_set_then_reset_on_early_return);
     return UNITY_END();

--- a/tests/unit/test_nt_ui_stats.c
+++ b/tests/unit/test_nt_ui_stats.c
@@ -17,7 +17,7 @@
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_TEST_ARENA_SIZE];
 static ui_walker_fixture_t s_fx;
 
-#define MAX_TEST_CMDS 8
+#define MAX_TEST_CMDS 16
 static Clay_RenderCommand s_test_cmds[MAX_TEST_CMDS];
 
 void setUp(void) {
@@ -128,11 +128,161 @@ static void test_getters_reflect_latest_walk_only(void) {
     TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_command_count(s_fx.ctx));
 }
 
+// #region phase55_counter_tests
+/* 3 RECTANGLE commands -> rect_count == 3, others 0. */
+static void test_per_type_rect_count(void) {
+    for (int i = 0; i < 3; ++i) {
+        Clay_RenderCommand *c = &s_test_cmds[i];
+        c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+        c->boundingBox = (Clay_BoundingBox){.x = (float)(i * 30), .y = 0.0F, .width = 20.0F, .height = 20.0F};
+        c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255.0F, .g = 0.0F, .b = 0.0F, .a = 255.0F};
+    }
+    inject_frozen_cmds(3);
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    TEST_ASSERT_EQUAL_UINT32(3U, nt_ui_get_last_walk_rect_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_image_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_text_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_border_count(s_fx.ctx));
+}
+
+/* 1 RECT + 1 TEXT + 1 BORDER + 1 RECT -> rect=2, text=1, border=1, image=0. */
+static void test_per_type_mixed_commands(void) {
+    /* cmd 0: RECTANGLE */
+    {
+        Clay_RenderCommand *c = &s_test_cmds[0];
+        c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+        c->boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 100.0F, .height = 100.0F};
+        c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255.0F, .g = 0.0F, .b = 0.0F, .a = 255.0F};
+    }
+    /* cmd 1: TEXT */
+    {
+        Clay_RenderCommand *c = &s_test_cmds[1];
+        c->commandType = CLAY_RENDER_COMMAND_TYPE_TEXT;
+        c->boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 100.0F, .height = 20.0F};
+        c->renderData.text.stringContents = (Clay_StringSlice){.chars = "test", .length = 4};
+        c->renderData.text.textColor = (Clay_Color){.r = 255.0F, .g = 255.0F, .b = 255.0F, .a = 255.0F};
+        c->renderData.text.fontSize = 16;
+        c->renderData.text.fontId = 0;
+    }
+    /* cmd 2: BORDER */
+    {
+        Clay_RenderCommand *c = &s_test_cmds[2];
+        c->commandType = CLAY_RENDER_COMMAND_TYPE_BORDER;
+        c->boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 100.0F, .height = 100.0F};
+        c->renderData.border.color = (Clay_Color){.r = 255.0F, .g = 0.0F, .b = 0.0F, .a = 255.0F};
+        c->renderData.border.width = (Clay_BorderWidth){.left = 2, .right = 2, .top = 2, .bottom = 2};
+    }
+    /* cmd 3: RECTANGLE */
+    {
+        Clay_RenderCommand *c = &s_test_cmds[3];
+        c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+        c->boundingBox = (Clay_BoundingBox){.x = 120.0F, .y = 0.0F, .width = 50.0F, .height = 50.0F};
+        c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 0.0F, .g = 255.0F, .b = 0.0F, .a = 255.0F};
+    }
+    inject_frozen_cmds(4);
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_rect_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_image_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_text_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_border_count(s_fx.ctx));
+}
+
+/* SCISSOR_START + RECT + SCISSOR_END -> scissor_count=1, max_depth=1. */
+static void test_scissor_count_and_depth(void) {
+    /* cmd 0: SCISSOR_START */
+    {
+        Clay_RenderCommand *c = &s_test_cmds[0];
+        c->commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
+        c->boundingBox = (Clay_BoundingBox){.x = 0.0F, .y = 0.0F, .width = 400.0F, .height = 300.0F};
+        c->renderData.clip.horizontal = true;
+        c->renderData.clip.vertical = true;
+    }
+    /* cmd 1: RECTANGLE */
+    {
+        Clay_RenderCommand *c = &s_test_cmds[1];
+        c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+        c->boundingBox = (Clay_BoundingBox){.x = 10.0F, .y = 10.0F, .width = 80.0F, .height = 80.0F};
+        c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 0.0F, .g = 0.0F, .b = 255.0F, .a = 255.0F};
+    }
+    /* cmd 2: SCISSOR_END */
+    {
+        Clay_RenderCommand *c = &s_test_cmds[2];
+        c->commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
+    }
+    inject_frozen_cmds(3);
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_scissor_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_max_scissor_depth(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_rect_count(s_fx.ctx));
+}
+
+/* Walk with 2 RECTs, assert rect=2. Walk again with 0 cmds, assert all 0. */
+static void test_counters_reset_each_walk(void) {
+    for (int i = 0; i < 2; ++i) {
+        Clay_RenderCommand *c = &s_test_cmds[i];
+        c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+        c->boundingBox = (Clay_BoundingBox){.x = (float)(i * 30), .y = 0.0F, .width = 20.0F, .height = 20.0F};
+        c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255.0F, .g = 255.0F, .b = 255.0F, .a = 255.0F};
+    }
+    inject_frozen_cmds(2);
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &target);
+    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_rect_count(s_fx.ctx));
+
+    /* Second walk: empty. All per-type counters must be zero. */
+    inject_frozen_cmds(0);
+    nt_ui_walk(s_fx.ctx, &target);
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_rect_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_image_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_text_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_get_last_walk_border_count(s_fx.ctx));
+}
+
+/* layout_ms is written by nt_ui_end; verify ctx field is non-negative. */
+static void test_layout_ms_nonnegative(void) {
+    /* ctx was set up by fixture; last_layout_ms should be 0.0F (no end called
+     * in this test cycle) or >= 0 if fixture ran begin/end. Either way, >= 0. */
+    TEST_ASSERT_TRUE(nt_ui_get_last_layout_ms(s_fx.ctx) >= 0.0F);
+}
+
+/* walk_ms is non-negative after a walk with commands. */
+static void test_walk_ms_nonzero_with_commands(void) {
+    for (int i = 0; i < 3; ++i) {
+        Clay_RenderCommand *c = &s_test_cmds[i];
+        c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
+        c->boundingBox = (Clay_BoundingBox){.x = (float)(i * 20), .y = 0.0F, .width = 10.0F, .height = 10.0F};
+        c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255.0F, .g = 0.0F, .b = 0.0F, .a = 255.0F};
+    }
+    inject_frozen_cmds(3);
+
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    TEST_ASSERT_TRUE(nt_ui_get_last_walk_ms(s_fx.ctx) >= 0.0F);
+}
+// #endregion
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_get_last_walk_draw_calls_after_rect);
     RUN_TEST(test_get_last_walk_command_count_matches_frozen_cmds);
     RUN_TEST(test_metrics_bridge_publishes_to_nt_stats);
     RUN_TEST(test_getters_reflect_latest_walk_only);
+    RUN_TEST(test_per_type_rect_count);
+    RUN_TEST(test_per_type_mixed_commands);
+    RUN_TEST(test_scissor_count_and_depth);
+    RUN_TEST(test_counters_reset_each_walk);
+    RUN_TEST(test_layout_ms_nonnegative);
+    RUN_TEST(test_walk_ms_nonzero_with_commands);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_stats.c
+++ b/tests/unit/test_nt_ui_stats.c
@@ -263,6 +263,8 @@ static void test_walk_ms_set_then_reset_on_early_return(void) {
     }
     inject_frozen_cmds(3);
 
+    /* Sentinel: a removed walk-exit write leaves -1.0F and trips the assert. */
+    s_fx.ctx->last_walk_ms = -1.0F;
     nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
     nt_ui_walk(s_fx.ctx, &target);
     TEST_ASSERT_TRUE(nt_ui_get_last_walk_ms(s_fx.ctx) >= 0.0F);

--- a/tests/unit/test_nt_ui_transform.c
+++ b/tests/unit/test_nt_ui_transform.c
@@ -109,7 +109,7 @@ static void test_push_pop_transform_balanced(void) {
 
     /* Phase 55 counters: one transform push marker, one IMAGE dispatched. */
     TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_transform_pushes(s_fx.ctx));
-    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_image_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_image_command_count(s_fx.ctx));
 }
 
 /* Push 17 transforms (depth > 16). Expect NT_ASSERT overflow. */

--- a/tests/unit/test_nt_ui_transform.c
+++ b/tests/unit/test_nt_ui_transform.c
@@ -106,6 +106,10 @@ static void test_push_pop_transform_balanced(void) {
 
     /* Walk completed without assert = balanced. */
     TEST_ASSERT_EQUAL_UINT32(4U, nt_sprite_renderer_test_last_emit_vertex_count());
+
+    /* Phase 55 counters: one transform push marker, one IMAGE dispatched. */
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_transform_pushes(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_image_count(s_fx.ctx));
 }
 
 /* Push 17 transforms (depth > 16). Expect NT_ASSERT overflow. */
@@ -148,6 +152,9 @@ static void test_opacity_inheritance(void) {
 
     /* Walk succeeded; alpha = 255 * 0.25 = 63..64. */
     TEST_ASSERT_EQUAL_UINT32(4U, nt_sprite_renderer_test_last_emit_vertex_count());
+
+    /* Phase 55 counter: two opacity push markers. */
+    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_opacity_pushes(s_fx.ctx));
 }
 
 /* Push transform with offset_x=10. Emit rect. Verify the rect's x


### PR DESCRIPTION
## Summary
- Adds CPU timing + per-type/scissor/marker counters to the `nt_ui` walker, exposed via 10 new public getters following the established `nt_ui_get_last_walk_*` pattern.
- Wires `slice9_demo` with a `"frame"` GPU timer segment, a metrics bridge into `nt_stats_count`, and a stats overlay via `nt_stats_draw` — demonstrating the game-side pattern for consuming the new metrics.
- `nt_time` added as an explicit PRIVATE dependency of `nt_ui`.

## Details
**Engine (`engine/ui/`):**
- 10 new fields on `nt_ui_context_t`: `last_layout_ms`, `last_walk_ms` (float) + 8 uint32_t counters (rect/image/text/border counts, scissor_count, max_scissor_depth, transform_pushes, opacity_pushes).
- Layout timing wraps `Clay_EndLayout()` in `nt_ui_end`; walk timing wraps the full walker in `nt_ui_walk`.
- Per-type counting via a local `nt_ui_walk_counters_t` struct threaded through `dispatch_command`/`process_marker` — keeps `ctx` const in `dispatch_command`.
- All counters reset each walk; zero-viewport and atlas-not-ready early returns zero every new field.

**Demo (`examples/slice9_demo/main.c`):**
- `nt_gfx_begin_segment("frame")` / `nt_gfx_end_segment()` around the UI walk.
- Metrics bridge publishes all getters as `nt_stats_count` user counters; timing encoded as integer microseconds.
- Overlay drawn with `nt_stats_draw`.

## Scope change
- **WALK-07 / WALK-08 (sort-by-material walker flag) deferred to backlog** (D-55-12/D-55-13) — layers already provide explicit draw-order control.
- STATS-01/STATS-02 addressed via the game-side GPU segment pattern (D-55-08/D-55-09).

## Test plan
- [x] `cmake --build build/_cmake/native-debug` + `native-release` + `wasm-debug` — clean
- [x] `ctest --test-dir build/_cmake/native-debug` — 55/55 pass (6 new tests in `test_nt_ui_stats.c`)
- [x] `clang-format --dry-run --Werror` — clean on all modified files
- [x] `bash scripts/tidy.sh` (clang-tidy) — clean
- [ ] Visual: stats overlay positioning + GPU timer accuracy in `slice9_demo` (manual)

Closes #193