### PR TITLE
Late-bound atlas region ref + tombstone-reclaim (#202)

### DIFF
--- a/docs/neotolis_engine_spec_1.md
+++ b/docs/neotolis_engine_spec_1.md
@@ -826,10 +826,11 @@ Two ways to bind a sprite to a region, picked by what the game knows:
   or read it back from a previously resolved sprite. Skips the hash lookup
   on bind and on stable frames (the atlas-revision gate inside sync resolves
   to a no-op when nothing changed). After atlas republish, sync re-resolves
-  via hash to confirm the cached index still points to the same region —
-  this is how tombstoning is detected. The atlas merge contract guarantees
-  that surviving regions keep the same index across republish, so the cached
-  index stays stable as long as the underlying region is not tombstoned.
+  via hash to pick up a removed region going dead (`vertex_count==0`). The
+  atlas merge contract guarantees every region ever present keeps the same
+  index for the atlas lifetime — removed regions are marked dead in place but
+  keep their index and revive there if re-added — so the cached index never
+  moves; a dead region simply zero-draws.
 
 Game code is free to read back the cached region index for animation logic
 (e.g. cycle to the next frame). It is stable across atlas republish for
@@ -1536,8 +1537,8 @@ Runtime keeps an owned atlas snapshot in slot `user_data`, not a raw mmap view. 
 Subsequent publications merge by `name_hash` to preserve stable region indices across pack stacking:
 - common regions update metadata in place and rewrite their copied vertex/index payload
 - new regions append to the end
-- removed regions become tombstones (`vertex_count = index_count = 0`, `name_hash = NT_ATLAS_TOMBSTONE_HASH`)
-- the hash table is rebuilt from live regions after each merge
+- removed regions are marked dead in place (`vertex_count = index_count = 0`) but KEEP their `name_hash` and stay in the hash table, so a later merge that re-adds the name revives the SAME index — a resolved region index is therefore stable for the atlas lifetime
+- the hash table is rebuilt from all named regions (live + dead) after each merge
 
 Page texture resource ids are copied during `on_resolve`. The actual `nt_resource_t` page handles are materialized in `on_post_resolve` and cached in the atlas snapshot, so `nt_atlas_get_page_resource()` remains O(1).
 

--- a/engine/atlas/nt_atlas.c
+++ b/engine/atlas/nt_atlas.c
@@ -122,14 +122,13 @@ static uint32_t hash_find(const nt_atlas_data_t *ad, uint64_t name_hash) {
     return NT_ATLAS_INVALID_REGION;
 }
 
-/* Free the old hash table and rebuild from all named regions.
- * Called once after first parse and once after each merge.
- * Dead-but-named slots (vertex_count==0) stay in the table so a removed name
- * still resolves to its stable index and revives in place on re-add. */
+/* Free the old hash table and rebuild from all named regions. Dead-but-named
+ * slots (vertex_count==0) stay in the table so a removed name still resolves to
+ * its stable index and revives in place on re-add. */
 static void hash_rebuild(nt_atlas_data_t *ad) {
     free(ad->hash_table);
 
-    /* Every runtime slot carries a real name now (removal keeps name_hash). */
+    /* Every runtime slot carries a real name (removal keeps name_hash). */
     uint32_t cap = next_pow2(ad->region_count * 2U);
     if (cap < 16U) {
         cap = 16U;

--- a/engine/atlas/nt_atlas.c
+++ b/engine/atlas/nt_atlas.c
@@ -122,19 +122,15 @@ static uint32_t hash_find(const nt_atlas_data_t *ad, uint64_t name_hash) {
     return NT_ATLAS_INVALID_REGION;
 }
 
-/* Free the old hash table and rebuild from live (non-tombstone) regions.
- * Called once after first parse and once after each merge. */
+/* Free the old hash table and rebuild from all named regions.
+ * Called once after first parse and once after each merge.
+ * Dead-but-named slots (vertex_count==0) stay in the table so a removed name
+ * still resolves to its stable index and revives in place on re-add. */
 static void hash_rebuild(nt_atlas_data_t *ad) {
     free(ad->hash_table);
 
-    uint32_t live = 0;
-    for (uint32_t i = 0; i < ad->region_count; i++) {
-        if (ad->regions[i].name_hash != NT_ATLAS_TOMBSTONE_HASH) {
-            live++;
-        }
-    }
-
-    uint32_t cap = next_pow2(live * 2U);
+    /* Every runtime slot carries a real name now (removal keeps name_hash). */
+    uint32_t cap = next_pow2(ad->region_count * 2U);
     if (cap < 16U) {
         cap = 16U;
     }
@@ -145,9 +141,6 @@ static void hash_rebuild(nt_atlas_data_t *ad) {
 
     const uint32_t mask = cap - 1;
     for (uint32_t i = 0; i < ad->region_count; i++) {
-        if (ad->regions[i].name_hash == NT_ATLAS_TOMBSTONE_HASH) {
-            continue;
-        }
         uint32_t pos = (uint32_t)(ad->regions[i].name_hash & mask);
         for (uint32_t steps = 0; steps < cap; steps++) {
             nt_atlas_hash_entry_t *e = &ad->hash_table[pos];
@@ -381,7 +374,7 @@ static void atlas_precompute_all(nt_atlas_data_t *ad) {
     const float ipu = ad->ipu;
     for (uint32_t i = 0; i < ad->region_count; i++) {
         const nt_texture_region_t *r = &ad->regions[i];
-        if (r->name_hash == NT_ATLAS_TOMBSTONE_HASH || r->vertex_count == 0) {
+        if (r->vertex_count == 0) {
             continue;
         }
         const float trim_off_x = (float)r->trim_offset_x;
@@ -524,16 +517,18 @@ static void atlas_on_resolve(const uint8_t *data, uint32_t size, uint32_t runtim
     }
     // #endregion
 
-    // #region pass 2: tombstones
+    // #region pass 2: tombstone-reclaim
+    /* Removed regions keep their name_hash and stay in the hash table (dead via
+     * vertex_count==0). A later merge that re-adds the name revives the SAME
+     * index in pass 1, so a resolved region index is stable for the atlas life. */
     for (uint32_t i = 0; i < pre_merge_count; i++) {
         nt_texture_region_t *r = &ad->regions[i];
-        if (r->name_hash == NT_ATLAS_TOMBSTONE_HASH) {
+        if (r->vertex_count == 0) {
             continue;
         }
         const bool still_present = (seen[i / 8U] >> (i % 8U)) & 1U;
         if (!still_present) {
             NT_LOG_WARN("atlas merge: region 0x%016llx removed (not in new blob)", (unsigned long long)r->name_hash);
-            r->name_hash = NT_ATLAS_TOMBSTONE_HASH;
             r->vertex_start = 0;
             r->index_start = 0;
             r->vertex_count = 0;

--- a/engine/atlas/nt_atlas.h
+++ b/engine/atlas/nt_atlas.h
@@ -3,9 +3,13 @@
 
 #include <stdint.h>
 
+#include "core/nt_assert.h" /* NT_ASSERT_MODE gates the dev-only resolve warn below */
 #include "core/nt_types.h"
 #include "nt_atlas_format.h"
 #include "resource/nt_resource.h"
+#if NT_ASSERT_MODE == NT_ASSERT_FULL
+#include "log/nt_log.h"
+#endif
 
 /* ---- Public constants ---- */
 
@@ -105,6 +109,15 @@ uint32_t nt_atlas_find_region(nt_resource_t atlas, uint64_t name_hash);
 static inline void nt_atlas_resolve_ref(nt_atlas_region_ref_t *ref) {
     if (ref->region == NT_ATLAS_INVALID_REGION && ref->atlas.id != 0U && nt_resource_is_ready(ref->atlas)) {
         ref->region = nt_atlas_find_region(ref->atlas, ref->name_hash);
+#if NT_ASSERT_MODE == NT_ASSERT_FULL
+        /* Ready atlas + name never present = a typo'd name_hash, not a load race: a removed region keeps a
+         * valid (dead) index, so INVALID here means the name was never packed. Dev-only warn; release stays a
+         * silent skip so a missing optional asset never traps a shipped game. */
+        if (ref->region == NT_ATLAS_INVALID_REGION) {
+            /* Plain (domain-less) variant: this inline is included by game/example TUs that do not define NT_LOG_DOMAIN. */
+            nt_log_warn_once("nt_atlas_resolve_ref: name_hash 0x%016llx not present in ready atlas %u (typo?)", (unsigned long long)ref->name_hash, (unsigned)ref->atlas.id);
+        }
+#endif
     }
 }
 

--- a/engine/atlas/nt_atlas.h
+++ b/engine/atlas/nt_atlas.h
@@ -102,10 +102,9 @@ uint8_t nt_atlas_page_count(nt_resource_t atlas);
  * NT_ATLAS_INVALID_REGION only for names never present. */
 uint32_t nt_atlas_find_region(nt_resource_t atlas, uint64_t name_hash);
 
-/* Resolve-and-memoize: if unresolved and the atlas is ready, find by name and write the index back
- * into the ref. After return, region is a valid index (emit) or still INVALID (caller skips emit:
- * atlas not ready or bad name). One-shot — tombstone-reclaim keeps the index stable for life, so
- * there is no revision compare. */
+/* Resolve-and-memoize: under a ready atlas, find by name and write the index into the ref.
+ * After return region is a valid index (emit) or still INVALID (skip: not ready or bad name).
+ * One-shot — tombstone-reclaim keeps the index stable for life, so no revision compare. */
 static inline void nt_atlas_resolve_ref(nt_atlas_region_ref_t *ref) {
     if (ref->region == NT_ATLAS_INVALID_REGION && ref->atlas.id != 0U && nt_resource_is_ready(ref->atlas)) {
         ref->region = nt_atlas_find_region(ref->atlas, ref->name_hash);

--- a/engine/atlas/nt_atlas.h
+++ b/engine/atlas/nt_atlas.h
@@ -47,7 +47,7 @@ typedef struct {
  *
  * Total: 48 bytes on 64-bit (uint64_t alignment drives 8-byte boundary). */
 typedef struct {
-    uint64_t name_hash;      /*  0: xxh64 of region name (or NT_ATLAS_TOMBSTONE_HASH) */
+    uint64_t name_hash;      /*  0: xxh64 of region name (always a real hash at runtime) */
     uint32_t vertex_start;   /*  8: index into nt_atlas_data_t.vertices[] */
     uint32_t index_start;    /* 12: index into nt_atlas_data_t.indices[]  */
     float origin_x;          /* 16: normalized pivot 0..1 (may lie outside) */
@@ -56,7 +56,7 @@ typedef struct {
     uint16_t source_h;       /* 26 */
     int16_t trim_offset_x;   /* 28: pixels stripped from left edge */
     int16_t trim_offset_y;   /* 30 */
-    uint8_t vertex_count;    /* 32: 0 = tombstone (and also degenerate) */
+    uint8_t vertex_count;    /* 32: 0 = dead marker (removed by merge or degenerate) */
     uint8_t index_count;     /* 33 */
     uint8_t page_index;      /* 34 */
     uint8_t transform;       /* 35: orientation — bit0=flipH, bit1=flipV, bit2=diagonal */
@@ -83,12 +83,13 @@ uint32_t nt_atlas_region_count(nt_resource_t atlas);
 uint8_t nt_atlas_page_count(nt_resource_t atlas);
 
 /* O(1) amortized lookup of a region by its name hash.
- * Returns NT_ATLAS_INVALID_REGION if the hash is not present (including
- * tombstoned regions that have been removed by a later merge). */
+ * Returns a stable index for any name that was ever present (alive -> live
+ * index; removed -> dead index that draws nothing; revived -> the SAME index).
+ * NT_ATLAS_INVALID_REGION only for names never present. */
 uint32_t nt_atlas_find_region(nt_resource_t atlas, uint64_t name_hash);
 
 /* O(1) pointer access by region index.
- * Always returns a non-NULL pointer when index < region_count. Tombstoned
+ * Always returns a non-NULL pointer when index < region_count. Dead/removed
  * regions return a struct with vertex_count==0 / index_count==0 — the renderer
  * naturally produces zero draws without a NULL branch in the hot path.
  * Out-of-range indices trip NT_ASSERT (caller bug). */

--- a/engine/atlas/nt_atlas.h
+++ b/engine/atlas/nt_atlas.h
@@ -18,13 +18,23 @@
 
 /* ---- Public types ---- */
 
-/* Canonical "sprite-in-atlas" identity — an atlas resource handle paired with a region index.
- * atlas.id == 0 is the unset/invalid handle; consumers assign their own meaning to it. */
+/* Self-resolving "sprite-in-atlas" handle. region==NT_ATLAS_INVALID_REGION resolves lazily under
+ * is_ready and memoizes back into ref->region (the type's defined contract, not a hidden side-effect);
+ * atlas.id==0 = unset/no-art. Field order {name_hash, atlas, region} packs to 16 B with zero padding. */
 typedef struct {
-    nt_resource_t atlas;
-    uint32_t region;
+    uint64_t name_hash;  /*  0: xxh64 of region name (stable identity) */
+    nt_resource_t atlas; /*  8: handle; may be set BEFORE atlas data loads */
+    uint32_t region;     /* 12: NT_ATLAS_INVALID_REGION = resolve lazily; else resolved index */
 } nt_atlas_region_ref_t;
-_Static_assert(sizeof(nt_atlas_region_ref_t) == 8, "nt_atlas_region_ref_t stable ABI (4B handle + 4B region)");
+_Static_assert(sizeof(nt_atlas_region_ref_t) == 16, "nt_atlas_region_ref_t stable ABI (8B hash + 4B handle + 4B region)");
+
+/* Construct unresolved: region=INVALID resolves lazily on first emit under a ready atlas. */
+static inline nt_atlas_region_ref_t nt_atlas_ref(nt_resource_t atlas, uint64_t name_hash) { return (nt_atlas_region_ref_t){.name_hash = name_hash, .atlas = atlas, .region = NT_ATLAS_INVALID_REGION}; }
+
+/* Construct pre-resolved with a known index (skips the lazy probe). */
+static inline nt_atlas_region_ref_t nt_atlas_ref_idx(nt_resource_t atlas, uint64_t name_hash, uint32_t region) {
+    return (nt_atlas_region_ref_t){.name_hash = name_hash, .atlas = atlas, .region = region};
+}
 
 /* Mirrors NtAtlasVertex from shared/include/nt_atlas_format.h (8 bytes, same field order).
  * Runtime stores it identically; nt_atlas precomputes float positions/UVs before sprite batching.
@@ -87,6 +97,16 @@ uint8_t nt_atlas_page_count(nt_resource_t atlas);
  * index; removed -> dead index that draws nothing; revived -> the SAME index).
  * NT_ATLAS_INVALID_REGION only for names never present. */
 uint32_t nt_atlas_find_region(nt_resource_t atlas, uint64_t name_hash);
+
+/* Resolve-and-memoize: if unresolved and the atlas is ready, find by name and write the index back
+ * into the ref. After return, region is a valid index (emit) or still INVALID (caller skips emit:
+ * atlas not ready or bad name). One-shot — tombstone-reclaim keeps the index stable for life, so
+ * there is no revision compare. */
+static inline void nt_atlas_resolve_ref(nt_atlas_region_ref_t *ref) {
+    if (ref->region == NT_ATLAS_INVALID_REGION && ref->atlas.id != 0U && nt_resource_is_ready(ref->atlas)) {
+        ref->region = nt_atlas_find_region(ref->atlas, ref->name_hash);
+    }
+}
 
 /* O(1) pointer access by region index.
  * Always returns a non-NULL pointer when index < region_count. Dead/removed

--- a/engine/atlas/nt_atlas.h
+++ b/engine/atlas/nt_atlas.h
@@ -113,8 +113,9 @@ static inline void nt_atlas_resolve_ref(nt_atlas_region_ref_t *ref) {
          * valid (dead) index, so INVALID here means the name was never packed. Dev-only warn; release stays a
          * silent skip so a missing optional asset never traps a shipped game. */
         if (ref->region == NT_ATLAS_INVALID_REGION) {
-            /* Plain (domain-less) variant: this inline is included by game/example TUs that do not define NT_LOG_DOMAIN. */
-            nt_log_warn_once("nt_atlas_resolve_ref: name_hash 0x%016llx not present in ready atlas %u (typo?)", (unsigned long long)ref->name_hash, (unsigned)ref->atlas.id);
+            /* Per-message dedup via nt_log: each distinct name_hash warns once. Plain variant — this
+             * inline lands in game/example TUs without NT_LOG_DOMAIN. */
+            nt_log_warn_unique("nt_atlas_resolve_ref: name_hash 0x%016llx not present in ready atlas %u (typo?)", (unsigned long long)ref->name_hash, (unsigned)ref->atlas.id);
         }
 #endif
     }

--- a/engine/log/CMakeLists.txt
+++ b/engine/log/CMakeLists.txt
@@ -8,6 +8,9 @@ nt_add_module(nt_log LOG_DOMAIN "log"
     nt_log.h
 )
 
+# Real impl dedups nt_log_write_unique by xxHash64 of the message; the stub stays dep-free.
+target_link_libraries(nt_log PRIVATE nt_hash)
+
 nt_add_module(nt_log_stub LOG_DOMAIN "log_stub"
     stub/nt_log_stub.c
     nt_log.h

--- a/engine/log/default/nt_log.c
+++ b/engine/log/default/nt_log.c
@@ -1,4 +1,5 @@
 #include "log/nt_log.h"
+#include "hash/nt_hash.h"
 #include <stdarg.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -80,15 +81,6 @@ static uint64_t s_unique_hashes[NT_LOG_UNIQUE_MAX];
 static uint32_t s_unique_count;
 static bool s_unique_saturated;
 
-static uint64_t nt_log_msg_hash(const char *s, size_t len) {
-    uint64_t h = 1469598103934665603ULL; /* FNV-1a 64 offset basis */
-    for (size_t i = 0; i < len; i++) {
-        h ^= (uint8_t)s[i];
-        h *= 1099511628211ULL; /* FNV prime */
-    }
-    return h;
-}
-
 bool nt_log_write_unique(nt_log_level_t level, const char *domain, const char *fmt, ...) {
     if (s_log_level > level || level >= NT_LOG_LEVEL_NONE) {
         return false; /* filtered: don't record, so it can still log if the level is lowered later */
@@ -102,7 +94,7 @@ bool nt_log_write_unique(nt_log_level_t level, const char *domain, const char *f
         return false;
     }
     const size_t len = (written < (int)sizeof(msg)) ? (size_t)written : sizeof(msg) - 1;
-    const uint64_t h = nt_log_msg_hash(msg, len);
+    const uint64_t h = nt_hash64(msg, (uint32_t)len).value;
     for (uint32_t i = 0; i < s_unique_count; i++) {
         if (s_unique_hashes[i] == h) {
             return false; /* this exact message already logged */

--- a/engine/log/default/nt_log.c
+++ b/engine/log/default/nt_log.c
@@ -1,5 +1,6 @@
 #include "log/nt_log.h"
 #include <stdarg.h>
+#include <stdint.h>
 #include <stdio.h>
 
 #ifdef __EMSCRIPTEN__
@@ -67,4 +68,54 @@ void nt_log_write(nt_log_level_t level, const char *domain, const char *fmt, ...
         (void)fprintf(stream, "%s %s\n", level_names[level], msg);
     }
 #endif
+}
+
+/* Content-dedup for nt_log_write_unique: remembers message HASHES (not full text), so each
+ * distinct message logs once. Saturates without eviction — N distinct messages already means
+ * "go look", further ones add no signal. Single-threaded (same assumption as NT_LOG_ONCE_). */
+#ifndef NT_LOG_UNIQUE_MAX
+#define NT_LOG_UNIQUE_MAX 1024
+#endif
+static uint64_t s_unique_hashes[NT_LOG_UNIQUE_MAX];
+static uint32_t s_unique_count;
+static bool s_unique_saturated;
+
+static uint64_t nt_log_msg_hash(const char *s, size_t len) {
+    uint64_t h = 1469598103934665603ULL; /* FNV-1a 64 offset basis */
+    for (size_t i = 0; i < len; i++) {
+        h ^= (uint8_t)s[i];
+        h *= 1099511628211ULL; /* FNV prime */
+    }
+    return h;
+}
+
+bool nt_log_write_unique(nt_log_level_t level, const char *domain, const char *fmt, ...) {
+    if (s_log_level > level || level >= NT_LOG_LEVEL_NONE) {
+        return false; /* filtered: don't record, so it can still log if the level is lowered later */
+    }
+    char msg[NT_LOG_BUF_SIZE];
+    va_list args;
+    va_start(args, fmt);
+    int written = vsnprintf(msg, sizeof(msg), fmt, args);
+    va_end(args);
+    if (written < 0) {
+        return false;
+    }
+    const size_t len = (written < (int)sizeof(msg)) ? (size_t)written : sizeof(msg) - 1;
+    const uint64_t h = nt_log_msg_hash(msg, len);
+    for (uint32_t i = 0; i < s_unique_count; i++) {
+        if (s_unique_hashes[i] == h) {
+            return false; /* this exact message already logged */
+        }
+    }
+    if (s_unique_count == NT_LOG_UNIQUE_MAX) {
+        if (!s_unique_saturated) {
+            s_unique_saturated = true;
+            nt_log_write(NT_LOG_LEVEL_WARN, NULL, "nt_log: unique-dedup saturated at %d messages, suppressing further", NT_LOG_UNIQUE_MAX);
+        }
+        return false;
+    }
+    s_unique_hashes[s_unique_count++] = h;
+    nt_log_write(level, domain, "%s", msg);
+    return true;
 }

--- a/engine/log/nt_log.h
+++ b/engine/log/nt_log.h
@@ -24,6 +24,11 @@ void nt_log_set_level(nt_log_level_t level);
 /* --- Single log function --- */
 void nt_log_write(nt_log_level_t level, const char *domain, const char *fmt, ...) NT_PRINTF_ATTR(3, 4);
 
+/* Write the formatted message at most once per distinct content, program-wide (dedups by the
+ * produced string, unlike the per-call-site *_once macros). Returns true if it actually wrote.
+ * Bounded + saturating; single-threaded (same assumption as NT_LOG_ONCE_). */
+bool nt_log_write_unique(nt_log_level_t level, const char *domain, const char *fmt, ...) NT_PRINTF_ATTR(3, 4);
+
 /* --- Plain macros (no domain, for game/example code) --- */
 #define nt_log_info(...) nt_log_write(NT_LOG_LEVEL_INFO, NULL, __VA_ARGS__)
 #define nt_log_warn(...) nt_log_write(NT_LOG_LEVEL_WARN, NULL, __VA_ARGS__)
@@ -46,6 +51,11 @@ void nt_log_write(nt_log_level_t level, const char *domain, const char *fmt, ...
 #define nt_log_warn_once(...) NT_LOG_ONCE_(nt_log_write(NT_LOG_LEVEL_WARN, NULL, __VA_ARGS__))
 #define nt_log_error_once(...) NT_LOG_ONCE_(nt_log_write(NT_LOG_LEVEL_ERROR, NULL, __VA_ARGS__))
 
+/* --- Content-deduped variants (dedup by message text, program-wide) --- */
+#define nt_log_info_unique(...) nt_log_write_unique(NT_LOG_LEVEL_INFO, NULL, __VA_ARGS__)
+#define nt_log_warn_unique(...) nt_log_write_unique(NT_LOG_LEVEL_WARN, NULL, __VA_ARGS__)
+#define nt_log_error_unique(...) nt_log_write_unique(NT_LOG_LEVEL_ERROR, NULL, __VA_ARGS__)
+
 /* --- Domain resolution --- */
 #ifndef NT_LOG_DOMAIN
 #ifdef NT_LOG_DOMAIN_DEFAULT
@@ -61,6 +71,9 @@ void nt_log_write(nt_log_level_t level, const char *domain, const char *fmt, ...
 #define NT_LOG_INFO_ONCE(...) NT_LOG_ONCE_(NT_LOG_INFO(__VA_ARGS__))
 #define NT_LOG_WARN_ONCE(...) NT_LOG_ONCE_(NT_LOG_WARN(__VA_ARGS__))
 #define NT_LOG_ERROR_ONCE(...) NT_LOG_ONCE_(NT_LOG_ERROR(__VA_ARGS__))
+#define NT_LOG_INFO_UNIQUE(...) nt_log_write_unique(NT_LOG_LEVEL_INFO, NT_LOG_DOMAIN, __VA_ARGS__)
+#define NT_LOG_WARN_UNIQUE(...) nt_log_write_unique(NT_LOG_LEVEL_WARN, NT_LOG_DOMAIN, __VA_ARGS__)
+#define NT_LOG_ERROR_UNIQUE(...) nt_log_write_unique(NT_LOG_LEVEL_ERROR, NT_LOG_DOMAIN, __VA_ARGS__)
 #else
 /* Compile error when domain macros used without domain defined */
 #define NT_LOG_INFO(...)                                                                                                                                                                               \

--- a/engine/log/stub/nt_log_stub.c
+++ b/engine/log/stub/nt_log_stub.c
@@ -7,3 +7,10 @@ void nt_log_write(nt_log_level_t level, const char *domain, const char *fmt, ...
     (void)domain;
     (void)fmt;
 }
+
+bool nt_log_write_unique(nt_log_level_t level, const char *domain, const char *fmt, ...) {
+    (void)level;
+    (void)domain;
+    (void)fmt;
+    return false;
+}

--- a/engine/sprite_comp/nt_sprite_comp.c
+++ b/engine/sprite_comp/nt_sprite_comp.c
@@ -248,7 +248,7 @@ void nt_sprite_comp_set_region(nt_entity_t entity, nt_resource_t atlas, uint16_t
     NT_ASSERT(region_index < nt_atlas_region_count(atlas) && "sprite region index out of range");
 
     const nt_texture_region_t *region = nt_atlas_get_region(atlas, region_index);
-    NT_ASSERT(region->name_hash != NT_ATLAS_TOMBSTONE_HASH && "sprite region points at a tombstone");
+    NT_ASSERT(region->vertex_count != 0 && "sprite region is dead/removed (vertex_count==0, draws nothing)");
 
     s_atlas[idx] = atlas;
     s_region_hash[idx] = region->name_hash;

--- a/engine/ui/nt_ui_button.c
+++ b/engine/ui/nt_ui_button.c
@@ -30,7 +30,7 @@ static void assert_state_valid(const nt_ui_btn_state_t *st, const char *which) {
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-void nt_ui_button_begin(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint32_t id, const nt_ui_button_style_t *style, const Clay_ElementDeclaration *decl, bool enabled) {
+void nt_ui_button_begin(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint32_t id, nt_ui_button_style_t *style, const Clay_ElementDeclaration *decl, bool enabled) {
     NT_ASSERT(ctx != NULL && "nt_ui_button_begin: ctx must be non-NULL");
     NT_ASSERT(ctx->in_frame && ctx == nt_ui_internal_get_inframe_ctx() && "nt_ui_button_begin: must be called between nt_ui_begin and nt_ui_end on the active ctx");
     NT_ASSERT(style != NULL && "nt_ui_button_begin: style must be non-NULL");
@@ -64,8 +64,8 @@ void nt_ui_button_begin(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, 
         nt_ui_debug_record_disabled_zone(ctx, id, style->hit_padding_lrtb);
     }
 
-    /* Priority: disabled → pressed → hover → idle. */
-    const nt_ui_btn_state_t *st = &style->idle;
+    /* Priority: disabled → pressed → hover → idle. Non-const so the resolve memoizes into the style. */
+    nt_ui_btn_state_t *st = &style->idle;
     if (!enabled) {
         st = &style->disabled;
     } else if (in.pressed) {
@@ -107,6 +107,10 @@ void nt_ui_button_begin(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, 
     const nt_ui_element_data_t *btn_data = nt_ui_make_element_data_xform((data != NULL) ? data->layer : 0U, (data != NULL) ? data->user_data : NULL, &btn_t, a->opacity);
     // #endregion
     // #region open_clay_image
+    /* Resolve the STYLE-OWNED refs in place FIRST (memoizes into the style), then inherit by value —
+     * resolving the by-value bg would lose the memoize (Pitfall 1). */
+    nt_atlas_resolve_ref(&st->bg);
+    nt_atlas_resolve_ref(&style->idle.bg);
     /* Atomic ref: a non-idle state with atlas.id==0 inherits the idle state's whole ref. */
     const nt_atlas_region_ref_t bg = nt_ui_ref_or(st->bg, style->idle.bg);
     const nt_resource_t st_atlas = bg.atlas;
@@ -116,8 +120,9 @@ void nt_ui_button_begin(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, 
 
     Clay_ElementDeclaration final = (decl != NULL) ? *decl : (Clay_ElementDeclaration){0};
     final.id = (Clay_ElementId){.id = id};
-    /* Resolved atlas.id == 0 = text-only button: no background art, no IMAGE payload. */
-    if (st_atlas.id != 0U) {
+    /* Resolved atlas.id == 0 = text-only button (no art). region still INVALID = atlas not ready yet:
+     * skip the IMAGE this frame (mirror the image skip) rather than emit an invalid region_index. */
+    if (st_atlas.id != 0U && region != NT_ATLAS_INVALID_REGION) {
         nt_ui_image_payload_t *p = NT_MEM_SCRATCH_ALLOC(nt_ui_image_payload_t);
         NT_ASSERT(p != NULL && "nt_ui_button_begin: scratch alloc failed (image_payload)");
         *p = (nt_ui_image_payload_t){
@@ -152,7 +157,7 @@ bool nt_ui_button_end(nt_ui_context_t *ctx) {
     return clicked;
 }
 
-bool nt_ui_button(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint32_t id, const nt_ui_button_style_t *style, const Clay_ElementDeclaration *decl, bool enabled) {
+bool nt_ui_button(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint32_t id, nt_ui_button_style_t *style, const Clay_ElementDeclaration *decl, bool enabled) {
     nt_ui_button_begin(ctx, data, id, style, decl, enabled);
     return nt_ui_button_end(ctx);
 }

--- a/engine/ui/nt_ui_button.c
+++ b/engine/ui/nt_ui_button.c
@@ -108,7 +108,7 @@ void nt_ui_button_begin(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, 
     // #endregion
     // #region open_clay_image
     /* Resolve the STYLE-OWNED refs in place FIRST (memoizes into the style), then inherit by value —
-     * resolving the by-value bg would lose the memoize (Pitfall 1). */
+     * resolving the by-value bg would lose the memoize. */
     nt_atlas_resolve_ref(&st->bg);
     nt_atlas_resolve_ref(&style->idle.bg);
     /* Atomic ref: a non-idle state with atlas.id==0 inherits the idle state's whole ref. */

--- a/engine/ui/nt_ui_button.h
+++ b/engine/ui/nt_ui_button.h
@@ -33,15 +33,17 @@ typedef struct {
     /* Multiplies the atlas region's baked slice9 borders. */
     float slice9_scale;
 } nt_ui_button_style_t;
+_Static_assert(sizeof(nt_ui_btn_state_t) == 40, "nt_ui_btn_state_t stable ABI (16 ref + tint + 4 float + 8B align pad)");
+_Static_assert(sizeof(nt_ui_button_style_t) == 176, "nt_ui_button_style_t stable ABI");
 
 /* enabled=false short-circuits interaction and forces the disabled visual.
  * Engine OWNS .id/.image/.backgroundColor/.userData on the Clay decl.
  * style->idle.bg.atlas.id == 0 = text-only button (no background IMAGE emitted);
  * other states inherit idle when their bg.atlas.id == 0. */
-void nt_ui_button_begin(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint32_t id, const nt_ui_button_style_t *style, const Clay_ElementDeclaration *decl, bool enabled);
+void nt_ui_button_begin(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint32_t id, nt_ui_button_style_t *style, const Clay_ElementDeclaration *decl, bool enabled);
 bool nt_ui_button_end(nt_ui_context_t *ctx);
 
 /* Content-less button (slice9 bg only). Returns clicked. Same args as begin. */
-bool nt_ui_button(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint32_t id, const nt_ui_button_style_t *style, const Clay_ElementDeclaration *decl, bool enabled);
+bool nt_ui_button(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint32_t id, nt_ui_button_style_t *style, const Clay_ElementDeclaration *decl, bool enabled);
 
 #endif /* NT_UI_BUTTON_H */

--- a/engine/ui/nt_ui_checkbox.c
+++ b/engine/ui/nt_ui_checkbox.c
@@ -224,7 +224,7 @@ static void cb_core(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint
     *out_clicked = in.clicked;
     // #endregion
     // #region value-row + state pick
-    /* Non-const row so the resolve memoizes into the style-owned cell refs (Pitfall 1). */
+    /* Non-const row so the resolve memoizes into the style-owned cell refs. */
     nt_ui_cb_state_t *row = value_is_checked ? style->checked : style->unchecked;
     int state = NT_UI_CB_IDLE;
     if (!enabled) {

--- a/engine/ui/nt_ui_checkbox.c
+++ b/engine/ui/nt_ui_checkbox.c
@@ -103,8 +103,8 @@ static void cb_emit_box(const cb_emit_args_t *e) {
                 .childAlignment = {align_x, CLAY_ALIGN_Y_CENTER},
             },
     };
-    /* No-art terminal: resolved box atlas.id == 0 => skip the IMAGE. */
-    if (e->box_ref.atlas.id != 0U) {
+    /* No-art terminal: atlas.id == 0 => skip the IMAGE. region still INVALID = atlas not ready: skip too. */
+    if (e->box_ref.atlas.id != 0U && e->box_ref.region != NT_ATLAS_INVALID_REGION) {
         nt_ui_image_payload_t *p = NT_MEM_SCRATCH_ALLOC(nt_ui_image_payload_t);
         NT_ASSERT(p != NULL && "nt_ui_checkbox: scratch alloc failed (box payload)");
         *p = (nt_ui_image_payload_t){.atlas = e->box_ref.atlas, .region_index = e->box_ref.region, .slice9_scale = 1.0F};
@@ -183,7 +183,7 @@ static void cb_emit_text(const cb_emit_args_t *e) {
  *   out_clicked        receives the release-over-widget edge for the wrapper. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void cb_core(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint8_t label_layer, uint32_t id, const char *label, bool value_is_checked, bool is_toggle, const nt_ui_widget_def_t *def,
-                    const nt_ui_checkbox_style_t *style, const Clay_ElementDeclaration *decl, bool enabled, bool *out_clicked) {
+                    nt_ui_checkbox_style_t *style, const Clay_ElementDeclaration *decl, bool enabled, bool *out_clicked) {
     // #region entry asserts
     NT_ASSERT(ctx != NULL && "nt_ui_checkbox: ctx must be non-NULL");
     NT_ASSERT(ctx->in_frame && ctx == nt_ui_internal_get_inframe_ctx() && "nt_ui_checkbox: must be called between nt_ui_begin and nt_ui_end on the active ctx");
@@ -224,7 +224,8 @@ static void cb_core(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint
     *out_clicked = in.clicked;
     // #endregion
     // #region value-row + state pick
-    const nt_ui_cb_state_t *row = value_is_checked ? style->checked : style->unchecked;
+    /* Non-const row so the resolve memoizes into the style-owned cell refs (Pitfall 1). */
+    nt_ui_cb_state_t *row = value_is_checked ? style->checked : style->unchecked;
     int state = NT_UI_CB_IDLE;
     if (!enabled) {
         state = NT_UI_CB_DISABLED;
@@ -233,7 +234,12 @@ static void cb_core(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint
     } else if (in.hovered) {
         state = NT_UI_CB_HOVER;
     }
-    const nt_ui_cb_state_t *cell = &row[state];
+    nt_ui_cb_state_t *cell = &row[state];
+    /* Resolve the STYLE-OWNED cell + idle-row terminal refs in place BEFORE the inherit pick. */
+    nt_atlas_resolve_ref(&cell->box);
+    nt_atlas_resolve_ref(&cell->check);
+    nt_atlas_resolve_ref(&row[NT_UI_CB_IDLE].box);
+    nt_atlas_resolve_ref(&row[NT_UI_CB_IDLE].check);
     const nt_atlas_region_ref_t box_ref = nt_ui_ref_or(cell->box, row[NT_UI_CB_IDLE].box);
     const nt_atlas_region_ref_t check_ref = nt_ui_ref_or(cell->check, row[NT_UI_CB_IDLE].check);
     // #endregion
@@ -311,7 +317,7 @@ static void cb_core(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint
     nt_ui_clay_priv_close_element(); /* close ROW */
 }
 
-bool nt_ui_checkbox(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint8_t label_layer, uint32_t id, const char *label, bool *value, const nt_ui_checkbox_style_t *style,
+bool nt_ui_checkbox(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint8_t label_layer, uint32_t id, const char *label, bool *value, nt_ui_checkbox_style_t *style,
                     const Clay_ElementDeclaration *decl, bool enabled) {
     NT_ASSERT(value != NULL && "nt_ui_checkbox: value must be non-NULL");
     bool clicked = false;
@@ -323,7 +329,7 @@ bool nt_ui_checkbox(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint
     return false;
 }
 
-bool nt_ui_radio(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint8_t label_layer, uint32_t id, const char *label, int *selected, int my_value, const nt_ui_checkbox_style_t *style,
+bool nt_ui_radio(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint8_t label_layer, uint32_t id, const char *label, int *selected, int my_value, nt_ui_checkbox_style_t *style,
                  const Clay_ElementDeclaration *decl, bool enabled) {
     NT_ASSERT(selected != NULL && "nt_ui_radio: selected must be non-NULL");
     /* Exclusivity is FREE: every radio in the group reads the same *selected, so
@@ -339,7 +345,7 @@ bool nt_ui_radio(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint8_t
     return false;
 }
 
-bool nt_ui_toggle(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint8_t label_layer, uint32_t id, const char *label, bool *value, const nt_ui_checkbox_style_t *style,
+bool nt_ui_toggle(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint8_t label_layer, uint32_t id, const char *label, bool *value, nt_ui_checkbox_style_t *style,
                   const Clay_ElementDeclaration *decl, bool enabled) {
     NT_ASSERT(value != NULL && "nt_ui_toggle: value must be non-NULL");
     /* Same value logic as checkbox; is_toggle=true drives the always-visible

--- a/engine/ui/nt_ui_checkbox.c
+++ b/engine/ui/nt_ui_checkbox.c
@@ -143,7 +143,9 @@ static void cb_emit_box(const cb_emit_args_t *e) {
         const Clay_ElementDeclaration ov_decl = {
             .layout = {.sizing = {CLAY_SIZING_FIXED(e->style->overlay_w), CLAY_SIZING_FIXED(e->style->overlay_h)}},
         };
-        nt_ui_image(e->ctx, ov_data, e->check_ref, &ov_style, &ov_decl);
+        /* check_ref is already resolved in cb_core; the by-pointer image API needs a mutable lvalue. */
+        nt_atlas_region_ref_t ov_ref = e->check_ref;
+        nt_ui_image(e->ctx, ov_data, &ov_ref, &ov_style, &ov_decl);
     }
 
     nt_ui_clay_priv_close_element();

--- a/engine/ui/nt_ui_checkbox.h
+++ b/engine/ui/nt_ui_checkbox.h
@@ -37,7 +37,7 @@ typedef struct {
     float scale, offset_x, offset_y; /* whole-widget render-only transform */
     float opacity;                   /* whole-widget, INHERITS to children */
 } nt_ui_cb_state_t;
-_Static_assert(sizeof(nt_ui_cb_state_t) == 44, "nt_ui_cb_state_t stable ABI (2x8 ref + 3 tint + 4 float)");
+_Static_assert(sizeof(nt_ui_cb_state_t) == 64, "nt_ui_cb_state_t stable ABI (2x16 ref + 3 tint + 4 float + 8B align pad)");
 
 /* ONE shared style for all three widgets (strict superset). Layout
  * sizing/padding live on the Clay decl; the FIXED box_w/box_h size only the
@@ -58,7 +58,7 @@ typedef struct {
 /* scale_label occupies one of label_side's former tail padding bytes -> size unchanged.
  * Layers are NOT in the style (mirrors button/label): the indicator layer comes from
  * data->layer, the label layer from the label_layer function arg. */
-_Static_assert(sizeof(nt_ui_checkbox_style_t) == 420, "nt_ui_checkbox_style_t stable ABI");
+_Static_assert(sizeof(nt_ui_checkbox_style_t) == 584, "nt_ui_checkbox_style_t stable ABI");
 
 /* All three are LEAF widgets (no begin/end). Returns `changed` = the frame the value
  * flipped (checkbox/toggle: *value = !*value; radio: *selected = my_value).

--- a/engine/ui/nt_ui_checkbox.h
+++ b/engine/ui/nt_ui_checkbox.h
@@ -77,16 +77,16 @@ _Static_assert(sizeof(nt_ui_checkbox_style_t) == 584, "nt_ui_checkbox_style_t st
  * data->flags must NOT set HAS_TRANSFORM/HAS_OPACITY (the widget owns these).
  * box_w/box_h > 0 required; each value row needs box.idle OR check.idle non-zero.
  * enabled=false short-circuits interaction + forces the disabled cell. */
-bool nt_ui_checkbox(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint8_t label_layer, uint32_t id, const char *label, bool *value, const nt_ui_checkbox_style_t *style,
+bool nt_ui_checkbox(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint8_t label_layer, uint32_t id, const char *label, bool *value, nt_ui_checkbox_style_t *style,
                     const Clay_ElementDeclaration *decl, bool enabled);
 
 /* Exclusive single-choice over a shared int*. changed when *selected flips to my_value. */
-bool nt_ui_radio(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint8_t label_layer, uint32_t id, const char *label, int *selected, int my_value, const nt_ui_checkbox_style_t *style,
+bool nt_ui_radio(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint8_t label_layer, uint32_t id, const char *label, int *selected, int my_value, nt_ui_checkbox_style_t *style,
                  const Clay_ElementDeclaration *decl, bool enabled);
 
 /* Sliding-thumb boolean. Same return contract as checkbox; the thumb x is a
  * render-only offset DELTA eased by value_t. */
-bool nt_ui_toggle(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint8_t label_layer, uint32_t id, const char *label, bool *value, const nt_ui_checkbox_style_t *style,
+bool nt_ui_toggle(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint8_t label_layer, uint32_t id, const char *label, bool *value, nt_ui_checkbox_style_t *style,
                   const Clay_ElementDeclaration *decl, bool enabled);
 
 /* A valid baseline style: every cell scale/opacity = 1, no tint, sensible sizes and

--- a/engine/ui/nt_ui_image.c
+++ b/engine/ui/nt_ui_image.c
@@ -16,11 +16,11 @@ const nt_ui_widget_def_t NT_UI_IMAGE_DEF = {
 };
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-void nt_ui_image(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, nt_atlas_region_ref_t region, const nt_ui_image_style_t *style, const Clay_ElementDeclaration *decl) {
+void nt_ui_image(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, nt_atlas_region_ref_t *region, const nt_ui_image_style_t *style, const Clay_ElementDeclaration *decl) {
     NT_ASSERT(ctx != NULL && "nt_ui_image: ctx must be non-NULL");
     NT_ASSERT(ctx->in_frame && ctx == nt_ui_internal_get_inframe_ctx() && "nt_ui_image: must be called between nt_ui_begin and nt_ui_end on the active ctx");
     NT_ASSERT(style != NULL && "nt_ui_image: style must be non-NULL");
-    NT_ASSERT(region.atlas.id != 0 && "nt_ui_image: invalid atlas handle");
+    NT_ASSERT(region != NULL && region->atlas.id != 0 && "nt_ui_image: invalid atlas handle");
     NT_ASSERT(isfinite(style->slice9_scale) && style->slice9_scale > 0.0F && "nt_ui_image: style.slice9_scale must be finite > 0");
     if (style->flags & NT_UI_IMAGE_ORIGIN_OVERRIDE) {
         NT_ASSERT(isfinite(style->origin_x) && isfinite(style->origin_y) && "nt_ui_image: ORIGIN_OVERRIDE -> style.origin_{x,y} must be finite");
@@ -32,11 +32,17 @@ void nt_ui_image(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, nt_atla
         NT_ASSERT(decl->userData == NULL && "nt_ui_image: decl->userData must be NULL (data param controls)");
     }
 
+    /* Late-bind: resolve lazily, memoize into *region. Unresolved (atlas not ready or bad name) -> skip emit. */
+    nt_atlas_resolve_ref(region);
+    if (region->region == NT_ATLAS_INVALID_REGION) {
+        return;
+    }
+
     nt_ui_image_payload_t *p = NT_MEM_SCRATCH_ALLOC(nt_ui_image_payload_t);
     NT_ASSERT(p != NULL && "nt_ui_image: scratch alloc failed");
     *p = (nt_ui_image_payload_t){
-        .atlas = region.atlas,
-        .region_index = region.region,
+        .atlas = region->atlas,
+        .region_index = region->region,
         .origin_x = style->origin_x,
         .origin_y = style->origin_y,
         .slice9_scale = style->slice9_scale,

--- a/engine/ui/nt_ui_image.h
+++ b/engine/ui/nt_ui_image.h
@@ -31,7 +31,8 @@ _Static_assert(sizeof(nt_ui_image_style_t) <= 28, "nt_ui_image_style_t fits in 2
 /* Use instead of bare {0} — color_packed=0 would render fully transparent. */
 static inline nt_ui_image_style_t nt_ui_image_style_defaults(void) { return (nt_ui_image_style_t){.color_packed = 0xFFFFFFFF, .origin_x = 0.5F, .origin_y = 0.5F, .slice9_scale = 1.0F}; }
 
-/* decl may be NULL (GROW/GROW); engine owns image/backgroundColor/userData. */
-void nt_ui_image(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, nt_atlas_region_ref_t region, const nt_ui_image_style_t *style, const Clay_ElementDeclaration *decl);
+/* decl may be NULL (GROW/GROW); engine owns image/backgroundColor/userData.
+ * region is by-pointer: the engine resolves it lazily and memoizes the index into *region. */
+void nt_ui_image(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, nt_atlas_region_ref_t *region, const nt_ui_image_style_t *style, const Clay_ElementDeclaration *decl);
 
 #endif /* NT_UI_IMAGE_H */

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -90,8 +90,8 @@ static inline Clay_Color nt_ui_unpack_abgr(uint32_t packed) {
  * (the walker maps a {0,0,0,0} backgroundColor back to white). Text must NOT use this. */
 static inline Clay_Color nt_ui_unpack_tint(uint32_t packed) { return (packed == 0xFFFFFFFFU) ? (Clay_Color){0} : nt_ui_unpack_abgr(packed); }
 
-/* Atomic ref inherit: `ref` if its atlas is set, else `fallback`. Keyed on atlas.id
- * (region 0 is a valid index, so it can't double as the "unset" sentinel). */
+/* Atomic ref inherit: copies the WHOLE ref (incl. name_hash + memoized region) if its atlas is set,
+ * else `fallback`. Keyed on atlas.id (region 0 is a valid index, so it can't double as "unset"). */
 static inline nt_atlas_region_ref_t nt_ui_ref_or(nt_atlas_region_ref_t ref, nt_atlas_region_ref_t fallback) { return (ref.atlas.id != 0U) ? ref : fallback; }
 
 /* Identity baked xform — DFS seed + walker OOB fallback. */

--- a/engine/ui/nt_ui_panel.c
+++ b/engine/ui/nt_ui_panel.c
@@ -21,11 +21,11 @@ const nt_ui_widget_def_t NT_UI_GROUP_DEF = {
 };
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-void nt_ui_panel_begin(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, nt_atlas_region_ref_t region, const nt_ui_image_style_t *style, const Clay_ElementDeclaration *decl) {
+void nt_ui_panel_begin(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, nt_atlas_region_ref_t *region, const nt_ui_image_style_t *style, const Clay_ElementDeclaration *decl) {
     NT_ASSERT(ctx != NULL && "nt_ui_panel_begin: ctx must be non-NULL");
     NT_ASSERT(ctx->in_frame && ctx == nt_ui_internal_get_inframe_ctx() && "nt_ui_panel_begin: must be called between nt_ui_begin and nt_ui_end on the active ctx");
     NT_ASSERT(style != NULL && "nt_ui_panel_begin: style must be non-NULL");
-    NT_ASSERT(region.atlas.id != 0 && "nt_ui_panel_begin: invalid atlas handle");
+    NT_ASSERT(region != NULL && region->atlas.id != 0 && "nt_ui_panel_begin: invalid atlas handle");
     NT_ASSERT(isfinite(style->slice9_scale) && style->slice9_scale > 0.0F && "nt_ui_panel_begin: style.slice9_scale must be finite > 0");
     if (style->flags & NT_UI_IMAGE_ORIGIN_OVERRIDE) {
         NT_ASSERT(isfinite(style->origin_x) && isfinite(style->origin_y) && "nt_ui_panel_begin: ORIGIN_OVERRIDE -> style.origin_{x,y} must be finite");
@@ -37,25 +37,29 @@ void nt_ui_panel_begin(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, n
         NT_ASSERT(decl->userData == NULL && "nt_ui_panel_begin: decl->userData must be NULL (data param controls)");
     }
 
-    nt_ui_image_payload_t *p = NT_MEM_SCRATCH_ALLOC(nt_ui_image_payload_t);
-    NT_ASSERT(p != NULL && "nt_ui_panel_begin: scratch alloc failed");
-    *p = (nt_ui_image_payload_t){
-        .atlas = region.atlas,
-        .region_index = region.region,
-        .origin_x = style->origin_x,
-        .origin_y = style->origin_y,
-        .slice9_scale = style->slice9_scale,
-        .flip_bits = style->flip_bits,
-        .flags = style->flags,
-    };
-    memcpy(p->slice9_override, style->slice9_lrtb, sizeof(p->slice9_override));
-
     const Clay_Color tint = nt_ui_unpack_tint(style->color_packed);
 
     Clay_ElementDeclaration final = (decl != NULL) ? *decl : (Clay_ElementDeclaration){0};
     final.backgroundColor = tint;
-    final.image = (Clay_ImageElementConfig){.imageData = p};
     final.userData = (void *)data;
+
+    /* Late-bind: resolve lazily, memoize into *region. Unresolved -> open the container with no bg IMAGE. */
+    nt_atlas_resolve_ref(region);
+    if (region->region != NT_ATLAS_INVALID_REGION) {
+        nt_ui_image_payload_t *p = NT_MEM_SCRATCH_ALLOC(nt_ui_image_payload_t);
+        NT_ASSERT(p != NULL && "nt_ui_panel_begin: scratch alloc failed");
+        *p = (nt_ui_image_payload_t){
+            .atlas = region->atlas,
+            .region_index = region->region,
+            .origin_x = style->origin_x,
+            .origin_y = style->origin_y,
+            .slice9_scale = style->slice9_scale,
+            .flip_bits = style->flip_bits,
+            .flags = style->flags,
+        };
+        memcpy(p->slice9_override, style->slice9_lrtb, sizeof(p->slice9_override));
+        final.image = (Clay_ImageElementConfig){.imageData = p};
+    }
     nt_ui_clay_priv_open_element();
     nt_ui_clay_priv_configure_open_element(final);
 

--- a/engine/ui/nt_ui_panel.h
+++ b/engine/ui/nt_ui_panel.h
@@ -15,8 +15,10 @@ typedef struct nt_ui_context nt_ui_context_t;
 extern const nt_ui_widget_def_t NT_UI_PANEL_DEF;
 extern const nt_ui_widget_def_t NT_UI_GROUP_DEF;
 
-/* Engine OWNS .image / .backgroundColor / .userData on the decl. */
-void nt_ui_panel_begin(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, nt_atlas_region_ref_t region, const nt_ui_image_style_t *style, const Clay_ElementDeclaration *decl);
+/* Engine OWNS .image / .backgroundColor / .userData on the decl.
+ * region is by-pointer: the engine resolves it lazily and memoizes the index into *region;
+ * an unresolved ref opens the container with no bg IMAGE (still balanced for end). */
+void nt_ui_panel_begin(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, nt_atlas_region_ref_t *region, const nt_ui_image_style_t *style, const Clay_ElementDeclaration *decl);
 void nt_ui_panel_end(nt_ui_context_t *ctx);
 
 /* Engine OWNS .custom (anchor) + .userData on the decl. */

--- a/examples/slice9_demo/main.c
+++ b/examples/slice9_demo/main.c
@@ -108,11 +108,14 @@ static nt_font_t s_font;
 static bool s_atlas_bound;
 static bool s_font_bound;
 static uint32_t s_white_region_idx;
-static uint32_t s_panel_beige_idx;
-static uint32_t s_panel_blue_idx;
-static uint32_t s_panel_brown_idx;
-static uint32_t s_button_blue_idx;
-static uint32_t s_button_green_idx;
+
+/* Late-bound art refs filled upfront (init_atlas_refs); mutable so the engine memoizes
+ * the resolved region index in place on first emit under a ready atlas. */
+static nt_atlas_region_ref_t s_panel_beige_ref;
+static nt_atlas_region_ref_t s_panel_blue_ref;
+static nt_atlas_region_ref_t s_panel_brown_ref;
+static nt_atlas_region_ref_t s_button_blue_ref;
+static nt_atlas_region_ref_t s_button_green_ref;
 
 #define LAYER_BG 0
 #define LAYER_IMG 1
@@ -130,7 +133,17 @@ static float s_time;
 // #endregion
 
 // #region binding
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+/* Fill the late-bound art refs upfront; the handle is valid before the data loads
+ * (D-58.1-01) and the widget resolves + memoizes the region lazily. */
+static void init_atlas_refs(void) {
+    s_panel_beige_ref = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_SLICE9_DEMO_ATLAS_PANEL_BEIGE.value);
+    s_panel_blue_ref = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_SLICE9_DEMO_ATLAS_PANEL_BLUE.value);
+    s_panel_brown_ref = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_SLICE9_DEMO_ATLAS_PANEL_BROWN.value);
+    s_button_blue_ref = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_SLICE9_DEMO_ATLAS_BUTTON_BLUE.value);
+    s_button_green_ref = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_SLICE9_DEMO_ATLAS_BUTTON_GREEN.value);
+}
+
+/* White-region + font stay is_ready-gated (white is the deferred path; font needs the loaded resource). */
 static void try_bind_resources(void) {
     if (s_atlas_bound && s_font_bound) {
         return;
@@ -139,18 +152,9 @@ static void try_bind_resources(void) {
     if (!s_atlas_bound && nt_resource_is_ready(s_atlas_handle)) {
         s_white_region_idx = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_SLICE9_DEMO_ATLAS__WHITE.value);
         NT_ASSERT(s_white_region_idx != NT_ATLAS_INVALID_REGION);
-
-        s_panel_beige_idx = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_SLICE9_DEMO_ATLAS_PANEL_BEIGE.value);
-        s_panel_blue_idx = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_SLICE9_DEMO_ATLAS_PANEL_BLUE.value);
-        s_panel_brown_idx = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_SLICE9_DEMO_ATLAS_PANEL_BROWN.value);
-        s_button_blue_idx = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_SLICE9_DEMO_ATLAS_BUTTON_BLUE.value);
-        s_button_green_idx = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_SLICE9_DEMO_ATLAS_BUTTON_GREEN.value);
-        NT_ASSERT(s_panel_beige_idx != NT_ATLAS_INVALID_REGION);
-        NT_ASSERT(s_button_blue_idx != NT_ATLAS_INVALID_REGION);
-
         nt_ui_set_atlas_white_region(s_ctx, s_atlas_handle, s_white_region_idx);
         s_atlas_bound = true;
-        nt_log_info("slice9_demo: atlas bound (5 Kenney regions + white)");
+        nt_log_info("slice9_demo: atlas white region bound");
     }
 
     if (!s_font_bound && nt_resource_is_ready(s_font_resource)) {
@@ -172,26 +176,16 @@ static void declare_static_panels(void) {
     CLAY({.id = CLAY_ID("static-row"),
           .layout = {.sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_FIT(0)}, .layoutDirection = CLAY_LEFT_TO_RIGHT, .childGap = 16, .childAlignment = {CLAY_ALIGN_X_CENTER, CLAY_ALIGN_Y_CENTER}}}) {
 
-        CLAY({.layout = {.sizing = {CLAY_SIZING_FIXED(80), CLAY_SIZING_FIXED(60)}}}) {
-            nt_ui_image(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), (nt_atlas_region_ref_t){s_atlas_handle, s_panel_beige_idx}, &g_panel_style, NULL);
-        }
-        CLAY({.layout = {.sizing = {CLAY_SIZING_FIXED(200), CLAY_SIZING_FIXED(70)}}}) {
-            nt_ui_image(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), (nt_atlas_region_ref_t){s_atlas_handle, s_panel_blue_idx}, &g_panel_style, NULL);
-        }
-        CLAY({.layout = {.sizing = {CLAY_SIZING_FIXED(350), CLAY_SIZING_FIXED(80)}}}) {
-            nt_ui_image(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), (nt_atlas_region_ref_t){s_atlas_handle, s_panel_brown_idx}, &g_panel_style, NULL);
-        }
+        CLAY({.layout = {.sizing = {CLAY_SIZING_FIXED(80), CLAY_SIZING_FIXED(60)}}}) { nt_ui_image(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), &s_panel_beige_ref, &g_panel_style, NULL); }
+        CLAY({.layout = {.sizing = {CLAY_SIZING_FIXED(200), CLAY_SIZING_FIXED(70)}}}) { nt_ui_image(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), &s_panel_blue_ref, &g_panel_style, NULL); }
+        CLAY({.layout = {.sizing = {CLAY_SIZING_FIXED(350), CLAY_SIZING_FIXED(80)}}}) { nt_ui_image(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), &s_panel_brown_ref, &g_panel_style, NULL); }
     }
 
     /* Kenney buttons */
     CLAY({.id = CLAY_ID("btn-row"),
           .layout = {.sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_FIT(0)}, .layoutDirection = CLAY_LEFT_TO_RIGHT, .childGap = 12, .childAlignment = {CLAY_ALIGN_X_CENTER, CLAY_ALIGN_Y_CENTER}}}) {
-        CLAY({.layout = {.sizing = {CLAY_SIZING_FIXED(160), CLAY_SIZING_FIXED(40)}}}) {
-            nt_ui_image(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), (nt_atlas_region_ref_t){s_atlas_handle, s_button_blue_idx}, &g_panel_style, NULL);
-        }
-        CLAY({.layout = {.sizing = {CLAY_SIZING_FIXED(250), CLAY_SIZING_FIXED(40)}}}) {
-            nt_ui_image(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), (nt_atlas_region_ref_t){s_atlas_handle, s_button_green_idx}, &g_panel_style, NULL);
-        }
+        CLAY({.layout = {.sizing = {CLAY_SIZING_FIXED(160), CLAY_SIZING_FIXED(40)}}}) { nt_ui_image(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), &s_button_blue_ref, &g_panel_style, NULL); }
+        CLAY({.layout = {.sizing = {CLAY_SIZING_FIXED(250), CLAY_SIZING_FIXED(40)}}}) { nt_ui_image(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), &s_button_green_ref, &g_panel_style, NULL); }
     }
 }
 // #endregion
@@ -228,7 +222,7 @@ static void declare_animated_panel(void) {
                          .childGap = 8,
                          .childAlignment = {CLAY_ALIGN_X_CENTER, CLAY_ALIGN_Y_CENTER}},
               .userData = (void *)NT_UI_DATA_XFORM(0U, &t, opacity)}) {
-            nt_ui_panel_begin(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), (nt_atlas_region_ref_t){s_atlas_handle, s_panel_brown_idx}, &g_panel_style, NULL);
+            nt_ui_panel_begin(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), &s_panel_brown_ref, &g_panel_style, NULL);
             {
                 nt_ui_label(s_ctx, NT_UI_DATA_LAYER(LAYER_TEXT), "Animated Panel", &g_panel_label_style);
                 nt_ui_label(s_ctx, NT_UI_DATA_LAYER(LAYER_TEXT), "Hello World", &g_child_label_style);
@@ -272,16 +266,16 @@ static void declare_nested_panels(void) {
         /* Outer beige panel — userData carries outer_t to all children via DFS. */
         CLAY({.layout = {.sizing = {CLAY_SIZING_FIXED(500), CLAY_SIZING_FIXED(140)}, .padding = CLAY_PADDING_ALL(12), .childAlignment = {CLAY_ALIGN_X_CENTER, CLAY_ALIGN_Y_CENTER}},
               .userData = (void *)NT_UI_DATA_XFORM(0U, &outer_t, 1.0F)}) {
-            nt_ui_panel_begin(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), (nt_atlas_region_ref_t){s_atlas_handle, s_panel_beige_idx}, &g_panel_style, NULL);
+            nt_ui_panel_begin(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), &s_panel_beige_ref, &g_panel_style, NULL);
             {
                 /* Middle blue panel — wrapping CLAY composes mid_opacity onto inherited outer_t. */
                 CLAY({.layout = {.sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0)}, .padding = CLAY_PADDING_ALL(10), .childAlignment = {CLAY_ALIGN_X_CENTER, CLAY_ALIGN_Y_CENTER}},
                       .userData = (void *)NT_UI_DATA_XFORM(0U, &mid_identity, mid_opacity)}) {
-                    nt_ui_panel_begin(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), (nt_atlas_region_ref_t){s_atlas_handle, s_panel_blue_idx}, &g_panel_style, NULL);
+                    nt_ui_panel_begin(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), &s_panel_blue_ref, &g_panel_style, NULL);
                     {
                         // clang-format off
                         CLAY({.layout = {.sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0)}, .padding = CLAY_PADDING_ALL(8), .childGap = 4, .childAlignment = {CLAY_ALIGN_X_CENTER, CLAY_ALIGN_Y_CENTER}}}) {
-                            nt_ui_panel_begin(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), (nt_atlas_region_ref_t){s_atlas_handle, s_panel_brown_idx}, &g_panel_style, NULL);
+                            nt_ui_panel_begin(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), &s_panel_brown_ref, &g_panel_style, NULL);
                             { nt_ui_label(s_ctx, NT_UI_DATA_LAYER(LAYER_TEXT), "Nested child", &g_child_label_style); }
                             nt_ui_panel_end(s_ctx);
                         }
@@ -545,6 +539,9 @@ int main(int argc, char *argv[]) {
     s_atlas_handle = nt_resource_request(ASSET_ATLAS_SLICE9_DEMO_ATLAS, NT_ASSET_ATLAS);
     s_atlas_tex_handle = nt_resource_request(ASSET_TEXTURE_SLICE9_DEMO_ATLAS_TEX0, NT_ASSET_TEXTURE);
     s_font_resource = nt_resource_request(ASSET_FONT_SLICE9_DEMO_FONT, NT_ASSET_FONT);
+
+    /* Handle is valid immediately (D-58.1-01); fill late-bound art refs upfront. */
+    init_atlas_refs();
 
     s_sprite_material = nt_material_create(&(nt_material_create_desc_t){
         .vs = s_sprite_vs_handle,

--- a/examples/slice9_demo/main.c
+++ b/examples/slice9_demo/main.c
@@ -134,7 +134,7 @@ static float s_time;
 
 // #region binding
 /* Fill the late-bound art refs upfront; the handle is valid before the data loads
- * (D-58.1-01) and the widget resolves + memoizes the region lazily. */
+ * and the widget resolves + memoizes the region lazily. */
 static void init_atlas_refs(void) {
     s_panel_beige_ref = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_SLICE9_DEMO_ATLAS_PANEL_BEIGE.value);
     s_panel_blue_ref = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_SLICE9_DEMO_ATLAS_PANEL_BLUE.value);
@@ -540,7 +540,7 @@ int main(int argc, char *argv[]) {
     s_atlas_tex_handle = nt_resource_request(ASSET_TEXTURE_SLICE9_DEMO_ATLAS_TEX0, NT_ASSET_TEXTURE);
     s_font_resource = nt_resource_request(ASSET_FONT_SLICE9_DEMO_FONT, NT_ASSET_FONT);
 
-    /* Handle is valid immediately (D-58.1-01); fill late-bound art refs upfront. */
+    /* Handle is valid immediately; fill late-bound art refs upfront. */
     init_atlas_refs();
 
     s_sprite_material = nt_material_create(&(nt_material_create_desc_t){

--- a/examples/ui_3d_demo/main.c
+++ b/examples/ui_3d_demo/main.c
@@ -155,8 +155,7 @@ static nt_buffer_t s_frame_ubo;
 static nt_ui_context_t *s_ctx;
 _Alignas(16) static uint8_t s_ui_arena[UI_ARENA_SIZE];
 static uint32_t s_white_region_idx;
-static uint32_t s_button_blue_idx;
-static uint32_t s_button_green_idx;
+/* Mutable so the engine memoizes the resolved region in place; bg refs filled upfront. */
 static nt_ui_button_style_t s_btn_idle;
 static nt_ui_button_style_t s_btn_active; /* highlighted for current selection */
 static const Clay_ElementDeclaration s_btn_decl = {
@@ -450,35 +449,37 @@ static bool cursor_object_distance(float px, float py, float fb_w, float fb_h, c
 // #endregion
 
 // #region resource binding
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+/* Fill the button-bg refs upfront; the handle is valid before the atlas data loads
+ * (D-58.1-01) and the widget resolves + memoizes the region lazily. */
+static void init_button_styles(void) {
+    const uint64_t blue = ASSET_ATLAS_REGION_UI_BUTTONS_DEMO_ATLAS_BUTTON_BLUE.value;
+    const uint64_t green = ASSET_ATLAS_REGION_UI_BUTTONS_DEMO_ATLAS_BUTTON_GREEN.value;
+
+    /* IDLE: blue everywhere with a small hover-press ease. */
+    s_btn_idle = (nt_ui_button_style_t){
+        .idle = {.bg = nt_atlas_ref(s_atlas_handle, blue), .bg_tint = 0xFFFFFFFFU, .scale = 1.0F, .opacity = 1.0F},
+        .hover = {.bg = nt_atlas_ref(s_atlas_handle, blue), .bg_tint = 0xFFFFFFFFU, .scale = 1.04F, .opacity = 1.0F},
+        .pressed = {.bg = nt_atlas_ref(s_atlas_handle, blue), .bg_tint = 0xFFFFFFFFU, .scale = 0.96F, .opacity = 1.0F},
+        .disabled = {.bg = nt_atlas_ref(s_atlas_handle, blue), .bg_tint = 0xFFFFFFFFU, .scale = 1.0F, .opacity = 0.4F},
+        .transition_speed = 8.0F,
+        .slice9_scale = 1.0F,
+    };
+    /* ACTIVE: green (currently-selected) — same animation but different art. */
+    s_btn_active = s_btn_idle;
+    s_btn_active.idle.bg = nt_atlas_ref(s_atlas_handle, green);
+    s_btn_active.hover.bg = nt_atlas_ref(s_atlas_handle, green);
+    s_btn_active.pressed.bg = nt_atlas_ref(s_atlas_handle, green);
+    s_btn_active.disabled.bg = nt_atlas_ref(s_atlas_handle, green);
+}
+
+/* White-region + font stay is_ready-gated (white is the deferred path; font needs the loaded resource). */
 static void try_bind_resources(void) {
     if (!s_atlas_bound && nt_resource_is_ready(s_atlas_handle)) {
         s_white_region_idx = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_UI_BUTTONS_DEMO_ATLAS__WHITE.value);
         NT_ASSERT(s_white_region_idx != NT_ATLAS_INVALID_REGION);
-        s_button_blue_idx = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_UI_BUTTONS_DEMO_ATLAS_BUTTON_BLUE.value);
-        NT_ASSERT(s_button_blue_idx != NT_ATLAS_INVALID_REGION);
-        s_button_green_idx = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_UI_BUTTONS_DEMO_ATLAS_BUTTON_GREEN.value);
-        NT_ASSERT(s_button_green_idx != NT_ATLAS_INVALID_REGION);
         nt_ui_set_atlas_white_region(s_ctx, s_atlas_handle, s_white_region_idx);
-
-        /* IDLE: blue everywhere with a small hover-press ease. */
-        s_btn_idle = (nt_ui_button_style_t){
-            .idle = {.bg = {.atlas = s_atlas_handle, .region = s_button_blue_idx}, .bg_tint = 0xFFFFFFFFU, .scale = 1.0F, .opacity = 1.0F},
-            .hover = {.bg = {.atlas = s_atlas_handle, .region = s_button_blue_idx}, .bg_tint = 0xFFFFFFFFU, .scale = 1.04F, .opacity = 1.0F},
-            .pressed = {.bg = {.atlas = s_atlas_handle, .region = s_button_blue_idx}, .bg_tint = 0xFFFFFFFFU, .scale = 0.96F, .opacity = 1.0F},
-            .disabled = {.bg = {.atlas = s_atlas_handle, .region = s_button_blue_idx}, .bg_tint = 0xFFFFFFFFU, .scale = 1.0F, .opacity = 0.4F},
-            .transition_speed = 8.0F,
-            .slice9_scale = 1.0F,
-        };
-        /* ACTIVE: green (currently-selected) — same animation but different art. */
-        s_btn_active = s_btn_idle;
-        s_btn_active.idle.bg.region = s_button_green_idx;
-        s_btn_active.hover.bg.region = s_button_green_idx;
-        s_btn_active.pressed.bg.region = s_button_green_idx;
-        s_btn_active.disabled.bg.region = s_button_green_idx;
-
         s_atlas_bound = true;
-        nt_log_info("ui_3d_demo: atlas bound");
+        nt_log_info("ui_3d_demo: atlas white region bound");
     }
     if (!s_font_bound && nt_resource_is_ready(s_font_resource)) {
         nt_font_add(s_font, s_font_resource);
@@ -533,7 +534,7 @@ static int test_panel_body(const char *title, const uint32_t ids[TPICK_COUNT], i
         nt_ui_label(s_ctx, NT_UI_DATA_LAYER(LAYER_LABEL), title, &s_panel_title_style);
     }
     for (int i = 0; i < TPICK_COUNT; ++i) {
-        const nt_ui_button_style_t *style = (i == sel) ? &s_btn_active : &s_btn_idle;
+        nt_ui_button_style_t *style = (i == sel) ? &s_btn_active : &s_btn_idle;
         nt_ui_button_begin(s_ctx, NT_UI_DATA_LAYER(LAYER_PANEL), ids[i], style, &s_tbtn_decl, true);
         nt_ui_label(s_ctx, NT_UI_DATA_LAYER(LAYER_LABEL), (i == TPICK_A) ? "A" : "B", &s_btn_label_style);
         if (nt_ui_button_end(s_ctx)) {
@@ -619,7 +620,7 @@ static void declare_panels(void) {
                 nt_ui_label(s_ctx, NT_UI_DATA_LAYER(LAYER_LABEL), "SHAPE", &s_panel_title_style);
             }
             for (int i = 0; i < SHAPE_COUNT; ++i) {
-                const nt_ui_button_style_t *style = (i == s_shape_kind) ? &s_btn_active : &s_btn_idle;
+                nt_ui_button_style_t *style = (i == s_shape_kind) ? &s_btn_active : &s_btn_idle;
                 nt_ui_button_begin(s_ctx, NT_UI_DATA_LAYER(LAYER_PANEL), s_id_shape_btn[i], style, &s_btn_decl, true);
                 nt_ui_label(s_ctx, NT_UI_DATA_LAYER(LAYER_LABEL), s_shape_labels[i], &s_btn_label_style);
                 if (nt_ui_button_end(s_ctx)) {
@@ -643,7 +644,7 @@ static void declare_panels(void) {
                 nt_ui_label(s_ctx, NT_UI_DATA_LAYER(LAYER_LABEL), "SPEED", &s_panel_title_style);
             }
             for (int i = 0; i < SPEED_COUNT; ++i) {
-                const nt_ui_button_style_t *style = (i == s_speed_kind) ? &s_btn_active : &s_btn_idle;
+                nt_ui_button_style_t *style = (i == s_speed_kind) ? &s_btn_active : &s_btn_idle;
                 nt_ui_button_begin(s_ctx, NT_UI_DATA_LAYER(LAYER_PANEL), s_id_speed_btn[i], style, &s_btn_decl, true);
                 nt_ui_label(s_ctx, NT_UI_DATA_LAYER(LAYER_LABEL), s_speed_labels[i], &s_btn_label_style);
                 if (nt_ui_button_end(s_ctx)) {
@@ -1010,6 +1011,9 @@ int main(int argc, char *argv[]) {
     s_atlas_handle = nt_resource_request(ASSET_ATLAS_UI_BUTTONS_DEMO_ATLAS, NT_ASSET_ATLAS);
     s_atlas_tex_handle = nt_resource_request(ASSET_TEXTURE_UI_BUTTONS_DEMO_ATLAS_TEX0, NT_ASSET_TEXTURE);
     s_font_resource = nt_resource_request(ASSET_FONT_UI_BUTTONS_DEMO_FONT, NT_ASSET_FONT);
+
+    /* Handle is valid immediately (D-58.1-01); fill late-bound button-bg refs upfront. */
+    init_button_styles();
 
     /* World-mounted UI: depth_write ON so overlapping panels sort by depth (nearer occludes farther
      * across sprite+text layers). The cutoff sprite variant discards transparent button corners so

--- a/examples/ui_3d_demo/main.c
+++ b/examples/ui_3d_demo/main.c
@@ -450,7 +450,7 @@ static bool cursor_object_distance(float px, float py, float fb_w, float fb_h, c
 
 // #region resource binding
 /* Fill the button-bg refs upfront; the handle is valid before the atlas data loads
- * (D-58.1-01) and the widget resolves + memoizes the region lazily. */
+ * and the widget resolves + memoizes the region lazily. */
 static void init_button_styles(void) {
     const uint64_t blue = ASSET_ATLAS_REGION_UI_BUTTONS_DEMO_ATLAS_BUTTON_BLUE.value;
     const uint64_t green = ASSET_ATLAS_REGION_UI_BUTTONS_DEMO_ATLAS_BUTTON_GREEN.value;
@@ -1012,7 +1012,7 @@ int main(int argc, char *argv[]) {
     s_atlas_tex_handle = nt_resource_request(ASSET_TEXTURE_UI_BUTTONS_DEMO_ATLAS_TEX0, NT_ASSET_TEXTURE);
     s_font_resource = nt_resource_request(ASSET_FONT_UI_BUTTONS_DEMO_FONT, NT_ASSET_FONT);
 
-    /* Handle is valid immediately (D-58.1-01); fill late-bound button-bg refs upfront. */
+    /* Handle is valid immediately; fill late-bound button-bg refs upfront. */
     init_button_styles();
 
     /* World-mounted UI: depth_write ON so overlapping panels sort by depth (nearer occludes farther

--- a/examples/ui_buttons_demo/main.c
+++ b/examples/ui_buttons_demo/main.c
@@ -256,10 +256,9 @@ static float s_xform_deg;
 // #endregion
 
 // #region binding
-/* Fill each variant's bg refs upfront from the const templates. The handle is valid before
- * the atlas data loads; the widget resolves + memoizes the region lazily. Only
- * the IDLE bg carries the ref — non-idle states inherit it via nt_ui_ref_or unless they set
- * their own (SWAP wants distinct hover/pressed art, so it does). */
+/* Fill each variant's bg refs upfront from the const templates (resolved + memoized lazily).
+ * Only the IDLE bg carries the ref — non-idle states inherit it via nt_ui_ref_or unless they
+ * set their own (SWAP wants distinct hover/pressed art, so it does). */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void init_button_styles(void) {
     const nt_atlas_region_ref_t blue = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_UI_BUTTONS_DEMO_ATLAS_BUTTON_BLUE.value);

--- a/examples/ui_buttons_demo/main.c
+++ b/examples/ui_buttons_demo/main.c
@@ -137,8 +137,8 @@ static const nt_ui_button_style_t g_btn_scale_style = {
     .slice9_scale = 1.0F,
 };
 
-/* (c) VISUAL SWAP: bg_region differs per state (blue/green/red); bg_region 0
- * in the const = sentinel, patched at runtime once atlas indices are known. */
+/* (c) VISUAL SWAP: bg differs per state (blue/green/red); bg left unset in the const
+ * template and filled upfront with late-bound refs in init_button_styles. */
 static const nt_ui_button_style_t g_btn_swap_style = {
     .idle = {.bg_tint = 0xFFFFFFFF, .scale = 1.0F, .offset_x = 0.0F, .offset_y = 0.0F, .opacity = 1.0F},
     .hover = {.bg_tint = 0xFFFFFFFF, .scale = 1.05F, .offset_x = 0.0F, .offset_y = 0.0F, .opacity = 1.0F},
@@ -201,13 +201,13 @@ static nt_font_t s_font;
 static bool s_atlas_bound;
 static bool s_font_bound;
 static uint32_t s_white_region_idx;
-static uint32_t s_button_blue_idx;
-static uint32_t s_button_green_idx;
-static uint32_t s_button_red_idx;
-static uint32_t s_icon_bunny_idx;
 
-/* Reference-button runtime styles: const templates copied + bg_region patched
- * once the atlas binds. ids precomputed via nt_ui_id on the first Clay frame. */
+/* Late-bound icon ref filled upfront; mutable so the engine memoizes its resolved index. */
+static nt_atlas_region_ref_t s_icon_bunny_ref;
+
+/* Reference-button runtime styles: const templates copied + bg refs filled upfront
+ * (init_button_styles); mutable so the engine memoizes the resolved index in place.
+ * ids precomputed via nt_ui_id on the first Clay frame. */
 static nt_ui_button_style_t s_btn_standard;
 static nt_ui_button_style_t s_btn_scale;
 static nt_ui_button_style_t s_btn_swap;
@@ -256,7 +256,48 @@ static float s_xform_deg;
 // #endregion
 
 // #region binding
+/* Fill each variant's bg refs upfront from the const templates. The handle is valid before
+ * the atlas data loads (D-58.1-01); the widget resolves + memoizes the region lazily. Only
+ * the IDLE bg carries the ref — non-idle states inherit it via nt_ui_ref_or unless they set
+ * their own (SWAP wants distinct hover/pressed art, so it does). */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
+static void init_button_styles(void) {
+    const nt_atlas_region_ref_t blue = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_UI_BUTTONS_DEMO_ATLAS_BUTTON_BLUE.value);
+    const nt_atlas_region_ref_t green = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_UI_BUTTONS_DEMO_ATLAS_BUTTON_GREEN.value);
+    const nt_atlas_region_ref_t red = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_UI_BUTTONS_DEMO_ATLAS_BUTTON_RED.value);
+
+    s_icon_bunny_ref = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_UI_BUTTONS_DEMO_ATLAS_ICON_BUNNY.value);
+
+    s_btn_standard = g_btn_standard_style;
+    s_btn_standard.idle.bg = blue;
+
+    s_btn_scale = g_btn_scale_style;
+    s_btn_scale.idle.bg = blue;
+
+    /* VISUAL-SWAP: blue idle/disabled, green hover, red pressed. */
+    s_btn_swap = g_btn_swap_style;
+    s_btn_swap.idle.bg = blue;
+    s_btn_swap.hover.bg = green;
+    s_btn_swap.pressed.bg = red;
+
+    s_btn_nopad = g_btn_nopad_style;
+    s_btn_nopad.idle.bg = blue;
+
+    /* (g) SLICE9_SCALE row — same blue art, only slice9_scale differs. */
+    s_btn_s9_quarter = g_btn_s9_base;
+    s_btn_s9_quarter.idle.bg = blue;
+    s_btn_s9_quarter.slice9_scale = 0.25F;
+
+    s_btn_s9_one = g_btn_s9_base;
+    s_btn_s9_one.idle.bg = blue;
+    s_btn_s9_one.slice9_scale = 1.0F;
+
+    s_btn_s9_four = g_btn_s9_base;
+    s_btn_s9_four.idle.bg = blue;
+    s_btn_s9_four.slice9_scale = 4.0F;
+}
+
+/* White-region + font stay is_ready-gated (white is the deferred path; font needs the loaded resource). */
 static void try_bind_resources(void) {
     if (s_atlas_bound && s_font_bound) {
         return;
@@ -265,83 +306,9 @@ static void try_bind_resources(void) {
     if (!s_atlas_bound && nt_resource_is_ready(s_atlas_handle)) {
         s_white_region_idx = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_UI_BUTTONS_DEMO_ATLAS__WHITE.value);
         NT_ASSERT(s_white_region_idx != NT_ATLAS_INVALID_REGION);
-
-        s_button_blue_idx = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_UI_BUTTONS_DEMO_ATLAS_BUTTON_BLUE.value);
-        NT_ASSERT(s_button_blue_idx != NT_ATLAS_INVALID_REGION);
-
-        s_button_green_idx = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_UI_BUTTONS_DEMO_ATLAS_BUTTON_GREEN.value);
-        NT_ASSERT(s_button_green_idx != NT_ATLAS_INVALID_REGION);
-
-        s_button_red_idx = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_UI_BUTTONS_DEMO_ATLAS_BUTTON_RED.value);
-        NT_ASSERT(s_button_red_idx != NT_ATLAS_INVALID_REGION);
-
-        s_icon_bunny_idx = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_UI_BUTTONS_DEMO_ATLAS_ICON_BUNNY.value);
-        NT_ASSERT(s_icon_bunny_idx != NT_ATLAS_INVALID_REGION);
-
         nt_ui_set_atlas_white_region(s_ctx, s_atlas_handle, s_white_region_idx);
-
-        /* Patch each variant's bg_region from the templates. */
-        s_btn_standard = g_btn_standard_style;
-        s_btn_standard.idle.bg.region = s_button_blue_idx;
-        s_btn_standard.hover.bg.region = s_button_blue_idx;
-        s_btn_standard.pressed.bg.region = s_button_blue_idx;
-        s_btn_standard.disabled.bg.region = s_button_blue_idx;
-
-        s_btn_scale = g_btn_scale_style;
-        s_btn_scale.idle.bg.region = s_button_blue_idx;
-        s_btn_scale.hover.bg.region = s_button_blue_idx;
-        s_btn_scale.pressed.bg.region = s_button_blue_idx;
-        s_btn_scale.disabled.bg.region = s_button_blue_idx;
-
-        /* VISUAL-SWAP: blue idle/disabled, green hover/pressed. */
-        s_btn_swap = g_btn_swap_style;
-        s_btn_swap.idle.bg.region = s_button_blue_idx;
-        s_btn_swap.hover.bg.region = s_button_green_idx;
-        s_btn_swap.pressed.bg.region = s_button_red_idx;
-        s_btn_swap.disabled.bg.region = s_button_blue_idx;
-
-        s_btn_nopad = g_btn_nopad_style;
-        s_btn_nopad.idle.bg.region = s_button_blue_idx;
-        s_btn_nopad.hover.bg.region = s_button_blue_idx;
-        s_btn_nopad.pressed.bg.region = s_button_blue_idx;
-        s_btn_nopad.disabled.bg.region = s_button_blue_idx;
-
-        /* (g) SLICE9_SCALE row — same blue art, only slice9_scale differs. */
-        s_btn_s9_quarter = g_btn_s9_base;
-        s_btn_s9_quarter.idle.bg.region = s_button_blue_idx;
-        s_btn_s9_quarter.hover.bg.region = s_button_blue_idx;
-        s_btn_s9_quarter.pressed.bg.region = s_button_blue_idx;
-        s_btn_s9_quarter.disabled.bg.region = s_button_blue_idx;
-        s_btn_s9_quarter.slice9_scale = 0.25F;
-
-        s_btn_s9_one = g_btn_s9_base;
-        s_btn_s9_one.idle.bg.region = s_button_blue_idx;
-        s_btn_s9_one.hover.bg.region = s_button_blue_idx;
-        s_btn_s9_one.pressed.bg.region = s_button_blue_idx;
-        s_btn_s9_one.disabled.bg.region = s_button_blue_idx;
-        s_btn_s9_one.slice9_scale = 1.0F;
-
-        s_btn_s9_four = g_btn_s9_base;
-        s_btn_s9_four.idle.bg.region = s_button_blue_idx;
-        s_btn_s9_four.hover.bg.region = s_button_blue_idx;
-        s_btn_s9_four.pressed.bg.region = s_button_blue_idx;
-        s_btn_s9_four.disabled.bg.region = s_button_blue_idx;
-        s_btn_s9_four.slice9_scale = 4.0F;
-
-        /* All 7 styles share the demo atlas; non-idle states inherit idle's whole ref
-         * unless they set their own atlas -- SWAP wants distinct hover/pressed art, so it does. */
-        s_btn_standard.idle.bg.atlas = s_atlas_handle;
-        s_btn_scale.idle.bg.atlas = s_atlas_handle;
-        s_btn_swap.idle.bg.atlas = s_atlas_handle;
-        s_btn_swap.hover.bg.atlas = s_atlas_handle;
-        s_btn_swap.pressed.bg.atlas = s_atlas_handle;
-        s_btn_nopad.idle.bg.atlas = s_atlas_handle;
-        s_btn_s9_quarter.idle.bg.atlas = s_atlas_handle;
-        s_btn_s9_one.idle.bg.atlas = s_atlas_handle;
-        s_btn_s9_four.idle.bg.atlas = s_atlas_handle;
-
         s_atlas_bound = true;
-        nt_log_info("ui_buttons_demo: atlas bound (button_blue + button_green + _white + icon_bunny)");
+        nt_log_info("ui_buttons_demo: atlas white region bound");
     }
 
     if (!s_font_bound && nt_resource_is_ready(s_font_resource)) {
@@ -480,9 +447,7 @@ static void declare_reference_buttons(void) {
                 CELL_LABELS("ICON ONLY", "no padding");
                 CLAY(BTN_SLOT_LAYOUT) {
                     nt_ui_button_begin(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), s_id_icon, &s_btn_nopad, &s_btn_decl, true);
-                    CLAY({.layout = {.sizing = {CLAY_SIZING_FIXED(96), CLAY_SIZING_FIXED(96)}}}) {
-                        nt_ui_image(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), (nt_atlas_region_ref_t){s_atlas_handle, s_icon_bunny_idx}, &g_btn_icon_style, NULL);
-                    }
+                    CLAY({.layout = {.sizing = {CLAY_SIZING_FIXED(96), CLAY_SIZING_FIXED(96)}}}) { nt_ui_image(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), &s_icon_bunny_ref, &g_btn_icon_style, NULL); }
                     if (nt_ui_button_end(s_ctx)) {
                         s_clicks_icon++;
                     }
@@ -507,9 +472,7 @@ static void declare_reference_buttons(void) {
                             },
                     };
                     nt_ui_button_begin(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), s_id_icontext, &s_btn_nopad, &s_btn_decl_icontext, true);
-                    CLAY({.layout = {.sizing = {CLAY_SIZING_FIXED(80), CLAY_SIZING_FIXED(80)}}}) {
-                        nt_ui_image(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), (nt_atlas_region_ref_t){s_atlas_handle, s_icon_bunny_idx}, &g_btn_icon_style, NULL);
-                    }
+                    CLAY({.layout = {.sizing = {CLAY_SIZING_FIXED(80), CLAY_SIZING_FIXED(80)}}}) { nt_ui_image(s_ctx, NT_UI_DATA_LAYER(LAYER_IMG), &s_icon_bunny_ref, &g_btn_icon_style, NULL); }
                     nt_ui_label(s_ctx, NT_UI_DATA_LAYER(LAYER_TEXT), "Play", &g_btn_label_style);
                     if (nt_ui_button_end(s_ctx)) {
                         s_clicks_icontext++;
@@ -899,6 +862,9 @@ int main(int argc, char *argv[]) {
     s_atlas_handle = nt_resource_request(ASSET_ATLAS_UI_BUTTONS_DEMO_ATLAS, NT_ASSET_ATLAS);
     s_atlas_tex_handle = nt_resource_request(ASSET_TEXTURE_UI_BUTTONS_DEMO_ATLAS_TEX0, NT_ASSET_TEXTURE);
     s_font_resource = nt_resource_request(ASSET_FONT_UI_BUTTONS_DEMO_FONT, NT_ASSET_FONT);
+
+    /* Handle is valid immediately (D-58.1-01); fill late-bound bg + icon refs upfront. */
+    init_button_styles();
 
     s_sprite_material = nt_material_create(&(nt_material_create_desc_t){
         .vs = s_sprite_vs_handle,

--- a/examples/ui_buttons_demo/main.c
+++ b/examples/ui_buttons_demo/main.c
@@ -257,7 +257,7 @@ static float s_xform_deg;
 
 // #region binding
 /* Fill each variant's bg refs upfront from the const templates. The handle is valid before
- * the atlas data loads (D-58.1-01); the widget resolves + memoizes the region lazily. Only
+ * the atlas data loads; the widget resolves + memoizes the region lazily. Only
  * the IDLE bg carries the ref — non-idle states inherit it via nt_ui_ref_or unless they set
  * their own (SWAP wants distinct hover/pressed art, so it does). */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
@@ -863,7 +863,7 @@ int main(int argc, char *argv[]) {
     s_atlas_tex_handle = nt_resource_request(ASSET_TEXTURE_UI_BUTTONS_DEMO_ATLAS_TEX0, NT_ASSET_TEXTURE);
     s_font_resource = nt_resource_request(ASSET_FONT_UI_BUTTONS_DEMO_FONT, NT_ASSET_FONT);
 
-    /* Handle is valid immediately (D-58.1-01); fill late-bound bg + icon refs upfront. */
+    /* Handle is valid immediately; fill late-bound bg + icon refs upfront. */
     init_button_styles();
 
     s_sprite_material = nt_material_create(&(nt_material_create_desc_t){

--- a/examples/ui_stateful_demo/main.c
+++ b/examples/ui_stateful_demo/main.c
@@ -554,7 +554,7 @@ int main(int argc, char *argv[]) {
     s_atlas_tex_handle = nt_resource_request(ASSET_TEXTURE_UI_STATEFUL_DEMO_ATLAS_TEX0, NT_ASSET_TEXTURE);
     s_font_resource = nt_resource_request(ASSET_FONT_UI_STATEFUL_DEMO_FONT, NT_ASSET_FONT);
 
-    /* Handle is valid immediately (D-58.1-01); fill late-bound widget refs upfront. */
+    /* Handle is valid immediately; fill late-bound widget refs upfront. */
     init_widget_styles();
 
     s_sprite_material = nt_material_create(&(nt_material_create_desc_t){

--- a/examples/ui_stateful_demo/main.c
+++ b/examples/ui_stateful_demo/main.c
@@ -74,9 +74,9 @@ static const nt_ui_label_style_t g_help_style = {
 // #endregion
 
 // #region widget style templates
-/* Box/check atlas refs are patched per-cell at runtime (region indices come from the
- * bound atlas). Every cell sets scale=1 / opacity=1 to satisfy assert_cell_valid;
- * pressed dips scale, disabled dips opacity. */
+/* Box/check atlas refs are filled upfront from these templates (init_widget_styles);
+ * the engine resolves the region lazily. Every cell sets scale=1 / opacity=1 to satisfy
+ * assert_cell_valid; pressed dips scale, disabled dips opacity. */
 
 /* ---- checkbox: checkmark pops in (fast value pop) ---- */
 static const nt_ui_checkbox_style_t g_check_tmpl = {
@@ -186,8 +186,8 @@ static nt_font_t s_font;
 static bool s_atlas_bound;
 static bool s_font_bound;
 
-/* Runtime widget styles: const templates copied + atlas refs patched once the
- * atlas binds (region indices are not known at compile time). */
+/* Runtime widget styles: const templates copied + late-bound atlas refs filled upfront
+ * (init_widget_styles); mutable so the engine's resolve memoizes the index in place. */
 static nt_ui_checkbox_style_t s_check;
 static nt_ui_checkbox_style_t s_switch;
 static nt_ui_checkbox_style_t s_radio;
@@ -217,17 +217,30 @@ static bool s_ids_ready;
 // #endregion
 
 // #region binding
-static void patch_row_atlas(nt_ui_cb_state_t row[4], nt_resource_t atlas, uint32_t box_region, uint32_t check_region) {
-    /* Only the IDLE cell carries the atlas refs; non-idle cells inherit the whole ref
-     * (resolve_ref). check_region == NT_ATLAS_INVALID_REGION = no overlay art (e.g. the
-     * radio unchecked row has no dot). */
-    row[NT_UI_CB_IDLE].box = (nt_atlas_region_ref_t){atlas, box_region};
-    if (check_region != NT_ATLAS_INVALID_REGION) {
-        row[NT_UI_CB_IDLE].check = (nt_atlas_region_ref_t){atlas, check_region};
-    }
+/* Fill the idle cell's late-bound refs; non-idle cells inherit the whole ref (nt_ui_ref_or).
+ * The handle is valid before the atlas data loads — the widget resolves + memoizes lazily. */
+static void init_widget_styles(void) {
+    /* Checkbox: box on both rows; only checked carries the check overlay. */
+    s_check = g_check_tmpl;
+    s_check.unchecked[NT_UI_CB_IDLE].box = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_UI_STATEFUL_DEMO_ATLAS_BOX_OFF.value);
+    s_check.checked[NT_UI_CB_IDLE].box = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_UI_STATEFUL_DEMO_ATLAS_BOX_OFF.value);
+    s_check.checked[NT_UI_CB_IDLE].check = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_UI_STATEFUL_DEMO_ATLAS_CHECKMARK.value);
+
+    /* Radio: ring on both rows; checked adds the dot. */
+    s_radio = g_radio_tmpl;
+    s_radio.unchecked[NT_UI_CB_IDLE].box = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_UI_STATEFUL_DEMO_ATLAS_RADIO_RING.value);
+    s_radio.checked[NT_UI_CB_IDLE].box = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_UI_STATEFUL_DEMO_ATLAS_RADIO_RING.value);
+    s_radio.checked[NT_UI_CB_IDLE].check = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_UI_STATEFUL_DEMO_ATLAS_RADIO_DOT.value);
+
+    /* Toggle: track recolors by value (off grey / on green); thumb on both. */
+    s_switch = g_switch_tmpl;
+    s_switch.unchecked[NT_UI_CB_IDLE].box = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_UI_STATEFUL_DEMO_ATLAS_TRACK_OFF.value);
+    s_switch.unchecked[NT_UI_CB_IDLE].check = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_UI_STATEFUL_DEMO_ATLAS_THUMB.value);
+    s_switch.checked[NT_UI_CB_IDLE].box = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_UI_STATEFUL_DEMO_ATLAS_TRACK_ON.value);
+    s_switch.checked[NT_UI_CB_IDLE].check = nt_atlas_ref(s_atlas_handle, ASSET_ATLAS_REGION_UI_STATEFUL_DEMO_ATLAS_THUMB.value);
 }
 
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+/* White-region + font stay is_ready-gated (white is the deferred path; font needs the loaded resource). */
 static void try_bind_resources(void) {
     if (s_atlas_bound && s_font_bound) {
         return;
@@ -235,36 +248,10 @@ static void try_bind_resources(void) {
 
     if (!s_atlas_bound && nt_resource_is_ready(s_atlas_handle)) {
         const uint32_t white = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_UI_STATEFUL_DEMO_ATLAS__WHITE.value);
-        const uint32_t box_off = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_UI_STATEFUL_DEMO_ATLAS_BOX_OFF.value);
-        const uint32_t checkmark = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_UI_STATEFUL_DEMO_ATLAS_CHECKMARK.value);
-        const uint32_t ring = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_UI_STATEFUL_DEMO_ATLAS_RADIO_RING.value);
-        const uint32_t dot = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_UI_STATEFUL_DEMO_ATLAS_RADIO_DOT.value);
-        const uint32_t track_off = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_UI_STATEFUL_DEMO_ATLAS_TRACK_OFF.value);
-        const uint32_t track_on = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_UI_STATEFUL_DEMO_ATLAS_TRACK_ON.value);
-        const uint32_t thumb = nt_atlas_find_region(s_atlas_handle, ASSET_ATLAS_REGION_UI_STATEFUL_DEMO_ATLAS_THUMB.value);
-        NT_ASSERT(white != NT_ATLAS_INVALID_REGION && box_off != NT_ATLAS_INVALID_REGION && checkmark != NT_ATLAS_INVALID_REGION);
-        NT_ASSERT(ring != NT_ATLAS_INVALID_REGION && dot != NT_ATLAS_INVALID_REGION);
-        NT_ASSERT(track_off != NT_ATLAS_INVALID_REGION && track_on != NT_ATLAS_INVALID_REGION && thumb != NT_ATLAS_INVALID_REGION);
-
+        NT_ASSERT(white != NT_ATLAS_INVALID_REGION);
         nt_ui_set_atlas_white_region(s_ctx, s_atlas_handle, white);
-
-        /* Checkbox: box+check on both rows; unchecked has no check overlay. */
-        s_check = g_check_tmpl;
-        patch_row_atlas(s_check.unchecked, s_atlas_handle, box_off, NT_ATLAS_INVALID_REGION);
-        patch_row_atlas(s_check.checked, s_atlas_handle, box_off, checkmark);
-
-        /* Radio: ring on both rows; checked adds the dot. */
-        s_radio = g_radio_tmpl;
-        patch_row_atlas(s_radio.unchecked, s_atlas_handle, ring, NT_ATLAS_INVALID_REGION);
-        patch_row_atlas(s_radio.checked, s_atlas_handle, ring, dot);
-
-        /* Toggle: track recolors by value (off grey / on green); thumb on both. */
-        s_switch = g_switch_tmpl;
-        patch_row_atlas(s_switch.unchecked, s_atlas_handle, track_off, thumb);
-        patch_row_atlas(s_switch.checked, s_atlas_handle, track_on, thumb);
-
         s_atlas_bound = true;
-        nt_log_info("ui_stateful_demo: atlas bound (box/check + ring/dot + track + thumb)");
+        nt_log_info("ui_stateful_demo: atlas white region bound");
     }
 
     if (!s_font_bound && nt_resource_is_ready(s_font_resource)) {
@@ -566,6 +553,9 @@ int main(int argc, char *argv[]) {
     s_atlas_handle = nt_resource_request(ASSET_ATLAS_UI_STATEFUL_DEMO_ATLAS, NT_ASSET_ATLAS);
     s_atlas_tex_handle = nt_resource_request(ASSET_TEXTURE_UI_STATEFUL_DEMO_ATLAS_TEX0, NT_ASSET_TEXTURE);
     s_font_resource = nt_resource_request(ASSET_FONT_UI_STATEFUL_DEMO_FONT, NT_ASSET_FONT);
+
+    /* Handle is valid immediately (D-58.1-01); fill late-bound widget refs upfront. */
+    init_widget_styles();
 
     s_sprite_material = nt_material_create(&(nt_material_create_desc_t){
         .vs = s_sprite_vs_handle,

--- a/scripts/wasm_examples.sh
+++ b/scripts/wasm_examples.sh
@@ -1,3 +1,3 @@
 # Single source of truth for WASM-capable examples.
 # Sourced by build_wasm_paired.sh, package_all_simd.sh, and CI workflows.
-WASM_EXAMPLES=(hello bench_shapes spinning_cube textured_quad sponza text atlas bunnymark ui_theme_demo ui_buttons_demo)
+WASM_EXAMPLES=(hello bench_shapes spinning_cube textured_quad sponza text atlas bunnymark ui_theme_demo ui_buttons_demo slice9_demo ui_stateful_demo ui_3d_demo)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,7 +82,7 @@ if(NOT EMSCRIPTEN)
     # --- Log API tests (domain functions, macros, level filtering) ---
     add_executable(test_log_api unit/test_log_api.c)
     target_link_libraries(test_log_api PRIVATE nt_log unity)
-    target_compile_definitions(test_log_api PRIVATE NT_LOG_DOMAIN_DEFAULT="test_mod")
+    target_compile_definitions(test_log_api PRIVATE NT_LOG_DOMAIN_DEFAULT="test_mod" NT_LOG_REAL_IMPL=1)
     nt_set_warning_flags(test_log_api)
     nt_set_sanitizer_flags(test_log_api)
     set_target_properties(test_log_api PROPERTIES

--- a/tests/unit/test_atlas.c
+++ b/tests/unit/test_atlas.c
@@ -683,7 +683,9 @@ void test_atlas_merge_new_region_appends_with_fresh_index(void) {
     TEST_ASSERT_EQUAL_UINT32(2, nt_atlas_test_find_region_raw(ad, 0xCCCULL)); /* fresh index == previous region_count */
 }
 
-/* ---- Test 9: removed region becomes a tombstone (stable indices) ---- */
+/* ---- Test 9: removed region keeps name + vertex_count==0, then revives in
+ * place (same index) on re-add. Index is stable across remove/re-add. ---- */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_atlas_merge_removed_region_becomes_tombstone(void) {
     /* Pages omitted. */
 
@@ -706,29 +708,40 @@ void test_atlas_merge_removed_region_becomes_tombstone(void) {
     nt_atlas_test_drive_resolve(buf1, size1, &s_user_data);
     const struct nt_atlas_data *ad = (const struct nt_atlas_data *)s_user_data;
     TEST_ASSERT_EQUAL_UINT32(3, nt_atlas_test_region_count(ad));
+    const uint32_t b_idx = nt_atlas_test_find_region_raw(ad, 0xBBBULL);
+    TEST_ASSERT_EQUAL_UINT32(1, b_idx);
 
     nt_atlas_test_drive_resolve(buf2, size2, &s_user_data);
 
-    /* Tombstones don't shrink the count — region_count stays at 3. */
+    /* Dead slots don't shrink the count — region_count stays at 3. */
     TEST_ASSERT_EQUAL_UINT32(3, nt_atlas_test_region_count(ad));
 
     /* Surviving indices are NOT renumbered. */
     TEST_ASSERT_EQUAL_UINT32(0, nt_atlas_test_find_region_raw(ad, 0xAAAULL));
     TEST_ASSERT_EQUAL_UINT32(2, nt_atlas_test_find_region_raw(ad, 0xCCCULL));
-    TEST_ASSERT_EQUAL_UINT32(NT_ATLAS_INVALID_REGION, nt_atlas_test_find_region_raw(ad, 0xBBBULL));
 
-    /* Slot 1 is a tombstone: NT_ATLAS_TOMBSTONE_HASH, zero counts. */
-    const nt_texture_region_t *r1 = nt_atlas_test_get_region_raw(ad, 1);
+    /* B is dead but its NAME is retained and still resolves to the SAME index. */
+    TEST_ASSERT_EQUAL_UINT32(b_idx, nt_atlas_test_find_region_raw(ad, 0xBBBULL));
+    const nt_texture_region_t *r1 = nt_atlas_test_get_region_raw(ad, b_idx);
     TEST_ASSERT_NOT_NULL(r1);
-    TEST_ASSERT_EQUAL_UINT64(NT_ATLAS_TOMBSTONE_HASH, r1->name_hash);
+    TEST_ASSERT_EQUAL_UINT64(0xBBBULL, r1->name_hash);
+    TEST_ASSERT_NOT_EQUAL_UINT64(NT_ATLAS_TOMBSTONE_HASH, r1->name_hash);
     TEST_ASSERT_EQUAL_UINT8(0, r1->vertex_count);
     TEST_ASSERT_EQUAL_UINT8(0, r1->index_count);
+
+    /* Re-add B → revives the SAME index in place; region_count does NOT grow. */
+    nt_atlas_test_drive_resolve(buf1, size1, &s_user_data);
+    TEST_ASSERT_EQUAL_UINT32(3, nt_atlas_test_region_count(ad));
+    TEST_ASSERT_EQUAL_UINT32(b_idx, nt_atlas_test_find_region_raw(ad, 0xBBBULL));
+    const nt_texture_region_t *r1_revived = nt_atlas_test_get_region_raw(ad, b_idx);
+    TEST_ASSERT_TRUE(r1_revived->vertex_count > 0);
 }
 
-/* ---- Test 9: find_region returns INVALID for a tombstoned hash across
- * multiple merges; re-adding a previously-tombstoned hash creates a NEW
- * region at a fresh monotonic index — the old tombstone stays dead. ---- */
-void test_atlas_find_region_returns_invalid_for_tombstone(void) {
+/* ---- Test 9: find_region returns a STABLE index for a removed-then-readded
+ * hash across multiple merges; re-adding a removed hash revives the SAME index
+ * in place — region_count never grows for a name that was ever present. ---- */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+void test_atlas_find_region_returns_same_index_after_revive(void) {
     /* Pages omitted. */
 
     merge_region_spec_t only_a[1] = {
@@ -751,24 +764,21 @@ void test_atlas_find_region_returns_invalid_for_tombstone(void) {
     const uint32_t b_first_idx = nt_atlas_test_find_region_raw(ad, 0xBBBULL);
     TEST_ASSERT_EQUAL_UINT32(1, b_first_idx);
 
-    /* Merge 2: {A} — B is tombstoned. */
+    /* Merge 2: {A} — B removed, but its name stays → still resolves to b_first_idx. */
     nt_atlas_test_drive_resolve(buf_a, size_a, &s_user_data);
     TEST_ASSERT_EQUAL_UINT32(2, nt_atlas_test_region_count(ad));
-    TEST_ASSERT_EQUAL_UINT32(NT_ATLAS_INVALID_REGION, nt_atlas_test_find_region_raw(ad, 0xBBBULL));
+    TEST_ASSERT_EQUAL_UINT32(b_first_idx, nt_atlas_test_find_region_raw(ad, 0xBBBULL));
 
-    /* Merge 3: {A, B} — re-adding B MUST create a fresh index (monotonic). */
+    /* Merge 3: {A, B} — re-adding B revives the SAME index; count does NOT grow. */
     nt_atlas_test_drive_resolve(buf_ab, size_ab, &s_user_data);
     const uint32_t b_second_idx = nt_atlas_test_find_region_raw(ad, 0xBBBULL);
-    TEST_ASSERT_NOT_EQUAL_UINT32(NT_ATLAS_INVALID_REGION, b_second_idx);
-    /* The old tombstone at index 1 stays dead, new B lives at a higher
-     * index. region_count must have grown by exactly 1. */
-    TEST_ASSERT_EQUAL_UINT32(3, nt_atlas_test_region_count(ad));
-    TEST_ASSERT_TRUE_MESSAGE(b_second_idx > b_first_idx, "re-added region must get a strictly higher index");
+    TEST_ASSERT_EQUAL_UINT32(b_first_idx, b_second_idx);
+    TEST_ASSERT_EQUAL_UINT32(2, nt_atlas_test_region_count(ad));
 
-    /* Merge 4: {A} — tombstone the re-added B again. */
+    /* Merge 4: {A} — remove the revived B again; index still stable. */
     nt_atlas_test_drive_resolve(buf_a, size_a, &s_user_data);
-    TEST_ASSERT_EQUAL_UINT32(NT_ATLAS_INVALID_REGION, nt_atlas_test_find_region_raw(ad, 0xBBBULL));
-    TEST_ASSERT_EQUAL_UINT32(3, nt_atlas_test_region_count(ad));
+    TEST_ASSERT_EQUAL_UINT32(b_first_idx, nt_atlas_test_find_region_raw(ad, 0xBBBULL));
+    TEST_ASSERT_EQUAL_UINT32(2, nt_atlas_test_region_count(ad));
 
     /* A stayed at index 0 through the whole chain. */
     TEST_ASSERT_EQUAL_UINT32(0, nt_atlas_test_find_region_raw(ad, 0xAAAULL));
@@ -800,12 +810,14 @@ void test_atlas_get_region_returns_vertex_count_zero_for_tombstone(void) {
 
     const struct nt_atlas_data *ad = (const struct nt_atlas_data *)s_user_data;
 
-    /* get_region(1) on the tombstone returns non-NULL with zero counts. */
+    /* get_region(1) on the dead slot returns non-NULL with zero counts;
+     * the name (0xBBB) is RETAINED for revive-by-name. */
     const nt_texture_region_t *r1 = nt_atlas_test_get_region_raw(ad, 1);
     TEST_ASSERT_NOT_NULL(r1); /* no NULL branch in the hot path */
     TEST_ASSERT_EQUAL_UINT8(0, r1->vertex_count);
     TEST_ASSERT_EQUAL_UINT8(0, r1->index_count);
-    TEST_ASSERT_EQUAL_UINT64(NT_ATLAS_TOMBSTONE_HASH, r1->name_hash);
+    TEST_ASSERT_NOT_EQUAL_UINT64(NT_ATLAS_TOMBSTONE_HASH, r1->name_hash);
+    TEST_ASSERT_EQUAL_UINT64(0xBBBULL, r1->name_hash);
 }
 
 /* ---- Test 11: Hash collisions resolve correctly via linear probing ----
@@ -1042,12 +1054,13 @@ void test_atlas_hash_table_growth_under_1000_regions(void) {
     /* region_count should be 1500: original 1000 + 500 new (1001..1500) */
     TEST_ASSERT_EQUAL_UINT32(1500, nt_atlas_test_region_count(ad));
 
-    /* Regions [0..499] (hashes 1..500) should be tombstoned. */
+    /* Regions [0..499] (hashes 1..500) are removed: name retained, dead via
+     * vertex_count==0, and still resolve to their original stable index. */
     for (uint32_t i = 0; i < 500; i++) {
         uint32_t idx = nt_atlas_test_find_region_raw(ad, (uint64_t)i + 1U);
-        TEST_ASSERT_EQUAL_UINT32_MESSAGE(NT_ATLAS_INVALID_REGION, idx, "tombstoned region still findable");
+        TEST_ASSERT_EQUAL_UINT32_MESSAGE(i, idx, "removed region must keep its stable index");
         const nt_texture_region_t *r = nt_atlas_test_get_region_raw(ad, i);
-        TEST_ASSERT_EQUAL_UINT8_MESSAGE(0, r->vertex_count, "tombstoned region vertex_count != 0");
+        TEST_ASSERT_EQUAL_UINT8_MESSAGE(0, r->vertex_count, "removed region vertex_count != 0");
     }
 
     /* Regions [500..999] (hashes 501..1000) are common — indices unchanged. */
@@ -1920,8 +1933,9 @@ void test_atlas_tombstone_cached_zero(void) {
 
     const struct nt_atlas_data *ad = (const struct nt_atlas_data *)s_user_data;
     const nt_texture_region_t *r0 = nt_atlas_test_get_region_raw(ad, 0);
-    /* AAA tombstoned → vertex_count==0, vertex_start==0. */
-    TEST_ASSERT_EQUAL_UINT64(NT_ATLAS_TOMBSTONE_HASH, r0->name_hash);
+    /* AAA removed → name retained, vertex_count==0, vertex_start==0. */
+    TEST_ASSERT_NOT_EQUAL_UINT64(NT_ATLAS_TOMBSTONE_HASH, r0->name_hash);
+    TEST_ASSERT_EQUAL_UINT64(0xAAAULL, r0->name_hash);
     TEST_ASSERT_EQUAL_UINT8(0, r0->vertex_count);
     TEST_ASSERT_EQUAL_UINT32(0, r0->vertex_start);
 
@@ -2236,7 +2250,7 @@ int main(void) {
     RUN_TEST(test_atlas_merge_preserves_shared_payload_slices);
     RUN_TEST(test_atlas_merge_new_region_appends_with_fresh_index);
     RUN_TEST(test_atlas_merge_removed_region_becomes_tombstone);
-    RUN_TEST(test_atlas_find_region_returns_invalid_for_tombstone);
+    RUN_TEST(test_atlas_find_region_returns_same_index_after_revive);
     RUN_TEST(test_atlas_get_region_returns_vertex_count_zero_for_tombstone);
     RUN_TEST(test_atlas_hash_collisions_probe_correctly);
     RUN_TEST(test_atlas_hash_table_growth_under_1000_regions);

--- a/tests/unit/test_log_api.c
+++ b/tests/unit/test_log_api.c
@@ -64,6 +64,35 @@ void test_log_set_level_none_filters_all(void) {
     TEST_PASS();
 }
 
+/* Content-dedup: same message logs once, repeat is suppressed.
+ * Real impl asserts the dedup; the stub build (returns false) smoke-runs the calls. */
+void test_log_unique_dedups_same_message(void) {
+    bool first = nt_log_warn_unique("unique-dedup-A id=%d", 7);
+    bool again = nt_log_warn_unique("unique-dedup-A id=%d", 7);
+#ifdef NT_LOG_REAL_IMPL
+    TEST_ASSERT_TRUE(first);  /* first occurrence logs */
+    TEST_ASSERT_FALSE(again); /* identical content deduped */
+#else
+    (void)first;
+    (void)again;
+    TEST_PASS();
+#endif
+}
+
+/* Content-dedup: distinct messages from the same call site each log. */
+void test_log_unique_distinct_messages_each_log(void) {
+    bool a = nt_log_warn_unique("unique-dedup-B id=%d", 1);
+    bool b = nt_log_warn_unique("unique-dedup-B id=%d", 2);
+#ifdef NT_LOG_REAL_IMPL
+    TEST_ASSERT_TRUE(a);
+    TEST_ASSERT_TRUE(b);
+#else
+    (void)a;
+    (void)b;
+    TEST_PASS();
+#endif
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_log_domain_info);
@@ -76,5 +105,7 @@ int main(void) {
     RUN_TEST(test_log_set_level_filters_info);
     RUN_TEST(test_log_set_level_allows_error);
     RUN_TEST(test_log_set_level_none_filters_all);
+    RUN_TEST(test_log_unique_dedups_same_message);
+    RUN_TEST(test_log_unique_distinct_messages_each_log);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_button.c
+++ b/tests/unit/test_nt_ui_button.c
@@ -134,7 +134,7 @@ static void test_button_icon_only_children(void) {
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
     CLAY({.id = CLAY_ID("root")}) {
         nt_ui_button_begin(s_fx.ctx, NULL, nt_ui_id("btn"), &s_btn_style, NULL, true);
-        nt_ui_image(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s_img_style, NULL);
+        nt_ui_image(s_fx.ctx, NULL, &(nt_atlas_region_ref_t){.atlas = s_fx.atlas.handle, .region = s_fx.atlas.white_region_idx}, &s_img_style, NULL);
         (void)nt_ui_button_end(s_fx.ctx);
     }
     nt_ui_end(s_fx.ctx);
@@ -150,7 +150,7 @@ static void test_button_icon_and_text_children(void) {
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
     CLAY({.id = CLAY_ID("root")}) {
         nt_ui_button_begin(s_fx.ctx, NULL, nt_ui_id("btn"), &s_btn_style, NULL, true);
-        nt_ui_image(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s_img_style, NULL);
+        nt_ui_image(s_fx.ctx, NULL, &(nt_atlas_region_ref_t){.atlas = s_fx.atlas.handle, .region = s_fx.atlas.white_region_idx}, &s_img_style, NULL);
         nt_ui_label(s_fx.ctx, NULL, "Save", &s_label_style);
         (void)nt_ui_button_end(s_fx.ctx);
     }
@@ -275,7 +275,7 @@ static void test_button_slice9_scale_asserts_negative(void) {
 }
 
 /* Per-state visual fields must be finite + in range. */
-static void try_bad_state(const nt_ui_button_style_t *bad) {
+static void try_bad_state(nt_ui_button_style_t *bad) {
     nt_pointer_t mouse = {0};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
     CLAY({.id = CLAY_ID("root")}) { NT_TEST_EXPECT_ASSERT(nt_ui_button_begin(s_fx.ctx, NULL, nt_ui_id("btn"), bad, NULL, true)); }

--- a/tests/unit/test_nt_ui_checkbox.c
+++ b/tests/unit/test_nt_ui_checkbox.c
@@ -52,8 +52,8 @@ static const nt_ui_label_style_t s_label_style = {
 
 static void init_style(void) {
     s_style = (nt_ui_checkbox_style_t){0};
-    const nt_atlas_region_ref_t box = {s_fx.atlas.handle, s_fx.atlas.white_region_idx};
-    const nt_atlas_region_ref_t check = {s_fx.atlas.handle, s_fx.atlas.white_region_idx};
+    const nt_atlas_region_ref_t box = nt_atlas_ref_idx(s_fx.atlas.handle, 0, s_fx.atlas.white_region_idx);
+    const nt_atlas_region_ref_t check = nt_atlas_ref_idx(s_fx.atlas.handle, 0, s_fx.atlas.white_region_idx);
     for (int i = 0; i < 4; ++i) {
         s_style.unchecked[i] = (nt_ui_cb_state_t){.box = box, .box_tint = 0xFFFFFFFFU, .check_tint = 0xFFFFFFFFU, .scale = 1.0F, .opacity = 1.0F};
         s_style.checked[i] = (nt_ui_cb_state_t){.box = box, .check = check, .box_tint = 0xFFFFFFFFU, .check_tint = 0xFFFFFFFFU, .scale = 1.0F, .opacity = 1.0F};
@@ -348,7 +348,7 @@ static void test_style_defaults_valid_baseline(void) {
     }
     TEST_ASSERT_TRUE(s.box_w > 0.0F && s.box_h > 0.0F);
     /* Defaults leave art refs zero; supply idle art so the value row is valid. */
-    const nt_atlas_region_ref_t art = {s_fx.atlas.handle, s_fx.atlas.white_region_idx};
+    const nt_atlas_region_ref_t art = nt_atlas_ref_idx(s_fx.atlas.handle, 0, s_fx.atlas.white_region_idx);
     s.unchecked[NT_UI_CB_IDLE].box = art;
     s.checked[NT_UI_CB_IDLE].box = art;
     s.checked[NT_UI_CB_IDLE].check = art;

--- a/tests/unit/test_nt_ui_image.c
+++ b/tests/unit/test_nt_ui_image.c
@@ -49,7 +49,8 @@ static const Clay_RenderCommand *find_first_image_cmd(const nt_ui_context_t *ctx
 static void test_image_basic(void) {
     nt_pointer_t mouse = {0};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
-    CLAY({.id = CLAY_ID("root")}) { nt_ui_image(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s_style_default, NULL); }
+    nt_atlas_region_ref_t ref = nt_atlas_ref_idx(s_fx.atlas.handle, 0, s_fx.atlas.white_region_idx);
+    CLAY({.id = CLAY_ID("root")}) { nt_ui_image(s_fx.ctx, NULL, &ref, &s_style_default, NULL); }
     nt_ui_end(s_fx.ctx);
 
     const Clay_RenderCommand *c = find_first_image_cmd(s_fx.ctx);
@@ -72,7 +73,8 @@ static void test_image_slice9_override(void) {
     };
     nt_pointer_t mouse = {0};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
-    CLAY({.id = CLAY_ID("root")}) { nt_ui_image(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s, NULL); }
+    nt_atlas_region_ref_t ref = nt_atlas_ref_idx(s_fx.atlas.handle, 0, s_fx.atlas.white_region_idx);
+    CLAY({.id = CLAY_ID("root")}) { nt_ui_image(s_fx.ctx, NULL, &ref, &s, NULL); }
     nt_ui_end(s_fx.ctx);
 
     const Clay_RenderCommand *c = find_first_image_cmd(s_fx.ctx);
@@ -94,7 +96,8 @@ static void test_image_tint_color(void) {
     };
     nt_pointer_t mouse = {0};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
-    CLAY({.id = CLAY_ID("root")}) { nt_ui_image(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s, NULL); }
+    nt_atlas_region_ref_t ref = nt_atlas_ref_idx(s_fx.atlas.handle, 0, s_fx.atlas.white_region_idx);
+    CLAY({.id = CLAY_ID("root")}) { nt_ui_image(s_fx.ctx, NULL, &ref, &s, NULL); }
     nt_ui_end(s_fx.ctx);
 
     const Clay_RenderCommand *c = find_first_image_cmd(s_fx.ctx);
@@ -111,7 +114,8 @@ static void test_image_element_data_passthrough(void) {
     int marker = 77;
     nt_pointer_t mouse = {0};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
-    CLAY({.id = CLAY_ID("root")}) { nt_ui_image(s_fx.ctx, NT_UI_DATA_FULL(5, &marker), (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s_style_default, NULL); }
+    nt_atlas_region_ref_t ref = nt_atlas_ref_idx(s_fx.atlas.handle, 0, s_fx.atlas.white_region_idx);
+    CLAY({.id = CLAY_ID("root")}) { nt_ui_image(s_fx.ctx, NT_UI_DATA_FULL(5, &marker), &ref, &s_style_default, NULL); }
     nt_ui_end(s_fx.ctx);
 
     const Clay_RenderCommand *c = find_first_image_cmd(s_fx.ctx);
@@ -132,7 +136,8 @@ static void test_image_flip_bits(void) {
     };
     nt_pointer_t mouse = {0};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
-    CLAY({.id = CLAY_ID("root")}) { nt_ui_image(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s, NULL); }
+    nt_atlas_region_ref_t ref = nt_atlas_ref_idx(s_fx.atlas.handle, 0, s_fx.atlas.white_region_idx);
+    CLAY({.id = CLAY_ID("root")}) { nt_ui_image(s_fx.ctx, NULL, &ref, &s, NULL); }
     nt_ui_end(s_fx.ctx);
 
     const Clay_RenderCommand *c = find_first_image_cmd(s_fx.ctx);
@@ -153,7 +158,8 @@ static void test_image_flags_origin(void) {
     };
     nt_pointer_t mouse = {0};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
-    CLAY({.id = CLAY_ID("root")}) { nt_ui_image(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s, NULL); }
+    nt_atlas_region_ref_t ref = nt_atlas_ref_idx(s_fx.atlas.handle, 0, s_fx.atlas.white_region_idx);
+    CLAY({.id = CLAY_ID("root")}) { nt_ui_image(s_fx.ctx, NULL, &ref, &s, NULL); }
     nt_ui_end(s_fx.ctx);
 
     const Clay_RenderCommand *c = find_first_image_cmd(s_fx.ctx);
@@ -174,6 +180,43 @@ static void test_image_style_defaults(void) {
     TEST_ASSERT_EQUAL_UINT8(0, d.flip_bits);
 }
 
+/* Fixture white region 0 is registered under this name hash (ui_atlas.c region0). */
+#define UI_ATLAS_WHITE_HASH 0x57484954454E4555ULL /* "WHITEENU" */
+
+/* ---- Test 8: ref built unresolved resolves to the white index under a ready atlas + memoizes ---- */
+static void test_image_resolves_from_invalid_under_ready_atlas(void) {
+    nt_pointer_t mouse = {0};
+    nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
+    /* Constructed unresolved (region == INVALID); the fixture atlas is READY so the engine resolves it. */
+    nt_atlas_region_ref_t ref = nt_atlas_ref(s_fx.atlas.handle, UI_ATLAS_WHITE_HASH);
+    TEST_ASSERT_EQUAL_UINT32(NT_ATLAS_INVALID_REGION, ref.region);
+    CLAY({.id = CLAY_ID("root")}) { nt_ui_image(s_fx.ctx, NULL, &ref, &s_style_default, NULL); }
+    nt_ui_end(s_fx.ctx);
+
+    /* (a) an IMAGE command was emitted. */
+    const Clay_RenderCommand *c = find_first_image_cmd(s_fx.ctx);
+    TEST_ASSERT_NOT_NULL(c);
+    /* (b) the payload resolved to the white region index. */
+    const nt_ui_image_payload_t *p = (const nt_ui_image_payload_t *)c->renderData.image.imageData;
+    TEST_ASSERT_EQUAL_UINT32(s_fx.atlas.white_region_idx, p->region_index);
+    /* (c) the ref was memoized back (no longer INVALID). */
+    TEST_ASSERT_EQUAL_UINT32(s_fx.atlas.white_region_idx, ref.region);
+}
+
+/* ---- Test 9: ref with a name never present skips emit, no assert (NOT a death test) ---- */
+static void test_image_unresolved_skips_emit_no_assert(void) {
+    nt_pointer_t mouse = {0};
+    nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
+    /* Atlas is READY so resolve runs, but find_region returns INVALID for a never-present name. */
+    nt_atlas_region_ref_t ref = nt_atlas_ref(s_fx.atlas.handle, 0xDEADBEEFCAFEBABEULL);
+    CLAY({.id = CLAY_ID("root")}) { nt_ui_image(s_fx.ctx, NULL, &ref, &s_style_default, NULL); }
+    nt_ui_end(s_fx.ctx);
+
+    /* No IMAGE command emitted; the ref stays INVALID; reaching here means no assert fired. */
+    TEST_ASSERT_NULL(find_first_image_cmd(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(NT_ATLAS_INVALID_REGION, ref.region);
+}
+
 /* ---- Death tests (NT_ASSERT_FULL only) ---- */
 #if NT_ASSERT_MODE == NT_ASSERT_FULL
 
@@ -181,7 +224,8 @@ static void test_image_style_defaults(void) {
 static void test_image_null_style_asserts(void) {
     nt_pointer_t mouse = {0};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
-    CLAY({.id = CLAY_ID("root")}) { NT_TEST_EXPECT_ASSERT(nt_ui_image(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, 0}, NULL, NULL)); }
+    nt_atlas_region_ref_t ref = nt_atlas_ref_idx(s_fx.atlas.handle, 0, 0);
+    CLAY({.id = CLAY_ID("root")}) { NT_TEST_EXPECT_ASSERT(nt_ui_image(s_fx.ctx, NULL, &ref, NULL, NULL)); }
     nt_ui_end(s_fx.ctx);
 }
 
@@ -190,7 +234,8 @@ static void test_image_invalid_atlas_asserts(void) {
     nt_resource_t bad = {.id = 0};
     nt_pointer_t mouse = {0};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
-    CLAY({.id = CLAY_ID("root")}) { NT_TEST_EXPECT_ASSERT(nt_ui_image(s_fx.ctx, NULL, (nt_atlas_region_ref_t){bad, 0}, &s_style_default, NULL)); }
+    nt_atlas_region_ref_t ref = nt_atlas_ref_idx(bad, 0, 0);
+    CLAY({.id = CLAY_ID("root")}) { NT_TEST_EXPECT_ASSERT(nt_ui_image(s_fx.ctx, NULL, &ref, &s_style_default, NULL)); }
     nt_ui_end(s_fx.ctx);
 }
 
@@ -205,6 +250,8 @@ int main(void) {
     RUN_TEST(test_image_flip_bits);
     RUN_TEST(test_image_flags_origin);
     RUN_TEST(test_image_style_defaults);
+    RUN_TEST(test_image_resolves_from_invalid_under_ready_atlas);
+    RUN_TEST(test_image_unresolved_skips_emit_no_assert);
 #if NT_ASSERT_MODE == NT_ASSERT_FULL
     RUN_TEST(test_image_null_style_asserts);
     RUN_TEST(test_image_invalid_atlas_asserts);

--- a/tests/unit/test_nt_ui_inspector.c
+++ b/tests/unit/test_nt_ui_inspector.c
@@ -166,7 +166,7 @@ static void test_panel_widget_tagged(void) {
      * so we can't easily look it up by name. Verify by counting tags: at least
      * one PANEL-def entry must exist in the registry after declaration. */
     CLAY({.id = CLAY_ID("root")}) {
-        nt_ui_panel_begin(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s_img_style, NULL);
+        nt_ui_panel_begin(s_fx.ctx, NULL, &(nt_atlas_region_ref_t){.atlas = s_fx.atlas.handle, .region = s_fx.atlas.white_region_idx}, &s_img_style, NULL);
         nt_ui_panel_end(s_fx.ctx);
     }
     /* Scan the registry for any slot pointing at NT_UI_PANEL_DEF. */
@@ -184,7 +184,7 @@ static void test_panel_widget_tagged(void) {
 static void test_image_widget_tagged(void) {
     nt_pointer_t mouse = make_pointer(0.0F, 0.0F);
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
-    CLAY({.id = CLAY_ID("root")}) { nt_ui_image(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s_img_style, NULL); }
+    CLAY({.id = CLAY_ID("root")}) { nt_ui_image(s_fx.ctx, NULL, &(nt_atlas_region_ref_t){.atlas = s_fx.atlas.handle, .region = s_fx.atlas.white_region_idx}, &s_img_style, NULL); }
     uint32_t image_count = 0U;
     for (uint32_t i = 0; i < s_fx.ctx->widget_registry_cap; ++i) {
         if (s_fx.ctx->widget_registry[i].id != 0U && s_fx.ctx->widget_registry[i].def == &NT_UI_IMAGE_DEF) {
@@ -220,7 +220,7 @@ static void test_label_does_not_clobber_parent_widget(void) {
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
     /* Panel parent + label child -- common pattern from the demo. */
     CLAY({.id = CLAY_ID("root")}) {
-        nt_ui_panel_begin(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s_img_style, NULL);
+        nt_ui_panel_begin(s_fx.ctx, NULL, &(nt_atlas_region_ref_t){.atlas = s_fx.atlas.handle, .region = s_fx.atlas.white_region_idx}, &s_img_style, NULL);
         nt_ui_label(s_fx.ctx, NULL, "hi", &s_label_style);
         nt_ui_panel_end(s_fx.ctx);
     }
@@ -615,7 +615,7 @@ static void test_inspector_emits_hex_for_unnamed_widget(void) {
     nt_pointer_t mouse = make_pointer(0.0F, 0.0F);
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
     CLAY({.id = CLAY_ID("root_unnamed_panel")}) {
-        nt_ui_panel_begin(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s_img_style, NULL);
+        nt_ui_panel_begin(s_fx.ctx, NULL, &(nt_atlas_region_ref_t){.atlas = s_fx.atlas.handle, .region = s_fx.atlas.white_region_idx}, &s_img_style, NULL);
         nt_ui_panel_end(s_fx.ctx);
     }
     const int32_t before = nt_ui_internal_get_layout_element_count(s_fx.ctx);
@@ -951,7 +951,9 @@ static void test_inspector_reads_layer_from_shared_config_userdata(void) {
     nt_pointer_t mouse = make_pointer(0.0F, 0.0F);
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
     const nt_ui_element_data_t *data_with_layer = NT_UI_DATA_LAYER((nt_ui_layer_t)3);
-    CLAY({.id = CLAY_ID("root_shared_layer")}) { nt_ui_image(s_fx.ctx, data_with_layer, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s_img_style, NULL); }
+    CLAY({.id = CLAY_ID("root_shared_layer")}) {
+        nt_ui_image(s_fx.ctx, data_with_layer, &(nt_atlas_region_ref_t){.atlas = s_fx.atlas.handle, .region = s_fx.atlas.white_region_idx}, &s_img_style, NULL);
+    }
     nt_ui_end(s_fx.ctx);
     /* Clay stored data in SHARED; cdv_element_layer's SHARED branch returns the layer. */
     TEST_ASSERT_EQUAL_UINT8(3U, (uint8_t)data_with_layer->layer);
@@ -1213,7 +1215,7 @@ static void test_inspector_inner_emits_carry_debug_layer(void) {
         nt_ui_button_begin(s_fx.ctx, NULL, nt_ui_id("inspect_btn"), &s_btn_style, NULL, true);
         nt_ui_label(s_fx.ctx, NULL, "OK", &s_label_style);
         (void)nt_ui_button_end(s_fx.ctx);
-        nt_ui_image(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s_img_style, NULL);
+        nt_ui_image(s_fx.ctx, NULL, &(nt_atlas_region_ref_t){.atlas = s_fx.atlas.handle, .region = s_fx.atlas.white_region_idx}, &s_img_style, NULL);
     }
     s_fx.ctx->inspector_selected_id = nt_ui_id("inspect_btn");
     nt_ui_end(s_fx.ctx);
@@ -1225,7 +1227,7 @@ static void test_inspector_inner_emits_carry_debug_layer(void) {
         nt_ui_button_begin(s_fx.ctx, NULL, nt_ui_id("inspect_btn"), &s_btn_style, NULL, true);
         nt_ui_label(s_fx.ctx, NULL, "OK", &s_label_style);
         (void)nt_ui_button_end(s_fx.ctx);
-        nt_ui_image(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s_img_style, NULL);
+        nt_ui_image(s_fx.ctx, NULL, &(nt_atlas_region_ref_t){.atlas = s_fx.atlas.handle, .region = s_fx.atlas.white_region_idx}, &s_img_style, NULL);
     }
     nt_ui_end(s_fx.ctx);
 
@@ -1287,7 +1289,7 @@ static void test_inspector_alternations_capped_after_strategy_a(void) {
         nt_ui_button_begin(s_fx.ctx, NULL, nt_ui_id("perf_btn"), &s_btn_style, NULL, true);
         nt_ui_label(s_fx.ctx, NULL, "OK", &s_label_style);
         (void)nt_ui_button_end(s_fx.ctx);
-        nt_ui_image(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s_img_style, NULL);
+        nt_ui_image(s_fx.ctx, NULL, &(nt_atlas_region_ref_t){.atlas = s_fx.atlas.handle, .region = s_fx.atlas.white_region_idx}, &s_img_style, NULL);
     }
     s_fx.ctx->inspector_selected_id = nt_ui_id("perf_btn");
     nt_ui_end(s_fx.ctx);
@@ -1299,7 +1301,7 @@ static void test_inspector_alternations_capped_after_strategy_a(void) {
         nt_ui_button_begin(s_fx.ctx, NULL, nt_ui_id("perf_btn"), &s_btn_style, NULL, true);
         nt_ui_label(s_fx.ctx, NULL, "OK", &s_label_style);
         (void)nt_ui_button_end(s_fx.ctx);
-        nt_ui_image(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s_img_style, NULL);
+        nt_ui_image(s_fx.ctx, NULL, &(nt_atlas_region_ref_t){.atlas = s_fx.atlas.handle, .region = s_fx.atlas.white_region_idx}, &s_img_style, NULL);
     }
     nt_ui_end(s_fx.ctx);
 
@@ -1446,7 +1448,7 @@ static void test_inspector_layer_split_collapses_dispatch(void) {
         nt_ui_button_begin(s_fx.ctx, NULL, nt_ui_id("split_btn"), &s_btn_style, NULL, true);
         nt_ui_label(s_fx.ctx, NULL, "OK", &s_label_style);
         (void)nt_ui_button_end(s_fx.ctx);
-        nt_ui_image(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s_img_style, NULL);
+        nt_ui_image(s_fx.ctx, NULL, &(nt_atlas_region_ref_t){.atlas = s_fx.atlas.handle, .region = s_fx.atlas.white_region_idx}, &s_img_style, NULL);
     }
     s_fx.ctx->inspector_selected_id = nt_ui_id("split_btn");
     nt_ui_end(s_fx.ctx);
@@ -1458,7 +1460,7 @@ static void test_inspector_layer_split_collapses_dispatch(void) {
         nt_ui_button_begin(s_fx.ctx, NULL, nt_ui_id("split_btn"), &s_btn_style, NULL, true);
         nt_ui_label(s_fx.ctx, NULL, "OK", &s_label_style);
         (void)nt_ui_button_end(s_fx.ctx);
-        nt_ui_image(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s_img_style, NULL);
+        nt_ui_image(s_fx.ctx, NULL, &(nt_atlas_region_ref_t){.atlas = s_fx.atlas.handle, .region = s_fx.atlas.white_region_idx}, &s_img_style, NULL);
     }
     nt_ui_end(s_fx.ctx);
 

--- a/tests/unit/test_nt_ui_panel.c
+++ b/tests/unit/test_nt_ui_panel.c
@@ -69,7 +69,7 @@ static void test_panel_begin_end_balanced(void) {
     nt_pointer_t mouse = {0};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
     CLAY({.id = CLAY_ID("root")}) {
-        nt_ui_panel_begin(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s_panel_style, NULL);
+        nt_ui_panel_begin(s_fx.ctx, NULL, &(nt_atlas_region_ref_t){.atlas = s_fx.atlas.handle, .region = s_fx.atlas.white_region_idx}, &s_panel_style, NULL);
         {
             nt_ui_label(s_fx.ctx, NULL, "Inside panel", &s_label_style);
         }
@@ -91,7 +91,7 @@ static void test_panel_with_transform(void) {
     nt_pointer_t mouse = {0};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
     CLAY({.id = CLAY_ID("root"), .userData = (void *)NT_UI_DATA_XFORM(0U, &t, 1.0F)}) {
-        nt_ui_panel_begin(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s_panel_style, NULL);
+        nt_ui_panel_begin(s_fx.ctx, NULL, &(nt_atlas_region_ref_t){.atlas = s_fx.atlas.handle, .region = s_fx.atlas.white_region_idx}, &s_panel_style, NULL);
         {
             nt_ui_label(s_fx.ctx, NULL, "Offset", &s_label_style);
         }
@@ -108,7 +108,7 @@ static void test_panel_no_transform(void) {
     nt_pointer_t mouse = {0};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
     CLAY({.id = CLAY_ID("root")}) {
-        nt_ui_panel_begin(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s_panel_style, NULL);
+        nt_ui_panel_begin(s_fx.ctx, NULL, &(nt_atlas_region_ref_t){.atlas = s_fx.atlas.handle, .region = s_fx.atlas.white_region_idx}, &s_panel_style, NULL);
         nt_ui_panel_end(s_fx.ctx);
     }
     nt_ui_end(s_fx.ctx);
@@ -175,7 +175,7 @@ static void test_panel_payload_carries_atlas(void) {
     nt_pointer_t mouse = {0};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
     CLAY({.id = CLAY_ID("root")}) {
-        nt_ui_panel_begin(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s_panel_style, NULL);
+        nt_ui_panel_begin(s_fx.ctx, NULL, &(nt_atlas_region_ref_t){.atlas = s_fx.atlas.handle, .region = s_fx.atlas.white_region_idx}, &s_panel_style, NULL);
         nt_ui_panel_end(s_fx.ctx);
     }
     nt_ui_end(s_fx.ctx);
@@ -193,7 +193,7 @@ static void test_nested_panel_group(void) {
     nt_pointer_t mouse = {0};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
     CLAY({.id = CLAY_ID("root")}) {
-        nt_ui_panel_begin(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s_panel_style, NULL);
+        nt_ui_panel_begin(s_fx.ctx, NULL, &(nt_atlas_region_ref_t){.atlas = s_fx.atlas.handle, .region = s_fx.atlas.white_region_idx}, &s_panel_style, NULL);
         {
             CLAY({.userData = (void *)NT_UI_DATA_XFORM(0U, &identity, 0.8F)}) {
                 nt_ui_group_begin(s_fx.ctx, NULL, NULL);
@@ -225,7 +225,7 @@ static void test_panel_payload_flags_origin(void) {
     nt_pointer_t mouse = {0};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
     CLAY({.id = CLAY_ID("root")}) {
-        nt_ui_panel_begin(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, s_fx.atlas.white_region_idx}, &s, NULL);
+        nt_ui_panel_begin(s_fx.ctx, NULL, &(nt_atlas_region_ref_t){.atlas = s_fx.atlas.handle, .region = s_fx.atlas.white_region_idx}, &s, NULL);
         nt_ui_panel_end(s_fx.ctx);
     }
     nt_ui_end(s_fx.ctx);
@@ -245,7 +245,7 @@ static void test_panel_payload_flags_origin(void) {
 static void test_panel_null_style_asserts(void) {
     nt_pointer_t mouse = {0};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
-    CLAY({.id = CLAY_ID("root")}) { NT_TEST_EXPECT_ASSERT(nt_ui_panel_begin(s_fx.ctx, NULL, (nt_atlas_region_ref_t){s_fx.atlas.handle, 0}, NULL, NULL)); }
+    CLAY({.id = CLAY_ID("root")}) { NT_TEST_EXPECT_ASSERT(nt_ui_panel_begin(s_fx.ctx, NULL, &(nt_atlas_region_ref_t){.atlas = s_fx.atlas.handle, .region = 0}, NULL, NULL)); }
     nt_ui_end(s_fx.ctx);
 }
 
@@ -254,7 +254,7 @@ static void test_panel_invalid_atlas_asserts(void) {
     nt_resource_t bad = {.id = 0};
     nt_pointer_t mouse = {0};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
-    CLAY({.id = CLAY_ID("root")}) { NT_TEST_EXPECT_ASSERT(nt_ui_panel_begin(s_fx.ctx, NULL, (nt_atlas_region_ref_t){bad, 0}, &s_panel_style, NULL)); }
+    CLAY({.id = CLAY_ID("root")}) { NT_TEST_EXPECT_ASSERT(nt_ui_panel_begin(s_fx.ctx, NULL, &(nt_atlas_region_ref_t){.atlas = bad, .region = 0}, &s_panel_style, NULL)); }
     nt_ui_end(s_fx.ctx);
 }
 

--- a/tests/unit/test_nt_ui_radio.c
+++ b/tests/unit/test_nt_ui_radio.c
@@ -49,8 +49,8 @@ static const nt_ui_label_style_t s_label_style = {
 
 static void init_style(void) {
     s_style = (nt_ui_checkbox_style_t){0};
-    const nt_atlas_region_ref_t box = {s_fx.atlas.handle, s_fx.atlas.white_region_idx};
-    const nt_atlas_region_ref_t dot = {s_fx.atlas.handle, s_fx.atlas.white_region_idx};
+    const nt_atlas_region_ref_t box = nt_atlas_ref_idx(s_fx.atlas.handle, 0, s_fx.atlas.white_region_idx);
+    const nt_atlas_region_ref_t dot = nt_atlas_ref_idx(s_fx.atlas.handle, 0, s_fx.atlas.white_region_idx);
     for (int i = 0; i < 4; ++i) {
         s_style.unchecked[i] = (nt_ui_cb_state_t){.box = box, .box_tint = 0xFFFFFFFFU, .check_tint = 0xFFFFFFFFU, .scale = 1.0F, .opacity = 1.0F};
         s_style.checked[i] = (nt_ui_cb_state_t){.box = box, .check = dot, .box_tint = 0xFFFFFFFFU, .check_tint = 0xFFFFFFFFU, .scale = 1.0F, .opacity = 1.0F};

--- a/tests/unit/test_nt_ui_toggle.c
+++ b/tests/unit/test_nt_ui_toggle.c
@@ -58,8 +58,8 @@ static const nt_ui_label_style_t s_label_style = {
 
 static void init_style(void) {
     s_style = (nt_ui_checkbox_style_t){0};
-    const nt_atlas_region_ref_t track = {s_fx.atlas.handle, s_fx.atlas.white_region_idx};
-    const nt_atlas_region_ref_t thumb = {s_fx.atlas.handle, s_fx.atlas.white_region_idx};
+    const nt_atlas_region_ref_t track = nt_atlas_ref_idx(s_fx.atlas.handle, 0, s_fx.atlas.white_region_idx);
+    const nt_atlas_region_ref_t thumb = nt_atlas_ref_idx(s_fx.atlas.handle, 0, s_fx.atlas.white_region_idx);
     /* Both rows carry the thumb art so the thumb is present at BOTH ends. */
     for (int i = 0; i < 4; ++i) {
         s_style.unchecked[i] = (nt_ui_cb_state_t){.box = track, .check = thumb, .box_tint = 0xFFFFFFFFU, .check_tint = 0xFFFFFFFFU, .scale = 1.0F, .opacity = 1.0F};

--- a/tests/unit/test_sprite_comp.c
+++ b/tests/unit/test_sprite_comp.c
@@ -501,9 +501,11 @@ static uint32_t build_fixture_atlas_blob_r0_only(uint8_t *atlas_blob, uint32_t c
     return build_mock_atlas_blob(atlas_blob, cap, &spec);
 }
 
-/* ---- Test 12: republish that tombstones a bound region clears RESOLVED and origin ---- */
+/* ---- Test 12: republish that removes a bound region keeps it resolved at its
+ * stable (dead) index — the region zero-draws via vertex_count==0. Tombstone-
+ * reclaim makes find_region return the stable index, so the sprite stays bound. ---- */
 
-void test_sprite_sync_clears_resolved_when_region_tombstoned(void) {
+void test_sprite_sync_keeps_resolved_when_region_removed(void) {
     setup_atlas_fixture(true);
 
     nt_entity_t e = nt_entity_create();
@@ -511,6 +513,7 @@ void test_sprite_sync_clears_resolved_when_region_tombstoned(void) {
     nt_sprite_comp_bind_by_hash(e, s_atlas_res, FIXTURE_R1_HASH);
     nt_sprite_comp_sync_resources();
     TEST_ASSERT_TRUE(nt_sprite_comp_is_resolved(e));
+    const uint16_t r1_idx = *nt_sprite_comp_region_index(e);
 
     uint8_t atlas_blob[1024];
     uint32_t atlas_blob_size = build_fixture_atlas_blob_r0_only(atlas_blob, sizeof(atlas_blob));
@@ -522,13 +525,16 @@ void test_sprite_sync_clears_resolved_when_region_tombstoned(void) {
     nt_resource_step();
     nt_sprite_comp_sync_resources();
 
-    TEST_ASSERT_FALSE(nt_sprite_comp_is_resolved(e));
-    TEST_ASSERT_BITS(NT_SPRITE_FLAG_RESOLVED, 0, *nt_sprite_comp_flags(e));
+    /* R1 removed but its name + index are retained → sprite stays resolved at
+     * the SAME index; the region is dead (vertex_count==0) so it zero-draws. */
+    TEST_ASSERT_TRUE(nt_sprite_comp_is_resolved(e));
+    TEST_ASSERT_BITS(NT_SPRITE_FLAG_RESOLVED, NT_SPRITE_FLAG_RESOLVED, *nt_sprite_comp_flags(e));
     TEST_ASSERT_EQUAL_UINT64(FIXTURE_R1_HASH, *nt_sprite_comp_region_hash(e)); /* identity preserved */
+    TEST_ASSERT_EQUAL_UINT16(r1_idx, *nt_sprite_comp_region_index(e));         /* stable index */
 
-    const float *origin_after = nt_sprite_comp_origin(e);
-    TEST_ASSERT_TRUE(origin_after[0] == 0.0F); /* NOLINT */
-    TEST_ASSERT_TRUE(origin_after[1] == 0.0F); /* NOLINT */
+    const nt_texture_region_t *region = nt_atlas_get_region(s_atlas_res, *nt_sprite_comp_region_index(e));
+    TEST_ASSERT_NOT_NULL(region);
+    TEST_ASSERT_EQUAL_UINT8(0, region->vertex_count); /* dead → zero-draw */
 }
 
 /* ---- Test 13: set_flip sets bits correctly and isolates from other flags ---- */
@@ -709,7 +715,7 @@ int main(void) {
     RUN_TEST(test_sprite_swap_and_pop_preserves_state);
     RUN_TEST(test_sprite_sync_refreshes_authored_origin_on_atlas_republish);
     RUN_TEST(test_sprite_sync_preserves_override_on_atlas_republish);
-    RUN_TEST(test_sprite_sync_clears_resolved_when_region_tombstoned);
+    RUN_TEST(test_sprite_sync_keeps_resolved_when_region_removed);
     RUN_TEST(test_sprite_set_flip_bit_isolation);
     RUN_TEST(test_sprite_view_matches_per_entity_reads);
     RUN_TEST(test_entity_destroy_removes_sprite);


### PR DESCRIPTION
## Phase 58.1 — Late-bound atlas region ref + tombstone-reclaim

Implements GitHub issue #202. Makes `nt_atlas_region_ref_t` a self-resolving handle and removes the per-frame "binding dance" from the UI demos: the game sets refs upfront and the engine resolves + memoizes lazily once the atlas loads.

Closes #202.

### Wave 1 — Atlas tombstone-reclaim
- A removed region keeps its `name_hash` and is marked dead via `vertex_count == 0` (no longer `NT_ATLAS_TOMBSTONE_HASH`).
- Dead-but-named slots stay in the hash table → re-adding a name revives the **same** index in place; `region_count` never grows.
- `nt_atlas_find_region` returns a stable index for any name ever present; `INVALID` only for names never present.
- Result: a resolved region index is stable for the atlas lifetime — the prerequisite for resolve-once with no revision tracking.

### Wave 2 — Ref type + widget migration (ABI ripple)
- `nt_atlas_region_ref_t` widened to a 16 B self-resolving handle `{name_hash, atlas, region}` + `nt_atlas_ref` / `nt_atlas_ref_idx` constructors + shared `nt_atlas_resolve_ref` (is_ready-gated, memoizes, no revision compare).
- image/panel take the ref by-pointer; button/checkbox/radio/toggle take a non-const style; resolve-and-memoize into the style-owned sub-object; resolve-then-skip-emit on `INVALID`.
- Embedding-struct ABI `_Static_assert`s re-baselined to measured sizes (`cb_state` 64, `checkbox_style` 584 — `uint64_t name_hash` forces 8-byte alignment).
- +2 image-resolve tests.

### Wave 3 — Demo migration
- Deleted the binding dance (`try_bind_resources` / `patch_row_atlas` / per-frame `find_region` + is_ready-wait) in the 4 demos; refs set upfront via `nt_atlas_ref(handle, hash)`.
- Behavior-preserving — engine resolves + memoizes lazily.

### Review follow-ups
- **feat**: dev-only (`NT_ASSERT_FULL`) `nt_log_warn_once` when a ready atlas can't resolve a ref name (typo guard); zero release/wasm overhead.
- **fix**: `nt_sprite_comp` dead-region assert retargeted from the now-unreachable sentinel-hash check to `vertex_count==0`.
- **docs**: spec §17.8 updated to describe tombstone-reclaim.
- **style**: dropped phase/PR reference tags from comments.

### Verification
- native-debug build ✓ · ctest **68/68** ✓ · clang-format ✓ · wasm-debug build ✓ · clang-tidy ✓
- Manual visual QA of the 5 UI demos: recommended (migration is behavior-preserving; GL surfaces don't capture reliably headless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
