### PR TITLE
UI: 3D-ctx world-space text + inspector overlay/pick (#197)

### DIFF
--- a/assets/shaders/slug_text.frag
+++ b/assets/shaders/slug_text.frag
@@ -8,6 +8,7 @@ precision highp int;
 uniform sampler2D u_curve_texture;       // RGBA16F -- curve control points as float16
 uniform highp usampler2D u_band_texture; // RG16UI -- (curve_start, curve_count) per band
 uniform int u_curve_tex_width;           // For linear-to-2D addressing
+uniform vec4 u_alpha_cutoff;             // .x = coverage discard threshold (set per material; 0 disables)
 
 in vec2 v_texcoord;
 flat in uvec4 v_glyph;       // curve_offset_y, band_row, curve_offset_x, band_count
@@ -163,7 +164,7 @@ float SlugRender(vec2 coord) {
 void main() {
     float coverage = SlugRender(v_texcoord);
 
-    if (coverage < 1.0 / 255.0)
+    if (coverage < u_alpha_cutoff.x)
         discard;
 
     // Premultiplied alpha output

--- a/assets/shaders/slug_text.vert
+++ b/assets/shaders/slug_text.vert
@@ -4,18 +4,20 @@ precision highp int;
 #include "common/globals.glsl"
 
 // CPU-SIDE PACKING FORMAT (nt_text vertex buffer contract):
-// Stride: 68 bytes per vertex, 4 vertices per glyph quad (2 triangles = 6 indices)
+// Stride: 72 bytes per vertex, 4 vertices per glyph quad (2 triangles = 6 indices)
 // location 0: vec3  a_position     - world-space quad corner (float32 x3, full 3D)
 // location 1: vec2  a_texcoord     - em-space coordinate (float32 x2)
 // location 2: vec4  a_glyph_data   - packed as floatBitsToUint: (curve_offset_y, band_row, curve_offset_x, band_count)
 // location 3: vec4  a_glyph_bounds - bbox x0/y0/x1/y1 in em-space (float32 x4)
 // location 4: vec4  a_color        - text color RGBA (float32 x4)
+// location 5: float a_depth_bias   - per-glyph NDC depth bias toward the near plane (float32)
 
 layout(location = 0) in vec3 a_position;
 layout(location = 1) in vec2 a_texcoord;
 layout(location = 2) in vec4 a_glyph_data;
 layout(location = 3) in vec4 a_glyph_bounds;
 layout(location = 4) in vec4 a_color;
+layout(location = 5) in float a_depth_bias;
 
 out vec2 v_texcoord;
 flat out uvec4 v_glyph;
@@ -29,4 +31,7 @@ void main() {
     v_color = a_color;
 
     gl_Position = view_proj * vec4(a_position, 1.0);
+    // Per-glyph bias toward the near plane (view-independent) so depth-writing glyph
+    // quads don't z-fight at overlapping AA fringes. 0 = no shift.
+    gl_Position.z -= a_depth_bias * gl_Position.w;
 }

--- a/assets/shaders/sprite_cutoff.frag
+++ b/assets/shaders/sprite_cutoff.frag
@@ -1,0 +1,23 @@
+precision mediump float;
+
+uniform sampler2D u_texture;
+uniform vec4 u_alpha_cutoff; // .x = alpha discard threshold (set per material; 0 disables)
+
+in vec2 v_texcoord;
+in vec4 v_color;
+
+out vec4 frag_color;
+
+/* sprite.frag + an alpha discard so near-transparent fragments don't write depth. Needed when a
+ * sprite material has depth_write ON (e.g. overlapping world-space UI panels): without it a button's
+ * transparent corners punch holes into the depth buffer. cutoff 0 = no discard (== sprite.frag). */
+void main() {
+    // Premultiplied alpha, same as sprite.frag (texture is premultiplied; premultiply vertex color).
+    vec4 tex = texture(u_texture, v_texcoord);
+    vec4 c = vec4(v_color.rgb * v_color.a, v_color.a);
+    vec4 px = tex * c;
+    if (px.a < u_alpha_cutoff.x) {
+        discard;
+    }
+    frag_color = px;
+}

--- a/docs/neotolis_engine_spec_1.md
+++ b/docs/neotolis_engine_spec_1.md
@@ -190,6 +190,23 @@ If a decision can be deferred without loss of base architecture — it is deferr
   Result: 1-frame IM-lag is intrinsic (current frame reads previous
   frame's bbox); no stuck input on widget disappearance.
 
+  **Front-most arbitration.** When interactive widgets overlap a pointer, only
+  the front-most may react; the rest are gated off. The hot widget per pointer
+  is resolved once per frame — lazily, on the first `step_interaction` /
+  `query_interaction` / `nt_ui_pointer_hot` — from the PREVIOUS frame's
+  interactive registry; only widgets that called `nt_ui_step_interaction` last
+  frame are candidates. 3D ctx (`use_raycast_input`): nearest world ray-distance
+  within a game-fed occlusion cutoff (`nt_ui_set_pointer_occlusion`, reset each
+  begin) so UI can't be clicked through world geometry — the game owns the
+  raycast, the engine only takes the cutoff distance; `nt_ui_interaction_t.distance`
+  reports the hit distance. 2D ctx: highest effective Clay zIndex (tie →
+  last-declared). A free pointer drives a widget only if it is the resolved hot
+  widget or already holds capture; `nt_ui_pointer_hot` exposes the resolved id.
+  Consequence: a freshly-shown widget registers on its first step and only
+  becomes eligible the NEXT frame; on the first frame (empty registry) nothing
+  reacts — reliability over instant first-frame response, no raw-hit fallback
+  (matches Dear ImGui). This trades immediacy for unambiguous overlap/occlusion.
+
   **Anim cache.** `nt_ui_anim_*` provides per-id eased state for widget
   visuals. Open-addressing direct-mapped table (`NT_UI_ANIM_SLOTS`,
   default 64); 4-probe chain; full-chain collision evicts the LAST

--- a/docs/neotolis_engine_spec_1.md
+++ b/docs/neotolis_engine_spec_1.md
@@ -169,7 +169,11 @@ If a decision can be deferred without loss of base architecture — it is deferr
     from the regular 3D walk and drawn by `nt_ui_debug_inspector_walk` as
     a separate final screen-space pass. The game binds a 2D UI projection
     first; `nt_ui_make_screen_view_proj(w, h, ...)` provides the standard
-    Y-up orthographic matrix used by 2D demos.
+    Y-up orthographic matrix used by 2D demos. The post-walk highlight
+    overlay (`nt_ui_inspector_overlay_draw`) differs: in 3D ctx it emits the
+    hovered element's bbox under that element's `hit_baked` world matrix, so
+    the game binds the perspective VP for it while the sidebar tree stays
+    orthographic.
 
   Both modes use the same `tree_baked[layout_idx]` + per-id mirror
   `hit_baked[slot]` (Clay's hashmap is persistent across frames;

--- a/docs/neotolis_engine_spec_1.md
+++ b/docs/neotolis_engine_spec_1.md
@@ -200,7 +200,9 @@ If a decision can be deferred without loss of base architecture — it is deferr
   begin) so UI can't be clicked through world geometry — the game owns the
   raycast, the engine only takes the cutoff distance; `nt_ui_interaction_t.distance`
   reports the hit distance. 2D ctx: highest effective Clay zIndex (tie →
-  last-declared). A free pointer drives a widget only if it is the resolved hot
+  last-registered, i.e. the later `step_interaction` call; widget code should step
+  in declaration order so this matches paint order). A free pointer drives a
+  widget only if it is the resolved hot
   widget or already holds capture; `nt_ui_pointer_hot` exposes the resolved id.
   Consequence: a freshly-shown widget registers on its first step and only
   becomes eligible the NEXT frame; on the first frame (empty registry) nothing

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -41,7 +41,7 @@ static struct {
     nt_material_t material;
     nt_font_t font;
     /* Per-glyph clip-space NDC z bias so depth-writing glyph quads don't z-fight at overlapping AA
-     * fringes; 0 = off, signed. Lives in s_text so init/shutdown/restore_gpu memset clears it. */
+     * fringes; 0 = off, signed. Logical state: cleared by cold init/shutdown, preserved by restore_gpu. */
     float glyph_depth_bias;
 
     /* Cached pipeline state */
@@ -135,27 +135,16 @@ static void create_pipeline(void) {
 // #endregion
 
 // #region Lifecycle
-void nt_text_renderer_init(void) {
-    NT_ASSERT(!s_text.initialized);
-    memset(&s_text, 0, sizeof(s_text));
-
-    /* Generate quad indices */
+/* GPU resources only — the pipeline is created lazily in flush, so this owns just the buffers + index
+ * pattern. Split out so restore_gpu can rebuild them WITHOUT touching s_text's logical fields. */
+static void create_gpu_resources(void) {
     generate_quad_indices();
-
-    /* Register pre-flush callback so font cache clears draw our staging
-     * buffer while texture offsets are still valid. Safe when staging is
-     * empty — flush does early return on glyph_count == 0. */
-    nt_font_set_pre_flush_callback(nt_text_renderer_flush);
-
-    /* Create dynamic vertex buffer */
     s_text.vbo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
         .type = NT_BUFFER_VERTEX,
         .usage = NT_USAGE_DYNAMIC,
         .size = NT_TEXT_RENDERER_MAX_VERTICES * (uint32_t)sizeof(nt_text_vertex_t),
         .label = "text_vbo",
     });
-
-    /* Create immutable index buffer with pre-generated quad pattern */
     s_text.ibo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
         .type = NT_BUFFER_INDEX,
         .usage = NT_USAGE_IMMUTABLE,
@@ -164,7 +153,28 @@ void nt_text_renderer_init(void) {
         .index_type = NT_INDEX_UINT16,
         .label = "text_ibo",
     });
+}
 
+static void destroy_gpu_resources(void) {
+    if (s_text.pipeline.id != 0) {
+        nt_gfx_destroy_pipeline(s_text.pipeline);
+        s_text.pipeline = (nt_pipeline_t){0};
+    }
+    nt_gfx_destroy_buffer(s_text.vbo);
+    nt_gfx_destroy_buffer(s_text.ibo);
+    s_text.vbo = (nt_buffer_t){0};
+    s_text.ibo = (nt_buffer_t){0};
+}
+
+void nt_text_renderer_init(void) {
+    NT_ASSERT(!s_text.initialized);
+    memset(&s_text, 0, sizeof(s_text)); /* cold start: clear everything, GPU + logical */
+
+    /* Pre-flush hook so font-cache evictions flush our staging while texture offsets are still valid.
+     * Safe when staging is empty (flush early-returns on glyph_count == 0). */
+    nt_font_set_pre_flush_callback(nt_text_renderer_flush);
+
+    create_gpu_resources();
     s_text.initialized = true;
 }
 
@@ -172,11 +182,7 @@ void nt_text_renderer_shutdown(void) {
     if (!s_text.initialized) {
         return;
     }
-    if (s_text.pipeline.id != 0) {
-        nt_gfx_destroy_pipeline(s_text.pipeline);
-    }
-    nt_gfx_destroy_buffer(s_text.vbo);
-    nt_gfx_destroy_buffer(s_text.ibo);
+    destroy_gpu_resources();
     nt_font_set_pre_flush_callback(NULL);
     memset(&s_text, 0, sizeof(s_text));
 }
@@ -185,21 +191,14 @@ void nt_text_renderer_restore_gpu(void) {
     if (!s_text.initialized) {
         return;
     }
-
-    /* Save state that survives context loss */
-    nt_material_t saved_material = s_text.material;
-    nt_font_t saved_font = s_text.font;
-    float saved_glyph_depth_bias = s_text.glyph_depth_bias;
-
-    /* Full shutdown → init cycle (frees pool slots, no leaks) */
-    nt_text_renderer_shutdown();
-    nt_text_renderer_init();
-
-    /* Restore state */
-    s_text.material = saved_material;
-    s_text.font = saved_font;
-    s_text.glyph_depth_bias = saved_glyph_depth_bias; /* logical state survives restore, like material/font */
-    s_text.pipeline_material_version = 0;             /* force pipeline recreation on next flush */
+    /* Context-loss recovery: rebuild ONLY GPU resources. Logical state (material, font,
+     * glyph_depth_bias) is left untouched, so it survives by default — no save/restore list to forget
+     * when a field is added (the bug that made glyph_depth_bias drop before this split). */
+    destroy_gpu_resources();
+    create_gpu_resources();
+    s_text.vertex_count = 0; /* in-flight staging is dropped across context loss */
+    s_text.glyph_count = 0;
+    s_text.pipeline_material_version = 0; /* pipeline destroyed above → flush rebuilds it lazily */
 }
 // #endregion
 

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -19,8 +19,9 @@ typedef struct {
     float glyph_data[4];   /* 16B: packed uint via memcpy (curve_offset, band_row, curve_offset_x, band_count) */
     float glyph_bounds[4]; /* 16B: bbox x0/y0/x1/y1 in em-space */
     float color[4];        /* 16B: RGBA float */
+    float depth_bias;      /* 4B: per-glyph clip-space depth bias (subtracted from NDC z in the VS) */
 } nt_text_vertex_t;
-_Static_assert(sizeof(nt_text_vertex_t) == 68, "text vertex stride must be 68 bytes");
+_Static_assert(sizeof(nt_text_vertex_t) == 72, "text vertex stride must be 72 bytes");
 // #endregion
 
 // #region Module state
@@ -86,10 +87,10 @@ static void create_pipeline(void) {
         nt_gfx_destroy_pipeline(s_text.pipeline);
     }
 
-    /* Slug vertex layout: 5 attributes, stride = 68 bytes */
+    /* Slug vertex layout: 6 attributes, stride = 72 bytes */
     nt_vertex_layout_t layout = {
-        .attr_count = 5,
-        .stride = 68,
+        .attr_count = 6,
+        .stride = 72,
         .attrs =
             {
                 {.location = 0, .format = NT_FORMAT_FLOAT3, .offset = 0},  /* a_position */
@@ -97,6 +98,7 @@ static void create_pipeline(void) {
                 {.location = 2, .format = NT_FORMAT_FLOAT4, .offset = 20}, /* a_glyph_data */
                 {.location = 3, .format = NT_FORMAT_FLOAT4, .offset = 36}, /* a_glyph_bounds */
                 {.location = 4, .format = NT_FORMAT_FLOAT4, .offset = 52}, /* a_color */
+                {.location = 5, .format = NT_FORMAT_FLOAT, .offset = 68},  /* a_depth_bias */
             },
     };
 
@@ -241,6 +243,10 @@ void nt_text_renderer_set_font(nt_font_t font) {
 // #region Vertex generation helpers
 static void pack_uint_as_float(float *out, uint32_t val) { memcpy(out, &val, 4); /* bit-preserving uint-to-float, never cast */ }
 
+/* Per-glyph depth offset (model-local +Z) so depth-writing glyph quads don't z-fight at their
+ * overlapping AA fringes. 0 = off. Set via nt_text_renderer_set_glyph_depth_bias. */
+static float s_glyph_depth_bias = 0.0F;
+
 static void transform_point(float out[3], const float model[16], float x, float y) {
     /* mat4 * vec4(x, y, 0, 1) -- full 3D transform */
     out[0] = model[0] * x + model[4] * y + model[12];
@@ -248,7 +254,7 @@ static void transform_point(float out[3], const float model[16], float x, float 
     out[2] = model[2] * x + model[6] * y + model[14];
 }
 
-static void emit_quad(const nt_glyph_cache_entry_t *g, const float model[16], float scale, float pen_x, float pen_y, const float color[4], uint8_t band_count) {
+static void emit_quad(const nt_glyph_cache_entry_t *g, const float model[16], float scale, float pen_x, float pen_y, const float color[4], uint8_t band_count, float glyph_bias) {
     if (s_text.glyph_count >= NT_TEXT_RENDERER_MAX_GLYPHS) {
         nt_text_renderer_flush();
     }
@@ -294,6 +300,7 @@ static void emit_quad(const nt_glyph_cache_entry_t *g, const float model[16], fl
     v[0].glyph_bounds[2] = (float)g->bbox_x1;
     v[0].glyph_bounds[3] = (float)g->bbox_y1;
     memcpy(v[0].color, color, 16);
+    v[0].depth_bias = glyph_bias;
     v[1] = v[0];
     v[2] = v[0];
     v[3] = v[0];
@@ -351,6 +358,7 @@ void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16]
     uint32_t prev_cp = 0;
     float pen_x = 0.0F;
     float pen_y = 0.0F;
+    float glyph_bias = 0.0F; /* accumulates per emitted glyph (clip-space depth bias) */
     /* Natural line advance from font metrics, plus user-supplied leading. */
     const float natural_line_advance = (metrics.line_height != 0) ? ((float)metrics.line_height * scale) : size;
     const float line_advance = natural_line_advance + line_leading;
@@ -397,7 +405,8 @@ void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16]
 
         /* Emit quad if glyph has visible bbox */
         if (g->bbox_x1 > g->bbox_x0) {
-            emit_quad(g, model, scale, pen_x, pen_y, color, band_count);
+            emit_quad(g, model, scale, pen_x, pen_y, color, band_count, glyph_bias);
+            glyph_bias += s_glyph_depth_bias;
         }
 
         pen_x += (float)g->advance * scale;
@@ -405,6 +414,8 @@ void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16]
         had_glyph_on_line = true;
     }
 }
+
+void nt_text_renderer_set_glyph_depth_bias(float bias_per_glyph) { s_glyph_depth_bias = bias_per_glyph; }
 
 void nt_text_renderer_draw(const char *utf8, const float model[16], float size, const float color[4], float letter_tracking, float line_leading) {
     nt_text_renderer_draw_n(utf8, utf8 ? strlen(utf8) : 0U, model, size, color, letter_tracking, line_leading);

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -9,6 +9,7 @@
 
 #include "utf8/nt_utf8.h"
 
+#include <math.h>
 #include <string.h>
 
 // #region Vertex format
@@ -39,6 +40,9 @@ static struct {
     /* Current state */
     nt_material_t material;
     nt_font_t font;
+    /* Per-glyph clip-space NDC z bias so depth-writing glyph quads don't z-fight at overlapping AA
+     * fringes; 0 = off, signed. Lives in s_text so init/shutdown/restore_gpu memset clears it. */
+    float glyph_depth_bias;
 
     /* Cached pipeline state */
     uint32_t pipeline_material_version; /* version when pipeline was last created */
@@ -243,10 +247,6 @@ void nt_text_renderer_set_font(nt_font_t font) {
 // #region Vertex generation helpers
 static void pack_uint_as_float(float *out, uint32_t val) { memcpy(out, &val, 4); /* bit-preserving uint-to-float, never cast */ }
 
-/* Per-glyph depth offset (model-local +Z) so depth-writing glyph quads don't z-fight at their
- * overlapping AA fringes. 0 = off. Set via nt_text_renderer_set_glyph_depth_bias. */
-static float s_glyph_depth_bias = 0.0F;
-
 static void transform_point(float out[3], const float model[16], float x, float y) {
     /* mat4 * vec4(x, y, 0, 1) -- full 3D transform */
     out[0] = model[0] * x + model[4] * y + model[12];
@@ -406,7 +406,7 @@ void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16]
         /* Emit quad if glyph has visible bbox */
         if (g->bbox_x1 > g->bbox_x0) {
             emit_quad(g, model, scale, pen_x, pen_y, color, band_count, glyph_bias);
-            glyph_bias += s_glyph_depth_bias;
+            glyph_bias += s_text.glyph_depth_bias;
         }
 
         pen_x += (float)g->advance * scale;
@@ -415,7 +415,10 @@ void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16]
     }
 }
 
-void nt_text_renderer_set_glyph_depth_bias(float bias_per_glyph) { s_glyph_depth_bias = bias_per_glyph; }
+void nt_text_renderer_set_glyph_depth_bias(float bias_per_glyph) {
+    NT_ASSERT(isfinite(bias_per_glyph) && "nt_text_renderer_set_glyph_depth_bias: bias must be finite");
+    s_text.glyph_depth_bias = bias_per_glyph; /* signed: subtracted from NDC z in the VS */
+}
 
 void nt_text_renderer_draw(const char *utf8, const float model[16], float size, const float color[4], float letter_tracking, float line_leading) {
     nt_text_renderer_draw_n(utf8, utf8 ? strlen(utf8) : 0U, model, size, color, letter_tracking, line_leading);
@@ -457,6 +460,19 @@ void nt_text_renderer_flush(void) {
         nt_gfx_set_uniform_int("u_curve_texture", 0);
         nt_gfx_set_uniform_int("u_band_texture", 1);
         nt_gfx_set_uniform_int("u_curve_tex_width", (int)nt_font_get_curve_texture_width(s_text.font));
+    }
+
+    /* Re-read material vec4 params every flush (e.g. u_alpha_cutoff) — same contract sprite/mesh
+     * renderers honor; without this the shader sees uninitialized uniforms. */
+    if (s_text.material.id != 0) {
+        const nt_material_info_t *mi = nt_material_get_info(s_text.material);
+        if (mi != NULL) {
+            for (uint8_t p = 0; p < mi->param_count; p++) {
+                if (mi->param_names[p] != NULL) {
+                    nt_gfx_set_uniform_vec4(mi->param_names[p], mi->params[p]);
+                }
+            }
+        }
     }
 
     /* Single draw call per flush */

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -189,6 +189,7 @@ void nt_text_renderer_restore_gpu(void) {
     /* Save state that survives context loss */
     nt_material_t saved_material = s_text.material;
     nt_font_t saved_font = s_text.font;
+    float saved_glyph_depth_bias = s_text.glyph_depth_bias;
 
     /* Full shutdown → init cycle (frees pool slots, no leaks) */
     nt_text_renderer_shutdown();
@@ -197,7 +198,8 @@ void nt_text_renderer_restore_gpu(void) {
     /* Restore state */
     s_text.material = saved_material;
     s_text.font = saved_font;
-    s_text.pipeline_material_version = 0; /* force pipeline recreation on next flush */
+    s_text.glyph_depth_bias = saved_glyph_depth_bias; /* logical state survives restore, like material/font */
+    s_text.pipeline_material_version = 0;             /* force pipeline recreation on next flush */
 }
 // #endregion
 
@@ -499,5 +501,6 @@ void nt_text_renderer_test_reset_call_counters(void) {
 }
 const float *nt_text_renderer_test_last_model(void) { return s_text.test_last_model; }
 uint32_t nt_text_renderer_test_draw_n_calls(void) { return s_text.test_draw_n_calls; }
+float nt_text_renderer_test_glyph_depth_bias(void) { return s_text.glyph_depth_bias; }
 #endif
 // #endregion

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -136,7 +136,7 @@ static void create_pipeline(void) {
 
 // #region Lifecycle
 /* GPU resources only — the pipeline is created lazily in flush, so this owns just the buffers + index
- * pattern. Split out so restore_gpu can rebuild them WITHOUT touching s_text's logical fields. */
+ * pattern. Must not touch s_text's logical fields; restore_gpu rebuilds these without wiping them. */
 static void create_gpu_resources(void) {
     generate_quad_indices();
     s_text.vbo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
@@ -193,7 +193,7 @@ void nt_text_renderer_restore_gpu(void) {
     }
     /* Context-loss recovery: rebuild ONLY GPU resources. Logical state (material, font,
      * glyph_depth_bias) is left untouched, so it survives by default — no save/restore list to forget
-     * when a field is added (the bug that made glyph_depth_bias drop before this split). */
+     * when a field is added. */
     destroy_gpu_resources();
     create_gpu_resources();
     s_text.vertex_count = 0; /* in-flight staging is dropped across context loss */

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -13,7 +13,7 @@
 #include <string.h>
 
 // #region Vertex format
-/* 68 bytes per vertex, matching slug_text.vert contract */
+/* 72 bytes per vertex, matching slug_text.vert contract */
 typedef struct {
     float position[3];     /* 12B: world-space quad corner (full 3D) */
     float texcoord[2];     /* 8B: em-space coordinate */

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -417,6 +417,7 @@ void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16]
 }
 
 void nt_text_renderer_set_glyph_depth_bias(float bias_per_glyph) {
+    NT_ASSERT(s_text.initialized);
     NT_ASSERT(isfinite(bias_per_glyph) && "nt_text_renderer_set_glyph_depth_bias: bias must be finite");
     s_text.glyph_depth_bias = bias_per_glyph; /* signed: subtracted from NDC z in the VS */
 }

--- a/engine/renderers/nt_text_renderer.h
+++ b/engine/renderers/nt_text_renderer.h
@@ -43,6 +43,10 @@ void nt_text_renderer_set_font(nt_font_t font);
 void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16], float size, const float color[4], float letter_tracking, float line_leading);
 void nt_text_renderer_draw(const char *utf8, const float model[16], float size, const float color[4], float letter_tracking, float line_leading);
 
+/* Per-glyph model-local +Z step. With depth_write, coplanar glyph quads z-fight at overlapping AA
+ * fringes; a small step separates them by draw order. 0 (default) = off. Persists until changed. */
+void nt_text_renderer_set_glyph_depth_bias(float bias_per_glyph);
+
 void nt_text_renderer_flush(void);
 
 // #region test_access

--- a/engine/renderers/nt_text_renderer.h
+++ b/engine/renderers/nt_text_renderer.h
@@ -29,8 +29,9 @@ void nt_text_renderer_restore_gpu(void);
  * the renderer binds only the params the material declares (it never injects a default), so declaring
  *     .params[0] = {.name = "u_alpha_cutoff", .value = {NT_TEXT_ALPHA_CUTOFF_DEFAULT}}, .param_count = 1,
  * enables the frag's `discard coverage < u_alpha_cutoff.x`. Omit it and the uniform stays 0 (GL-spec
- * default for an unset uniform) → no discard. Omitting is a valid choice, not an error; depth-writing
- * world-space text that wants clean AA edges should declare it. Both setters auto-flush on change. */
+ * default for an unset uniform) → no discard. Omitting is a valid choice, not an error. Depth-writing
+ * world-space text should declare it; see NT_TEXT_ALPHA_CUTOFF_DEFAULT for the cutoff value to use.
+ * Both setters auto-flush on change. */
 void nt_text_renderer_set_material(nt_material_t mat);
 void nt_text_renderer_set_font(nt_font_t font);
 

--- a/engine/renderers/nt_text_renderer.h
+++ b/engine/renderers/nt_text_renderer.h
@@ -64,6 +64,7 @@ void nt_text_renderer_test_reset_call_counters(void);
  * Lets tests pin nt_ui's emit_text mat4 construction without needing a real font. */
 const float *nt_text_renderer_test_last_model(void);
 uint32_t nt_text_renderer_test_draw_n_calls(void);
+float nt_text_renderer_test_glyph_depth_bias(void);
 #endif
 // #endregion
 

--- a/engine/renderers/nt_text_renderer.h
+++ b/engine/renderers/nt_text_renderer.h
@@ -29,9 +29,8 @@ void nt_text_renderer_restore_gpu(void);
  * the renderer binds only the params the material declares (it never injects a default), so declaring
  *     .params[0] = {.name = "u_alpha_cutoff", .value = {NT_TEXT_ALPHA_CUTOFF_DEFAULT}}, .param_count = 1,
  * enables the frag's `discard coverage < u_alpha_cutoff.x`. Omit it and the uniform stays 0 (GL-spec
- * default for an unset uniform) → no discard. Omitting is a valid choice, not an error. Depth-writing
- * world-space text should declare it; see NT_TEXT_ALPHA_CUTOFF_DEFAULT for the cutoff value to use.
- * Both setters auto-flush on change. */
+ * default for an unset uniform) → no discard. Depth-writing world-space text should declare it; see
+ * NT_TEXT_ALPHA_CUTOFF_DEFAULT for the cutoff value. Both setters auto-flush on change. */
 void nt_text_renderer_set_material(nt_material_t mat);
 void nt_text_renderer_set_font(nt_font_t font);
 

--- a/engine/renderers/nt_text_renderer.h
+++ b/engine/renderers/nt_text_renderer.h
@@ -18,7 +18,9 @@
 _Static_assert(NT_TEXT_RENDERER_MAX_GLYPHS <= 16383, "NT_TEXT_RENDERER_MAX_GLYPHS > 16383 overflows uint16 index buffer");
 
 /* Default for the slug_text `u_alpha_cutoff.x` param: discards only fully-empty glyph-quad pixels.
- * World-space text that writes depth should raise this (~0.5) so AA edges don't write depth and halo. */
+ * Good even for depth-writing world text: pair it with a per-glyph depth bias
+ * (nt_text_renderer_set_glyph_depth_bias) to separate overlapping glyphs — raising the cutoff would
+ * harden AA edges without removing a real halo. */
 #define NT_TEXT_ALPHA_CUTOFF_DEFAULT (1.0F / 255.0F)
 
 void nt_text_renderer_init(void);

--- a/engine/renderers/nt_text_renderer.h
+++ b/engine/renderers/nt_text_renderer.h
@@ -25,12 +25,10 @@ void nt_text_renderer_init(void);
 void nt_text_renderer_shutdown(void);
 void nt_text_renderer_restore_gpu(void);
 
-/* The bound material uses the slug_text vs/fs, ALPHA blend, cull NONE. The alpha-clip is OPT-IN:
- * the renderer binds only the params the material declares (it never injects a default), so declaring
- *     .params[0] = {.name = "u_alpha_cutoff", .value = {NT_TEXT_ALPHA_CUTOFF_DEFAULT}}, .param_count = 1,
- * enables the frag's `discard coverage < u_alpha_cutoff.x`. Omit it and the uniform stays 0 (GL-spec
- * default for an unset uniform) → no discard. Depth-writing world-space text should declare it; see
- * NT_TEXT_ALPHA_CUTOFF_DEFAULT for the cutoff value. Both setters auto-flush on change. */
+/* Material must use the slug_text vs/fs, ALPHA blend, cull NONE. u_alpha_cutoff is an opt-in param:
+ * declare it (value = NT_TEXT_ALPHA_CUTOFF_DEFAULT) to enable the frag's coverage discard; omit it and
+ * the unset uniform reads 0 → no discard (the renderer binds only declared params). Both setters
+ * auto-flush staging on change. */
 void nt_text_renderer_set_material(nt_material_t mat);
 void nt_text_renderer_set_font(nt_font_t font);
 

--- a/engine/renderers/nt_text_renderer.h
+++ b/engine/renderers/nt_text_renderer.h
@@ -25,11 +25,12 @@ void nt_text_renderer_init(void);
 void nt_text_renderer_shutdown(void);
 void nt_text_renderer_restore_gpu(void);
 
-/* The bound material must use the slug_text vs/fs, ALPHA blend, cull NONE, and set the alpha-clip
- * param (frag discards coverage < u_alpha_cutoff.x; a missing/0 param disables the discard):
- *     .params[0] = {.name = "u_alpha_cutoff", .value = {NT_TEXT_ALPHA_CUTOFF_DEFAULT}},
- *     .param_count = 1,
- * Both setters auto-flush staging on change. */
+/* The bound material uses the slug_text vs/fs, ALPHA blend, cull NONE. The alpha-clip is OPT-IN:
+ * the renderer binds only the params the material declares (it never injects a default), so declaring
+ *     .params[0] = {.name = "u_alpha_cutoff", .value = {NT_TEXT_ALPHA_CUTOFF_DEFAULT}}, .param_count = 1,
+ * enables the frag's `discard coverage < u_alpha_cutoff.x`. Omit it and the uniform stays 0 (GL-spec
+ * default for an unset uniform) → no discard. Omitting is a valid choice, not an error; depth-writing
+ * world-space text that wants clean AA edges should declare it. Both setters auto-flush on change. */
 void nt_text_renderer_set_material(nt_material_t mat);
 void nt_text_renderer_set_font(nt_font_t font);
 
@@ -43,8 +44,10 @@ void nt_text_renderer_set_font(nt_font_t font);
 void nt_text_renderer_draw_n(const char *utf8, size_t len, const float model[16], float size, const float color[4], float letter_tracking, float line_leading);
 void nt_text_renderer_draw(const char *utf8, const float model[16], float size, const float color[4], float letter_tracking, float line_leading);
 
-/* Per-glyph model-local +Z step. With depth_write, coplanar glyph quads z-fight at overlapping AA
- * fringes; a small step separates them by draw order. 0 (default) = off. Persists until changed. */
+/* Per-glyph clip-space depth bias toward the near plane — the VS does gl_Position.z -= bias * w, NOT a
+ * world/model-space +Z offset. With depth_write, coplanar glyph quads z-fight at overlapping AA fringes;
+ * a small per-glyph bias separates them by draw order. Signed. 0 (default) = off. Persists until changed
+ * (kept across restore_gpu, cleared on cold init/shutdown). */
 void nt_text_renderer_set_glyph_depth_bias(float bias_per_glyph);
 
 void nt_text_renderer_flush(void);

--- a/engine/renderers/nt_text_renderer.h
+++ b/engine/renderers/nt_text_renderer.h
@@ -17,11 +17,19 @@
 /* uint16 index buffer: base = glyph_index * 4, must not overflow */
 _Static_assert(NT_TEXT_RENDERER_MAX_GLYPHS <= 16383, "NT_TEXT_RENDERER_MAX_GLYPHS > 16383 overflows uint16 index buffer");
 
+/* Default for the slug_text `u_alpha_cutoff.x` param: discards only fully-empty glyph-quad pixels.
+ * World-space text that writes depth should raise this (~0.5) so AA edges don't write depth and halo. */
+#define NT_TEXT_ALPHA_CUTOFF_DEFAULT (1.0F / 255.0F)
+
 void nt_text_renderer_init(void);
 void nt_text_renderer_shutdown(void);
 void nt_text_renderer_restore_gpu(void);
 
-/* Both setters auto-flush staging on change. */
+/* The bound material must use the slug_text vs/fs, ALPHA blend, cull NONE, and set the alpha-clip
+ * param (frag discards coverage < u_alpha_cutoff.x; a missing/0 param disables the discard):
+ *     .params[0] = {.name = "u_alpha_cutoff", .value = {NT_TEXT_ALPHA_CUTOFF_DEFAULT}},
+ *     .param_count = 1,
+ * Both setters auto-flush staging on change. */
 void nt_text_renderer_set_material(nt_material_t mat);
 void nt_text_renderer_set_font(nt_font_t font);
 

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -2021,6 +2021,7 @@ uint32_t nt_ui_internal_pick_zone_3d(const nt_ui_context_t *ctx, float px, float
     if (!ctx->use_raycast_input) {
         return 0U;
     }
+    NT_ASSERT(ctx->view_proj_set && "nt_ui_internal_pick_zone_3d: 3D ctx but nt_ui_set_view_proj was not called this frame");
     const float screen_w = nt_ui_clay_priv_layout_width(ctx->clay);
     const float screen_h = nt_ui_clay_priv_layout_height(ctx->clay);
     /* Reverse order: deepest-declared zone wins, matching the 2D scan. */

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -2008,14 +2008,9 @@ static bool ui_hit_test(const nt_ui_context_t *ctx, uint32_t id, float px, float
 }
 
 #if NT_UI_DEBUG_TOOLS
-/* Inspector viewport pick in 3D ctx: last-declared recorded zone whose cursor ray-vs-plane hit lands
- * in its visual bbox, using the game view_proj (scene elements). Reverse-declaration order, NOT
- * camera distance — overlapping panels resolve by declaration, matching the 2D scan and per-widget
- * clicks. The 2D-affine screen scan can't do this — z->m maps Clay→world in 3D, not Clay→screen.
- * SCOPE: only recorded debug_zones (interactive widgets / explicitly recorded ids) are hover-pickable
- * in 3D — there is no full-layout raycast. Non-interactive elements (panels, labels) are selectable
- * via the inspector tree (which resolves any id through hit_baked), just not by scene hover.
- * Returns 0 when nothing is under the cursor. */
+/* The 2D-affine screen scan can't be reused in 3D ctx — z->m maps Clay→world there, not Clay→screen —
+ * so the cursor is ray-cast against each recorded zone's plane. Contract, scope, and ordering: see the
+ * declaration in nt_ui_internal.h. */
 uint32_t nt_ui_internal_pick_zone_3d(const nt_ui_context_t *ctx, float px, float py) {
     NT_ASSERT(ctx != NULL && "nt_ui_internal_pick_zone_3d: ctx must be non-NULL");
     if (!ctx->use_raycast_input) {

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -2110,10 +2110,11 @@ static nt_ui_widget_pidx_state_t resolve_widget_pidx_state(nt_ui_context_t *ctx,
             continue; /* α: pointer bound elsewhere, invisible to this widget */
         }
         /* Front-most arbitration: a free pointer drives this widget only if it is the resolved hot
-         * widget. hot == 0 (nothing resolved yet — first frame / freshly-appeared) falls back to the
-         * raw hit so newly-shown widgets still work; a capture holder always keeps the pointer. */
+         * widget (or this widget holds capture). hot == 0 (no interactive widget was under the pointer
+         * last frame) gates OFF — a freshly-shown / just-moved widget waits one frame to register
+         * before it can react. Reliability over instant first-frame response (matches Dear ImGui). */
         const uint32_t hot = ctx->pointer_hot[i].id;
-        const bool arbitrated_ok = (hot == 0U) || (hot == id) || (cap->active_id == id);
+        const bool arbitrated_ok = (hot == id) || (cap->active_id == id);
         float hit_t = 0.0F;
         const bool over = arbitrated_ok && ui_hit_test(ctx, id, p->x, p->y, pad_lrtb, &hit_t, NULL);
         if (!over) {
@@ -2136,9 +2137,12 @@ static nt_ui_widget_pidx_state_t resolve_widget_pidx_state(nt_ui_context_t *ctx,
     return s;
 }
 
-/* Compute-pure: same returned struct N calls per frame. The only side effect
- * is an idempotent OR of pointer_over_any (observability for nt_ui_wants_pointer);
- * state-machine writes (capture, button edges) live in step_interaction_padded. */
+static void resolve_hot_if_needed(nt_ui_context_t *ctx); /* defined below; query triggers it too */
+
+/* Compute-pure: same returned struct N calls per frame. Side effects are idempotent and frame-scoped:
+ * an OR of pointer_over_any (observability for nt_ui_wants_pointer) and the once-per-frame hot resolve
+ * (so a query-only frame still arbitrates); state-machine writes (capture, button edges) live in
+ * step_interaction_padded. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 nt_ui_interaction_t nt_ui_query_interaction_padded(nt_ui_context_t *ctx, uint32_t id, const int16_t pad_lrtb[4]) {
     NT_ASSERT(ctx != NULL && "nt_ui_query_interaction_padded: ctx must be non-NULL");
@@ -2165,6 +2169,7 @@ nt_ui_interaction_t nt_ui_query_interaction_padded(nt_ui_context_t *ctx, uint32_
         return out;
     }
 
+    resolve_hot_if_needed(ctx); /* once per frame; lets a query-only frame arbitrate (no step needed) */
     const nt_ui_widget_pidx_state_t s = resolve_widget_pidx_state(ctx, id, pad_lrtb);
     out.hovered = s.any_hovered;
     out.distance = s.distance; /* world hit distance (3D); 0 in 2D or when not hovered */
@@ -2211,15 +2216,16 @@ nt_ui_interaction_t nt_ui_query_interaction_padded(nt_ui_context_t *ctx, uint32_
 
 nt_ui_interaction_t nt_ui_query_interaction(nt_ui_context_t *ctx, uint32_t id) { return nt_ui_query_interaction_padded(ctx, id, NULL); }
 
-/* Sentinel hot id: a pointer hit one or more widgets but all were beyond the occlusion cutoff. Stored
- * so the gate's hot==0 fallback can't re-admit the occluded widget. A real Clay id is never UINT32_MAX
- * with meaningful probability; nt_ui_pointer_hot maps it back to 0 for callers. */
+/* Sentinel hot id: a pointer hit one or more widgets but all were beyond the occlusion cutoff. Kept
+ * distinct from hot==0 (nothing under the pointer) so the resolve's occluded≠empty intent stays
+ * explicit, though both now gate to "skip". A real Clay id is never UINT32_MAX with meaningful
+ * probability; nt_ui_pointer_hot maps it back to 0 for callers. */
 #define NT_UI_HOT_BLOCKED UINT32_MAX
 
 /* Lazy once-per-frame resolve of the front-most interactive widget per pointer, from LAST frame's
  * registry (this frame's transforms/bboxes are still prev-frame until nt_ui_end). 3D: nearest world
- * distance within the occlusion cutoff; 2D: last-in-declaration-order hit (~ topmost). Registry holds
- * game-layer widgets only, so their distances share one view_proj and compare cleanly. */
+ * distance within the occlusion cutoff; 2D: highest effective zIndex (tie → last-declared). Registry
+ * holds game-layer widgets only, so their distances share one view_proj and compare cleanly. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void resolve_hot_if_needed(nt_ui_context_t *ctx) {
     if (ctx->hot_resolved) {
@@ -2260,8 +2266,8 @@ static void resolve_hot_if_needed(nt_ui_context_t *ctx) {
                 }
             }
         }
-        /* Hit something but the cutoff blocked all of it → block (don't let hot==0 fallback re-admit
-         * it). True hot==0 (nothing was under the pointer) still falls back so new widgets work. */
+        /* Hit something but the cutoff blocked all of it → mark blocked (occluded ≠ empty). Both a
+         * blocked region and a true hot==0 gate to skip; a new widget just waits a frame to register. */
         if (!found && occluded) {
             best.id = NT_UI_HOT_BLOCKED;
         }

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -173,6 +173,8 @@ size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc) {
     const size_t hit_baked_bytes = NT_ALIGN_UP(sizeof(nt_ui_baked_xform_t) * desc->max_elements, NT_UI_CACHE_LINE);
     const size_t hit_clip_bytes = NT_ALIGN_UP(sizeof(*((nt_ui_context_t *)0)->hit_clip_parent_id) * desc->max_elements, NT_UI_CACHE_LINE);
     const size_t hit_gen_bytes = NT_ALIGN_UP(sizeof(*((nt_ui_context_t *)0)->hit_generation) * desc->max_elements, NT_UI_CACHE_LINE);
+    /* Double-buffered interactive registry (always-on). */
+    const size_t interactive_bytes = NT_ALIGN_UP(sizeof(nt_ui_interactive_t) * desc->max_elements, NT_UI_CACHE_LINE);
 #if NT_UI_DEBUG_TOOLS
     const size_t hit_layer_bytes = NT_ALIGN_UP(sizeof(*((nt_ui_context_t *)0)->hit_layer) * desc->max_elements, NT_UI_CACHE_LINE);
     const uint32_t widget_cap = nt_ui_next_pow2_u32(desc->max_elements * 2U);
@@ -185,8 +187,8 @@ size_t nt_ui_min_arena_size(const nt_ui_create_desc_t *desc) {
     const size_t debug_zones_bytes = 0U;
     const size_t inspector_collapsed_bytes = 0U;
 #endif
-    return NT_ALIGN_UP(sizeof(struct nt_ui_context), NT_UI_CACHE_LINE) + tree_baked_bytes + tree_root_bytes + tree_dfs_bytes + hit_baked_bytes + hit_clip_bytes + hit_gen_bytes + hit_layer_bytes +
-           widget_registry_bytes + debug_zones_bytes + inspector_collapsed_bytes + clay_bytes;
+    return NT_ALIGN_UP(sizeof(struct nt_ui_context), NT_UI_CACHE_LINE) + tree_baked_bytes + tree_root_bytes + tree_dfs_bytes + hit_baked_bytes + hit_clip_bytes + hit_gen_bytes +
+           (2U * interactive_bytes) + hit_layer_bytes + widget_registry_bytes + debug_zones_bytes + inspector_collapsed_bytes + clay_bytes;
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
@@ -232,6 +234,11 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_u
     const size_t hit_layer_bytes = 0U;
 #endif
     const size_t after_tree = ctx_size + tree_baked_bytes + tree_root_bytes + tree_dfs_bytes + hit_baked_bytes + hit_clip_bytes + hit_gen_bytes + hit_layer_bytes;
+    /* Always-on interactive registry (double buffer) carved before the debug-only block. */
+    const size_t interactive_bytes = NT_ALIGN_UP(sizeof(nt_ui_interactive_t) * desc->max_elements, NT_UI_CACHE_LINE);
+    ctx->interactive_prev = (nt_ui_interactive_t *)((char *)arena + after_tree);
+    ctx->interactive_cur = (nt_ui_interactive_t *)((char *)arena + after_tree + interactive_bytes);
+    const size_t after_interactive = after_tree + (2U * interactive_bytes);
 #if NT_UI_DEBUG_TOOLS
     ctx->widget_registry_cap = nt_ui_next_pow2_u32(desc->max_elements * 2U);
     ctx->widget_registry_mask = ctx->widget_registry_cap - 1U;
@@ -240,12 +247,12 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_u
     const size_t widget_registry_bytes = NT_ALIGN_UP(sizeof(nt_ui_widget_slot_t) * ctx->widget_registry_cap, NT_UI_CACHE_LINE);
     const size_t debug_zones_bytes = NT_ALIGN_UP(sizeof(nt_ui_debug_zone_t) * desc->max_elements, NT_UI_CACHE_LINE);
     const size_t inspector_collapsed_bytes = NT_ALIGN_UP(sizeof(uint32_t) * desc->max_elements, NT_UI_CACHE_LINE);
-    ctx->widget_registry = (nt_ui_widget_slot_t *)((char *)arena + after_tree);
-    ctx->debug_zones = (nt_ui_debug_zone_t *)((char *)arena + after_tree + widget_registry_bytes);
-    ctx->inspector_collapsed_ids = (uint32_t *)((char *)arena + after_tree + widget_registry_bytes + debug_zones_bytes);
-    const size_t after_debug = after_tree + widget_registry_bytes + debug_zones_bytes + inspector_collapsed_bytes;
+    ctx->widget_registry = (nt_ui_widget_slot_t *)((char *)arena + after_interactive);
+    ctx->debug_zones = (nt_ui_debug_zone_t *)((char *)arena + after_interactive + widget_registry_bytes);
+    ctx->inspector_collapsed_ids = (uint32_t *)((char *)arena + after_interactive + widget_registry_bytes + debug_zones_bytes);
+    const size_t after_debug = after_interactive + widget_registry_bytes + debug_zones_bytes + inspector_collapsed_bytes;
 #else
-    const size_t after_debug = after_tree;
+    const size_t after_debug = after_interactive;
 #endif
     void *clay_mem = (char *)arena + after_debug;
     const size_t clay_size = arena_size - after_debug;
@@ -326,6 +333,14 @@ void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, float dt,
     }
     ctx->pointer_over_any = false;
     ctx->hot_resolved = false;
+
+    /* Swap the interactive registry: this frame's resolve reads last frame's set (now _prev); _cur is
+     * refilled by this frame's step_interaction calls. */
+    nt_ui_interactive_t *interactive_swap = ctx->interactive_prev;
+    ctx->interactive_prev = ctx->interactive_cur;
+    ctx->interactive_cur = interactive_swap;
+    ctx->interactive_prev_count = ctx->interactive_cur_count;
+    ctx->interactive_cur_count = 0U;
 
 #if NT_UI_DEBUG_TOOLS
     ctx->debug_zone_count = 0U;
@@ -2193,6 +2208,18 @@ nt_ui_interaction_t nt_ui_step_interaction_padded(nt_ui_context_t *ctx, uint32_t
     NT_ASSERT((pad_lrtb == NULL || (pad_lrtb[0] >= 0 && pad_lrtb[1] >= 0 && pad_lrtb[2] >= 0 && pad_lrtb[3] >= 0)) && "nt_ui_step_interaction_padded: pad_lrtb components must be >= 0");
 
     const nt_ui_interaction_t out = nt_ui_query_interaction_padded(ctx, id, pad_lrtb);
+
+    /* Record this interactive widget for NEXT frame's hot resolve (resolve re-validates id/transform,
+     * so recording an id that later vanishes is harmless). Capped at max_elements. */
+    if (ctx->interactive_cur_count < ctx->max_elements) {
+        nt_ui_interactive_t *rec = &ctx->interactive_cur[ctx->interactive_cur_count++];
+        rec->id = id;
+        if (pad_lrtb != NULL) {
+            memcpy(rec->pad, pad_lrtb, sizeof rec->pad);
+        } else {
+            memset(rec->pad, 0, sizeof rec->pad);
+        }
+    }
 
 #if NT_UI_DEBUG_TOOLS
     /* capture_seen stays 0 so next begin's orphan cleanup wipes in-progress capture (no phantom drag). */

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -1512,6 +1512,22 @@ static void nt_ui_walk_impl(nt_ui_context_t *ctx, const nt_ui_target_t *target, 
         nt_gfx_set_viewport((int)target->viewport[0], (int)target->viewport[1], (int)target->viewport[2], (int)target->viewport[3]);
     }
 
+#if NT_UI_DEBUG_TOOLS
+    /* DEBUG_INSPECTOR: render with the inspector's own overlay materials (typically depth-off) when the
+     * game supplied them, so the debug view stays on top without touching the game scene's depth.
+     * Restored at exit-flush. After the early-outs, the path to exit has no further returns. */
+    const nt_material_t saved_sprite_mat = ctx->sprite_material;
+    const nt_material_t saved_text_mat = ctx->text_material;
+    if (mode == NT_UI_WALK_MODE_DEBUG_INSPECTOR) {
+        if (ctx->inspector_sprite_material.id != 0) {
+            ctx->sprite_material = ctx->inspector_sprite_material;
+        }
+        if (ctx->inspector_text_material.id != 0) {
+            ctx->text_material = ctx->inspector_text_material;
+        }
+    }
+#endif
+
     /* Sprite material up-front; text binds lazily inside emit_text. */
     nt_sprite_renderer_set_material(ctx->sprite_material);
 
@@ -1641,6 +1657,9 @@ static void nt_ui_walk_impl(nt_ui_context_t *ctx, const nt_ui_target_t *target, 
 #endif
     }
 #if NT_UI_DEBUG_TOOLS
+    /* Restore the game's materials swapped in for the inspector pass. */
+    ctx->sprite_material = saved_sprite_mat;
+    ctx->text_material = saved_text_mat;
     /* Inspector strings backed by module-level rings are now consumed; release ownership. */
     if (should_release_inspector_strings(ctx, mode)) {
         nt_ui_internal_inspector_strings_release(ctx);

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -2008,9 +2008,11 @@ static bool ui_hit_test(const nt_ui_context_t *ctx, uint32_t id, float px, float
 }
 
 #if NT_UI_DEBUG_TOOLS
-/* Inspector viewport pick in 3D ctx: topmost recorded zone whose cursor ray-vs-plane hit lands in
- * its visual bbox, using the game view_proj (scene elements). The 2D-affine screen scan can't do
- * this — z->m maps Clay→world in 3D, not Clay→screen. Returns 0 when nothing is under the cursor. */
+/* Inspector viewport pick in 3D ctx: last-declared recorded zone whose cursor ray-vs-plane hit lands
+ * in its visual bbox, using the game view_proj (scene elements). Reverse-declaration order, NOT
+ * camera distance — overlapping panels resolve by declaration, matching the 2D scan and per-widget
+ * clicks. The 2D-affine screen scan can't do this — z->m maps Clay→world in 3D, not Clay→screen.
+ * Returns 0 when nothing is under the cursor. */
 uint32_t nt_ui_internal_pick_zone_3d(const nt_ui_context_t *ctx, float px, float py) {
     NT_ASSERT(ctx != NULL && "nt_ui_internal_pick_zone_3d: ctx must be non-NULL");
     if (!ctx->use_raycast_input) {

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -321,8 +321,11 @@ void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, float dt,
             ctx->captures[i].active_id = 0U;
         }
         ctx->capture_seen[i] = 0U;
+        ctx->pointer_hot[i] = (nt_ui_hot_t){0}; /* resolved lazily on first step/query this frame */
+        ctx->pointer_occlusion[i] = INFINITY;   /* game re-feeds per frame; default = no cutoff */
     }
     ctx->pointer_over_any = false;
+    ctx->hot_resolved = false;
 
 #if NT_UI_DEBUG_TOOLS
     ctx->debug_zone_count = 0U;
@@ -2335,6 +2338,21 @@ bool nt_ui_wants_pointer(const nt_ui_context_t *ctx) {
         }
     }
     return false;
+}
+
+void nt_ui_set_pointer_occlusion(nt_ui_context_t *ctx, uint32_t pointer_index, float max_world_distance) {
+    NT_ASSERT(ctx != NULL && "nt_ui_set_pointer_occlusion: ctx must be non-NULL");
+    NT_ASSERT(ctx->use_raycast_input && "nt_ui_set_pointer_occlusion: only meaningful in 3D ctx (use_raycast_input)");
+    NT_ASSERT(pointer_index < NT_INPUT_MAX_POINTERS && "nt_ui_set_pointer_occlusion: pointer_index out of range");
+    /* Negative = occlude everything (all hits have t >= 0); the game owns that choice, so no assert. */
+    ctx->pointer_occlusion[pointer_index] = max_world_distance;
+}
+
+nt_ui_hot_t nt_ui_pointer_hot(nt_ui_context_t *ctx, uint32_t pointer_index) {
+    NT_ASSERT(ctx != NULL && "nt_ui_pointer_hot: ctx must be non-NULL");
+    NT_ASSERT(pointer_index < NT_INPUT_MAX_POINTERS && "nt_ui_pointer_hot: pointer_index out of range");
+    /* Lazy resolve wired in a later slice; for now returns the per-frame default until then. */
+    return ctx->pointer_hot[pointer_index];
 }
 // #endregion
 

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -1828,8 +1828,9 @@ static void mat4_inv_trs(const float m[16], float out[16]) {
  * then inverse-transform the hit point into widget-local Clay coords for bbox check.
  * Returns local hit (lx, ly) in widget-local space; caller pads + bbox-tests against Clay bbox.
  * inv_view_proj caller-chosen: game view_proj for layer < 240, inspector ortho for inspector layers. */
-/* out_t (nullable): ray parameter at the hit = world distance from the near point along the ray —
- * used by the input resolve to pick the nearest widget and to compare against an occlusion cutoff. */
+/* out_t (nullable, read ONLY when this returns true): world distance from the NEAR plane to the hit.
+ * Comparable only among hits sharing one inv_view_proj — a perspective game ray and the ortho
+ * inspector ray are different units, so the resolve must not min() across that boundary. */
 static bool raycast_hit(const float inv_view_proj[16], const nt_ui_baked_xform_t *baked, float px, float py, float screen_w, float screen_h, float *out_lx, float *out_ly, float *out_t) {
     /* Screen → NDC: (-1..1, -1..1). Note Clay px is Y-down; NDC Y is up — flip. */
     const float px_ndc = ((px / screen_w) * 2.0F) - 1.0F;
@@ -1879,7 +1880,9 @@ static bool raycast_hit(const float inv_view_proj[16], const nt_ui_baked_xform_t
     *out_lx = (inv[0] * hx) + (inv[4] * hy) + (inv[8] * hz) + inv[12];
     *out_ly = (inv[1] * hx) + (inv[5] * hy) + (inv[9] * hz) + inv[13];
     if (out_t != NULL) {
-        *out_t = t;
+        /* t is the near→far ray parameter; scale by the (un-normalized) segment length so the value
+         * is a world distance from the near plane, matching a game-fed occlusion cutoff in world units. */
+        *out_t = t * sqrtf((dx * dx) + (dy * dy) + (dz * dz));
     }
     return true;
 }
@@ -1945,7 +1948,8 @@ static bool hit_clip_chain(const nt_ui_context_t *ctx, uint32_t start_clip_id, i
     return true;
 }
 
-/* out_t (nullable): world ray distance to the hit in 3D ctx; 0 in 2D ctx (no depth). */
+/* out_t (nullable, valid only when this returns true): world distance from the near plane to the hit
+ * in 3D ctx; 0 in 2D ctx (no depth). The game's occlusion cutoff is near-plane-relative too. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static bool ui_hit_test(const nt_ui_context_t *ctx, uint32_t id, float px, float py, const int16_t pad_lrtb[4], float *out_t) {
     if (id == 0U) {

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -1966,10 +1966,11 @@ static bool hit_clip_chain(const nt_ui_context_t *ctx, uint32_t start_clip_id, i
     return true;
 }
 
-/* out_t (nullable, valid only when this returns true): world distance from the near plane to the hit
- * in 3D ctx; 0 in 2D ctx (no depth). The game's occlusion cutoff is near-plane-relative too. */
+/* out_t / out_zindex (both nullable, valid only when this returns true): out_t = world distance from
+ * the near plane to the hit in 3D ctx (0 in 2D); out_zindex = the hit element's effective Clay zIndex
+ * (its floating tree-root's), used for 2D front-most arbitration. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-static bool ui_hit_test(const nt_ui_context_t *ctx, uint32_t id, float px, float py, const int16_t pad_lrtb[4], float *out_t) {
+static bool ui_hit_test(const nt_ui_context_t *ctx, uint32_t id, float px, float py, const int16_t pad_lrtb[4], float *out_t, int16_t *out_zindex) {
     if (id == 0U) {
         return false;
     }
@@ -2001,6 +2002,9 @@ static bool ui_hit_test(const nt_ui_context_t *ctx, uint32_t id, float px, float
 
     const Clay_BoundingBox box = d.boundingBox;
     const nt_ui_baked_xform_t b = ctx->hit_baked[slot];
+    if (out_zindex != NULL) {
+        *out_zindex = b.zindex; /* slot already gated by hit_generation above */
+    }
     float lx;
     float ly;
     if (ctx->use_raycast_input) {
@@ -2111,7 +2115,7 @@ static nt_ui_widget_pidx_state_t resolve_widget_pidx_state(nt_ui_context_t *ctx,
         const uint32_t hot = ctx->pointer_hot[i].id;
         const bool arbitrated_ok = (hot == 0U) || (hot == id) || (cap->active_id == id);
         float hit_t = 0.0F;
-        const bool over = arbitrated_ok && ui_hit_test(ctx, id, p->x, p->y, pad_lrtb, &hit_t);
+        const bool over = arbitrated_ok && ui_hit_test(ctx, id, p->x, p->y, pad_lrtb, &hit_t, NULL);
         if (!over) {
             continue;
         }
@@ -2173,7 +2177,7 @@ nt_ui_interaction_t nt_ui_query_interaction_padded(nt_ui_context_t *ctx, uint32_
         const nt_pointer_t *p = &ctx->frame_pointers[pidx];
         const nt_ui_capture_t *cap = &ctx->captures[pidx];
         const nt_button_state_t btn = p->buttons[NT_BUTTON_LEFT];
-        const bool over = ui_hit_test(ctx, id, p->x, p->y, pad_lrtb, NULL);
+        const bool over = ui_hit_test(ctx, id, p->x, p->y, pad_lrtb, NULL, NULL);
         out.pressed = btn.is_down;
         out.released_now = btn.is_released;
         out.pressed_now = s.new_capture;
@@ -2226,11 +2230,13 @@ static void resolve_hot_if_needed(nt_ui_context_t *ctx) {
         const nt_pointer_t *p = &ctx->frame_pointers[pidx];
         nt_ui_hot_t best = {0};
         bool found = false;
-        bool occluded = false; /* hit >= 1 widget, but the cutoff blocked all of them */
+        bool occluded = false;           /* hit >= 1 widget, but the cutoff blocked all of them */
+        int16_t best_zindex = INT16_MIN; /* 2D: highest effective zIndex seen so far */
         for (uint32_t k = 0; k < ctx->interactive_prev_count; ++k) {
             const nt_ui_interactive_t *rec = &ctx->interactive_prev[k];
             float t = 0.0F;
-            if (!ui_hit_test(ctx, rec->id, p->x, p->y, rec->pad, &t)) {
+            int16_t zi = 0;
+            if (!ui_hit_test(ctx, rec->id, p->x, p->y, rec->pad, &t, &zi)) {
                 continue;
             }
             if (ctx->use_raycast_input) {
@@ -2244,10 +2250,14 @@ static void resolve_hot_if_needed(nt_ui_context_t *ctx) {
                     found = true;
                 }
             } else {
-                /* 2D: no depth — later-declared (drawn-on-top) hit wins; overwrite on each hit. */
-                best.id = rec->id;
-                best.distance = 0.0F;
-                found = true;
+                /* 2D: highest effective zIndex wins; >= so a later-declared tie still overwrites,
+                 * preserving paint-order behavior within one z tier. */
+                if (!found || zi >= best_zindex) {
+                    best.id = rec->id;
+                    best.distance = 0.0F;
+                    best_zindex = zi;
+                    found = true;
+                }
             }
         }
         /* Hit something but the cutoff blocked all of it → block (don't let hot==0 fallback re-admit
@@ -2548,7 +2558,7 @@ bool nt_ui_test_hit(nt_ui_context_t *ctx, uint32_t id, float px, float py) {
     NT_ASSERT(ctx != NULL && "nt_ui_test_hit: ctx must be non-NULL");
     Clay_Context *saved = Clay_GetCurrentContext();
     Clay_SetCurrentContext(ctx->clay);
-    const bool hit = ui_hit_test(ctx, id, px, py, NULL, NULL);
+    const bool hit = ui_hit_test(ctx, id, px, py, NULL, NULL, NULL);
     Clay_SetCurrentContext(saved);
     return hit;
 }
@@ -2557,7 +2567,7 @@ bool nt_ui_test_hit_padded(nt_ui_context_t *ctx, uint32_t id, float px, float py
     NT_ASSERT(ctx != NULL && "nt_ui_test_hit_padded: ctx must be non-NULL");
     Clay_Context *saved = Clay_GetCurrentContext();
     Clay_SetCurrentContext(ctx->clay);
-    const bool hit = ui_hit_test(ctx, id, px, py, pad_lrtb, NULL);
+    const bool hit = ui_hit_test(ctx, id, px, py, pad_lrtb, NULL, NULL);
     Clay_SetCurrentContext(saved);
     return hit;
 }

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -1215,6 +1215,11 @@ static bool command_is_debug_layer(const Clay_RenderCommand *c) {
 static bool command_matches_walk_mode(const nt_ui_context_t *ctx, nt_ui_walk_mode_t mode, const Clay_RenderCommand *c) {
     const bool is_debug = command_is_debug_layer(c);
     if (mode == NT_UI_WALK_MODE_DEBUG_INSPECTOR) {
+        /* Scissors are structural — skipping a non-debug-tagged clip (e.g. a floating clipTo) would
+         * drop its whole subtree, hiding the inspector tree text that lives inside it. */
+        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_SCISSOR_START || c->commandType == CLAY_RENDER_COMMAND_TYPE_SCISSOR_END) {
+            return true;
+        }
         return is_debug;
     }
     if (ctx->use_raycast_input) {

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -2218,8 +2218,9 @@ nt_ui_interaction_t nt_ui_query_interaction(nt_ui_context_t *ctx, uint32_t id) {
 
 /* Lazy once-per-frame resolve of the front-most interactive widget per pointer, from LAST frame's
  * registry (this frame's transforms/bboxes are still prev-frame until nt_ui_end). 3D: nearest world
- * distance within the occlusion cutoff; 2D: highest effective zIndex (tie → last-declared). Registry
- * holds game-layer widgets only, so their distances share one view_proj and compare cleanly. */
+ * distance within the occlusion cutoff; 2D: highest effective zIndex (tie → last-registered, i.e.
+ * later step_interaction call). Registry holds game-layer widgets only, so their distances share one
+ * view_proj and compare cleanly. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void resolve_hot_if_needed(nt_ui_context_t *ctx) {
     if (ctx->hot_resolved) {

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -971,7 +971,7 @@ static void emit_image(const Clay_RenderCommand *c, const float world_mat4[16]) 
 
 // #region helper_emit_text
 /* dispatch_command flushes sprite before and lazy-rebinds after. */
-static void emit_text(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, float text_scale, const float world_mat4[16], bool force_screen_space) {
+static void emit_text(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, float text_scale, const float world_mat4[16]) {
     const Clay_TextRenderData *t = &c->renderData.text;
     NT_ASSERT((uint32_t)t->fontId < NT_UI_MAX_FONTS && "nt_ui TEXT: fontId >= NT_UI_MAX_FONTS");
     nt_font_t font = ctx->fonts[t->fontId];
@@ -982,24 +982,28 @@ static void emit_text(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, f
 
     const float font_size = (float)t->fontSize * text_scale;
     nt_font_metrics_t metrics = nt_font_get_metrics(font);
-    const float scale = (metrics.units_per_em > 0) ? (font_size / (float)metrics.units_per_em) : 0.0F;
-    const float text_h = (float)(metrics.ascent - metrics.descent) * scale;
+    /* Vertical centering lives in Clay layout space (bbox is Clay px), so use the Clay font size —
+     * the world font_size folds in text_scale and would collapse the offset under a 3D XFORM. */
+    const float layout_scale = (metrics.units_per_em > 0) ? ((float)t->fontSize / (float)metrics.units_per_em) : 0.0F;
+    const float text_h = (float)(metrics.ascent - metrics.descent) * layout_scale;
     const float center_offset = (c->boundingBox.height - text_h) * 0.5F;
     /* Y-down: baseline = bbox.y(top) + center_offset + ascent*scale. */
-    const float baseline_y = c->boundingBox.y + center_offset + ((float)metrics.ascent * scale);
+    const float baseline_y = c->boundingBox.y + center_offset + ((float)metrics.ascent * layout_scale);
 
-    /* Text renderer local is Y-up. In 2D ctx the ortho VP carries an implicit screen Y-flip,
-     * so negating col1 cancels it and glyphs read upright. In 3D ctx (use_raycast_input) the
-     * baked world matrix has no implicit Y-flip — keeping the negate there leaves labels
-     * upside-down inside otherwise-correct panels. Sign chosen per-ctx. */
+    /* Text-renderer local is Y-up; Clay positions are Y-down. Negating col1 always opposes the two
+     * so glyphs read upright — independent of how world_mat4 maps Clay→world (2D ortho, 3D billboard
+     * via negative scale_y, or inspector screen-space). */
     const float ox = c->boundingBox.x;
     const float oy = baseline_y;
-    const float sign_y = (ctx->use_raycast_input && !force_screen_space) ? +1.0F : -1.0F;
+    const float sign_y = -1.0F;
+    /* size already folds in text_scale (world X-magnitude), so the model handed to the renderer must
+     * be scale-free like every other call site — else the X scale lands twice and glyphs shrink ~text_scale. */
+    const float inv_ts = (text_scale > 0.0F) ? (1.0F / text_scale) : 0.0F;
     float m[16];
     for (int rr = 0; rr < 4; ++rr) {
-        m[rr] = world_mat4[rr];
-        m[4 + rr] = sign_y * world_mat4[4 + rr];
-        m[8 + rr] = world_mat4[8 + rr];
+        m[rr] = world_mat4[rr] * inv_ts;
+        m[4 + rr] = sign_y * world_mat4[4 + rr] * inv_ts;
+        m[8 + rr] = world_mat4[8 + rr] * inv_ts;
         m[12 + rr] = (ox * world_mat4[rr]) + (oy * world_mat4[4 + rr]) + world_mat4[12 + rr];
     }
     const float color[4] = {
@@ -1331,7 +1335,7 @@ static void dispatch_command(const nt_ui_context_t *ctx, const Clay_RenderComman
         Clay_RenderCommand local = *c;
         /* Round-to-nearest to match RECT's apply_opacity. */
         local.renderData.text.textColor.a = (float)lrintf(local.renderData.text.textColor.a * ws->accum_opacity);
-        emit_text(ctx, &local, text_scale, world_mat4, force_screen_space);
+        emit_text(ctx, &local, text_scale, world_mat4);
         return;
     }
     case CLAY_RENDER_COMMAND_TYPE_IMAGE: {

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -2007,6 +2007,38 @@ static bool ui_hit_test(const nt_ui_context_t *ctx, uint32_t id, float px, float
     return (lx >= box.x - pl) && (lx <= box.x + box.width + pr) && (ly >= box.y - pt) && (ly <= box.y + box.height + pb);
 }
 
+#if NT_UI_DEBUG_TOOLS
+/* Inspector viewport pick in 3D ctx: topmost recorded zone whose cursor ray-vs-plane hit lands in
+ * its visual bbox, using the game view_proj (scene elements). The 2D-affine screen scan can't do
+ * this — z->m maps Clay→world in 3D, not Clay→screen. Returns 0 when nothing is under the cursor. */
+uint32_t nt_ui_internal_pick_zone_3d(const nt_ui_context_t *ctx, float px, float py) {
+    NT_ASSERT(ctx != NULL && "nt_ui_internal_pick_zone_3d: ctx must be non-NULL");
+    if (!ctx->use_raycast_input) {
+        return 0U;
+    }
+    const float screen_w = nt_ui_clay_priv_layout_width(ctx->clay);
+    const float screen_h = nt_ui_clay_priv_layout_height(ctx->clay);
+    /* Reverse order: deepest-declared zone wins, matching the 2D scan. */
+    for (int32_t zi = (int32_t)ctx->debug_zone_count - 1; zi >= 0; --zi) {
+        const nt_ui_debug_zone_t *z = &ctx->debug_zones[zi];
+        if (z->id == 0U) {
+            continue;
+        }
+        nt_ui_baked_xform_t b = {0};
+        memcpy(b.m, z->m, sizeof b.m);
+        float lx;
+        float ly;
+        if (!raycast_hit(ctx->inv_view_proj, &b, px, py, screen_w, screen_h, &lx, &ly)) {
+            continue;
+        }
+        if (lx >= z->visual_l && lx <= z->visual_r && ly >= z->visual_t && ly <= z->visual_b) {
+            return z->id;
+        }
+    }
+    return 0U;
+}
+#endif
+
 /* Resolves the single pidx that "owns" a widget for this frame under α-semantics:
  *   - a pointer holding this id wins (already captured)
  *   - else first pidx with empty capture that's pressed_now over the widget

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -2104,7 +2104,12 @@ static nt_ui_widget_pidx_state_t resolve_widget_pidx_state(nt_ui_context_t *ctx,
         if (cap->active_id != 0U && cap->active_id != id) {
             continue; /* α: pointer bound elsewhere, invisible to this widget */
         }
-        const bool over = ui_hit_test(ctx, id, p->x, p->y, pad_lrtb, NULL);
+        /* Front-most arbitration: a free pointer drives this widget only if it is the resolved hot
+         * widget. hot == 0 (nothing resolved yet — first frame / freshly-appeared) falls back to the
+         * raw hit so newly-shown widgets still work; a capture holder always keeps the pointer. */
+        const uint32_t hot = ctx->pointer_hot[i].id;
+        const bool arbitrated_ok = (hot == 0U) || (hot == id) || (cap->active_id == id);
+        const bool over = arbitrated_ok && ui_hit_test(ctx, id, p->x, p->y, pad_lrtb, NULL);
         if (!over) {
             continue;
         }

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -2216,12 +2216,6 @@ nt_ui_interaction_t nt_ui_query_interaction_padded(nt_ui_context_t *ctx, uint32_
 
 nt_ui_interaction_t nt_ui_query_interaction(nt_ui_context_t *ctx, uint32_t id) { return nt_ui_query_interaction_padded(ctx, id, NULL); }
 
-/* Sentinel hot id: a pointer hit one or more widgets but all were beyond the occlusion cutoff. Kept
- * distinct from hot==0 (nothing under the pointer) so the resolve's occluded≠empty intent stays
- * explicit, though both now gate to "skip". A real Clay id is never UINT32_MAX with meaningful
- * probability; nt_ui_pointer_hot maps it back to 0 for callers. */
-#define NT_UI_HOT_BLOCKED UINT32_MAX
-
 /* Lazy once-per-frame resolve of the front-most interactive widget per pointer, from LAST frame's
  * registry (this frame's transforms/bboxes are still prev-frame until nt_ui_end). 3D: nearest world
  * distance within the occlusion cutoff; 2D: highest effective zIndex (tie → last-declared). Registry
@@ -2236,7 +2230,6 @@ static void resolve_hot_if_needed(nt_ui_context_t *ctx) {
         const nt_pointer_t *p = &ctx->frame_pointers[pidx];
         nt_ui_hot_t best = {0};
         bool found = false;
-        bool occluded = false;           /* hit >= 1 widget, but the cutoff blocked all of them */
         int16_t best_zindex = INT16_MIN; /* 2D: highest effective zIndex seen so far */
         for (uint32_t k = 0; k < ctx->interactive_prev_count; ++k) {
             const nt_ui_interactive_t *rec = &ctx->interactive_prev[k];
@@ -2247,8 +2240,7 @@ static void resolve_hot_if_needed(nt_ui_context_t *ctx) {
             }
             if (ctx->use_raycast_input) {
                 if (t > ctx->pointer_occlusion[pidx]) {
-                    occluded = true; /* behind the game-fed cutoff (e.g. a wall) */
-                    continue;
+                    continue; /* behind the game-fed cutoff (e.g. a wall) → occluded, leaves hot=0 (skip) */
                 }
                 if (!found || t < best.distance) {
                     best.id = rec->id;
@@ -2266,11 +2258,7 @@ static void resolve_hot_if_needed(nt_ui_context_t *ctx) {
                 }
             }
         }
-        /* Hit something but the cutoff blocked all of it → mark blocked (occluded ≠ empty). Both a
-         * blocked region and a true hot==0 gate to skip; a new widget just waits a frame to register. */
-        if (!found && occluded) {
-            best.id = NT_UI_HOT_BLOCKED;
-        }
+        /* best stays {0} when nothing was hit OR all hits were occluded — both gate to skip. */
         ctx->pointer_hot[pidx] = best;
     }
 }
@@ -2284,8 +2272,8 @@ nt_ui_interaction_t nt_ui_step_interaction_padded(nt_ui_context_t *ctx, uint32_t
     NT_ASSERT(ctx->frame_pointer_count > 0U && "nt_ui_step_interaction_padded: no frame pointer snapshot");
     NT_ASSERT((pad_lrtb == NULL || (pad_lrtb[0] >= 0 && pad_lrtb[1] >= 0 && pad_lrtb[2] >= 0 && pad_lrtb[3] >= 0)) && "nt_ui_step_interaction_padded: pad_lrtb components must be >= 0");
 
-    resolve_hot_if_needed(ctx); /* once per frame, from prev-frame registry; view_proj is set by now */
-
+    /* query_padded triggers the once-per-frame hot resolve; step reaches resolve_widget_pidx_state
+     * (which reads pointer_hot) only when query did NOT early-return, i.e. after that resolve ran. */
     const nt_ui_interaction_t out = nt_ui_query_interaction_padded(ctx, id, pad_lrtb);
 
     /* Record this interactive widget for NEXT frame's hot resolve (resolve re-validates id/transform,
@@ -2458,11 +2446,7 @@ nt_ui_hot_t nt_ui_pointer_hot(nt_ui_context_t *ctx, uint32_t pointer_index) {
     NT_ASSERT(ctx != NULL && "nt_ui_pointer_hot: ctx must be non-NULL");
     NT_ASSERT(pointer_index < NT_INPUT_MAX_POINTERS && "nt_ui_pointer_hot: pointer_index out of range");
     resolve_hot_if_needed(ctx); /* lazy: first step OR this query triggers the once-per-frame resolve */
-    nt_ui_hot_t hot = ctx->pointer_hot[pointer_index];
-    if (hot.id == NT_UI_HOT_BLOCKED) {
-        return (nt_ui_hot_t){0}; /* occlusion-blocked reads as "nothing" to the game */
-    }
-    return hot;
+    return ctx->pointer_hot[pointer_index];
 }
 // #endregion
 

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -2083,11 +2083,12 @@ typedef struct {
     int32_t first_hover_pidx; /* fallback for pos/id when no owner */
     bool any_hovered;
     bool new_capture; /* effective_pidx is a fresh press_now capture (no prior holder) */
+    float distance;   /* world hit distance for the first hovering pidx (3D); 0 in 2D / no hover */
 } nt_ui_widget_pidx_state_t;
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static nt_ui_widget_pidx_state_t resolve_widget_pidx_state(nt_ui_context_t *ctx, uint32_t id, const int16_t pad_lrtb[4]) {
-    nt_ui_widget_pidx_state_t s = {.effective_pidx = -1, .first_hover_pidx = -1, .any_hovered = false, .new_capture = false};
+    nt_ui_widget_pidx_state_t s = {.effective_pidx = -1, .first_hover_pidx = -1, .any_hovered = false, .new_capture = false, .distance = 0.0F};
     int32_t holder = -1;
     int32_t candidate = -1;
     /* Pass 1: existing holder. */
@@ -2109,12 +2110,14 @@ static nt_ui_widget_pidx_state_t resolve_widget_pidx_state(nt_ui_context_t *ctx,
          * raw hit so newly-shown widgets still work; a capture holder always keeps the pointer. */
         const uint32_t hot = ctx->pointer_hot[i].id;
         const bool arbitrated_ok = (hot == 0U) || (hot == id) || (cap->active_id == id);
-        const bool over = arbitrated_ok && ui_hit_test(ctx, id, p->x, p->y, pad_lrtb, NULL);
+        float hit_t = 0.0F;
+        const bool over = arbitrated_ok && ui_hit_test(ctx, id, p->x, p->y, pad_lrtb, &hit_t);
         if (!over) {
             continue;
         }
         if (s.first_hover_pidx < 0) {
             s.first_hover_pidx = (int32_t)i;
+            s.distance = hit_t; /* near-plane-relative world distance in 3D, 0 in 2D */
         }
         s.any_hovered = true;
         if (holder < 0 && candidate < 0 && cap->active_id == 0U) {
@@ -2160,6 +2163,7 @@ nt_ui_interaction_t nt_ui_query_interaction_padded(nt_ui_context_t *ctx, uint32_
 
     const nt_ui_widget_pidx_state_t s = resolve_widget_pidx_state(ctx, id, pad_lrtb);
     out.hovered = s.any_hovered;
+    out.distance = s.distance; /* world hit distance (3D); 0 in 2D or when not hovered */
     if (s.any_hovered) {
         ctx->pointer_over_any = true;
     }
@@ -2203,6 +2207,11 @@ nt_ui_interaction_t nt_ui_query_interaction_padded(nt_ui_context_t *ctx, uint32_
 
 nt_ui_interaction_t nt_ui_query_interaction(nt_ui_context_t *ctx, uint32_t id) { return nt_ui_query_interaction_padded(ctx, id, NULL); }
 
+/* Sentinel hot id: a pointer hit one or more widgets but all were beyond the occlusion cutoff. Stored
+ * so the gate's hot==0 fallback can't re-admit the occluded widget. A real Clay id is never UINT32_MAX
+ * with meaningful probability; nt_ui_pointer_hot maps it back to 0 for callers. */
+#define NT_UI_HOT_BLOCKED UINT32_MAX
+
 /* Lazy once-per-frame resolve of the front-most interactive widget per pointer, from LAST frame's
  * registry (this frame's transforms/bboxes are still prev-frame until nt_ui_end). 3D: nearest world
  * distance within the occlusion cutoff; 2D: last-in-declaration-order hit (~ topmost). Registry holds
@@ -2217,6 +2226,7 @@ static void resolve_hot_if_needed(nt_ui_context_t *ctx) {
         const nt_pointer_t *p = &ctx->frame_pointers[pidx];
         nt_ui_hot_t best = {0};
         bool found = false;
+        bool occluded = false; /* hit >= 1 widget, but the cutoff blocked all of them */
         for (uint32_t k = 0; k < ctx->interactive_prev_count; ++k) {
             const nt_ui_interactive_t *rec = &ctx->interactive_prev[k];
             float t = 0.0F;
@@ -2225,7 +2235,8 @@ static void resolve_hot_if_needed(nt_ui_context_t *ctx) {
             }
             if (ctx->use_raycast_input) {
                 if (t > ctx->pointer_occlusion[pidx]) {
-                    continue; /* behind the game-fed cutoff (e.g. a wall) */
+                    occluded = true; /* behind the game-fed cutoff (e.g. a wall) */
+                    continue;
                 }
                 if (!found || t < best.distance) {
                     best.id = rec->id;
@@ -2238,6 +2249,11 @@ static void resolve_hot_if_needed(nt_ui_context_t *ctx) {
                 best.distance = 0.0F;
                 found = true;
             }
+        }
+        /* Hit something but the cutoff blocked all of it → block (don't let hot==0 fallback re-admit
+         * it). True hot==0 (nothing was under the pointer) still falls back so new widgets work. */
+        if (!found && occluded) {
+            best.id = NT_UI_HOT_BLOCKED;
         }
         ctx->pointer_hot[pidx] = best;
     }
@@ -2426,7 +2442,11 @@ nt_ui_hot_t nt_ui_pointer_hot(nt_ui_context_t *ctx, uint32_t pointer_index) {
     NT_ASSERT(ctx != NULL && "nt_ui_pointer_hot: ctx must be non-NULL");
     NT_ASSERT(pointer_index < NT_INPUT_MAX_POINTERS && "nt_ui_pointer_hot: pointer_index out of range");
     resolve_hot_if_needed(ctx); /* lazy: first step OR this query triggers the once-per-frame resolve */
-    return ctx->pointer_hot[pointer_index];
+    nt_ui_hot_t hot = ctx->pointer_hot[pointer_index];
+    if (hot.id == NT_UI_HOT_BLOCKED) {
+        return (nt_ui_hot_t){0}; /* occlusion-blocked reads as "nothing" to the game */
+    }
+    return hot;
 }
 // #endregion
 

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -2252,8 +2252,9 @@ static void resolve_hot_if_needed(nt_ui_context_t *ctx) {
                     found = true;
                 }
             } else {
-                /* 2D: highest effective zIndex wins; >= so a later-declared tie still overwrites,
-                 * preserving paint-order behavior within one z tier. */
+                /* 2D: highest effective zIndex wins; >= so a later-registered tie overwrites. Registry
+                 * order = step_interaction call order = declaration (paint) order when the game steps in
+                 * declaration order — the normal pattern. */
                 if (!found || zi >= best_zindex) {
                     best.id = rec->id;
                     best.distance = 0.0F;

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -2444,6 +2444,7 @@ void nt_ui_set_pointer_occlusion(nt_ui_context_t *ctx, uint32_t pointer_index, f
     NT_ASSERT(ctx != NULL && "nt_ui_set_pointer_occlusion: ctx must be non-NULL");
     NT_ASSERT(ctx->use_raycast_input && "nt_ui_set_pointer_occlusion: only meaningful in 3D ctx (use_raycast_input)");
     NT_ASSERT(ctx->in_frame && "nt_ui_set_pointer_occlusion: call between nt_ui_begin and the first step/query (reset each begin)");
+    NT_ASSERT(!ctx->hot_resolved && "nt_ui_set_pointer_occlusion: fed too late — the hot resolve already latched this frame; feed BEFORE the first step/query/pointer_hot");
     NT_ASSERT(pointer_index < ctx->frame_pointer_count && "nt_ui_set_pointer_occlusion: pointer_index is not an active frame pointer");
     /* NaN makes the `t > cutoff` test always false, silently disabling occlusion (click-through-wall);
      * a broken game raycast must trip here. ±inf are valid (+inf = no cutoff, -inf/negative = occlude all). */

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -2012,6 +2012,9 @@ static bool ui_hit_test(const nt_ui_context_t *ctx, uint32_t id, float px, float
  * in its visual bbox, using the game view_proj (scene elements). Reverse-declaration order, NOT
  * camera distance — overlapping panels resolve by declaration, matching the 2D scan and per-widget
  * clicks. The 2D-affine screen scan can't do this — z->m maps Clay→world in 3D, not Clay→screen.
+ * SCOPE: only recorded debug_zones (interactive widgets / explicitly recorded ids) are hover-pickable
+ * in 3D — there is no full-layout raycast. Non-interactive elements (panels, labels) are selectable
+ * via the inspector tree (which resolves any id through hit_baked), just not by scene hover.
  * Returns 0 when nothing is under the cursor. */
 uint32_t nt_ui_internal_pick_zone_3d(const nt_ui_context_t *ctx, float px, float py) {
     NT_ASSERT(ctx != NULL && "nt_ui_internal_pick_zone_3d: ctx must be non-NULL");

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -2198,6 +2198,46 @@ nt_ui_interaction_t nt_ui_query_interaction_padded(nt_ui_context_t *ctx, uint32_
 
 nt_ui_interaction_t nt_ui_query_interaction(nt_ui_context_t *ctx, uint32_t id) { return nt_ui_query_interaction_padded(ctx, id, NULL); }
 
+/* Lazy once-per-frame resolve of the front-most interactive widget per pointer, from LAST frame's
+ * registry (this frame's transforms/bboxes are still prev-frame until nt_ui_end). 3D: nearest world
+ * distance within the occlusion cutoff; 2D: last-in-declaration-order hit (~ topmost). Registry holds
+ * game-layer widgets only, so their distances share one view_proj and compare cleanly. */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+static void resolve_hot_if_needed(nt_ui_context_t *ctx) {
+    if (ctx->hot_resolved) {
+        return;
+    }
+    ctx->hot_resolved = true;
+    for (uint32_t pidx = 0; pidx < ctx->frame_pointer_count; ++pidx) {
+        const nt_pointer_t *p = &ctx->frame_pointers[pidx];
+        nt_ui_hot_t best = {0};
+        bool found = false;
+        for (uint32_t k = 0; k < ctx->interactive_prev_count; ++k) {
+            const nt_ui_interactive_t *rec = &ctx->interactive_prev[k];
+            float t = 0.0F;
+            if (!ui_hit_test(ctx, rec->id, p->x, p->y, rec->pad, &t)) {
+                continue;
+            }
+            if (ctx->use_raycast_input) {
+                if (t > ctx->pointer_occlusion[pidx]) {
+                    continue; /* behind the game-fed cutoff (e.g. a wall) */
+                }
+                if (!found || t < best.distance) {
+                    best.id = rec->id;
+                    best.distance = t;
+                    found = true;
+                }
+            } else {
+                /* 2D: no depth — later-declared (drawn-on-top) hit wins; overwrite on each hit. */
+                best.id = rec->id;
+                best.distance = 0.0F;
+                found = true;
+            }
+        }
+        ctx->pointer_hot[pidx] = best;
+    }
+}
+
 /* Same compute as query_padded plus state-machine commits; ONCE per widget per frame. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 nt_ui_interaction_t nt_ui_step_interaction_padded(nt_ui_context_t *ctx, uint32_t id, const int16_t pad_lrtb[4]) {
@@ -2206,6 +2246,8 @@ nt_ui_interaction_t nt_ui_step_interaction_padded(nt_ui_context_t *ctx, uint32_t
     NT_ASSERT(id != 0U && "nt_ui_step_interaction_padded: id must be non-zero (0 = no widget)");
     NT_ASSERT(ctx->frame_pointer_count > 0U && "nt_ui_step_interaction_padded: no frame pointer snapshot");
     NT_ASSERT((pad_lrtb == NULL || (pad_lrtb[0] >= 0 && pad_lrtb[1] >= 0 && pad_lrtb[2] >= 0 && pad_lrtb[3] >= 0)) && "nt_ui_step_interaction_padded: pad_lrtb components must be >= 0");
+
+    resolve_hot_if_needed(ctx); /* once per frame, from prev-frame registry; view_proj is set by now */
 
     const nt_ui_interaction_t out = nt_ui_query_interaction_padded(ctx, id, pad_lrtb);
 
@@ -2378,7 +2420,7 @@ void nt_ui_set_pointer_occlusion(nt_ui_context_t *ctx, uint32_t pointer_index, f
 nt_ui_hot_t nt_ui_pointer_hot(nt_ui_context_t *ctx, uint32_t pointer_index) {
     NT_ASSERT(ctx != NULL && "nt_ui_pointer_hot: ctx must be non-NULL");
     NT_ASSERT(pointer_index < NT_INPUT_MAX_POINTERS && "nt_ui_pointer_hot: pointer_index out of range");
-    /* Lazy resolve wired in a later slice; for now returns the per-frame default until then. */
+    resolve_hot_if_needed(ctx); /* lazy: first step OR this query triggers the once-per-frame resolve */
     return ctx->pointer_hot[pointer_index];
 }
 // #endregion

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -2226,6 +2226,10 @@ static void resolve_hot_if_needed(nt_ui_context_t *ctx) {
         return;
     }
     ctx->hot_resolved = true;
+    /* ui_hit_test -> Clay_GetElementData reads the GLOBAL current Clay ctx, so make the resolve robust
+     * to nt_ui_pointer_hot being called outside the frame or under a different current ctx. */
+    Clay_Context *saved_clay = Clay_GetCurrentContext();
+    Clay_SetCurrentContext(ctx->clay);
     for (uint32_t pidx = 0; pidx < ctx->frame_pointer_count; ++pidx) {
         const nt_pointer_t *p = &ctx->frame_pointers[pidx];
         nt_ui_hot_t best = {0};
@@ -2261,6 +2265,7 @@ static void resolve_hot_if_needed(nt_ui_context_t *ctx) {
         /* best stays {0} when nothing was hit OR all hits were occluded — both gate to skip. */
         ctx->pointer_hot[pidx] = best;
     }
+    Clay_SetCurrentContext(saved_clay);
 }
 
 /* Same compute as query_padded plus state-machine commits; ONCE per widget per frame. */
@@ -2434,11 +2439,15 @@ bool nt_ui_wants_pointer(const nt_ui_context_t *ctx) {
     return false;
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) — count is all NT_ASSERT guards, not logic
 void nt_ui_set_pointer_occlusion(nt_ui_context_t *ctx, uint32_t pointer_index, float max_world_distance) {
     NT_ASSERT(ctx != NULL && "nt_ui_set_pointer_occlusion: ctx must be non-NULL");
     NT_ASSERT(ctx->use_raycast_input && "nt_ui_set_pointer_occlusion: only meaningful in 3D ctx (use_raycast_input)");
-    NT_ASSERT(pointer_index < NT_INPUT_MAX_POINTERS && "nt_ui_set_pointer_occlusion: pointer_index out of range");
-    /* Negative = occlude everything (all hits have t >= 0); the game owns that choice, so no assert. */
+    NT_ASSERT(ctx->in_frame && "nt_ui_set_pointer_occlusion: call between nt_ui_begin and the first step/query (reset each begin)");
+    NT_ASSERT(pointer_index < ctx->frame_pointer_count && "nt_ui_set_pointer_occlusion: pointer_index is not an active frame pointer");
+    /* NaN makes the `t > cutoff` test always false, silently disabling occlusion (click-through-wall);
+     * a broken game raycast must trip here. ±inf are valid (+inf = no cutoff, -inf/negative = occlude all). */
+    NT_ASSERT(!isnan(max_world_distance) && "nt_ui_set_pointer_occlusion: max_world_distance must not be NaN");
     ctx->pointer_occlusion[pointer_index] = max_world_distance;
 }
 

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -1828,7 +1828,9 @@ static void mat4_inv_trs(const float m[16], float out[16]) {
  * then inverse-transform the hit point into widget-local Clay coords for bbox check.
  * Returns local hit (lx, ly) in widget-local space; caller pads + bbox-tests against Clay bbox.
  * inv_view_proj caller-chosen: game view_proj for layer < 240, inspector ortho for inspector layers. */
-static bool raycast_hit(const float inv_view_proj[16], const nt_ui_baked_xform_t *baked, float px, float py, float screen_w, float screen_h, float *out_lx, float *out_ly) {
+/* out_t (nullable): ray parameter at the hit = world distance from the near point along the ray —
+ * used by the input resolve to pick the nearest widget and to compare against an occlusion cutoff. */
+static bool raycast_hit(const float inv_view_proj[16], const nt_ui_baked_xform_t *baked, float px, float py, float screen_w, float screen_h, float *out_lx, float *out_ly, float *out_t) {
     /* Screen → NDC: (-1..1, -1..1). Note Clay px is Y-down; NDC Y is up — flip. */
     const float px_ndc = ((px / screen_w) * 2.0F) - 1.0F;
     const float py_ndc = 1.0F - ((py / screen_h) * 2.0F);
@@ -1876,6 +1878,9 @@ static bool raycast_hit(const float inv_view_proj[16], const nt_ui_baked_xform_t
     mat4_inv_trs(baked->m, inv);
     *out_lx = (inv[0] * hx) + (inv[4] * hy) + (inv[8] * hz) + inv[12];
     *out_ly = (inv[1] * hx) + (inv[5] * hy) + (inv[9] * hz) + inv[13];
+    if (out_t != NULL) {
+        *out_t = t;
+    }
     return true;
 }
 
@@ -1917,7 +1922,7 @@ static bool hit_clip_chain(const nt_ui_context_t *ctx, uint32_t start_clip_id, i
                 iv = ctx->inv_inspector_view_proj;
             }
 #endif
-            if (!raycast_hit(iv, &cb, px, py, screen_w, screen_h, &clx, &cly)) {
+            if (!raycast_hit(iv, &cb, px, py, screen_w, screen_h, &clx, &cly, NULL)) {
                 return false;
             }
         } else {
@@ -1940,8 +1945,9 @@ static bool hit_clip_chain(const nt_ui_context_t *ctx, uint32_t start_clip_id, i
     return true;
 }
 
+/* out_t (nullable): world ray distance to the hit in 3D ctx; 0 in 2D ctx (no depth). */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-static bool ui_hit_test(const nt_ui_context_t *ctx, uint32_t id, float px, float py, const int16_t pad_lrtb[4]) {
+static bool ui_hit_test(const nt_ui_context_t *ctx, uint32_t id, float px, float py, const int16_t pad_lrtb[4], float *out_t) {
     if (id == 0U) {
         return false;
     }
@@ -1984,7 +1990,7 @@ static bool ui_hit_test(const nt_ui_context_t *ctx, uint32_t id, float px, float
             iv = ctx->inv_inspector_view_proj;
         }
 #endif
-        if (!raycast_hit(iv, &b, px, py, screen_w, screen_h, &lx, &ly)) {
+        if (!raycast_hit(iv, &b, px, py, screen_w, screen_h, &lx, &ly, out_t)) {
             return false;
         }
     } else {
@@ -1998,6 +2004,9 @@ static bool ui_hit_test(const nt_ui_context_t *ctx, uint32_t id, float px, float
         const float ry = py - b.m[13];
         lx = (inv_a * rx) + (inv_b * ry);
         ly = (inv_c * rx) + (inv_d * ry);
+        if (out_t != NULL) {
+            *out_t = 0.0F; /* 2D ctx has no depth */
+        }
     }
 
     const float pl = (pad_lrtb != NULL) ? (float)pad_lrtb[0] : 0.0F;
@@ -2029,7 +2038,7 @@ uint32_t nt_ui_internal_pick_zone_3d(const nt_ui_context_t *ctx, float px, float
         memcpy(b.m, z->m, sizeof b.m);
         float lx;
         float ly;
-        if (!raycast_hit(ctx->inv_view_proj, &b, px, py, screen_w, screen_h, &lx, &ly)) {
+        if (!raycast_hit(ctx->inv_view_proj, &b, px, py, screen_w, screen_h, &lx, &ly, NULL)) {
             continue;
         }
         if (lx >= z->visual_l && lx <= z->visual_r && ly >= z->visual_t && ly <= z->visual_b) {
@@ -2073,7 +2082,7 @@ static nt_ui_widget_pidx_state_t resolve_widget_pidx_state(nt_ui_context_t *ctx,
         if (cap->active_id != 0U && cap->active_id != id) {
             continue; /* α: pointer bound elsewhere, invisible to this widget */
         }
-        const bool over = ui_hit_test(ctx, id, p->x, p->y, pad_lrtb);
+        const bool over = ui_hit_test(ctx, id, p->x, p->y, pad_lrtb, NULL);
         if (!over) {
             continue;
         }
@@ -2133,7 +2142,7 @@ nt_ui_interaction_t nt_ui_query_interaction_padded(nt_ui_context_t *ctx, uint32_
         const nt_pointer_t *p = &ctx->frame_pointers[pidx];
         const nt_ui_capture_t *cap = &ctx->captures[pidx];
         const nt_button_state_t btn = p->buttons[NT_BUTTON_LEFT];
-        const bool over = ui_hit_test(ctx, id, p->x, p->y, pad_lrtb);
+        const bool over = ui_hit_test(ctx, id, p->x, p->y, pad_lrtb, NULL);
         out.pressed = btn.is_down;
         out.released_now = btn.is_released;
         out.pressed_now = s.new_capture;
@@ -2423,7 +2432,7 @@ bool nt_ui_test_hit(nt_ui_context_t *ctx, uint32_t id, float px, float py) {
     NT_ASSERT(ctx != NULL && "nt_ui_test_hit: ctx must be non-NULL");
     Clay_Context *saved = Clay_GetCurrentContext();
     Clay_SetCurrentContext(ctx->clay);
-    const bool hit = ui_hit_test(ctx, id, px, py, NULL);
+    const bool hit = ui_hit_test(ctx, id, px, py, NULL, NULL);
     Clay_SetCurrentContext(saved);
     return hit;
 }
@@ -2432,7 +2441,7 @@ bool nt_ui_test_hit_padded(nt_ui_context_t *ctx, uint32_t id, float px, float py
     NT_ASSERT(ctx != NULL && "nt_ui_test_hit_padded: ctx must be non-NULL");
     Clay_Context *saved = Clay_GetCurrentContext();
     Clay_SetCurrentContext(ctx->clay);
-    const bool hit = ui_hit_test(ctx, id, px, py, pad_lrtb);
+    const bool hit = ui_hit_test(ctx, id, px, py, pad_lrtb, NULL);
     Clay_SetCurrentContext(saved);
     return hit;
 }

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -2054,7 +2054,7 @@ uint32_t nt_ui_internal_pick_zone_3d(const nt_ui_context_t *ctx, float px, float
     NT_ASSERT(ctx->view_proj_set && "nt_ui_internal_pick_zone_3d: 3D ctx but nt_ui_set_view_proj was not called this frame");
     const float screen_w = nt_ui_clay_priv_layout_width(ctx->clay);
     const float screen_h = nt_ui_clay_priv_layout_height(ctx->clay);
-    /* Reverse order: deepest-declared zone wins, matching the 2D scan. */
+    /* Reverse order: deepest-recorded zone wins (record/step order), matching the 2D scan. */
     for (int32_t zi = (int32_t)ctx->debug_zone_count - 1; zi >= 0; --zi) {
         const nt_ui_debug_zone_t *z = &ctx->debug_zones[zi];
         if (z->id == 0U) {
@@ -2110,9 +2110,9 @@ static nt_ui_widget_pidx_state_t resolve_widget_pidx_state(nt_ui_context_t *ctx,
             continue; /* α: pointer bound elsewhere, invisible to this widget */
         }
         /* Front-most arbitration: a free pointer drives this widget only if it is the resolved hot
-         * widget (or this widget holds capture). hot == 0 (no interactive widget was under the pointer
-         * last frame) gates OFF — a freshly-shown / just-moved widget waits one frame to register
-         * before it can react. Reliability over instant first-frame response (matches Dear ImGui). */
+         * widget (or this widget holds capture). hot == 0 (nothing under the pointer last frame, or in
+         * 3D all hits beyond the occlusion cutoff) gates OFF — a freshly-shown / just-moved widget waits
+         * one frame to register before it can react. Reliability over instant first-frame response (matches Dear ImGui). */
         const uint32_t hot = ctx->pointer_hot[i].id;
         const bool arbitrated_ok = (hot == id) || (cap->active_id == id);
         float hit_t = 0.0F;

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -347,7 +347,14 @@ typedef struct {
     float pos[2];           /* current pointer pos (UI-space) */
     float drag_dx, drag_dy; /* = pos - press_pos (convenience) */
     uint32_t pointer_id;    /* which pointer captured (multitouch) */
+    float distance;         /* 3D ctx: world distance (near-plane-relative) to this widget; 0 in 2D */
 } nt_ui_interaction_t;
+
+/* Front-most interactive widget under a pointer, resolved per frame (3D: nearest; 2D: top zIndex). */
+typedef struct {
+    uint32_t id;    /* 0 = none under the pointer */
+    float distance; /* world distance in 3D ctx; 0 in 2D */
+} nt_ui_hot_t;
 
 /* PURE query (no mutation). Safe to call N times per frame; safe outside begin/end. */
 nt_ui_interaction_t nt_ui_query_interaction(nt_ui_context_t *ctx, uint32_t id);
@@ -363,6 +370,15 @@ nt_ui_interaction_t nt_ui_step_interaction_padded(nt_ui_context_t *ctx, uint32_t
 
 /* True when any capture is active OR a pointer is over a widget this frame. */
 bool nt_ui_wants_pointer(const nt_ui_context_t *ctx);
+
+/* 3D ctx only (asserts use_raycast_input): max world distance the pointer's ray may travel before UI
+ * stops registering. Feed the nearest world-geometry hit (so the player can't click UI through a
+ * wall) and/or an interaction range. Default +inf = no cutoff. Reset each nt_ui_begin. */
+void nt_ui_set_pointer_occlusion(nt_ui_context_t *ctx, uint32_t pointer_index, float max_world_distance);
+
+/* Front-most interactive widget under the pointer this frame (3D: nearest within the cutoff; 2D: top
+ * zIndex). Resolved lazily from prev-frame layout on the first step/query (mutating). id 0 = none. */
+nt_ui_hot_t nt_ui_pointer_hot(nt_ui_context_t *ctx, uint32_t pointer_index);
 // #endregion
 
 // #region test_access

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -380,7 +380,8 @@ bool nt_ui_wants_pointer(const nt_ui_context_t *ctx);
 void nt_ui_set_pointer_occlusion(nt_ui_context_t *ctx, uint32_t pointer_index, float max_world_distance);
 
 /* Front-most interactive widget under the pointer this frame (3D: nearest within the cutoff; 2D:
- * highest effective zIndex, tie → last-declared). Resolved lazily from the prev-frame registry on the
+ * highest effective zIndex, tie → last-registered = later step_interaction call, which equals
+ * declaration/paint order when widgets step in declaration order). Resolved lazily from the prev-frame registry on the
  * first step/query (mutating). Only widgets that called step_interaction last frame are candidates. In 3D ctx call
  * nt_ui_set_view_proj first — the lazy resolve hit-tests, which asserts view_proj is set. id 0 = none. */
 nt_ui_hot_t nt_ui_pointer_hot(nt_ui_context_t *ctx, uint32_t pointer_index);

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -356,7 +356,9 @@ typedef struct {
     float distance; /* world distance in 3D ctx; 0 in 2D */
 } nt_ui_hot_t;
 
-/* PURE query (no mutation). Safe to call N times per frame; safe outside begin/end. */
+/* Idempotent query: same result N times per frame; safe outside begin/end. Side effects are
+ * frame-scoped only (hover observability + the once-per-frame arbitration resolve), never capture or
+ * button-edge state — those live in step_interaction. */
 nt_ui_interaction_t nt_ui_query_interaction(nt_ui_context_t *ctx, uint32_t id);
 
 /* Inflates bbox BEFORE the inverse-affine for mobile touch-friendly hit areas.
@@ -374,12 +376,12 @@ bool nt_ui_wants_pointer(const nt_ui_context_t *ctx);
 /* 3D ctx only (asserts use_raycast_input): max world distance the pointer's ray may travel before UI
  * stops registering. Feed the nearest world-geometry hit (so the player can't click UI through a
  * wall) and/or an interaction range. Default +inf = no cutoff. Reset each nt_ui_begin; feed it BEFORE
- * this frame's first step_interaction / nt_ui_pointer_hot (the per-frame resolve latches once). */
+ * this frame's first step_interaction / query / nt_ui_pointer_hot (the per-frame resolve latches once). */
 void nt_ui_set_pointer_occlusion(nt_ui_context_t *ctx, uint32_t pointer_index, float max_world_distance);
 
 /* Front-most interactive widget under the pointer this frame (3D: nearest within the cutoff; 2D:
- * last-declared/paint-order). Resolved lazily from the prev-frame registry on the first step/query
- * (mutating). Only widgets that called step_interaction last frame are candidates. In 3D ctx call
+ * highest effective zIndex, tie → last-declared). Resolved lazily from the prev-frame registry on the
+ * first step/query (mutating). Only widgets that called step_interaction last frame are candidates. In 3D ctx call
  * nt_ui_set_view_proj first — the lazy resolve hit-tests, which asserts view_proj is set. id 0 = none. */
 nt_ui_hot_t nt_ui_pointer_hot(nt_ui_context_t *ctx, uint32_t pointer_index);
 // #endregion

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -373,7 +373,8 @@ bool nt_ui_wants_pointer(const nt_ui_context_t *ctx);
 
 /* 3D ctx only (asserts use_raycast_input): max world distance the pointer's ray may travel before UI
  * stops registering. Feed the nearest world-geometry hit (so the player can't click UI through a
- * wall) and/or an interaction range. Default +inf = no cutoff. Reset each nt_ui_begin. */
+ * wall) and/or an interaction range. Default +inf = no cutoff. Reset each nt_ui_begin; feed it BEFORE
+ * this frame's first step_interaction / nt_ui_pointer_hot (the per-frame resolve latches once). */
 void nt_ui_set_pointer_occlusion(nt_ui_context_t *ctx, uint32_t pointer_index, float max_world_distance);
 
 /* Front-most interactive widget under the pointer this frame (3D: nearest within the cutoff; 2D:

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -376,8 +376,10 @@ bool nt_ui_wants_pointer(const nt_ui_context_t *ctx);
  * wall) and/or an interaction range. Default +inf = no cutoff. Reset each nt_ui_begin. */
 void nt_ui_set_pointer_occlusion(nt_ui_context_t *ctx, uint32_t pointer_index, float max_world_distance);
 
-/* Front-most interactive widget under the pointer this frame (3D: nearest within the cutoff; 2D: top
- * zIndex). Resolved lazily from prev-frame layout on the first step/query (mutating). id 0 = none. */
+/* Front-most interactive widget under the pointer this frame (3D: nearest within the cutoff; 2D:
+ * last-declared/paint-order). Resolved lazily from the prev-frame registry on the first step/query
+ * (mutating). Only widgets that called step_interaction last frame are candidates. In 3D ctx call
+ * nt_ui_set_view_proj first — the lazy resolve hit-tests, which asserts view_proj is set. id 0 = none. */
 nt_ui_hot_t nt_ui_pointer_hot(nt_ui_context_t *ctx, uint32_t pointer_index);
 // #endregion
 

--- a/engine/ui/nt_ui_clay_impl.c
+++ b/engine/ui/nt_ui_clay_impl.c
@@ -1035,70 +1035,80 @@ static cdv_layout_data_t cdv_render_layout_elements_list(nt_ui_context_t *ctx, i
     if (highlightedElementId == 0U && !ctx->inspector_pointer_consumed) {
         const float panel_left_x = context->layoutDimensions.width - ctx->inspector_metrics.panel_width;
 
-        /* Transform-aware; LAST hit wins (deepest in declaration order). */
         const float px = context->pointerInfo.position.x;
         const float py = context->pointerInfo.position.y;
-        for (int32_t zi = (int32_t)ctx->debug_zone_count - 1; zi >= 0; --zi) {
-            const nt_ui_debug_zone_t *z = &ctx->debug_zones[zi];
-            if (z->id == 0U) {
-                continue;
-            }
-            /* Forward-transform the visual center; panel filter operates in screen space.
-             * Extract 2D affine subset from the recorded mat4 (a=m[0], b=m[4], c=m[1], d=m[5]). */
-            const float a = z->m[0];
-            const float b = z->m[4];
-            const float c = z->m[1];
-            const float dd = z->m[5];
-            const float tx = z->m[12];
-            const float ty = z->m[13];
-            const float screen_cx = (z->center_x * a) + (z->center_y * b) + tx;
-            if (screen_cx >= panel_left_x) {
-                continue;
-            }
-            const float det = (a * dd) - (b * c);
-            if (det == 0.0F) {
-                continue;
-            }
-            const float inv_a = dd / det;
-            const float inv_b = -b / det;
-            const float inv_c = -c / det;
-            const float inv_d = a / det;
-            const float rx = px - tx;
-            const float ry = py - ty;
-            const float lx = (inv_a * rx) + (inv_b * ry);
-            const float ly = (inv_c * rx) + (inv_d * ry);
-            if (lx >= z->visual_l && lx <= z->visual_r && ly >= z->visual_t && ly <= z->visual_b) {
-                highlightedElementId = z->id;
-                break;
-            }
-        }
 
-        /* Prefer a registered-widget id so panel/group/image/label surface over their wrappers. */
-        if (highlightedElementId == 0U) {
-            uint32_t fallback_id = 0U;
-            for (int32_t i = context->pointerOverIds.length - 1; i >= 0; --i) {
-                const Clay_ElementId *eid = Clay_ElementIdArray_Get(&context->pointerOverIds, i);
-                if (cdv_is_inspector_owned_id(eid->id)) {
+        if (ctx->use_raycast_input) {
+            /* 3D ctx: the 2D-affine screen scan below can't apply (z->m maps Clay→world, not
+             * Clay→screen). Pick via ray-vs-zone-plane with the game view_proj; skip the
+             * pointerOverIds fallback — that list is 2D and would grab the GROW root. */
+            if (px < panel_left_x) {
+                highlightedElementId = nt_ui_internal_pick_zone_3d(ctx, px, py);
+            }
+        } else {
+            /* Transform-aware; LAST hit wins (deepest in declaration order). */
+            for (int32_t zi = (int32_t)ctx->debug_zone_count - 1; zi >= 0; --zi) {
+                const nt_ui_debug_zone_t *z = &ctx->debug_zones[zi];
+                if (z->id == 0U) {
                     continue;
                 }
-                const Clay_LayoutElementHashMapItem *item = Clay__GetHashMapItem(eid->id);
-                if (item == NULL) {
+                /* Forward-transform the visual center; panel filter operates in screen space.
+                 * Extract 2D affine subset from the recorded mat4 (a=m[0], b=m[4], c=m[1], d=m[5]). */
+                const float a = z->m[0];
+                const float b = z->m[4];
+                const float c = z->m[1];
+                const float dd = z->m[5];
+                const float tx = z->m[12];
+                const float ty = z->m[13];
+                const float screen_cx = (z->center_x * a) + (z->center_y * b) + tx;
+                if (screen_cx >= panel_left_x) {
                     continue;
                 }
-                /* Skip anything inside the panel footprint — the named-id set is not exhaustive. */
-                if (item->boundingBox.x >= panel_left_x) {
+                const float det = (a * dd) - (b * c);
+                if (det == 0.0F) {
                     continue;
                 }
-                if (nt_ui_widget_lookup(ctx, eid->id) != NULL) {
-                    highlightedElementId = eid->id;
+                const float inv_a = dd / det;
+                const float inv_b = -b / det;
+                const float inv_c = -c / det;
+                const float inv_d = a / det;
+                const float rx = px - tx;
+                const float ry = py - ty;
+                const float lx = (inv_a * rx) + (inv_b * ry);
+                const float ly = (inv_c * rx) + (inv_d * ry);
+                if (lx >= z->visual_l && lx <= z->visual_r && ly >= z->visual_t && ly <= z->visual_b) {
+                    highlightedElementId = z->id;
                     break;
                 }
-                if (fallback_id == 0U) {
-                    fallback_id = eid->id;
-                }
             }
-            if (highlightedElementId == 0U && fallback_id != 0U) {
-                highlightedElementId = fallback_id;
+
+            /* Prefer a registered-widget id so panel/group/image/label surface over their wrappers. */
+            if (highlightedElementId == 0U) {
+                uint32_t fallback_id = 0U;
+                for (int32_t i = context->pointerOverIds.length - 1; i >= 0; --i) {
+                    const Clay_ElementId *eid = Clay_ElementIdArray_Get(&context->pointerOverIds, i);
+                    if (cdv_is_inspector_owned_id(eid->id)) {
+                        continue;
+                    }
+                    const Clay_LayoutElementHashMapItem *item = Clay__GetHashMapItem(eid->id);
+                    if (item == NULL) {
+                        continue;
+                    }
+                    /* Skip anything inside the panel footprint — the named-id set is not exhaustive. */
+                    if (item->boundingBox.x >= panel_left_x) {
+                        continue;
+                    }
+                    if (nt_ui_widget_lookup(ctx, eid->id) != NULL) {
+                        highlightedElementId = eid->id;
+                        break;
+                    }
+                    if (fallback_id == 0U) {
+                        fallback_id = eid->id;
+                    }
+                }
+                if (highlightedElementId == 0U && fallback_id != 0U) {
+                    highlightedElementId = fallback_id;
+                }
             }
         }
     }

--- a/engine/ui/nt_ui_clay_impl.c
+++ b/engine/ui/nt_ui_clay_impl.c
@@ -1049,7 +1049,7 @@ static cdv_layout_data_t cdv_render_layout_elements_list(nt_ui_context_t *ctx, i
                 highlightedElementId = nt_ui_internal_pick_zone_3d(ctx, px, py);
             }
         } else {
-            /* Transform-aware; LAST hit wins (deepest in declaration order). */
+            /* Transform-aware; LAST hit wins (deepest in record/step order). */
             for (int32_t zi = (int32_t)ctx->debug_zone_count - 1; zi >= 0; --zi) {
                 const nt_ui_debug_zone_t *z = &ctx->debug_zones[zi];
                 if (z->id == 0U) {

--- a/engine/ui/nt_ui_clay_impl.c
+++ b/engine/ui/nt_ui_clay_impl.c
@@ -423,7 +423,7 @@ static void compose_transform_level(const nt_ui_transform_t *t, float cx, float 
 
 /* Floating descendants skipped (handled by outer roots loop). Text leaves have no .children. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-static void bt_dfs_subtree(nt_ui_context_t *ctx, Clay_Context *cc, int32_t root_elem_idx, const nt_ui_baked_xform_t *seed) {
+static void bt_dfs_subtree(nt_ui_context_t *ctx, Clay_Context *cc, int32_t root_elem_idx, const nt_ui_baked_xform_t *seed, int16_t root_zindex) {
     nt_ui_dfs_frame_t *S = ctx->tree_dfs_stack;
     int32_t sp = 0;
     NT_ASSERT(sp < NT_UI_TREE_DFS_DEPTH_CAP);
@@ -460,6 +460,7 @@ static void bt_dfs_subtree(nt_ui_context_t *ctx, Clay_Context *cc, int32_t root_
             memcpy(ctx->tree_baked[f->elem_idx].m, m_cur, sizeof m_cur);
             ctx->tree_baked[f->elem_idx].opacity = op;
             ctx->tree_baked[f->elem_idx].hierarchy_depth = f->hierarchy_depth;
+            ctx->tree_baked[f->elem_idx].zindex = root_zindex; /* uniform per Clay tree root */
             memcpy(f->m, m_cur, sizeof m_cur);
             f->opacity = op;
         }
@@ -526,6 +527,8 @@ void nt_ui_internal_build_tree(nt_ui_context_t *ctx) {
         if (root_idx < 0) {
             continue;
         }
+        /* Effective Clay zIndex is uniform per tree root (Clay tags every command of a root with it). */
+        const int16_t root_zindex = Clay__LayoutElementTreeRootArray_Get(&cc->layoutElementTreeRoots, root_idx)->zIndex;
 
         nt_ui_baked_xform_t seed;
         if (root_idx == 0) {
@@ -549,7 +552,7 @@ void nt_ui_internal_build_tree(nt_ui_context_t *ctx) {
                 }
             }
         }
-        bt_dfs_subtree(ctx, cc, elem_idx, &seed);
+        bt_dfs_subtree(ctx, cc, elem_idx, &seed, root_zindex);
     }
     // #endregion
 

--- a/engine/ui/nt_ui_debug_hit_zones.c
+++ b/engine/ui/nt_ui_debug_hit_zones.c
@@ -86,14 +86,15 @@ const nt_ui_debug_zone_t *nt_ui_internal_find_debug_zone(const nt_ui_context_t *
 // #endregion
 
 // #region polygon emit helpers
-/* Vertices already in world space. */
-void nt_ui_internal_emit_filled_quad(nt_resource_t atlas, uint32_t region, const float v[4][2], uint32_t color) {
+/* `model` maps the quad corners into render space (identity = corners already there). */
+void nt_ui_internal_emit_filled_quad_m(nt_resource_t atlas, uint32_t region, const float v[4][2], const float model[16], uint32_t color) {
     const uint16_t indices[6] = {0, 1, 2, 0, 2, 3};
-    nt_sprite_renderer_emit_geometry(atlas, region, v, 4U, indices, 6U, NT_MATH_MAT4_IDENTITY, color);
+    nt_sprite_renderer_emit_geometry(atlas, region, v, 4U, indices, 6U, model, color);
 }
 
-/* 4 inset quads; inset direction = unit perpendicular toward centroid. */
-void nt_ui_internal_emit_outline(nt_resource_t atlas, uint32_t region, const float c[4][2], float thickness, uint32_t color) {
+/* 4 inset quads; inset direction = unit perpendicular toward centroid. Inset runs in the corners'
+ * own space, so `model` (set for 3D ctx) scales the outline thickness with the element. */
+void nt_ui_internal_emit_outline_m(nt_resource_t atlas, uint32_t region, const float c[4][2], float thickness, const float model[16], uint32_t color) {
     float cx = 0.0F;
     float cy = 0.0F;
     for (uint32_t i = 0; i < 4U; ++i) {
@@ -132,8 +133,15 @@ void nt_ui_internal_emit_outline(nt_resource_t atlas, uint32_t region, const flo
             {bx + (nx * t), by + (ny * t)},
             {ax + (nx * t), ay + (ny * t)},
         };
-        nt_ui_internal_emit_filled_quad(atlas, region, quad, color);
+        nt_ui_internal_emit_filled_quad_m(atlas, region, quad, model, color);
     }
+}
+
+/* Vertices already in world space (2D-ctx pre-projected path). */
+void nt_ui_internal_emit_filled_quad(nt_resource_t atlas, uint32_t region, const float v[4][2], uint32_t color) { nt_ui_internal_emit_filled_quad_m(atlas, region, v, NT_MATH_MAT4_IDENTITY, color); }
+
+void nt_ui_internal_emit_outline(nt_resource_t atlas, uint32_t region, const float c[4][2], float thickness, uint32_t color) {
+    nt_ui_internal_emit_outline_m(atlas, region, c, thickness, NT_MATH_MAT4_IDENTITY, color);
 }
 // #endregion
 
@@ -155,8 +163,8 @@ static bool zone_passes_mode(const nt_ui_debug_zone_t *z, nt_ui_debug_hit_mode_t
 // #endregion
 
 // #region label rendering
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
-static void draw_zone_label(const nt_ui_debug_zone_t *z, const float corner[2], nt_material_t text_mat, nt_font_t font, float size) {
+/* `text_model` already places the baseline; caller picks screen (2D) or z->m-mapped (3D) space. */
+static void draw_zone_label(const nt_ui_debug_zone_t *z, const float text_model[16], nt_material_t text_mat, nt_font_t font, float size) {
     if (size <= 0.0F) {
         return;
     }
@@ -175,15 +183,10 @@ static void draw_zone_label(const nt_ui_debug_zone_t *z, const float corner[2], 
     if (n <= 0) {
         return;
     }
-    /* GL Y-up: baseline sits inside the top edge. */
-    const float baseline_y = corner[1] - size - 2.0F;
-    const float model[16] = {
-        1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, corner[0] + 2.0F, baseline_y, 0.0F, 1.0F,
-    };
     const float color[4] = {1.0F, 1.0F, 1.0F, 1.0F};
     nt_text_renderer_set_material(text_mat);
     nt_text_renderer_set_font(font);
-    nt_text_renderer_draw_n(buf, (size_t)n, model, size, color, 0.0F, 0.0F);
+    nt_text_renderer_draw_n(buf, (size_t)n, text_model, size, color, 0.0F, 0.0F);
 }
 // #endregion
 
@@ -202,9 +205,14 @@ void nt_ui_debug_draw_hit_zones(nt_ui_context_t *ctx, const nt_ui_target_t *targ
     if (!nt_resource_is_ready(ctx->atlas)) {
         return;
     }
-    nt_sprite_renderer_set_material(ctx->sprite_material);
+    /* 3D ctx: emit Clay-layout corners under each zone's world mat4 (caller binds the perspective
+     * view_proj) and prefer the depth-off inspector materials so the overlay stays on top. */
+    const bool is_3d = ctx->use_raycast_input;
+    const nt_material_t smat = (is_3d && ctx->inspector_sprite_material.id != 0U) ? ctx->inspector_sprite_material : ctx->sprite_material;
+    const nt_material_t tmat = (is_3d && ctx->inspector_text_material.id != 0U) ? ctx->inspector_text_material : ctx->text_material;
+    nt_sprite_renderer_set_material(smat);
 
-    const bool can_label = (ctx->text_material.id != 0U) && (font.id != 0U) && (label_size > 0.0F);
+    const bool can_label = (tmat.id != 0U) && (font.id != 0U) && (label_size > 0.0F);
     const float vy = target->viewport[1];
     const float vh = target->viewport[3];
 
@@ -219,19 +227,39 @@ void nt_ui_debug_draw_hit_zones(nt_ui_context_t *ctx, const nt_ui_target_t *targ
             {z->layout_r, z->layout_b},
             {z->layout_l, z->layout_b},
         };
-        for (uint32_t k = 0; k < 4U; ++k) {
-            nt_ui_internal_project_layout_to_world(z, vy, vh, pad_corners[k][0], pad_corners[k][1], &pad_corners[k][0], &pad_corners[k][1]);
-        }
-        const uint32_t fill = color_for_state(z->state_flags);
-        nt_ui_internal_emit_filled_quad(ctx->atlas, ctx->white_region, pad_corners, fill);
-
-        /* Outline visual bbox so padding is visually distinct. */
         float vis_corners[4][2] = {
             {z->visual_l, z->visual_t},
             {z->visual_r, z->visual_t},
             {z->visual_r, z->visual_b},
             {z->visual_l, z->visual_b},
         };
+        const uint32_t fill = color_for_state(z->state_flags);
+
+        if (is_3d) {
+            nt_ui_internal_emit_filled_quad_m(ctx->atlas, ctx->white_region, pad_corners, z->m, fill);
+            /* Outline visual bbox so padding is visually distinct. */
+            nt_ui_internal_emit_outline_m(ctx->atlas, ctx->white_region, vis_corners, 2.0F, z->m, DEBUG_OUTLINE_COLOR);
+            if (can_label) {
+                /* Clay-px baseline at the top-left, mapped by z->m; col1 negated so glyphs read upright. */
+                const float ox = z->visual_l + 2.0F;
+                const float oy = z->visual_t + label_size + 2.0F;
+                float text_model[16];
+                for (int rr = 0; rr < 4; ++rr) {
+                    text_model[rr] = z->m[rr];
+                    text_model[4 + rr] = -z->m[4 + rr];
+                    text_model[8 + rr] = z->m[8 + rr];
+                    text_model[12 + rr] = (ox * z->m[rr]) + (oy * z->m[4 + rr]) + z->m[12 + rr];
+                }
+                draw_zone_label(z, text_model, tmat, font, label_size);
+            }
+            continue;
+        }
+
+        for (uint32_t k = 0; k < 4U; ++k) {
+            nt_ui_internal_project_layout_to_world(z, vy, vh, pad_corners[k][0], pad_corners[k][1], &pad_corners[k][0], &pad_corners[k][1]);
+        }
+        nt_ui_internal_emit_filled_quad(ctx->atlas, ctx->white_region, pad_corners, fill);
+
         for (uint32_t k = 0; k < 4U; ++k) {
             nt_ui_internal_project_layout_to_world(z, vy, vh, vis_corners[k][0], vis_corners[k][1], &vis_corners[k][0], &vis_corners[k][1]);
         }
@@ -247,8 +275,11 @@ void nt_ui_debug_draw_hit_zones(nt_ui_context_t *ctx, const nt_ui_target_t *targ
                     top_x = pad_corners[k][0];
                 }
             }
-            const float label_corner[2] = {top_x, top_y};
-            draw_zone_label(z, label_corner, ctx->text_material, font, label_size);
+            /* GL Y-up: baseline sits inside the top edge. */
+            const float text_model[16] = {
+                1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, top_x + 2.0F, top_y - label_size - 2.0F, 0.0F, 1.0F,
+            };
+            draw_zone_label(z, text_model, tmat, font, label_size);
         }
     }
     nt_sprite_renderer_flush();

--- a/engine/ui/nt_ui_debug_hit_zones.h
+++ b/engine/ui/nt_ui_debug_hit_zones.h
@@ -29,7 +29,9 @@ uint32_t nt_ui_debug_get_zone_count(const nt_ui_context_t *ctx);
 /* First-frame Clay miss → no zone recorded (not an assert). pad_lrtb NULL = zero padding. */
 void nt_ui_debug_record_disabled_zone(nt_ui_context_t *ctx, uint32_t id, const int16_t pad_lrtb[4]);
 
-/* `target` MUST match the nt_ui_walk target. label_size 0 skips labels. */
+/* `target` MUST match the nt_ui_walk target. label_size 0 skips labels.
+ * Side effect: leaves the sprite/text renderers bound to the inspector (or game) materials without
+ * restoring the prior binding — call as the terminal UI draw of the pass, or rebind afterward. */
 void nt_ui_debug_draw_hit_zones(nt_ui_context_t *ctx, const nt_ui_target_t *target, nt_ui_debug_hit_mode_t mode, nt_font_t font, float label_size);
 
 #else /* NT_UI_DEBUG_TOOLS */

--- a/engine/ui/nt_ui_inspector.c
+++ b/engine/ui/nt_ui_inspector.c
@@ -39,6 +39,7 @@ void nt_ui_inspector_set_metrics(nt_ui_context_t *ctx, const nt_ui_inspector_met
 
 void nt_ui_inspector_set_materials(nt_ui_context_t *ctx, nt_material_t sprite, nt_material_t text) {
     NT_ASSERT(ctx != NULL && "nt_ui_inspector_set_materials: ctx must be non-NULL");
+    NT_ASSERT(!ctx->in_frame && "nt_ui_inspector_set_materials: must be called outside begin/end");
     /* 0 handles fall back to the game's sprite/text material at walk time. */
     ctx->inspector_sprite_material = sprite;
     ctx->inspector_text_material = text;

--- a/engine/ui/nt_ui_inspector.c
+++ b/engine/ui/nt_ui_inspector.c
@@ -149,7 +149,10 @@ void nt_ui_inspector_overlay_draw(nt_ui_context_t *ctx, const nt_ui_target_t *ta
         nt_gfx_set_scissor_enabled(true);
     }
 
-    const bool can_label = ctx->text_material.id != 0U && font.id != 0U && label_size > 0.0F;
+    /* Inspector text material when set, else the game's (mirrors draw_hit_zones). Gate can_label on
+     * the resolved one so a depth-off-only inspector material still draws the label. */
+    const nt_material_t tmat = (ctx->inspector_text_material.id != 0U) ? ctx->inspector_text_material : ctx->text_material;
+    const bool can_label = tmat.id != 0U && font.id != 0U && label_size > 0.0F;
     const float white[4] = {1.0F, 1.0F, 1.0F, 1.0F};
 
     if (ctx->use_raycast_input) {
@@ -208,7 +211,6 @@ void nt_ui_inspector_overlay_draw(nt_ui_context_t *ctx, const nt_ui_target_t *ta
                         tm[8 + rr] = m[8 + rr];
                         tm[12 + rr] = (ox * m[rr]) + (oy * m[4 + rr]) + m[12 + rr];
                     }
-                    const nt_material_t tmat = (ctx->inspector_text_material.id != 0U) ? ctx->inspector_text_material : ctx->text_material;
                     nt_text_renderer_set_material(tmat);
                     nt_text_renderer_set_font(font);
                     nt_text_renderer_draw_n(buf, (size_t)n, tm, label_size, white, 0.0F, 0.0F);
@@ -273,7 +275,7 @@ void nt_ui_inspector_overlay_draw(nt_ui_context_t *ctx, const nt_ui_target_t *ta
                 n = snprintf(buf, sizeof buf, "id=#%08X", ctx->inspector_highlight_id);
             }
             if (n > 0) {
-                overlay_draw_text(ctx->text_material, font, top_x + 4.0F, top_y - label_size - 2.0F, label_size, white, buf, (size_t)n);
+                overlay_draw_text(tmat, font, top_x + 4.0F, top_y - label_size - 2.0F, label_size, white, buf, (size_t)n);
             }
         }
         nt_sprite_renderer_flush();
@@ -311,7 +313,7 @@ void nt_ui_inspector_overlay_draw(nt_ui_context_t *ctx, const nt_ui_target_t *ta
     overlay_emit_rect(ctx->atlas, ctx->white_region, gl_x, gl_y_top, w, h, 0x641C42A8U);
     overlay_emit_outline(ctx->atlas, ctx->white_region, gl_x, gl_y_top, w, h, 2.0F, 0xFFFFFFFFU);
 
-    if (ctx->text_material.id != 0U && font.id != 0U && label_size > 0.0F) {
+    if (can_label) {
         char buf[80];
         int n;
         if (info.id_string_len > 0U && info.id_string != NULL) {
@@ -321,13 +323,12 @@ void nt_ui_inspector_overlay_draw(nt_ui_context_t *ctx, const nt_ui_target_t *ta
             n = snprintf(buf, sizeof buf, "id=#%08X", ctx->inspector_highlight_id);
         }
         if (n > 0) {
-            const float color[4] = {1.0F, 1.0F, 1.0F, 1.0F};
-            overlay_draw_text(ctx->text_material, font, gl_x + 4.0F, gl_y_top - label_size - 2.0F, label_size, color, buf, (size_t)n);
+            overlay_draw_text(tmat, font, gl_x + 4.0F, gl_y_top - label_size - 2.0F, label_size, white, buf, (size_t)n);
         }
     }
 
     nt_sprite_renderer_flush();
-    if (ctx->text_material.id != 0U && font.id != 0U && label_size > 0.0F) {
+    if (can_label) {
         nt_text_renderer_flush();
     }
     if (scissor_w > 0 && scissor_h > 0) {

--- a/engine/ui/nt_ui_inspector.c
+++ b/engine/ui/nt_ui_inspector.c
@@ -202,7 +202,8 @@ void nt_ui_inspector_overlay_draw(nt_ui_context_t *ctx, const nt_ui_target_t *ta
                 }
                 if (n > 0) {
                     /* Label in Clay px at the top-left, mapped by m onto the element; col1 negated so
-                     * glyphs read upright — same convention as the walker's emit_text. */
+                     * glyphs read upright (same col1-flip as emit_text; no text_scale to divide out
+                     * here — label_size is already in renderer units). */
                     const float ox = vl + 2.0F;
                     const float oy = vt + label_size + 2.0F;
                     float tm[16];

--- a/engine/ui/nt_ui_inspector.c
+++ b/engine/ui/nt_ui_inspector.c
@@ -36,6 +36,13 @@ void nt_ui_inspector_set_metrics(nt_ui_context_t *ctx, const nt_ui_inspector_met
     NT_ASSERT(metrics->font_size > 0U && "nt_ui_inspector_set_metrics: font_size must be > 0");
     ctx->inspector_metrics = *metrics;
 }
+
+void nt_ui_inspector_set_materials(nt_ui_context_t *ctx, nt_material_t sprite, nt_material_t text) {
+    NT_ASSERT(ctx != NULL && "nt_ui_inspector_set_materials: ctx must be non-NULL");
+    /* 0 handles fall back to the game's sprite/text material at walk time. */
+    ctx->inspector_sprite_material = sprite;
+    ctx->inspector_text_material = text;
+}
 // #endregion
 
 // #region toggle + getters

--- a/engine/ui/nt_ui_inspector.c
+++ b/engine/ui/nt_ui_inspector.c
@@ -149,16 +149,86 @@ void nt_ui_inspector_overlay_draw(nt_ui_context_t *ctx, const nt_ui_target_t *ta
         nt_gfx_set_scissor_enabled(true);
     }
 
-    /* Fall back to axis-aligned bbox for plain Clay elements without a recorded zone. */
+    const bool can_label = ctx->text_material.id != 0U && font.id != 0U && label_size > 0.0F;
+    const float white[4] = {1.0F, 1.0F, 1.0F, 1.0F};
+
+    if (ctx->use_raycast_input) {
+        /* 3D ctx: every walked element (not only interactive widgets) has its world mat4 snapshotted
+         * in hit_baked, so fetch it by id and emit the element's Clay bbox under it. Caller binds the
+         * perspective view_proj; the depth-off inspector material keeps the highlight on top. */
+        const int32_t slot = nt_ui_clay_priv_hashmap_slot_for_id(ctx->clay, ctx->inspector_highlight_id);
+        const bool slot_ok = (slot >= 0) && (slot < (int32_t)ctx->max_elements) && (ctx->hit_generation[slot] == ctx->current_generation);
+        const float *m = slot_ok ? ctx->hit_baked[slot].m : NULL;
+        /* Identity affine + zero translation = no 3D placement (e.g. the GROW root): its full-canvas
+         * bbox would map to a screen-filling quad, so only highlight elements that carry a transform. */
+        const bool placed = (m != NULL) && (m[0] != 1.0F || m[4] != 0.0F || m[1] != 0.0F || m[5] != 1.0F || m[12] != 0.0F || m[13] != 0.0F || m[14] != 0.0F);
+        if (placed) {
+            const nt_material_t smat = (ctx->inspector_sprite_material.id != 0U) ? ctx->inspector_sprite_material : ctx->sprite_material;
+            nt_sprite_renderer_set_material(smat);
+
+            const float vl = info.bbox_x;
+            const float vt = info.bbox_y;
+            const float vr = info.bbox_x + info.bbox_w;
+            const float vb = info.bbox_y + info.bbox_h;
+
+            int16_t pad[4] = {0, 0, 0, 0};
+            if (nt_ui_widget_get_hit_padding(ctx, ctx->inspector_highlight_id, pad) && (pad[0] > 0 || pad[1] > 0 || pad[2] > 0 || pad[3] > 0)) {
+                const float pad_corners[4][2] = {
+                    {vl - (float)pad[0], vt - (float)pad[2]},
+                    {vr + (float)pad[1], vt - (float)pad[2]},
+                    {vr + (float)pad[1], vb + (float)pad[3]},
+                    {vl - (float)pad[0], vb + (float)pad[3]},
+                };
+                nt_ui_internal_emit_filled_quad_m(ctx->atlas, ctx->white_region, pad_corners, m, 0x6033FFFFU);
+                nt_ui_internal_emit_outline_m(ctx->atlas, ctx->white_region, pad_corners, 2.0F, m, 0xFF00FFFFU);
+            }
+            const float vis_corners[4][2] = {{vl, vt}, {vr, vt}, {vr, vb}, {vl, vb}};
+            nt_ui_internal_emit_filled_quad_m(ctx->atlas, ctx->white_region, vis_corners, m, 0x641C42A8U);
+            nt_ui_internal_emit_outline_m(ctx->atlas, ctx->white_region, vis_corners, 2.0F, m, 0xFFFFFFFFU);
+            nt_sprite_renderer_flush();
+
+            if (can_label) {
+                char buf[80];
+                int n;
+                if (info.id_string_len > 0U && info.id_string != NULL) {
+                    const int slen = (info.id_string_len > 48U) ? 48 : (int)info.id_string_len;
+                    n = snprintf(buf, sizeof buf, "id=%.*s", slen, info.id_string);
+                } else {
+                    n = snprintf(buf, sizeof buf, "id=#%08X", ctx->inspector_highlight_id);
+                }
+                if (n > 0) {
+                    /* Label in Clay px at the top-left, mapped by m onto the element; col1 negated so
+                     * glyphs read upright — same convention as the walker's emit_text. */
+                    const float ox = vl + 2.0F;
+                    const float oy = vt + label_size + 2.0F;
+                    float tm[16];
+                    for (int rr = 0; rr < 4; ++rr) {
+                        tm[rr] = m[rr];
+                        tm[4 + rr] = -m[4 + rr];
+                        tm[8 + rr] = m[8 + rr];
+                        tm[12 + rr] = (ox * m[rr]) + (oy * m[4 + rr]) + m[12 + rr];
+                    }
+                    const nt_material_t tmat = (ctx->inspector_text_material.id != 0U) ? ctx->inspector_text_material : ctx->text_material;
+                    nt_text_renderer_set_material(tmat);
+                    nt_text_renderer_set_font(font);
+                    nt_text_renderer_draw_n(buf, (size_t)n, tm, label_size, white, 0.0F, 0.0F);
+                    nt_text_renderer_flush();
+                }
+            }
+        }
+        if (scissor_w > 0 && scissor_h > 0) {
+            nt_gfx_set_scissor_enabled(false);
+        }
+        return;
+    }
+
+    /* 2D ctx: project the composed affine subset to screen and emit under identity. */
     const nt_ui_debug_zone_t *z = nt_ui_internal_find_debug_zone(ctx, ctx->inspector_highlight_id);
-    /* Skip projection when composed mat4 is identity (top-left 2×2 + col3 subset). */
     const bool z_has_xform = (z != NULL) && (z->m[0] != 1.0F || z->m[4] != 0.0F || z->m[1] != 0.0F || z->m[5] != 1.0F || z->m[12] != 0.0F || z->m[13] != 0.0F);
     if (z_has_xform) {
         nt_sprite_renderer_set_material(ctx->sprite_material);
-
         int16_t pad[4] = {0, 0, 0, 0};
         const bool has_pad = nt_ui_widget_get_hit_padding(ctx, ctx->inspector_highlight_id, pad) && (pad[0] > 0 || pad[1] > 0 || pad[2] > 0 || pad[3] > 0);
-
         if (has_pad) {
             float pad_corners[4][2] = {
                 {z->layout_l, z->layout_t},
@@ -172,7 +242,6 @@ void nt_ui_inspector_overlay_draw(nt_ui_context_t *ctx, const nt_ui_target_t *ta
             nt_ui_internal_emit_filled_quad(ctx->atlas, ctx->white_region, pad_corners, 0x6033FFFFU);
             nt_ui_internal_emit_outline(ctx->atlas, ctx->white_region, pad_corners, 1.0F, 0xFF00FFFFU);
         }
-
         float vis_corners[4][2] = {
             {z->visual_l, z->visual_t},
             {z->visual_r, z->visual_t},
@@ -186,7 +255,7 @@ void nt_ui_inspector_overlay_draw(nt_ui_context_t *ctx, const nt_ui_target_t *ta
         nt_ui_internal_emit_outline(ctx->atlas, ctx->white_region, vis_corners, 2.0F, 0xFFFFFFFFU);
 
         /* Label at corner with max y (GL-Y-up TOP of projected quad). */
-        if (ctx->text_material.id != 0U && font.id != 0U && label_size > 0.0F) {
+        if (can_label) {
             float top_x = vis_corners[0][0];
             float top_y = vis_corners[0][1];
             for (uint32_t k = 1; k < 4U; ++k) {
@@ -204,16 +273,11 @@ void nt_ui_inspector_overlay_draw(nt_ui_context_t *ctx, const nt_ui_target_t *ta
                 n = snprintf(buf, sizeof buf, "id=#%08X", ctx->inspector_highlight_id);
             }
             if (n > 0) {
-                const float color[4] = {1.0F, 1.0F, 1.0F, 1.0F};
-                overlay_draw_text(ctx->text_material, font, top_x + 4.0F, top_y - label_size - 2.0F, label_size, color, buf, (size_t)n);
+                overlay_draw_text(ctx->text_material, font, top_x + 4.0F, top_y - label_size - 2.0F, label_size, white, buf, (size_t)n);
             }
         }
-
         nt_sprite_renderer_flush();
-        if (ctx->text_material.id != 0U && font.id != 0U && label_size > 0.0F) {
-            nt_text_renderer_flush();
-        }
-        /* Flush BEFORE disable so panel-clipped staging carries the scissor. */
+        nt_text_renderer_flush();
         if (scissor_w > 0 && scissor_h > 0) {
             nt_gfx_set_scissor_enabled(false);
         }

--- a/engine/ui/nt_ui_inspector.h
+++ b/engine/ui/nt_ui_inspector.h
@@ -32,6 +32,11 @@ extern const nt_ui_inspector_metrics_t NT_UI_INSPECTOR_METRICS_DEFAULT;
 
 void nt_ui_inspector_set_metrics(nt_ui_context_t *ctx, const nt_ui_inspector_metrics_t *metrics);
 
+/* Optional overlay materials for the inspector — typically depth_test=false so the debug view stays
+ * on top without testing the game's 3D depth (a passive overlay, no shared-state side effects).
+ * Pass NT_MATERIAL_INVALID for either to fall back to the game's sprite/text material. */
+void nt_ui_inspector_set_materials(nt_ui_context_t *ctx, nt_material_t sprite, nt_material_t text);
+
 /* Called by nt_ui_end if active; not for game code. */
 void nt_ui_inspector_emit_layout(nt_ui_context_t *ctx);
 
@@ -66,6 +71,11 @@ static inline void nt_ui_inspector_set_metrics(nt_ui_context_t *ctx, const nt_ui
     (void)ctx;
     (void)metrics;
     nt_log_warn("nt_ui_inspector: NT_UI_DEBUG_TOOLS=OFF in this build — metrics ignored. Rebuild with -DNT_UI_DEBUG_TOOLS=ON.");
+}
+static inline void nt_ui_inspector_set_materials(nt_ui_context_t *ctx, nt_material_t sprite, nt_material_t text) {
+    (void)ctx;
+    (void)sprite;
+    (void)text;
 }
 static inline void nt_ui_inspector_emit_layout(nt_ui_context_t *ctx) { (void)ctx; }
 static inline void nt_ui_debug_inspector_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target) {

--- a/engine/ui/nt_ui_inspector.h
+++ b/engine/ui/nt_ui_inspector.h
@@ -33,7 +33,7 @@ extern const nt_ui_inspector_metrics_t NT_UI_INSPECTOR_METRICS_DEFAULT;
 void nt_ui_inspector_set_metrics(nt_ui_context_t *ctx, const nt_ui_inspector_metrics_t *metrics);
 
 /* Optional overlay materials for the inspector — typically depth_test=false so the debug view stays
- * on top without testing the game's 3D depth (a passive overlay, no shared-state side effects).
+ * on top without testing the game's 3D depth (a passive overlay, no depth-buffer side effects).
  * Pass NT_MATERIAL_INVALID for either to fall back to the game's sprite/text material. */
 void nt_ui_inspector_set_materials(nt_ui_context_t *ctx, nt_material_t sprite, nt_material_t text);
 

--- a/engine/ui/nt_ui_inspector.h
+++ b/engine/ui/nt_ui_inspector.h
@@ -44,7 +44,10 @@ void nt_ui_inspector_emit_layout(nt_ui_context_t *ctx);
  * screen-space view_proj first, e.g. nt_ui_make_screen_view_proj(...). */
 void nt_ui_debug_inspector_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
 
-/* Call AFTER debug inspector walk, BEFORE nt_gfx_end_pass. label_size <= 0 skips label. */
+/* Call AFTER debug inspector walk, BEFORE nt_gfx_end_pass. label_size <= 0 skips label.
+ * Side effect: leaves the sprite/text renderers bound to the inspector (or game) materials and does
+ * NOT restore the prior binding — call it as the terminal UI draw of the pass, or rebind your own
+ * materials afterward. */
 void nt_ui_inspector_overlay_draw(nt_ui_context_t *ctx, const nt_ui_target_t *target, nt_font_t font, float label_size);
 
 #else /* NT_UI_DEBUG_TOOLS */

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -264,7 +264,8 @@ int32_t nt_ui_internal_test_get_tree_root_for_elem(const nt_ui_context_t *ctx, i
 /* Shared overlay helpers — single source of truth for the Y-flip + per-level accum convention. */
 const nt_ui_debug_zone_t *nt_ui_internal_find_debug_zone(const nt_ui_context_t *ctx, uint32_t id);
 
-/* 3D-ctx inspector viewport pick: topmost recorded zone the cursor ray hits (game view_proj). 0 = none. */
+/* 3D-ctx inspector viewport pick: last-declared zone the cursor ray hits, game view_proj (declaration
+ * order, not camera distance). 0 = none. */
 uint32_t nt_ui_internal_pick_zone_3d(const nt_ui_context_t *ctx, float px, float py);
 
 void nt_ui_internal_project_layout_to_world(const nt_ui_debug_zone_t *z, float vy, float vh, float x, float y, float *out_x, float *out_y);

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -265,7 +265,8 @@ int32_t nt_ui_internal_test_get_tree_root_for_elem(const nt_ui_context_t *ctx, i
 const nt_ui_debug_zone_t *nt_ui_internal_find_debug_zone(const nt_ui_context_t *ctx, uint32_t id);
 
 /* 3D-ctx inspector viewport pick: last-declared zone the cursor ray hits, game view_proj (declaration
- * order, not camera distance). 0 = none. */
+ * order, not camera distance). Scope: recorded debug_zones only (interactive widgets) — non-interactive
+ * elements are tree-selectable, not scene-hover-pickable. 0 = none. */
 uint32_t nt_ui_internal_pick_zone_3d(const nt_ui_context_t *ctx, float px, float py);
 
 void nt_ui_internal_project_layout_to_world(const nt_ui_debug_zone_t *z, float vy, float vh, float x, float y, float *out_x, float *out_y);

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -55,7 +55,7 @@ typedef struct {
     float m[16];
     float opacity;
     uint16_t hierarchy_depth;
-    uint16_t _reserved;
+    int16_t zindex; /* effective Clay zIndex (the owning floating tree-root's); 0 for base content. */
     float _pad[2];
 } nt_ui_baked_xform_t;
 _Static_assert(sizeof(nt_ui_baked_xform_t) == 80, "nt_ui_baked_xform_t fixed at 80B");
@@ -77,7 +77,7 @@ _Static_assert(sizeof(nt_ui_dfs_frame_t) == 80, "nt_ui_dfs_frame_t fixed at 80B"
 /* Identity baked xform — DFS seed + walker OOB fallback. */
 static inline nt_ui_baked_xform_t nt_ui_internal_identity_baked(void) {
     nt_ui_baked_xform_t bx = {
-        .m = {1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F}, .opacity = 1.0F, .hierarchy_depth = 0U, ._reserved = 0U, ._pad = {0.0F, 0.0F}};
+        .m = {1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 0.0F, 0.0F, 1.0F}, .opacity = 1.0F, .hierarchy_depth = 0U, .zindex = 0, ._pad = {0.0F, 0.0F}};
     return bx;
 }
 

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -264,11 +264,21 @@ int32_t nt_ui_internal_test_get_tree_root_for_elem(const nt_ui_context_t *ctx, i
 /* Shared overlay helpers — single source of truth for the Y-flip + per-level accum convention. */
 const nt_ui_debug_zone_t *nt_ui_internal_find_debug_zone(const nt_ui_context_t *ctx, uint32_t id);
 
+/* 3D-ctx inspector viewport pick: topmost recorded zone the cursor ray hits (game view_proj). 0 = none. */
+uint32_t nt_ui_internal_pick_zone_3d(const nt_ui_context_t *ctx, float px, float py);
+
 void nt_ui_internal_project_layout_to_world(const nt_ui_debug_zone_t *z, float vy, float vh, float x, float y, float *out_x, float *out_y);
 
 void nt_ui_internal_emit_filled_quad(nt_resource_t atlas, uint32_t region, const float v[4][2], uint32_t color);
 
 void nt_ui_internal_emit_outline(nt_resource_t atlas, uint32_t region, const float c[4][2], float thickness, uint32_t color);
+
+/* 3D-ctx variants: corners stay in the element's Clay-layout space and `model` (the recorded world
+ * mat4) maps them into the scene. Caller binds the perspective view_proj so the debug overlay lands
+ * on the element in 3D. The 2D-ctx helpers above pre-project to screen and emit under identity. */
+void nt_ui_internal_emit_filled_quad_m(nt_resource_t atlas, uint32_t region, const float v[4][2], const float model[16], uint32_t color);
+
+void nt_ui_internal_emit_outline_m(nt_resource_t atlas, uint32_t region, const float c[4][2], float thickness, const float model[16], uint32_t color);
 
 /* (x,y) top-left, (wp,hp) size in logical layout pixels. Caller wraps in scissor_enabled(true/false). */
 void nt_ui_internal_apply_scissor_logical_to_physical(const nt_ui_target_t *target, int x, int y, int wp, int hp);

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -285,7 +285,7 @@ int32_t nt_ui_internal_test_get_tree_root_for_elem(const nt_ui_context_t *ctx, i
 /* Shared overlay helpers — single source of truth for the Y-flip + per-level accum convention. */
 const nt_ui_debug_zone_t *nt_ui_internal_find_debug_zone(const nt_ui_context_t *ctx, uint32_t id);
 
-/* 3D-ctx inspector viewport pick: last-declared zone the cursor ray hits, game view_proj (declaration
+/* 3D-ctx inspector viewport pick: last-recorded zone the cursor ray hits, game view_proj (record/step
  * order, not camera distance). Scope: recorded debug_zones only (interactive widgets) — non-interactive
  * elements are tree-selectable, not scene-hover-pickable. 0 = none. */
 uint32_t nt_ui_internal_pick_zone_3d(const nt_ui_context_t *ctx, float px, float py);

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -81,6 +81,13 @@ static inline nt_ui_baked_xform_t nt_ui_internal_identity_baked(void) {
     return bx;
 }
 
+/* Per-frame record of an interactive widget (one per step_interaction), used next frame by the
+ * front-most hot-widget resolve. The transform/bbox are re-fetched by id at resolve time. */
+typedef struct {
+    uint32_t id;
+    int16_t pad[4]; /* hit padding L/R/T/B */
+} nt_ui_interactive_t;
+
 /* Lives at arena head; hot fields first. Per-ctx — no module globals. */
 struct nt_ui_context {
     Clay_Context *clay;
@@ -127,7 +134,15 @@ struct nt_ui_context {
     nt_ui_baked_xform_t *hit_baked;
     uint32_t *hit_clip_parent_id;
     uint32_t *hit_generation;
+
+    /* Double-buffered interactive-widget registry (always-on). step_interaction appends to _cur this
+     * frame; the hot resolve reads _prev (last frame). Buffers swap each begin. Arena-allocated. */
+    nt_ui_interactive_t *interactive_prev;
+    nt_ui_interactive_t *interactive_cur;
+
     uint32_t current_generation;
+    uint32_t interactive_prev_count;
+    uint32_t interactive_cur_count;
 
     /* Per-walk metrics. */
     uint32_t last_walk_draw_call_delta;

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -191,6 +191,9 @@ struct nt_ui_context {
     uint32_t inspector_collapsed_count;
 
     nt_ui_inspector_metrics_t inspector_metrics;
+    /* Optional overlay materials (typically depth_test=false); 0 = fall back to the game's sprite/text material. */
+    nt_material_t inspector_sprite_material;
+    nt_material_t inspector_text_material;
 #endif /* NT_UI_DEBUG_TOOLS */
 
     Clay_Arena clay_arena;

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -93,8 +93,14 @@ struct nt_ui_context {
 
     /* capture_seen[] tracks who touched the capture this frame — orphans cleared on begin. */
     nt_ui_capture_t captures[NT_INPUT_MAX_POINTERS];
+    /* Per-pointer front-most interactive widget + game-fed occlusion cutoff (3D), resolved lazily once
+     * per frame from prev-frame layout (3D: nearest ray-t within cutoff; 2D: top zIndex). Ordered here
+     * by alignment (after the 4B-aligned captures) to avoid adding struct padding. */
+    nt_ui_hot_t pointer_hot[NT_INPUT_MAX_POINTERS];
+    float pointer_occlusion[NT_INPUT_MAX_POINTERS]; /* max world ray distance; default +inf = no cutoff */
     uint8_t capture_seen[NT_INPUT_MAX_POINTERS];
     bool pointer_over_any;
+    bool hot_resolved; /* gates the once-per-frame lazy hot resolve */
 
     /* Buttons do not nest (asserted). */
     struct {

--- a/examples/bunnymark/main.c
+++ b/examples/bunnymark/main.c
@@ -591,6 +591,8 @@ int main(void) {
         .depth_test = false,
         .depth_write = false,
         .cull_mode = NT_CULL_NONE,
+        .params[0] = {.name = "u_alpha_cutoff", .value = {NT_TEXT_ALPHA_CUTOFF_DEFAULT}},
+        .param_count = 1,
         .label = "stats_overlay",
     });
     s_overlay_font = nt_font_create(&(nt_font_create_desc_t){

--- a/examples/slice9_demo/main.c
+++ b/examples/slice9_demo/main.c
@@ -554,6 +554,8 @@ int main(int argc, char *argv[]) {
         .depth_test = false,
         .depth_write = false,
         .cull_mode = NT_CULL_NONE,
+        .params[0] = {.name = "u_alpha_cutoff", .value = {NT_TEXT_ALPHA_CUTOFF_DEFAULT}},
+        .param_count = 1,
         .label = "slice9_demo_text",
     });
 

--- a/examples/text/main.c
+++ b/examples/text/main.c
@@ -471,6 +471,8 @@ int main(void) {
         .depth_test = true,
         .depth_write = false,
         .cull_mode = NT_CULL_NONE,
+        .params[0] = {.name = "u_alpha_cutoff", .value = {NT_TEXT_ALPHA_CUTOFF_DEFAULT}},
+        .param_count = 1,
         .label = "slug_text",
     });
 

--- a/examples/ui_3d_demo/main.c
+++ b/examples/ui_3d_demo/main.c
@@ -372,6 +372,51 @@ static void draw_shape(void) {
         break;
     }
 }
+
+/* Cursor ray vs the central object's bounding sphere. *out_dist = world distance from the near plane
+ * to the front hit (same metric as the UI hit distance), or false on miss. Fed to
+ * nt_ui_set_pointer_occlusion so a panel directly behind the object can't be clicked through it. */
+static bool cursor_object_distance(float px, float py, float fb_w, float fb_h, const mat4 vp, float *out_dist) {
+    if (fb_w <= 0.0F || fb_h <= 0.0F) {
+        return false;
+    }
+    mat4 vp_copy;
+    memcpy(vp_copy, vp, sizeof vp_copy);
+    mat4 inv;
+    glm_mat4_inv(vp_copy, inv);
+    const float ndc_x = ((px / fb_w) * 2.0F) - 1.0F;
+    const float ndc_y = 1.0F - ((py / fb_h) * 2.0F); /* screen Y-down -> NDC Y-up */
+    vec4 np = {ndc_x, ndc_y, -1.0F, 1.0F};
+    vec4 fp = {ndc_x, ndc_y, 1.0F, 1.0F};
+    vec4 nw;
+    vec4 fw;
+    glm_mat4_mulv(inv, np, nw);
+    glm_mat4_mulv(inv, fp, fw);
+    if (nw[3] == 0.0F || fw[3] == 0.0F) {
+        return false;
+    }
+    vec3 o = {nw[0] / nw[3], nw[1] / nw[3], nw[2] / nw[3]};
+    vec3 fpt = {fw[0] / fw[3], fw[1] / fw[3], fw[2] / fw[3]};
+    vec3 dir;
+    glm_vec3_sub(fpt, o, dir);
+    vec3 center = {0.0F, ROOM_H * 0.5F, 0.0F};
+    const float radius = 1.7F; /* bounding sphere over cube/sphere/capsule */
+    vec3 oc;
+    glm_vec3_sub(o, center, oc);
+    const float a = glm_vec3_dot(dir, dir);
+    const float b = 2.0F * glm_vec3_dot(oc, dir);
+    const float c = glm_vec3_dot(oc, oc) - (radius * radius);
+    const float disc = (b * b) - (4.0F * a * c);
+    if (a <= 0.0F || disc < 0.0F) {
+        return false;
+    }
+    const float s = (-b - sqrtf(disc)) / (2.0F * a); /* nearest root along near->far */
+    if (s < 0.0F) {
+        return false; /* sphere behind the near plane */
+    }
+    *out_dist = s * sqrtf(a); /* ray param -> world distance from the near plane */
+    return true;
+}
 // #endregion
 
 // #region resource binding
@@ -718,6 +763,12 @@ static void frame(void) {
         const nt_pointer_t mouse_phys = g_nt_input.pointers[0];
         nt_ui_begin(s_ctx, fb_w, fb_h, dt, &mouse_phys, 1);
         nt_ui_set_view_proj(s_ctx, (const float *)vp_3d);
+        /* Occlusion: if the cursor ray crosses the central object, block UI beyond it — a panel
+         * behind the object can't be clicked through it (game owns the world raycast). */
+        float occl_dist = 0.0F;
+        if (cursor_object_distance(mouse_phys.x, mouse_phys.y, fb_w, fb_h, vp_3d, &occl_dist)) {
+            nt_ui_set_pointer_occlusion(s_ctx, 0, occl_dist);
+        }
         declare_panels();
         nt_ui_end(s_ctx);
 

--- a/examples/ui_3d_demo/main.c
+++ b/examples/ui_3d_demo/main.c
@@ -1013,7 +1013,7 @@ int main(int argc, char *argv[]) {
 
     /* World-mounted UI: depth_write ON so overlapping panels sort by depth (nearer occludes farther
      * across sprite+text layers). The cutoff sprite variant discards transparent button corners so
-     * they don't punch depth; the per-element bias keeps each panel's labels above its own bg. */
+     * they don't punch depth; the per-element depth bias (element_depth_bias_ndc) keeps each panel's labels above its own bg. */
     s_sprite_material = nt_material_create(&(nt_material_create_desc_t){
         .vs = s_sprite_vs_handle,
         .fs = s_sprite_cutoff_fs_handle,

--- a/examples/ui_3d_demo/main.c
+++ b/examples/ui_3d_demo/main.c
@@ -808,7 +808,7 @@ int main(int argc, char *argv[]) {
     nt_resource_set_activator(NT_ASSET_TEXTURE, nt_gfx_activate_texture, nt_gfx_deactivate_texture);
     nt_resource_set_activator(NT_ASSET_SHADER_CODE, nt_gfx_activate_shader, nt_gfx_deactivate_shader);
     nt_atlas_init();
-    nt_material_init(&(nt_material_desc_t){.max_materials = 4});
+    nt_material_init(&(nt_material_desc_t){.max_materials = 6}); /* sprite, text, text_3d, inspector sprite+text, + margin */
     nt_font_init(&(nt_font_desc_t){.max_fonts = 2});
 
     nt_shape_renderer_init();

--- a/examples/ui_3d_demo/main.c
+++ b/examples/ui_3d_demo/main.c
@@ -2,6 +2,11 @@
  * panels. Left wall hosts the SHAPE panel (CUBE / SPHERE / CAPSULE); right wall hosts the
  * SPEED panel (STOP / SLOW / MEDIUM / FAST). Same controls remain on keyboard for parity.
  *
+ * Behind the central object sit two overlapping test panels, NEAR and FAR (each A/B buttons),
+ * to exercise input arbitration: aiming THROUGH the object occludes their buttons (can't click
+ * through it), and where the two overlap only NEAR's button reacts (front-most wins). The HUD's
+ * "picked" line shows which button last fired. Strafe (A/D) so the object stops blocking to test.
+ *
  * Controls:
  *   WASD            walk along yaw (no collisions)
  *   Space / Shift   fly up / down
@@ -90,8 +95,16 @@
 #define BTN_H 64
 #define PANEL_SCALE 0.012F
 
+/* Occlusion / arbitration test panels, mounted BEHIND the central object. */
+#define TPANEL_W 240
+#define TPANEL_H 240
+#define TPANEL_TITLE_H 40
+#define TBTN_W 180
+#define TBTN_H 56
+
 enum { SHAPE_CUBE = 0, SHAPE_SPHERE, SHAPE_CAPSULE, SHAPE_COUNT };
 enum { SPEED_STOP = 0, SPEED_SLOW, SPEED_MED, SPEED_FAST, SPEED_COUNT };
+enum { TPICK_A = 0, TPICK_B, TPICK_COUNT };
 // #endregion
 
 // #region tables
@@ -169,7 +182,23 @@ static nt_ui_label_style_t s_btn_label_style = {
 /* Stable widget ids. */
 static uint32_t s_id_shape_btn[SHAPE_COUNT];
 static uint32_t s_id_speed_btn[SPEED_COUNT];
+static uint32_t s_id_near_btn[TPICK_COUNT];
+static uint32_t s_id_far_btn[TPICK_COUNT];
 static bool s_ids_ready;
+
+/* Occlusion/arbitration test panels: last-clicked button per panel (green highlight) + HUD readout. */
+static int s_near_sel = -1;
+static int s_far_sel = -1;
+static char s_last_pick[24] = "-";
+
+static const Clay_ElementDeclaration s_tbtn_decl = {
+    .layout =
+        {
+            .sizing = {CLAY_SIZING_FIXED(TBTN_W), CLAY_SIZING_FIXED(TBTN_H)},
+            .padding = CLAY_PADDING_ALL(6),
+            .childAlignment = {CLAY_ALIGN_X_CENTER, CLAY_ALIGN_Y_CENTER},
+        },
+};
 // #endregion
 
 // #region helpers
@@ -488,7 +517,74 @@ static void ensure_ids(void) {
     s_id_speed_btn[SPEED_SLOW] = nt_ui_id("btn_speed_slow");
     s_id_speed_btn[SPEED_MED] = nt_ui_id("btn_speed_med");
     s_id_speed_btn[SPEED_FAST] = nt_ui_id("btn_speed_fast");
+    s_id_near_btn[TPICK_A] = nt_ui_id("btn_near_a");
+    s_id_near_btn[TPICK_B] = nt_ui_id("btn_near_b");
+    s_id_far_btn[TPICK_A] = nt_ui_id("btn_far_a");
+    s_id_far_btn[TPICK_B] = nt_ui_id("btn_far_b");
     s_ids_ready = true;
+}
+
+/* Emits the title + two buttons of a test panel; returns the index clicked this frame (or -1).
+ * `sel` gets the green "active" art so the last pick stays visible on the panel itself. */
+static int test_panel_body(const char *title, const uint32_t ids[TPICK_COUNT], int sel) {
+    int clicked = -1;
+    CLAY({.layout = {.sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_FIXED(TPANEL_TITLE_H)}, .childAlignment = {CLAY_ALIGN_X_CENTER, CLAY_ALIGN_Y_CENTER}}}) {
+        nt_ui_label(s_ctx, NT_UI_DATA_LAYER(LAYER_LABEL), title, &s_panel_title_style);
+    }
+    for (int i = 0; i < TPICK_COUNT; ++i) {
+        const nt_ui_button_style_t *style = (i == sel) ? &s_btn_active : &s_btn_idle;
+        nt_ui_button_begin(s_ctx, NT_UI_DATA_LAYER(LAYER_PANEL), ids[i], style, &s_tbtn_decl, true);
+        nt_ui_label(s_ctx, NT_UI_DATA_LAYER(LAYER_LABEL), (i == TPICK_A) ? "A" : "B", &s_btn_label_style);
+        if (nt_ui_button_end(s_ctx)) {
+            clicked = i;
+        }
+    }
+    return clicked;
+}
+
+/* Two panels mounted BEHIND the central object so the cursor ray must pass it to reach them. NEAR
+ * (z=-2.5) sits slightly left, FAR (z=-4.0) slightly right → they overlap along the sightline.
+ *   - Aim THROUGH the object → buttons are occluded (set_pointer_occlusion blocks the click).
+ *   - Where NEAR & FAR overlap → only NEAR's button reacts (front-most arbitration); strafe (A/D)
+ *     so the object stops blocking to see it. The side that sticks out belongs to one panel only.
+ * Declared inside ui3d-root (floating, bbox at 0,0); the XFORM maps each to its world mount. */
+static void declare_test_panels(void) {
+    const float cy = ROOM_H * 0.5F;
+    const nt_ui_transform_t xf_far = make_wall_xform(0.7F, cy, -4.0F, 0.0F, (float)TPANEL_W, (float)TPANEL_H);
+    const nt_ui_transform_t xf_near = make_wall_xform(-0.7F, cy, -2.5F, 0.0F, (float)TPANEL_W, (float)TPANEL_H);
+
+    /* FAR first — declared/drawn under NEAR and farther along the ray, so it loses the overlap. */
+    CLAY({.id = CLAY_ID("test-far"),
+          .userData = (void *)NT_UI_DATA_XFORM(LAYER_PANEL, &xf_far, 1.0F),
+          .floating = {.attachTo = CLAY_ATTACH_TO_PARENT, .attachPoints = {.element = CLAY_ATTACH_POINT_LEFT_TOP, .parent = CLAY_ATTACH_POINT_LEFT_TOP}},
+          .layout = {.sizing = {CLAY_SIZING_FIXED(TPANEL_W), CLAY_SIZING_FIXED(TPANEL_H)},
+                     .padding = CLAY_PADDING_ALL(10),
+                     .layoutDirection = CLAY_TOP_TO_BOTTOM,
+                     .childGap = 10,
+                     .childAlignment = {CLAY_ALIGN_X_CENTER, CLAY_ALIGN_Y_TOP}},
+          .backgroundColor = {52.0F, 30.0F, 34.0F, 235.0F}}) {
+        const int hit = test_panel_body("FAR", s_id_far_btn, s_far_sel);
+        if (hit >= 0) {
+            s_far_sel = hit;
+            (void)snprintf(s_last_pick, sizeof s_last_pick, "FAR %c", (char)('A' + hit));
+        }
+    }
+    /* NEAR second — drawn on top, nearer along the ray → wins arbitration in the overlap. */
+    CLAY({.id = CLAY_ID("test-near"),
+          .userData = (void *)NT_UI_DATA_XFORM(LAYER_PANEL, &xf_near, 1.0F),
+          .floating = {.attachTo = CLAY_ATTACH_TO_PARENT, .attachPoints = {.element = CLAY_ATTACH_POINT_LEFT_TOP, .parent = CLAY_ATTACH_POINT_LEFT_TOP}},
+          .layout = {.sizing = {CLAY_SIZING_FIXED(TPANEL_W), CLAY_SIZING_FIXED(TPANEL_H)},
+                     .padding = CLAY_PADDING_ALL(10),
+                     .layoutDirection = CLAY_TOP_TO_BOTTOM,
+                     .childGap = 10,
+                     .childAlignment = {CLAY_ALIGN_X_CENTER, CLAY_ALIGN_Y_TOP}},
+          .backgroundColor = {30.0F, 38.0F, 52.0F, 235.0F}}) {
+        const int hit = test_panel_body("NEAR", s_id_near_btn, s_near_sel);
+        if (hit >= 0) {
+            s_near_sel = hit;
+            (void)snprintf(s_last_pick, sizeof s_last_pick, "NEAR %c", (char)('A' + hit));
+        }
+    }
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
@@ -554,6 +650,9 @@ static void declare_panels(void) {
                 }
             }
         }
+
+        /* Occlusion / arbitration test panels, mounted behind the central object. */
+        declare_test_panels();
     }
 }
 // #endregion
@@ -612,6 +711,12 @@ static void draw_hud(float fb_w, float fb_h) {
     char status[64];
     (void)snprintf(status, sizeof status, "shape: %-7s   speed: %s", s_shape_labels[s_shape_kind], s_speed_labels[s_speed_kind]);
     draw_hud_block(status, right_x, ry, HUD_SIZE, accent);
+    ry -= HUD_SIZE + 2.0F;
+
+    /* Which test-panel button last received a click (NEAR vs FAR proves front-most arbitration). */
+    char pick_line[48];
+    (void)snprintf(pick_line, sizeof pick_line, "picked: %s", s_last_pick);
+    draw_hud_block(pick_line, right_x, ry, HUD_SIZE, white);
 
     if (s_debug_overlay) {
         /* Anchor the debug block ABOVE the bottom; nt_stats is ~6 lines so allow ~110 px. */
@@ -772,11 +877,15 @@ static void frame(void) {
         declare_panels();
         nt_ui_end(s_ctx);
 
+        /* UI labels now write depth (world panels sort by depth) → bias glyph quads apart so their AA
+         * fringes don't z-fight; the walker emits text with the renderer's current bias. Reset after. */
+        nt_text_renderer_set_glyph_depth_bias(0.0001F);
         nt_ui_walk(s_ctx, &target);
         /* Flush UI draws under VP_3D BEFORE switching uniforms; otherwise labels emitted
          * by ui_walk get rasterized with the next pass's ortho matrix and vanish. */
         nt_sprite_renderer_flush();
         nt_text_renderer_flush();
+        nt_text_renderer_set_glyph_depth_bias(0.0F);
 
         /* World-space depth-writing text. The per-glyph clip-space bias keeps overlapping glyph
          * quads from z-fighting at their AA fringes (set before the draw, reset after). */
@@ -900,6 +1009,9 @@ int main(int argc, char *argv[]) {
     s_atlas_tex_handle = nt_resource_request(ASSET_TEXTURE_UI_BUTTONS_DEMO_ATLAS_TEX0, NT_ASSET_TEXTURE);
     s_font_resource = nt_resource_request(ASSET_FONT_UI_BUTTONS_DEMO_FONT, NT_ASSET_FONT);
 
+    /* World-mounted UI: depth_write ON so overlapping panels sort by depth (nearer occludes farther
+     * across sprite+text layers). sprite.frag has no alpha cutoff, so transparent button corners also
+     * write depth — fine here (back-to-front draw order), but a trap for future translucent overlap. */
     s_sprite_material = nt_material_create(&(nt_material_create_desc_t){
         .vs = s_sprite_vs_handle,
         .fs = s_sprite_fs_handle,
@@ -907,7 +1019,7 @@ int main(int argc, char *argv[]) {
         .texture_count = 1,
         .blend_mode = NT_BLEND_MODE_ALPHA,
         .depth_test = true,
-        .depth_write = false,
+        .depth_write = true,
         .cull_mode = NT_CULL_NONE,
         .label = "ui_3d_demo_sprite",
     });
@@ -935,7 +1047,9 @@ int main(int argc, char *argv[]) {
     });
 
     nt_ui_set_sprite_material(s_ctx, s_sprite_material);
-    nt_ui_set_text_material(s_ctx, s_text_material);
+    /* UI labels use the depth-writing text material so they sort with the panels (overlapping world
+     * panels). The HUD/stats keep s_text_material (depth_write=false) — they're a flat screen overlay. */
+    nt_ui_set_text_material(s_ctx, s_text_material_3d);
     /* Inspector overlay materials: same shaders, depth_test=false so the debug sidebar stays on top
      * without testing the 3D scene depth (passive overlay, no depth-buffer side effects). */
     s_inspector_sprite_material = nt_material_create(&(nt_material_create_desc_t){

--- a/examples/ui_3d_demo/main.c
+++ b/examples/ui_3d_demo/main.c
@@ -752,9 +752,17 @@ static void frame(void) {
     }
 
     if (ui_can_render && nt_ui_inspector_is_active(s_ctx)) {
+        /* Sidebar tree is its own screen-space pass (ortho). */
         nt_gfx_update_buffer(s_frame_ubo, &uniforms_2d, sizeof uniforms_2d);
         nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
         nt_ui_debug_inspector_walk(s_ctx, &target);
+        nt_sprite_renderer_flush();
+        nt_text_renderer_flush();
+
+        /* Highlight overlay emits the element's world geometry in 3D ctx → bind the perspective VP
+         * so it lands on the panel; the depth-off inspector materials keep it on top. */
+        nt_gfx_update_buffer(s_frame_ubo, &uniforms_3d, sizeof uniforms_3d);
+        nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
         nt_ui_inspector_overlay_draw(s_ctx, &target, s_font, 16.0F);
         nt_sprite_renderer_flush();
         nt_text_renderer_flush();

--- a/examples/ui_3d_demo/main.c
+++ b/examples/ui_3d_demo/main.c
@@ -129,7 +129,9 @@ static nt_resource_t s_atlas_tex_handle;
 static nt_resource_t s_font_resource;
 static nt_material_t s_sprite_material;
 static nt_material_t s_text_material;
-static nt_material_t s_text_material_3d; /* world-space text that writes + tests depth */
+static nt_material_t s_text_material_3d;          /* world-space text that writes + tests depth */
+static nt_material_t s_inspector_sprite_material; /* depth-off overlay materials for the F2 inspector */
+static nt_material_t s_inspector_text_material;
 static nt_font_t s_font;
 static bool s_atlas_bound;
 static bool s_font_bound;
@@ -875,6 +877,31 @@ int main(int argc, char *argv[]) {
 
     nt_ui_set_sprite_material(s_ctx, s_sprite_material);
     nt_ui_set_text_material(s_ctx, s_text_material);
+    /* Inspector overlay materials: same shaders, depth_test=false so the debug sidebar stays on top
+     * without testing the 3D scene depth (passive overlay, no depth-buffer side effects). */
+    s_inspector_sprite_material = nt_material_create(&(nt_material_create_desc_t){
+        .vs = s_sprite_vs_handle,
+        .fs = s_sprite_fs_handle,
+        .textures = {{.name = "u_texture", .resource = s_atlas_tex_handle}},
+        .texture_count = 1,
+        .blend_mode = NT_BLEND_MODE_ALPHA,
+        .depth_test = false,
+        .depth_write = false,
+        .cull_mode = NT_CULL_NONE,
+        .label = "ui_3d_demo_inspector_sprite",
+    });
+    s_inspector_text_material = nt_material_create(&(nt_material_create_desc_t){
+        .vs = s_text_vs_handle,
+        .fs = s_text_fs_handle,
+        .blend_mode = NT_BLEND_MODE_ALPHA,
+        .depth_test = false,
+        .depth_write = false,
+        .cull_mode = NT_CULL_NONE,
+        .params[0] = {.name = "u_alpha_cutoff", .value = {NT_TEXT_ALPHA_CUTOFF_DEFAULT}},
+        .param_count = 1,
+        .label = "ui_3d_demo_inspector_text",
+    });
+    nt_ui_inspector_set_materials(s_ctx, s_inspector_sprite_material, s_inspector_text_material);
 
     s_font = nt_font_create(&(nt_font_create_desc_t){
         .curve_texture_width = 1024,
@@ -907,6 +934,8 @@ int main(int argc, char *argv[]) {
     nt_material_destroy(s_sprite_material);
     nt_material_destroy(s_text_material);
     nt_material_destroy(s_text_material_3d);
+    nt_material_destroy(s_inspector_sprite_material);
+    nt_material_destroy(s_inspector_text_material);
     nt_material_shutdown();
     nt_stats_shutdown();
     nt_mem_scratch_shutdown();

--- a/examples/ui_3d_demo/main.c
+++ b/examples/ui_3d_demo/main.c
@@ -322,6 +322,26 @@ static void draw_room(void) {
     nt_shape_renderer_rect_rot(right_pos, wall_sz_lr, side_rot, wall_col);
 }
 
+/* Backing board behind each UI panel — visual reference to judge panel fit/alignment. */
+static void draw_boards(void) {
+    const float board_col[4] = {0.42F, 0.28F, 0.14F, 1.0F};
+    const float frame_col[4] = {0.22F, 0.14F, 0.07F, 1.0F};
+    const float hd = ROOM_D * 0.5F;
+    const float bz = -hd + 0.03F; /* between wall (-hd) and panel (-hd+0.05) */
+    const float fz = bz - 0.01F;
+    const float bw = (PANEL_W * PANEL_SCALE) + 0.5F;
+    const float bh = (PANEL_H * PANEL_SCALE) + 0.5F;
+    const float board_sz[2] = {bw, bh};
+    const float frame_sz[2] = {bw + 0.18F, bh + 0.18F};
+    const float xs[2] = {-4.5F, 4.5F};
+    for (int i = 0; i < 2; ++i) {
+        const float frame_pos[3] = {xs[i], 2.8F, fz};
+        const float board_pos[3] = {xs[i], 2.8F, bz};
+        nt_shape_renderer_rect(frame_pos, frame_sz, frame_col);
+        nt_shape_renderer_rect(board_pos, board_sz, board_col);
+    }
+}
+
 static void draw_shape(void) {
     const float pos[3] = {0.0F, ROOM_H * 0.5F, 0.0F};
     versor q;
@@ -393,7 +413,8 @@ static void try_bind_resources(void) {
 
 // #region UI panels
 /* Wall-mount XFORM: panel local Clay-bbox center maps to world `wx,wy,wz`.
- * Scale stays positive; rotation_x handles Clay Y-down -> world Y-up. */
+ * Negative scale_y reflects Clay Y-down -> world Y-up while keeping normal +Z (player-facing)
+ * and X un-mirrored — a rotation can't satisfy all three at once. */
 static nt_ui_transform_t make_wall_xform(float wx, float wy, float wz, float yaw, float panel_w_px, float panel_h_px) {
     nt_ui_transform_t t = nt_ui_transform_defaults();
     const float cx = panel_w_px * 0.5F;
@@ -401,10 +422,9 @@ static nt_ui_transform_t make_wall_xform(float wx, float wy, float wz, float yaw
     t.offset_x = wx - cx;
     t.offset_y = wy - cy;
     t.offset_z = wz;
-    t.rotation_x = NT_PI;
     t.rotation_y = yaw;
     t.scale_x = PANEL_SCALE;
-    t.scale_y = PANEL_SCALE;
+    t.scale_y = -PANEL_SCALE;
     t.scale_z = PANEL_SCALE;
     return t;
 }
@@ -679,6 +699,7 @@ static void frame(void) {
     nt_shape_renderer_set_cam_pos(cam_pos);
     nt_shape_renderer_set_depth(true);
     draw_room();
+    draw_boards();
     draw_shape();
     nt_shape_renderer_flush();
 
@@ -703,17 +724,16 @@ static void frame(void) {
         nt_sprite_renderer_flush();
         nt_text_renderer_flush();
 
-        /* DEBUG: standalone text directly in world space at (0, 4, 0). If this shows up,
-         * text material + font + VP_3D plumbing work — panel labels then disappear due to a
-         * walker emit issue. If this is also invisible, the bug is below nt_ui. */
+        /* World-space text centered on the shape; depth_test hides it behind the shape. No depth_write:
+         * coplanar glyph quads (0.5px AA dilation + kerning overlap) would self-z-fight. */
         if (s_font_bound) {
-            mat4 debug_model;
-            glm_mat4_identity(debug_model);
-            glm_translate(debug_model, (vec3){-2.5F, 4.0F, 0.0F});
+            mat4 text_model;
+            glm_mat4_identity(text_model);
+            glm_translate(text_model, (vec3){-2.5F, 4.9F, 0.0F});
             const float yellow[4] = {1.0F, 1.0F, 0.2F, 1.0F};
             nt_text_renderer_set_material(s_text_material);
             nt_text_renderer_set_font(s_font);
-            nt_text_renderer_draw("HELLO 3D WORLD", (const float *)debug_model, 0.6F, yellow, 0.0F, 0.0F);
+            nt_text_renderer_draw("HELLO 3D WORLD", (const float *)text_model, 0.6F, yellow, 0.0F, 0.0F);
             nt_text_renderer_flush();
         }
     }
@@ -834,6 +854,8 @@ int main(int argc, char *argv[]) {
         .depth_test = true,
         .depth_write = false,
         .cull_mode = NT_CULL_NONE,
+        .params[0] = {.name = "u_alpha_cutoff", .value = {NT_TEXT_ALPHA_CUTOFF_DEFAULT}},
+        .param_count = 1,
         .label = "ui_3d_demo_text",
     });
 

--- a/examples/ui_3d_demo/main.c
+++ b/examples/ui_3d_demo/main.c
@@ -129,6 +129,7 @@ static nt_resource_t s_atlas_tex_handle;
 static nt_resource_t s_font_resource;
 static nt_material_t s_sprite_material;
 static nt_material_t s_text_material;
+static nt_material_t s_text_material_3d; /* world-space text that writes + tests depth */
 static nt_font_t s_font;
 static bool s_atlas_bound;
 static bool s_font_bound;
@@ -724,16 +725,18 @@ static void frame(void) {
         nt_sprite_renderer_flush();
         nt_text_renderer_flush();
 
-        /* World-space text centered on the shape; depth_test hides it behind the shape. No depth_write:
-         * coplanar glyph quads (0.5px AA dilation + kerning overlap) would self-z-fight. */
+        /* World-space depth-writing text. The per-glyph clip-space bias keeps overlapping glyph
+         * quads from z-fighting at their AA fringes (set before the draw, reset after). */
         if (s_font_bound) {
+            const float yellow[4] = {1.0F, 1.0F, 0.2F, 1.0F};
+            nt_text_renderer_set_material(s_text_material_3d);
+            nt_text_renderer_set_font(s_font);
+            nt_text_renderer_set_glyph_depth_bias(0.0001F);
             mat4 text_model;
             glm_mat4_identity(text_model);
-            glm_translate(text_model, (vec3){-2.5F, 4.9F, 0.0F});
-            const float yellow[4] = {1.0F, 1.0F, 0.2F, 1.0F};
-            nt_text_renderer_set_material(s_text_material);
-            nt_text_renderer_set_font(s_font);
-            nt_text_renderer_draw("HELLO 3D WORLD", (const float *)text_model, 0.6F, yellow, 0.0F, 0.0F);
+            glm_translate(text_model, (vec3){-7.0F, 4.0F, 0.0F});
+            nt_text_renderer_draw("HELLO 3D WORLD", (const float *)text_model, 0.8F, yellow, 0.0F, 0.0F);
+            nt_text_renderer_set_glyph_depth_bias(0.0F);
             nt_text_renderer_flush();
         }
     }
@@ -858,6 +861,17 @@ int main(int argc, char *argv[]) {
         .param_count = 1,
         .label = "ui_3d_demo_text",
     });
+    s_text_material_3d = nt_material_create(&(nt_material_create_desc_t){
+        .vs = s_text_vs_handle,
+        .fs = s_text_fs_handle,
+        .blend_mode = NT_BLEND_MODE_ALPHA,
+        .depth_test = true,
+        .depth_write = true,
+        .cull_mode = NT_CULL_NONE,
+        .params[0] = {.name = "u_alpha_cutoff", .value = {NT_TEXT_ALPHA_CUTOFF_DEFAULT}},
+        .param_count = 1,
+        .label = "ui_3d_demo_text_3d",
+    });
 
     nt_ui_set_sprite_material(s_ctx, s_sprite_material);
     nt_ui_set_text_material(s_ctx, s_text_material);
@@ -892,6 +906,7 @@ int main(int argc, char *argv[]) {
     nt_font_shutdown();
     nt_material_destroy(s_sprite_material);
     nt_material_destroy(s_text_material);
+    nt_material_destroy(s_text_material_3d);
     nt_material_shutdown();
     nt_stats_shutdown();
     nt_mem_scratch_shutdown();

--- a/examples/ui_3d_demo/main.c
+++ b/examples/ui_3d_demo/main.c
@@ -135,6 +135,7 @@ static bool s_debug_overlay;
 static nt_hash32_t s_pack_id;
 static nt_resource_t s_sprite_vs_handle;
 static nt_resource_t s_sprite_fs_handle;
+static nt_resource_t s_sprite_cutoff_fs_handle; /* alpha-cutoff sprite variant for depth-writing UI */
 static nt_resource_t s_text_vs_handle;
 static nt_resource_t s_text_fs_handle;
 static nt_resource_t s_atlas_handle;
@@ -1003,6 +1004,7 @@ int main(int argc, char *argv[]) {
 
     s_sprite_vs_handle = nt_resource_request(ASSET_SHADER_ASSETS_SHADERS_SPRITE_VERT, NT_ASSET_SHADER_CODE);
     s_sprite_fs_handle = nt_resource_request(ASSET_SHADER_ASSETS_SHADERS_SPRITE_FRAG, NT_ASSET_SHADER_CODE);
+    s_sprite_cutoff_fs_handle = nt_resource_request(ASSET_SHADER_ASSETS_SHADERS_SPRITE_CUTOFF_FRAG, NT_ASSET_SHADER_CODE);
     s_text_vs_handle = nt_resource_request(ASSET_SHADER_ASSETS_SHADERS_SLUG_TEXT_VERT, NT_ASSET_SHADER_CODE);
     s_text_fs_handle = nt_resource_request(ASSET_SHADER_ASSETS_SHADERS_SLUG_TEXT_FRAG, NT_ASSET_SHADER_CODE);
     s_atlas_handle = nt_resource_request(ASSET_ATLAS_UI_BUTTONS_DEMO_ATLAS, NT_ASSET_ATLAS);
@@ -1010,17 +1012,19 @@ int main(int argc, char *argv[]) {
     s_font_resource = nt_resource_request(ASSET_FONT_UI_BUTTONS_DEMO_FONT, NT_ASSET_FONT);
 
     /* World-mounted UI: depth_write ON so overlapping panels sort by depth (nearer occludes farther
-     * across sprite+text layers). sprite.frag has no alpha cutoff, so transparent button corners also
-     * write depth — fine here (back-to-front draw order), but a trap for future translucent overlap. */
+     * across sprite+text layers). The cutoff sprite variant discards transparent button corners so
+     * they don't punch depth; the per-element bias keeps each panel's labels above its own bg. */
     s_sprite_material = nt_material_create(&(nt_material_create_desc_t){
         .vs = s_sprite_vs_handle,
-        .fs = s_sprite_fs_handle,
+        .fs = s_sprite_cutoff_fs_handle,
         .textures = {{.name = "u_texture", .resource = s_atlas_tex_handle}},
         .texture_count = 1,
         .blend_mode = NT_BLEND_MODE_ALPHA,
         .depth_test = true,
         .depth_write = true,
         .cull_mode = NT_CULL_NONE,
+        .params[0] = {.name = "u_alpha_cutoff", .value = {1.0F / 255.0F}},
+        .param_count = 1,
         .label = "ui_3d_demo_sprite",
     });
     s_text_material = nt_material_create(&(nt_material_create_desc_t){

--- a/examples/ui_buttons_demo/build_packs.c
+++ b/examples/ui_buttons_demo/build_packs.c
@@ -65,9 +65,11 @@ int main(int argc, char *argv[]) {
     // #region shaders (sprite for UI rects + Slug for text)
     nt_builder_add_shader(ctx, "assets/shaders/sprite.vert", NT_BUILD_SHADER_VERTEX);
     nt_builder_add_shader(ctx, "assets/shaders/sprite.frag", NT_BUILD_SHADER_FRAGMENT);
+    /* Depth-writing world UI (ui_3d_demo overlapping panels) uses this alpha-cutoff sprite variant. */
+    nt_builder_add_shader(ctx, "assets/shaders/sprite_cutoff.frag", NT_BUILD_SHADER_FRAGMENT);
     nt_builder_add_shader(ctx, "assets/shaders/slug_text.vert", NT_BUILD_SHADER_VERTEX);
     nt_builder_add_shader(ctx, "assets/shaders/slug_text.frag", NT_BUILD_SHADER_FRAGMENT);
-    (void)printf("  Shaders added: 4 (sprite + slug_text)\n");
+    (void)printf("  Shaders added: 5 (sprite + sprite_cutoff + slug_text)\n");
     // #endregion
 
     // #region atlas: button_blue (slice9) + white pixel

--- a/examples/ui_buttons_demo/generated/ui_buttons_demo.h
+++ b/examples/ui_buttons_demo/generated/ui_buttons_demo.h
@@ -13,6 +13,7 @@
 #define ASSET_SHADER_ASSETS_SHADERS_SLUG_TEXT_VERT ((nt_hash64_t){0x8ECB088C8983CC2FULL}) /* assets/shaders/slug_text.vert */
 #define ASSET_SHADER_ASSETS_SHADERS_SPRITE_FRAG ((nt_hash64_t){0x96ED6312E7B10087ULL}) /* assets/shaders/sprite.frag */
 #define ASSET_SHADER_ASSETS_SHADERS_SPRITE_VERT ((nt_hash64_t){0x75A9EEA4D1472026ULL}) /* assets/shaders/sprite.vert */
+#define ASSET_SHADER_ASSETS_SHADERS_SPRITE_CUTOFF_FRAG ((nt_hash64_t){0x8126896E5DC4B921ULL}) /* assets/shaders/sprite_cutoff.frag */
 
 /* --- FONT --- */
 #define ASSET_FONT_UI_BUTTONS_DEMO_FONT ((nt_hash64_t){0x9B7E68A3E7C91D40ULL}) /* ui_buttons_demo/font */
@@ -33,6 +34,7 @@ static inline void ui_buttons_demo_register_labels(void) {
     (void)nt_hash64_str("assets/shaders/slug_text.vert");
     (void)nt_hash64_str("assets/shaders/sprite.frag");
     (void)nt_hash64_str("assets/shaders/sprite.vert");
+    (void)nt_hash64_str("assets/shaders/sprite_cutoff.frag");
     (void)nt_hash64_str("ui_buttons_demo/font");
     (void)nt_hash64_str("ui_buttons_demo_atlas");
     (void)nt_hash64_str("ui_buttons_demo_atlas/_white");

--- a/examples/ui_buttons_demo/generated/ui_buttons_demo_assets.h
+++ b/examples/ui_buttons_demo/generated/ui_buttons_demo_assets.h
@@ -13,6 +13,7 @@
 #define ASSET_SHADER_ASSETS_SHADERS_SLUG_TEXT_VERT ((nt_hash64_t){0x8ECB088C8983CC2FULL}) /* assets/shaders/slug_text.vert */
 #define ASSET_SHADER_ASSETS_SHADERS_SPRITE_FRAG ((nt_hash64_t){0x96ED6312E7B10087ULL}) /* assets/shaders/sprite.frag */
 #define ASSET_SHADER_ASSETS_SHADERS_SPRITE_VERT ((nt_hash64_t){0x75A9EEA4D1472026ULL}) /* assets/shaders/sprite.vert */
+#define ASSET_SHADER_ASSETS_SHADERS_SPRITE_CUTOFF_FRAG ((nt_hash64_t){0x8126896E5DC4B921ULL}) /* assets/shaders/sprite_cutoff.frag */
 
 /* --- FONT --- */
 #define ASSET_FONT_UI_BUTTONS_DEMO_FONT ((nt_hash64_t){0x9B7E68A3E7C91D40ULL}) /* ui_buttons_demo/font */
@@ -33,6 +34,7 @@ static inline void ui_buttons_demo_assets_register_labels(void) {
     (void)nt_hash64_str("assets/shaders/slug_text.vert");
     (void)nt_hash64_str("assets/shaders/sprite.frag");
     (void)nt_hash64_str("assets/shaders/sprite.vert");
+    (void)nt_hash64_str("assets/shaders/sprite_cutoff.frag");
     (void)nt_hash64_str("ui_buttons_demo/font");
     (void)nt_hash64_str("ui_buttons_demo_atlas");
     (void)nt_hash64_str("ui_buttons_demo_atlas/_white");

--- a/examples/ui_buttons_demo/main.c
+++ b/examples/ui_buttons_demo/main.c
@@ -915,6 +915,8 @@ int main(int argc, char *argv[]) {
         .depth_test = false,
         .depth_write = false,
         .cull_mode = NT_CULL_NONE,
+        .params[0] = {.name = "u_alpha_cutoff", .value = {NT_TEXT_ALPHA_CUTOFF_DEFAULT}},
+        .param_count = 1,
         .label = "ui_buttons_demo_text",
     });
 

--- a/examples/ui_theme_demo/main.c
+++ b/examples/ui_theme_demo/main.c
@@ -518,6 +518,8 @@ int main(int argc, char *argv[]) {
         .depth_test = false,
         .depth_write = false,
         .cull_mode = NT_CULL_NONE,
+        .params[0] = {.name = "u_alpha_cutoff", .value = {NT_TEXT_ALPHA_CUTOFF_DEFAULT}},
+        .param_count = 1,
         .label = "ui_theme_demo_text",
     });
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -452,6 +452,7 @@ if(NOT EMSCRIPTEN)
         test_nt_ui_fit
         test_nt_ui_transform
         test_nt_ui_interaction
+        test_nt_ui_arbitration
         test_nt_ui_hittest
         test_nt_ui_3d_hittest
         test_nt_ui_clip_hittest

--- a/tests/unit/test_nt_ui_3d_hittest.c
+++ b/tests/unit/test_nt_ui_3d_hittest.c
@@ -96,13 +96,13 @@ static nt_ui_interaction_t step_bbox_3d(float px, float py, float occlusion) {
 }
 
 /* Widget sits at world distance ~1.0 (ortho near=-1/far=+1, Clay z=0 → t=0.5, dist=0.5*2). A cutoff
- * below that occludes it: the pointer hits nothing valid, and the gate's hot==0 fallback must NOT
- * re-admit it (this is the regression that shipped the occlusion feature broken). */
+ * below that occludes the only hit, so the resolve finds nothing in range → hot stays 0 → the gate
+ * skips the widget. */
 static void test_occlusion_blocks_widget_beyond_cutoff(void) {
     const float cx = BBOX_X + (BBOX_W * 0.5F);
     const float cy = BBOX_Y + (BBOX_H * 0.5F);
     declare_bbox_3d();                                        /* frame 1: bake bbox */
-    step_bbox_3d(cx, cy, -1.0F);                              /* frame 2: register (resolve sees empty registry → fallback) */
+    step_bbox_3d(cx, cy, -1.0F);                              /* frame 2: register (empty registry → skip; no cutoff) */
     nt_ui_interaction_t blocked = step_bbox_3d(cx, cy, 0.5F); /* frame 3: cutoff 0.5 < dist 1.0 */
     TEST_ASSERT_FALSE(blocked.hovered);
 }

--- a/tests/unit/test_nt_ui_3d_hittest.c
+++ b/tests/unit/test_nt_ui_3d_hittest.c
@@ -75,6 +75,48 @@ static void declare_bbox_3d(void) {
     nt_ui_end(s_fx.ctx);
 }
 
+/* One frame: begin + view_proj (+ optional occlusion cutoff) + declare hit3d + step. occlusion < 0
+ * leaves the default (+inf, no cutoff). */
+static nt_ui_interaction_t step_bbox_3d(float px, float py, float occlusion) {
+    float vp[16];
+    make_ortho_clay_y_down(vp);
+    nt_pointer_t mouse = {0};
+    mouse.x = px;
+    mouse.y = py;
+    mouse.active = true;
+    nt_ui_begin(s_fx.ctx, SCREEN_W, SCREEN_H, 0.0F, &mouse, 1);
+    nt_ui_set_view_proj(s_fx.ctx, vp);
+    if (occlusion >= 0.0F) {
+        nt_ui_set_pointer_occlusion(s_fx.ctx, 0U, occlusion);
+    }
+    CLAY({.id = CLAY_ID("hit3d"), .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .offset = {.x = BBOX_X, .y = BBOX_Y}}, .layout = {.sizing = {CLAY_SIZING_FIXED(BBOX_W), CLAY_SIZING_FIXED(BBOX_H)}}}) {}
+    nt_ui_interaction_t in = nt_ui_step_interaction(s_fx.ctx, nt_ui_id("hit3d"));
+    nt_ui_end(s_fx.ctx);
+    return in;
+}
+
+/* Widget sits at world distance ~1.0 (ortho near=-1/far=+1, Clay z=0 → t=0.5, dist=0.5*2). A cutoff
+ * below that occludes it: the pointer hits nothing valid, and the gate's hot==0 fallback must NOT
+ * re-admit it (this is the regression that shipped the occlusion feature broken). */
+static void test_occlusion_blocks_widget_beyond_cutoff(void) {
+    const float cx = BBOX_X + (BBOX_W * 0.5F);
+    const float cy = BBOX_Y + (BBOX_H * 0.5F);
+    declare_bbox_3d();                                        /* frame 1: bake bbox */
+    step_bbox_3d(cx, cy, -1.0F);                              /* frame 2: register (resolve sees empty registry → fallback) */
+    nt_ui_interaction_t blocked = step_bbox_3d(cx, cy, 0.5F); /* frame 3: cutoff 0.5 < dist 1.0 */
+    TEST_ASSERT_FALSE(blocked.hovered);
+}
+
+/* A cutoff beyond the widget distance leaves it interactive. */
+static void test_occlusion_allows_widget_within_cutoff(void) {
+    const float cx = BBOX_X + (BBOX_W * 0.5F);
+    const float cy = BBOX_Y + (BBOX_H * 0.5F);
+    declare_bbox_3d();
+    step_bbox_3d(cx, cy, -1.0F);
+    nt_ui_interaction_t allowed = step_bbox_3d(cx, cy, 2.0F); /* cutoff 2.0 > dist 1.0 */
+    TEST_ASSERT_TRUE(allowed.hovered);
+}
+
 /* ---- Test 1: view_proj setter caches inverse + flag, and round-trip is sane. ---- */
 static void test_view_proj_set_caches_inverse(void) {
     float vp[16];
@@ -185,5 +227,7 @@ int main(void) {
     RUN_TEST(test_hit_test_asserts_when_view_proj_not_set);
     RUN_TEST(test_set_view_proj_asserts_on_2d_ctx);
     RUN_TEST(test_raycast_hit_perspective);
+    RUN_TEST(test_occlusion_blocks_widget_beyond_cutoff);
+    RUN_TEST(test_occlusion_allows_widget_within_cutoff);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_arbitration.c
+++ b/tests/unit/test_nt_ui_arbitration.c
@@ -1,0 +1,117 @@
+/* Front-most input arbitration (2D ctx).
+ *
+ * Two fully-overlapping interactive widgets: only the front-most (last-declared, drawn-on-top in 2D)
+ * may hover/press a free pointer; the one behind it is gated off. Arbitration uses the PREVIOUS
+ * frame's interactive registry, so frame 1 (empty registry) falls back to the raw hit — both react —
+ * and arbitration kicks in from frame 2. */
+
+#include <stdalign.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "clay.h"
+#include "input/nt_input.h"
+#include "test_helpers/nt_assert_trap.h"
+#include "test_helpers/ui_test_arena.h"
+#include "test_helpers/ui_walker_fixture.h"
+#include "ui/nt_ui.h"
+#include "unity.h"
+
+alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_TEST_ARENA_SIZE];
+static ui_walker_fixture_t s_fx;
+
+/* Two overlapping floating boxes; the pointer sits in the shared region (275,275). */
+#define BOT_X 100.0F
+#define BOT_Y 100.0F
+#define TOP_X 200.0F
+#define TOP_Y 200.0F
+#define BOX_W 250.0F
+#define BOX_H 250.0F
+#define OVER_CX 275.0F
+#define OVER_CY 275.0F
+
+void setUp(void) {
+    nt_test_assert_install();
+    ui_walker_fixture_init(&s_fx, s_arena, sizeof s_arena, UI_WALKER_FX_BIND_ALL);
+}
+
+void tearDown(void) { ui_walker_fixture_shutdown(&s_fx); }
+
+static nt_pointer_t make_pointer(float x, float y, bool is_down, bool is_pressed) {
+    nt_pointer_t p = {0};
+    p.x = x;
+    p.y = y;
+    p.active = true;
+    p.buttons[NT_BUTTON_LEFT].is_down = is_down;
+    p.buttons[NT_BUTTON_LEFT].is_pressed = is_pressed;
+    return p;
+}
+
+/* Two overlapping floating widgets; "top" declared last → drawn on top in 2D. */
+static void declare_two(void) {
+    CLAY({.id = CLAY_ID("bottom"), .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .offset = {.x = BOT_X, .y = BOT_Y}}, .layout = {.sizing = {CLAY_SIZING_FIXED(BOX_W), CLAY_SIZING_FIXED(BOX_H)}}}) {}
+    CLAY({.id = CLAY_ID("top"), .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .offset = {.x = TOP_X, .y = TOP_Y}}, .layout = {.sizing = {CLAY_SIZING_FIXED(BOX_W), CLAY_SIZING_FIXED(BOX_H)}}}) {}
+}
+
+/* Frame 1 helper: declare only (no step) so Clay bakes the bbox/transform for next frame's hit-test.
+ * Stepping (hit-testing) on the very first frame is invalid — the transform isn't baked until end. */
+static void declare_only(const nt_pointer_t *p) {
+    nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, p, 1);
+    declare_two();
+    nt_ui_end(s_fx.ctx);
+}
+
+/* Declare both + step both (order: bottom, then top); returns both interactions. Also records both in
+ * this frame's interactive registry, consumed by NEXT frame's resolve. */
+static void step_two(const nt_pointer_t *p, nt_ui_interaction_t *bottom, nt_ui_interaction_t *top) {
+    nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, p, 1);
+    declare_two();
+    *bottom = nt_ui_step_interaction(s_fx.ctx, nt_ui_id("bottom"));
+    *top = nt_ui_step_interaction(s_fx.ctx, nt_ui_id("top"));
+    nt_ui_end(s_fx.ctx);
+}
+
+/* Registry empty (nothing stepped last frame) → hot==0 fallback → both overlapping widgets hover. */
+void test_empty_registry_fallback_both_hover(void) {
+    nt_pointer_t over = make_pointer(OVER_CX, OVER_CY, false, false);
+    nt_ui_interaction_t bottom;
+    nt_ui_interaction_t top;
+    declare_only(&over);            /* frame 1: bake bboxes, no registry */
+    step_two(&over, &bottom, &top); /* frame 2: resolve sees empty registry → fallback */
+    TEST_ASSERT_TRUE(bottom.hovered);
+    TEST_ASSERT_TRUE(top.hovered);
+}
+
+/* Once both are in the registry, the resolve makes "top" (last-declared) hot; "bottom" is gated off. */
+void test_overlap_top_wins_hover(void) {
+    nt_pointer_t over = make_pointer(OVER_CX, OVER_CY, false, false);
+    nt_ui_interaction_t bottom;
+    nt_ui_interaction_t top;
+    declare_only(&over);            /* frame 1: bake bboxes */
+    step_two(&over, &bottom, &top); /* frame 2: register both (still fallback) */
+    step_two(&over, &bottom, &top); /* frame 3: arbitrated from frame-2 registry */
+    TEST_ASSERT_TRUE(top.hovered);
+    TEST_ASSERT_FALSE(bottom.hovered);
+}
+
+/* Press lands on the front-most widget only; the one behind never captures. */
+void test_overlap_top_wins_press(void) {
+    nt_pointer_t over = make_pointer(OVER_CX, OVER_CY, false, false);
+    nt_ui_interaction_t bottom;
+    nt_ui_interaction_t top;
+    declare_only(&over);            /* frame 1: bake bboxes */
+    step_two(&over, &bottom, &top); /* frame 2: register both */
+
+    nt_pointer_t press = make_pointer(OVER_CX, OVER_CY, true, true);
+    step_two(&press, &bottom, &top); /* frame 3: press arbitrated */
+    TEST_ASSERT_TRUE(top.pressed_now);
+    TEST_ASSERT_FALSE(bottom.pressed_now);
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_empty_registry_fallback_both_hover);
+    RUN_TEST(test_overlap_top_wins_hover);
+    RUN_TEST(test_overlap_top_wins_press);
+    return UNITY_END();
+}

--- a/tests/unit/test_nt_ui_arbitration.c
+++ b/tests/unit/test_nt_ui_arbitration.c
@@ -1,9 +1,9 @@
 /* Front-most input arbitration (2D ctx).
  *
- * Two fully-overlapping interactive widgets: only the front-most (last-declared, drawn-on-top in 2D)
- * may hover/press a free pointer; the one behind it is gated off. Arbitration uses the PREVIOUS
- * frame's interactive registry, so frame 1 (empty registry) falls back to the raw hit — both react —
- * and arbitration kicks in from frame 2. */
+ * Among overlapping interactive widgets only the front-most (highest effective Clay zIndex; equal
+ * zIndex → last-declared) may hover/press a free pointer; those behind it are gated off. Arbitration
+ * uses the PREVIOUS frame's interactive registry, so frame 1 (empty registry) falls back to the raw
+ * hit — both react — and arbitration kicks in from frame 2. */
 
 #include <stdalign.h>
 #include <stdbool.h>

--- a/tests/unit/test_nt_ui_arbitration.c
+++ b/tests/unit/test_nt_ui_arbitration.c
@@ -2,8 +2,8 @@
  *
  * Among overlapping interactive widgets only the front-most (highest effective Clay zIndex; equal
  * zIndex → last-declared) may hover/press a free pointer; those behind it are gated off. Arbitration
- * uses the PREVIOUS frame's interactive registry, so frame 1 (empty registry) falls back to the raw
- * hit — both react — and arbitration kicks in from frame 2. */
+ * uses the PREVIOUS frame's interactive registry, so on frame 1 (empty registry) nothing reacts;
+ * each widget registers on its first step and becomes eligible from the next frame. */
 
 #include <stdalign.h>
 #include <stdbool.h>
@@ -71,15 +71,16 @@ static void step_two(const nt_pointer_t *p, nt_ui_interaction_t *bottom, nt_ui_i
     nt_ui_end(s_fx.ctx);
 }
 
-/* Registry empty (nothing stepped last frame) → hot==0 fallback → both overlapping widgets hover. */
-void test_empty_registry_fallback_both_hover(void) {
+/* Registry empty (nothing stepped last frame) → hot==0 → skip: neither overlapping widget reacts
+ * before it has registered (reliability over instant first-frame response). */
+void test_empty_registry_no_react(void) {
     nt_pointer_t over = make_pointer(OVER_CX, OVER_CY, false, false);
     nt_ui_interaction_t bottom;
     nt_ui_interaction_t top;
     declare_only(&over);            /* frame 1: bake bboxes, no registry */
-    step_two(&over, &bottom, &top); /* frame 2: resolve sees empty registry → fallback */
-    TEST_ASSERT_TRUE(bottom.hovered);
-    TEST_ASSERT_TRUE(top.hovered);
+    step_two(&over, &bottom, &top); /* frame 2: resolve sees empty registry → skip */
+    TEST_ASSERT_FALSE(bottom.hovered);
+    TEST_ASSERT_FALSE(top.hovered);
 }
 
 /* Once both are in the registry, the resolve makes "top" (last-declared) hot; "bottom" is gated off. */
@@ -144,7 +145,7 @@ void test_overlap_top_wins_press(void) {
 
 int main(void) {
     UNITY_BEGIN();
-    RUN_TEST(test_empty_registry_fallback_both_hover);
+    RUN_TEST(test_empty_registry_no_react);
     RUN_TEST(test_overlap_top_wins_hover);
     RUN_TEST(test_higher_zindex_wins_despite_earlier_declaration);
     RUN_TEST(test_overlap_top_wins_press);

--- a/tests/unit/test_nt_ui_arbitration.c
+++ b/tests/unit/test_nt_ui_arbitration.c
@@ -1,7 +1,8 @@
 /* Front-most input arbitration (2D ctx).
  *
  * Among overlapping interactive widgets only the front-most (highest effective Clay zIndex; equal
- * zIndex → last-declared) may hover/press a free pointer; those behind it are gated off. Arbitration
+ * zIndex → last-registered, i.e. the later step_interaction call) may hover/press a free pointer;
+ * those behind it are gated off. Arbitration
  * uses the PREVIOUS frame's interactive registry, so on frame 1 (empty registry) nothing reacts;
  * each widget registers on its first step and becomes eligible from the next frame. */
 
@@ -83,7 +84,8 @@ void test_empty_registry_no_react(void) {
     TEST_ASSERT_FALSE(top.hovered);
 }
 
-/* Once both are in the registry, the resolve makes "top" (last-declared) hot; "bottom" is gated off. */
+/* Once both are in the registry, the resolve makes "top" (last-registered: stepped after "bottom",
+ * equal zIndex) hot; "bottom" is gated off. */
 void test_overlap_top_wins_hover(void) {
     nt_pointer_t over = make_pointer(OVER_CX, OVER_CY, false, false);
     nt_ui_interaction_t bottom;
@@ -95,8 +97,8 @@ void test_overlap_top_wins_hover(void) {
     TEST_ASSERT_FALSE(bottom.hovered);
 }
 
-/* Two overlapping floating widgets where the HIGHER zIndex is declared FIRST: true z-order must pick
- * it (the old "last-declared wins" would wrongly pick the later, lower-z one). */
+/* Two overlapping floating widgets where the HIGHER zIndex is declared/stepped FIRST: zIndex must beat
+ * registration order — picking the later-registered, lower-z widget would be wrong. */
 static void declare_zindexed(void) {
     CLAY({.id = CLAY_ID("hiz"),
           .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .zIndex = 10, .offset = {.x = BOT_X, .y = BOT_Y}},

--- a/tests/unit/test_nt_ui_arbitration.c
+++ b/tests/unit/test_nt_ui_arbitration.c
@@ -89,7 +89,7 @@ void test_overlap_top_wins_hover(void) {
     nt_ui_interaction_t bottom;
     nt_ui_interaction_t top;
     declare_only(&over);            /* frame 1: bake bboxes */
-    step_two(&over, &bottom, &top); /* frame 2: register both (still fallback) */
+    step_two(&over, &bottom, &top); /* frame 2: register both (empty registry → both skip) */
     step_two(&over, &bottom, &top); /* frame 3: arbitrated from frame-2 registry */
     TEST_ASSERT_TRUE(top.hovered);
     TEST_ASSERT_FALSE(bottom.hovered);
@@ -123,7 +123,7 @@ void test_higher_zindex_wins_despite_earlier_declaration(void) {
     nt_ui_interaction_t hiz;
     nt_ui_interaction_t lowz;
     declare_zindexed_only(&over);      /* frame 1: bake */
-    step_zindexed(&over, &hiz, &lowz); /* frame 2: register (still fallback) */
+    step_zindexed(&over, &hiz, &lowz); /* frame 2: register (empty registry → both skip) */
     step_zindexed(&over, &hiz, &lowz); /* frame 3: arbitrated by zIndex */
     TEST_ASSERT_TRUE(hiz.hovered);     /* z=10 wins even though declared first */
     TEST_ASSERT_FALSE(lowz.hovered);

--- a/tests/unit/test_nt_ui_arbitration.c
+++ b/tests/unit/test_nt_ui_arbitration.c
@@ -94,6 +94,40 @@ void test_overlap_top_wins_hover(void) {
     TEST_ASSERT_FALSE(bottom.hovered);
 }
 
+/* Two overlapping floating widgets where the HIGHER zIndex is declared FIRST: true z-order must pick
+ * it (the old "last-declared wins" would wrongly pick the later, lower-z one). */
+static void declare_zindexed(void) {
+    CLAY({.id = CLAY_ID("hiz"),
+          .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .zIndex = 10, .offset = {.x = BOT_X, .y = BOT_Y}},
+          .layout = {.sizing = {CLAY_SIZING_FIXED(BOX_W), CLAY_SIZING_FIXED(BOX_H)}}}) {}
+    CLAY({.id = CLAY_ID("lowz"), .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .offset = {.x = TOP_X, .y = TOP_Y}}, .layout = {.sizing = {CLAY_SIZING_FIXED(BOX_W), CLAY_SIZING_FIXED(BOX_H)}}}) {}
+}
+
+static void declare_zindexed_only(const nt_pointer_t *p) {
+    nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, p, 1);
+    declare_zindexed();
+    nt_ui_end(s_fx.ctx);
+}
+
+static void step_zindexed(const nt_pointer_t *p, nt_ui_interaction_t *hiz, nt_ui_interaction_t *lowz) {
+    nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, p, 1);
+    declare_zindexed();
+    *hiz = nt_ui_step_interaction(s_fx.ctx, nt_ui_id("hiz"));
+    *lowz = nt_ui_step_interaction(s_fx.ctx, nt_ui_id("lowz"));
+    nt_ui_end(s_fx.ctx);
+}
+
+void test_higher_zindex_wins_despite_earlier_declaration(void) {
+    nt_pointer_t over = make_pointer(OVER_CX, OVER_CY, false, false);
+    nt_ui_interaction_t hiz;
+    nt_ui_interaction_t lowz;
+    declare_zindexed_only(&over);      /* frame 1: bake */
+    step_zindexed(&over, &hiz, &lowz); /* frame 2: register (still fallback) */
+    step_zindexed(&over, &hiz, &lowz); /* frame 3: arbitrated by zIndex */
+    TEST_ASSERT_TRUE(hiz.hovered);     /* z=10 wins even though declared first */
+    TEST_ASSERT_FALSE(lowz.hovered);
+}
+
 /* Press lands on the front-most widget only; the one behind never captures. */
 void test_overlap_top_wins_press(void) {
     nt_pointer_t over = make_pointer(OVER_CX, OVER_CY, false, false);
@@ -112,6 +146,7 @@ int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_empty_registry_fallback_both_hover);
     RUN_TEST(test_overlap_top_wins_hover);
+    RUN_TEST(test_higher_zindex_wins_despite_earlier_declaration);
     RUN_TEST(test_overlap_top_wins_press);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_debug_hit_zones.c
+++ b/tests/unit/test_nt_ui_debug_hit_zones.c
@@ -87,12 +87,17 @@ static void test_debug_recording_off_no_capture(void) {
 /* ---- Test 2: recording ON, 3 distinct queries -> count==3, ids match ---- */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void test_debug_recording_on_records_zones(void) {
-    /* Frame 1: declare 3 elements at distinct positions. */
+    /* Frame 1: declare 3 elements + step them so they enter the interactive registry (front-most
+     * arbitration reads the prev-frame registry; a widget reacts only once registered). */
     nt_pointer_t f1 = make_pointer(0.0F, 0.0F, false, false);
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &f1, 1);
     declare_btn("btnA", BTN_X, BTN_Y);
     declare_btn("btnB", BTN_X + 200.0F, BTN_Y);
     declare_btn("btnC", BTN_X, BTN_Y + 100.0F);
+    (void)nt_ui_step_interaction(s_fx.ctx, nt_ui_id("btnA"));
+    (void)nt_ui_step_interaction(s_fx.ctx, nt_ui_id("btnB"));
+    const int16_t pad_warm[4] = {8, 8, 8, 8};
+    (void)nt_ui_step_interaction_padded(s_fx.ctx, nt_ui_id("btnC"), pad_warm);
     nt_ui_end(s_fx.ctx);
 
     /* Frame 2: turn recording on, query all 3. */
@@ -185,11 +190,14 @@ static void test_debug_draw_off_mode_silent(void) {
 /* ---- Test 6: mode filter HOVER returns only zones with HOVERED flag ---- */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void test_debug_mode_filter(void) {
-    /* Two buttons. Pointer hovers only btnA. */
+    /* Two buttons. Pointer hovers only btnA. Frame 1 steps both so they register for next-frame
+     * arbitration (a widget reacts only once it is in the prev-frame interactive registry). */
     nt_pointer_t f1 = make_pointer(0.0F, 0.0F, false, false);
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &f1, 1);
     declare_btn("btnA", BTN_X, BTN_Y);
     declare_btn("btnB", BTN_X + 300.0F, BTN_Y);
+    (void)nt_ui_step_interaction(s_fx.ctx, nt_ui_id("btnA"));
+    (void)nt_ui_step_interaction(s_fx.ctx, nt_ui_id("btnB"));
     nt_ui_end(s_fx.ctx);
 
     nt_ui_debug_set_recording(s_fx.ctx, true);

--- a/tests/unit/test_nt_ui_inspector.c
+++ b/tests/unit/test_nt_ui_inspector.c
@@ -406,12 +406,13 @@ static void test_inspector_pointer_outside_sidebar_normal(void) {
     const float btn_cx = btn_x + (btn_w * 0.5F);
     const float btn_cy = btn_y + (btn_h * 0.5F);
 
-    /* Frame 1: declare bbox so the next frame has a hit-target. */
+    /* Frame 1: declare bbox + step so the button registers (front-most arbitration reads the
+     * prev-frame interactive registry; a widget reacts only once registered). */
     nt_pointer_t f1 = make_pointer(0.0F, 0.0F);
     nt_ui_begin(s_fx.ctx, screen_w, screen_h, 0.0F, &f1, 1);
-    CLAY(
-        {.id = CLAY_ID("visible_btn"), .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .offset = {.x = btn_x, .y = btn_y}}, .layout = {.sizing = {CLAY_SIZING_FIXED(btn_w), CLAY_SIZING_FIXED(btn_h)}}}) {
-    }
+    CLAY({.id = CLAY_ID("visible_btn"),
+          .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .offset = {.x = btn_x, .y = btn_y}},
+          .layout = {.sizing = {CLAY_SIZING_FIXED(btn_w), CLAY_SIZING_FIXED(btn_h)}}}){}(void)nt_ui_step_interaction(s_fx.ctx, nt_ui_id("visible_btn"));
     nt_ui_end(s_fx.ctx);
 
     /* Frame 2: pointer over the button center, NOT over the sidebar. */

--- a/tests/unit/test_nt_ui_inspector.c
+++ b/tests/unit/test_nt_ui_inspector.c
@@ -410,9 +410,10 @@ static void test_inspector_pointer_outside_sidebar_normal(void) {
      * prev-frame interactive registry; a widget reacts only once registered). */
     nt_pointer_t f1 = make_pointer(0.0F, 0.0F);
     nt_ui_begin(s_fx.ctx, screen_w, screen_h, 0.0F, &f1, 1);
-    CLAY({.id = CLAY_ID("visible_btn"),
-          .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .offset = {.x = btn_x, .y = btn_y}},
-          .layout = {.sizing = {CLAY_SIZING_FIXED(btn_w), CLAY_SIZING_FIXED(btn_h)}}}){}(void)nt_ui_step_interaction(s_fx.ctx, nt_ui_id("visible_btn"));
+    CLAY(
+        {.id = CLAY_ID("visible_btn"), .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .offset = {.x = btn_x, .y = btn_y}}, .layout = {.sizing = {CLAY_SIZING_FIXED(btn_w), CLAY_SIZING_FIXED(btn_h)}}}) {
+        (void)nt_ui_step_interaction(s_fx.ctx, nt_ui_id("visible_btn"));
+    }
     nt_ui_end(s_fx.ctx);
 
     /* Frame 2: pointer over the button center, NOT over the sidebar. */

--- a/tests/unit/test_nt_ui_interaction.c
+++ b/tests/unit/test_nt_ui_interaction.c
@@ -82,12 +82,30 @@ static nt_ui_interaction_t query_btn_frame(const nt_pointer_t *p) {
     return in;
 }
 
+/* Warm-up frame: declare + step so btn is BOTH baked (bbox) and entered into the interactive
+ * registry. Front-most arbitration reads the PREVIOUS frame's registry, so a widget reacts only from
+ * the frame after its first step; the warm-up itself reacts to nothing (empty registry → hot==0). */
+static void warm_btn_frame(const nt_pointer_t *p) {
+    nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, p, 1);
+    declare_btn_element();
+    (void)nt_ui_step_interaction(s_fx.ctx, nt_ui_id("btn"));
+    nt_ui_end(s_fx.ctx);
+}
+
+/* Warm-up that registers btn with a specific pad (the resolve hit-tests the registered pad). */
+static void warm_btn_frame_padded(const nt_pointer_t *p, const int16_t pad[4]) {
+    nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, p, 1);
+    declare_btn_element();
+    (void)nt_ui_step_interaction_padded(s_fx.ctx, nt_ui_id("btn"), pad);
+    nt_ui_end(s_fx.ctx);
+}
+
 /* ---- Test 1: press-then-release over widget -> clicked once (SC #1) ---- */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void test_interaction_click_on_release_within_bounds(void) {
     /* Frame 1: declare only (no buttons). Bbox stored for next frame. */
     nt_pointer_t f1 = make_pointer(BTN_CX, BTN_CY, false, false, false);
-    declare_btn_frame(&f1);
+    warm_btn_frame(&f1);
 
     /* Frame 2: press inside. */
     nt_pointer_t f2 = make_pointer(BTN_CX, BTN_CY, true, true, false);
@@ -125,7 +143,7 @@ static void test_interaction_click_on_release_within_bounds(void) {
 /* ---- Test 2: idle -> hover -> pressed state progression (SC #2) ---- */
 static void test_interaction_hover_then_pressed(void) {
     nt_pointer_t f1 = make_pointer(0.0F, 0.0F, false, false, false);
-    declare_btn_frame(&f1);
+    warm_btn_frame(&f1);
 
     /* Frame 2: pointer over, no button -> hovered, not pressed. */
     nt_pointer_t f2 = make_pointer(BTN_CX, BTN_CY, false, false, false);
@@ -146,7 +164,7 @@ static void test_interaction_hover_then_pressed(void) {
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void test_interaction_release_outside_cancels(void) {
     nt_pointer_t f1 = make_pointer(BTN_CX, BTN_CY, false, false, false);
-    declare_btn_frame(&f1);
+    warm_btn_frame(&f1);
 
     /* Frame 2: press inside -> capture begins. */
     nt_pointer_t f2 = make_pointer(BTN_CX, BTN_CY, true, true, false);
@@ -177,7 +195,7 @@ static void test_interaction_release_outside_cancels(void) {
 /* ---- Test 4: disabled widget skips hover + click ---- */
 static void test_interaction_disabled_skips(void) {
     nt_pointer_t f1 = make_pointer(BTN_CX, BTN_CY, false, false, false);
-    declare_btn_frame(&f1);
+    warm_btn_frame(&f1);
 
     /* Disabled = button never calls get_interaction → zeroed result, no capture. */
     nt_pointer_t f2 = make_pointer(BTN_CX, BTN_CY, true, true, false);
@@ -197,15 +215,16 @@ static void test_interaction_disabled_skips(void) {
 /* ---- Test 6: padded interaction inflates bbox before inverse-affine ---- */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void test_interaction_padded_hover_and_capture(void) {
-    /* Frame 1: declare bbox (no pointer over). */
+    /* Frame 1: declare + step (padded) so btn registers with the SAME pad the interaction uses —
+     * the next-frame resolve hit-tests the registered pad. */
+    const int16_t pad_right[4] = {0, 16, 0, 0};
     nt_pointer_t f1 = make_pointer(0.0F, 0.0F, false, false, false);
-    declare_btn_frame(&f1);
+    warm_btn_frame_padded(&f1, pad_right);
 
     /* Pointer 12 px past right edge + pad right 16 → hovered + pressed_now. */
     const float right_outside_x = BTN_X + BTN_W + 12.0F;
     const float center_y = BTN_Y + (BTN_H * 0.5F);
     nt_pointer_t f2 = make_pointer(right_outside_x, center_y, true, true, false);
-    const int16_t pad_right[4] = {0, 16, 0, 0};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &f2, 1);
     declare_btn_element();
     nt_ui_interaction_t in = nt_ui_step_interaction_padded(s_fx.ctx, nt_ui_id("btn"), pad_right);
@@ -226,7 +245,7 @@ static void test_interaction_padded_hover_and_capture(void) {
 /* ---- Test 7: padded query on a DISABLED widget stays non-hoverable ---- */
 static void test_interaction_disabled_with_padding_stays_disabled(void) {
     nt_pointer_t f1 = make_pointer(BTN_CX, BTN_CY, false, false, false);
-    declare_btn_frame(&f1);
+    warm_btn_frame(&f1);
 
     /* Frame 2: pointer over center, pressed, but enabled = false. Large
      * padding {32,32,32,32} must NOT cause hover/press/capture. */
@@ -249,7 +268,7 @@ static void test_interaction_disabled_with_padding_stays_disabled(void) {
 /* ---- Test 5: wants_pointer true on hover and while captured ---- */
 static void test_interaction_wants_pointer(void) {
     nt_pointer_t f1 = make_pointer(BTN_CX, BTN_CY, false, false, false);
-    declare_btn_frame(&f1);
+    warm_btn_frame(&f1);
 
     /* Hover only → wants_pointer true (persists until next begin). */
     nt_pointer_t f2 = make_pointer(BTN_CX, BTN_CY, false, false, false);
@@ -276,11 +295,13 @@ static void test_interaction_capture_excludes_other_widgets(void) {
     const float b_cx = b_x + (BTN_W * 0.5F);
     const float b_cy = b_y + (BTN_H * 0.5F);
 
-    /* Frame 1: declare both elements so Clay has bboxes for next frame. */
+    /* Frame 1: declare both + step both so they register for next-frame arbitration. */
     nt_pointer_t f1 = make_pointer(0.0F, 0.0F, false, false, false);
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &f1, 1);
-    CLAY({.id = CLAY_ID("btnA"), .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .offset = {.x = a_x, .y = a_y}}, .layout = {.sizing = {CLAY_SIZING_FIXED(BTN_W), CLAY_SIZING_FIXED(BTN_H)}}}) {}
-    CLAY({.id = CLAY_ID("btnB"), .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .offset = {.x = b_x, .y = b_y}}, .layout = {.sizing = {CLAY_SIZING_FIXED(BTN_W), CLAY_SIZING_FIXED(BTN_H)}}}) {}
+    CLAY({.id = CLAY_ID("btnA"), .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .offset = {.x = a_x, .y = a_y}}, .layout = {.sizing = {CLAY_SIZING_FIXED(BTN_W), CLAY_SIZING_FIXED(BTN_H)}}}){}(
+        void)nt_ui_step_interaction(s_fx.ctx, nt_ui_id("btnA"));
+    CLAY({.id = CLAY_ID("btnB"), .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .offset = {.x = b_x, .y = b_y}}, .layout = {.sizing = {CLAY_SIZING_FIXED(BTN_W), CLAY_SIZING_FIXED(BTN_H)}}}){}(
+        void)nt_ui_step_interaction(s_fx.ctx, nt_ui_id("btnB"));
     nt_ui_end(s_fx.ctx);
 
     /* Frame 2: press inside A -> A begins capture. Query A and B in declaration
@@ -358,7 +379,7 @@ static void test_interaction_capture_excludes_other_widgets(void) {
 static void test_query_is_idempotent(void) {
     /* Frame 1: declare. */
     nt_pointer_t f1 = make_pointer(BTN_CX, BTN_CY, false, false, false);
-    declare_btn_frame(&f1);
+    warm_btn_frame(&f1);
 
     /* Frame 2: press inside (capture begins via step). */
     nt_pointer_t f2 = make_pointer(BTN_CX, BTN_CY, true, true, false);
@@ -396,7 +417,7 @@ static void test_query_is_idempotent(void) {
 static void test_step_commits_what_query_previewed(void) {
     /* Frame 1: declare. */
     nt_pointer_t f1 = make_pointer(BTN_CX, BTN_CY, false, false, false);
-    declare_btn_frame(&f1);
+    warm_btn_frame(&f1);
 
     /* Frame 2: press_now. Pre-query first (capture still 0), then step. */
     nt_pointer_t f2 = make_pointer(BTN_CX, BTN_CY, true, true, false);
@@ -439,13 +460,16 @@ static void test_query_step_under_rotation(void) {
     nt_ui_transform_t rot = nt_ui_transform_defaults();
     rot.rotation_z = 30.0F * 0.017453292F;
 
-    /* Frame 1: declare the rotated button so prev-frame tree_baked carries it. */
+    /* Frame 1: declare the rotated button + step it so prev-frame tree_baked carries it AND it
+     * enters the interactive registry for next-frame arbitration. */
     nt_pointer_t f1 = make_pointer(0.0F, 0.0F, false, false, false);
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &f1, 1);
     CLAY({.id = CLAY_ID("rotbtn"),
           .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .offset = {.x = BTN_X, .y = BTN_Y}},
           .layout = {.sizing = {CLAY_SIZING_FIXED(BTN_W), CLAY_SIZING_FIXED(BTN_H)}},
-          .userData = (void *)NT_UI_DATA_XFORM(0U, &rot, 1.0F)}) {}
+          .userData = (void *)NT_UI_DATA_XFORM(0U, &rot, 1.0F)}) {
+        (void)nt_ui_step_interaction(s_fx.ctx, nt_ui_id("rotbtn"));
+    }
     nt_ui_end(s_fx.ctx);
 
     /* Frame 2: pointer at the forward-rotated layout right-center. */
@@ -484,9 +508,13 @@ static void test_step_outside_frame_asserts(void) {
 /* query is safe outside begin/end (snapshot/restore Clay ctx, like get_bbox). */
 static void test_query_outside_frame_returns_prev_frame_state(void) {
     nt_pointer_t mouse = {.x = 25.0F, .y = 25.0F, .active = true};
-    nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
-    CLAY({.id = CLAY_ID("btn"), .layout = {.sizing = {CLAY_SIZING_FIXED(50), CLAY_SIZING_FIXED(50)}}}) {}
-    nt_ui_end(s_fx.ctx);
+    /* Two step frames: frame 1 registers btn, frame 2's resolve (prev = frame-1 registry) makes it
+     * hot, so the outside query (which reuses that resolve) admits it past the front-most gate. */
+    for (int i = 0; i < 2; ++i) {
+        nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
+        CLAY({.id = CLAY_ID("btn"), .layout = {.sizing = {CLAY_SIZING_FIXED(50), CLAY_SIZING_FIXED(50)}}}) { (void)nt_ui_step_interaction(s_fx.ctx, nt_ui_id("btn")); }
+        nt_ui_end(s_fx.ctx);
+    }
     /* Outside frame: query reads prev-frame bbox + pointer, returns without asserting. */
     const nt_ui_interaction_t in = nt_ui_query_interaction(s_fx.ctx, nt_ui_id("btn"));
     TEST_ASSERT_TRUE_MESSAGE(in.hovered, "query outside frame must read prev-frame bbox");
@@ -504,10 +532,12 @@ static nt_ui_interaction_t step_btn_2p(const nt_pointer_t *a, const nt_pointer_t
     return in;
 }
 
-static void declare_btn_2p(const nt_pointer_t *a, const nt_pointer_t *b) {
+/* Two-pointer warm-up: declare + step so btn registers for next-frame arbitration. */
+static void warm_btn_2p(const nt_pointer_t *a, const nt_pointer_t *b) {
     const nt_pointer_t ptrs[2] = {*a, *b};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, ptrs, 2);
     declare_btn_element();
+    (void)nt_ui_step_interaction(s_fx.ctx, nt_ui_id("btn"));
     nt_ui_end(s_fx.ctx);
 }
 
@@ -517,7 +547,7 @@ static void declare_btn_2p(const nt_pointer_t *a, const nt_pointer_t *b) {
 static void test_multitouch_first_finger_wins_capture(void) {
     /* Frame 1: declare (no input) so bbox lands in Clay's hashmap. */
     nt_pointer_t idle = make_pointer(BTN_CX, BTN_CY, false, false, false);
-    declare_btn_2p(&idle, &idle);
+    warm_btn_2p(&idle, &idle);
 
     /* Frame 2: finger 0 presses inside; finger 1 idle off-widget. */
     nt_pointer_t f0_press = make_pointer(BTN_CX, BTN_CY, true, true, false);
@@ -563,7 +593,7 @@ static void test_multitouch_first_finger_wins_capture(void) {
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void test_multitouch_secondary_finger_captures_when_primary_idle(void) {
     nt_pointer_t idle = make_pointer(0.0F, 0.0F, false, false, false);
-    declare_btn_2p(&idle, &idle);
+    warm_btn_2p(&idle, &idle);
 
     /* Frame 2: finger 0 off, finger 1 presses inside widget → captures[1] holds. */
     nt_pointer_t f0_off = make_pointer(0.0F, 0.0F, false, false, false);

--- a/tests/unit/test_nt_ui_interaction.c
+++ b/tests/unit/test_nt_ui_interaction.c
@@ -298,10 +298,12 @@ static void test_interaction_capture_excludes_other_widgets(void) {
     /* Frame 1: declare both + step both so they register for next-frame arbitration. */
     nt_pointer_t f1 = make_pointer(0.0F, 0.0F, false, false, false);
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &f1, 1);
-    CLAY({.id = CLAY_ID("btnA"), .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .offset = {.x = a_x, .y = a_y}}, .layout = {.sizing = {CLAY_SIZING_FIXED(BTN_W), CLAY_SIZING_FIXED(BTN_H)}}}){}(
-        void)nt_ui_step_interaction(s_fx.ctx, nt_ui_id("btnA"));
-    CLAY({.id = CLAY_ID("btnB"), .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .offset = {.x = b_x, .y = b_y}}, .layout = {.sizing = {CLAY_SIZING_FIXED(BTN_W), CLAY_SIZING_FIXED(BTN_H)}}}){}(
-        void)nt_ui_step_interaction(s_fx.ctx, nt_ui_id("btnB"));
+    CLAY({.id = CLAY_ID("btnA"), .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .offset = {.x = a_x, .y = a_y}}, .layout = {.sizing = {CLAY_SIZING_FIXED(BTN_W), CLAY_SIZING_FIXED(BTN_H)}}}) {
+        (void)nt_ui_step_interaction(s_fx.ctx, nt_ui_id("btnA"));
+    }
+    CLAY({.id = CLAY_ID("btnB"), .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .offset = {.x = b_x, .y = b_y}}, .layout = {.sizing = {CLAY_SIZING_FIXED(BTN_W), CLAY_SIZING_FIXED(BTN_H)}}}) {
+        (void)nt_ui_step_interaction(s_fx.ctx, nt_ui_id("btnB"));
+    }
     nt_ui_end(s_fx.ctx);
 
     /* Frame 2: press inside A -> A begins capture. Query A and B in declaration

--- a/tests/unit/test_text_renderer.c
+++ b/tests/unit/test_text_renderer.c
@@ -440,6 +440,24 @@ static void bench_draw_mixed_ui(void) {
     (void)fflush(stdout);
 }
 
+/* ---- glyph depth bias lifecycle ---- */
+
+/* Renderer state, not a file-static: preserved across a GPU context-loss restore like material/font
+ * (a game sets it once for world-space nameplates and must not lose it on restore). */
+void test_glyph_depth_bias_persists_across_restore(void) {
+    nt_text_renderer_set_glyph_depth_bias(0.25F); /* exactly representable, so == is safe */
+    nt_text_renderer_restore_gpu();
+    TEST_ASSERT_TRUE(nt_text_renderer_test_glyph_depth_bias() == 0.25F);
+}
+
+/* Cold shutdown/init clears it (test isolation; no leak across renderer reinit). */
+void test_glyph_depth_bias_resets_on_reinit(void) {
+    nt_text_renderer_set_glyph_depth_bias(0.25F);
+    nt_text_renderer_shutdown();
+    nt_text_renderer_init();
+    TEST_ASSERT_TRUE(nt_text_renderer_test_glyph_depth_bias() == 0.0F);
+}
+
 /* ---- main ---- */
 
 int main(void) {
@@ -459,6 +477,8 @@ int main(void) {
     RUN_TEST(test_draw_n_letter_spacing_advances_pen);
     RUN_TEST(test_draw_n_line_leading_advances_pen_y);
     RUN_TEST(test_draw_n_does_not_over_read);
+    RUN_TEST(test_glyph_depth_bias_persists_across_restore);
+    RUN_TEST(test_glyph_depth_bias_resets_on_reinit);
     RUN_TEST(bench_draw_short_warm);
     RUN_TEST(bench_draw_mixed_ui);
     return UNITY_END();

--- a/tests/unit/test_text_renderer.c
+++ b/tests/unit/test_text_renderer.c
@@ -221,19 +221,19 @@ void test_measure_null_string(void) {
     TEST_ASSERT_TRUE(sz.height == 0.0F);
 }
 
-/* ---- Test 7: Vertex stride is 68 bytes (TEXT-01) ---- */
+/* ---- Test 7: Vertex stride is 72 bytes (TEXT-01) ---- */
 
-void test_vertex_stride_68(void) {
+void test_vertex_stride_72(void) {
     nt_text_renderer_draw("A", s_identity, 32.0F, s_white, 0.0F, 0.0F);
     TEST_ASSERT_EQUAL_UINT32(1, nt_text_renderer_test_glyph_count());
 
-    /* 4 vertices for one glyph, at 68 bytes stride */
+    /* 4 vertices for one glyph, at 72 bytes stride */
     const uint8_t *verts = (const uint8_t *)nt_text_renderer_test_vertices();
     TEST_ASSERT_NOT_NULL(verts);
 
-    /* Vertex 0 and vertex 1 should be at offsets 0 and 68 */
+    /* Vertex 0 and vertex 1 should be at offsets 0 and 72 */
     /* They represent different quad corners, so position data differs */
-    TEST_ASSERT_FALSE(memcmp(verts, verts + 68, 68) == 0);
+    TEST_ASSERT_FALSE(memcmp(verts, verts + 72, 72) == 0);
 }
 
 /* ---- Test 8: 4 vertices per glyph (TEXT-01) ---- */
@@ -278,8 +278,8 @@ void test_draw_newline_advances_to_next_line(void) {
     float second_y = 0.0F;
     memcpy(&first_x, verts + 0, sizeof(float));
     memcpy(&first_y, verts + 4, sizeof(float));
-    memcpy(&second_x, verts + ((size_t)4U * 68U), sizeof(float));
-    memcpy(&second_y, verts + ((size_t)4U * 68U) + 4U, sizeof(float));
+    memcpy(&second_x, verts + ((size_t)4U * 72U), sizeof(float));
+    memcpy(&second_y, verts + ((size_t)4U * 72U) + 4U, sizeof(float));
 
     TEST_ASSERT_TRUE(first_x == second_x);
     TEST_ASSERT_TRUE(second_y < first_y);
@@ -297,8 +297,8 @@ void test_draw_n_matches_draw(void) {
 
     /* Snapshot vertex bytes — flush will zero the staging buffer counters next,
      * so we copy out before reset. Stride is 68 bytes per nt_text_vertex_t. */
-    const size_t bytes_to_copy = (size_t)draw_vcount * 68U;
-    uint8_t buf_draw[8U * 68U];
+    const size_t bytes_to_copy = (size_t)draw_vcount * 72U;
+    uint8_t buf_draw[8U * 72U];
     memcpy(buf_draw, nt_text_renderer_test_vertices(), bytes_to_copy);
 
     /* Reset staging counters (no pipeline → flush warns + zeros counters). */
@@ -323,7 +323,7 @@ void test_draw_n_letter_spacing_advances_pen(void) {
     TEST_ASSERT_EQUAL_UINT32(8U, nt_text_renderer_test_vertex_count());
     const uint8_t *vraw = (const uint8_t *)nt_text_renderer_test_vertices();
     float base_b_x = 0.0F;
-    memcpy(&base_b_x, vraw + ((size_t)4U * 68U), sizeof(float));
+    memcpy(&base_b_x, vraw + ((size_t)4U * 72U), sizeof(float));
 
     nt_text_renderer_flush();
     TEST_ASSERT_EQUAL_UINT32(0U, nt_text_renderer_test_vertex_count());
@@ -332,7 +332,7 @@ void test_draw_n_letter_spacing_advances_pen(void) {
     nt_text_renderer_draw_n("AB", 2U, s_identity, 32.0F, s_white, 7.0F, 0.0F);
     const uint8_t *vspaced = (const uint8_t *)nt_text_renderer_test_vertices();
     float spaced_b_x = 0.0F;
-    memcpy(&spaced_b_x, vspaced + ((size_t)4U * 68U), sizeof(float));
+    memcpy(&spaced_b_x, vspaced + ((size_t)4U * 72U), sizeof(float));
 
     /* UNITY_EXCLUDE_FLOAT in this build: int-truncate to compare. */
     TEST_ASSERT_EQUAL_INT32((int32_t)(base_b_x + 7.0F), (int32_t)spaced_b_x);
@@ -347,7 +347,7 @@ void test_draw_n_line_leading_advances_pen_y(void) {
     const uint8_t *vraw = (const uint8_t *)nt_text_renderer_test_vertices();
     /* vertex 0 = A's first corner, vertex 4 = B's first corner. y is float[1]. */
     float base_b_y = 0.0F;
-    memcpy(&base_b_y, vraw + ((size_t)4U * 68U) + sizeof(float), sizeof(float));
+    memcpy(&base_b_y, vraw + ((size_t)4U * 72U) + sizeof(float), sizeof(float));
 
     nt_text_renderer_flush();
 
@@ -355,7 +355,7 @@ void test_draw_n_line_leading_advances_pen_y(void) {
     nt_text_renderer_draw_n("A\nB", 3U, s_identity, 32.0F, s_white, 0.0F, 10.0F);
     const uint8_t *vleading = (const uint8_t *)nt_text_renderer_test_vertices();
     float leading_b_y = 0.0F;
-    memcpy(&leading_b_y, vleading + ((size_t)4U * 68U) + sizeof(float), sizeof(float));
+    memcpy(&leading_b_y, vleading + ((size_t)4U * 72U) + sizeof(float), sizeof(float));
 
     /* B drew lower by exactly 10px (pen_y decreases by line_advance, which got +10). */
     TEST_ASSERT_EQUAL_INT32((int32_t)(base_b_y - 10.0F), (int32_t)leading_b_y);
@@ -369,8 +369,8 @@ void test_draw_n_does_not_over_read(void) {
     const uint32_t ref_vcount = nt_text_renderer_test_vertex_count();
     TEST_ASSERT_EQUAL_UINT32(8U, ref_vcount);
 
-    const size_t bytes_to_copy = (size_t)ref_vcount * 68U;
-    uint8_t buf_ref[8U * 68U];
+    const size_t bytes_to_copy = (size_t)ref_vcount * 72U;
+    uint8_t buf_ref[8U * 72U];
     memcpy(buf_ref, nt_text_renderer_test_vertices(), bytes_to_copy);
 
     nt_text_renderer_flush();
@@ -450,7 +450,7 @@ int main(void) {
     RUN_TEST(test_measure_returns_nonzero);
     RUN_TEST(test_measure_empty_string);
     RUN_TEST(test_measure_null_string);
-    RUN_TEST(test_vertex_stride_68);
+    RUN_TEST(test_vertex_stride_72);
     RUN_TEST(test_vertex_count_4_per_glyph);
     RUN_TEST(test_flush_resets_counts);
     RUN_TEST(test_measure_width_increases);

--- a/tests/unit/test_text_renderer.c
+++ b/tests/unit/test_text_renderer.c
@@ -296,7 +296,7 @@ void test_draw_n_matches_draw(void) {
     TEST_ASSERT_EQUAL_UINT32(2U, draw_gcount);
 
     /* Snapshot vertex bytes — flush will zero the staging buffer counters next,
-     * so we copy out before reset. Stride is 68 bytes per nt_text_vertex_t. */
+     * so we copy out before reset. Stride is 72 bytes per nt_text_vertex_t. */
     const size_t bytes_to_copy = (size_t)draw_vcount * 72U;
     uint8_t buf_draw[8U * 72U];
     memcpy(buf_draw, nt_text_renderer_test_vertices(), bytes_to_copy);


### PR DESCRIPTION
Closes #197.

Makes `nt_ui` usable in a 3D UI context (`use_raycast_input = true`), where elements are placed in the world via per-element transforms and rendered with a perspective view_proj. Fixes invisible labels and the inspector/debug overlay that previously rendered with a flat 2D approximation.

## Text (3D-ctx world-space)
- **Scale / orientation / centering** — `emit_text` normalizes the model so glyphs read upright regardless of how `world_mat4` maps Clay→world (2D ortho, 3D billboard via negative scale_y, inspector screen-space); vertical centering stays in Clay layout space.
- **`u_alpha_cutoff`** — slug text shaders take a cutoff uniform; two materials (2D no-discard, 3D with discard) share one shader, default `1/255`.
- **Per-glyph clip-space depth bias** — depth-writing world-space text (e.g. hundreds of nameplates) without self-z-fighting at overlapping AA fringes; RTT rejected as not scalable.

## Inspector / debug overlay
- **Scissor honored in the inspector walk** so the sidebar tree text renders.
- **Optional depth-off overlay materials** (`nt_ui_inspector_set_materials`) — a passive overlay that stays on top without testing the game's 3D depth; falls back to the game material when unset.
- **3D-ctx overlay rendering** — the highlight/hit-zone overlay emits the element's Clay-layout corners under its world mat4 (read straight from `hit_baked` by id, so any element highlights, not just interactive widgets), with the caller binding the perspective view_proj. Skips the un-transformed GROW root.
- **3D-ctx viewport pick** — scene hover picks the element under the cursor via the same ray-vs-plane test the engine uses for clicks, instead of a 2D-affine screen approximation that grabbed the root.

## Demo
- `ui_3d_demo` — walkable space, two wall panels (shape/speed), central rotating object, depth-writing "HELLO 3D WORLD"; inspector sidebar (ortho) + highlight (perspective).

## Verification
- `cmake --build build/_cmake/native-debug` ✅
- `ctest` 64/64 ✅
- `clang-format` clean ✅ · `scripts/tidy.sh` clean (165 files) ✅
- Visual QA in `ui_3d_demo` confirmed by author (labels, billboard orientation, depth-write text, inspector tree, 3D highlight on panels, 3D scene-pick).

🤖 Generated with [Claude Code](https://claude.com/claude-code)