### PR TITLE
[codex] Expose popup retained state cleanup

### DIFF
--- a/engine/ui/nt_ui_modal.c
+++ b/engine/ui/nt_ui_modal.c
@@ -171,6 +171,8 @@ bool nt_ui_modal_active(const nt_ui_context_t *ctx) {
     return ctx->modal_present_prev;
 }
 
+void nt_ui_modal_clear_state(nt_ui_context_t *ctx, uint32_t id) { nt_ui_popup_clear_state(ctx, id); }
+
 #ifdef NT_TEST_ACCESS
 uint16_t nt_ui_modal_test_last_zband(void) { return s_last_panel_zband; }
 uint16_t nt_ui_modal_test_last_backdrop_zband(void) { return s_last_backdrop_zband; }

--- a/engine/ui/nt_ui_modal.h
+++ b/engine/ui/nt_ui_modal.h
@@ -100,6 +100,11 @@ void nt_ui_modal_end(nt_ui_context_t *ctx);
  * nesting/z follow context. Two windows at once = two ids + two bools. */
 bool nt_ui_modal_visible(nt_ui_context_t *ctx, uint32_t id, const nt_ui_modal_style_t *style, bool *p_open);
 
+/* Drop modal-owned retained view state for `id` after a transient modal/sheet has closed. Child
+ * scroll/input/slider state inside the modal body remains caller-owned and should be cleared by id
+ * when it should not survive close/reopen. */
+void nt_ui_modal_clear_state(nt_ui_context_t *ctx, uint32_t id);
+
 /* True if a modal was up LAST frame (prev-frame presence — the live depth is 0 after nt_ui_end).
  * The game gates its keyboard/gameplay hotkeys on this; pointer routing is already auto-gated by
  * the backdrop occluder. */

--- a/engine/ui/nt_ui_popup.c
+++ b/engine/ui/nt_ui_popup.c
@@ -351,6 +351,14 @@ bool nt_ui_popup_visible(nt_ui_context_t *ctx, uint32_t id, const nt_ui_popup_st
     return true;
 }
 
+void nt_ui_popup_clear_state(nt_ui_context_t *ctx, uint32_t id) {
+    NT_ASSERT(ctx != NULL && "nt_ui_popup_clear_state: ctx must be non-NULL");
+    if (id == 0U) {
+        return;
+    }
+    nt_ui_state_clear(ctx, popup_tween_id(id));
+}
+
 #ifdef NT_TEST_ACCESS
 uint16_t nt_ui_popup_test_last_zband(void) { return s_last_panel_zband; }
 uint16_t nt_ui_popup_test_last_catcher_zband(void) { return s_last_catcher_zband; }

--- a/engine/ui/nt_ui_popup.h
+++ b/engine/ui/nt_ui_popup.h
@@ -86,6 +86,11 @@ void nt_ui_popup_end(nt_ui_context_t *ctx);
  *   } */
 bool nt_ui_popup_visible(nt_ui_context_t *ctx, uint32_t id, const nt_ui_popup_style_t *style, const nt_ui_popup_anchor_t *anchor, bool *p_open);
 
+/* Drop popup-owned retained view state for `id` after the game has closed a transient popup/sheet.
+ * This clears only popup-core state, not game-owned data or child widget state such as scroll/input
+ * cells inside the popup body. */
+void nt_ui_popup_clear_state(nt_ui_context_t *ctx, uint32_t id);
+
 #ifdef NT_TEST_ACCESS
 uint16_t nt_ui_popup_test_last_zband(void);                            /* panel z of the last begin */
 uint16_t nt_ui_popup_test_last_catcher_zband(void);                    /* catcher z of the last begin */

--- a/tests/unit/test_ui_popup.c
+++ b/tests/unit/test_ui_popup.c
@@ -16,6 +16,7 @@
 #include "ui/nt_ui.h"
 #include "ui/nt_ui_internal.h"
 #include "ui/nt_ui_popup.h"
+#include "ui/nt_ui_state.h"
 #include "unity.h"
 
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_TEST_ARENA_SIZE];
@@ -50,6 +51,8 @@ static nt_pointer_t pointer_at(float x, float y, bool is_down, bool is_pressed, 
     p.buttons[NT_BUTTON_LEFT].is_released = is_released;
     return p;
 }
+
+static void popup_frame(uint32_t id, const nt_ui_popup_style_t *st, const nt_ui_popup_anchor_t *anc, bool open, nt_ui_popup_result_t *out);
 
 /* ---- ABI sanity: the _Static_asserts compile; assert the runtime sizes match too. ---- */
 static void test_popup_abi_sizes(void) {
@@ -338,6 +341,19 @@ static void test_popup_no_dismiss_declares_no_catcher(void) {
     TEST_ASSERT_FALSE(nt_ui_popup_test_last_catcher_present());
 }
 
+static void test_popup_clear_state_releases_retained_tween_cell(void) {
+    nt_ui_popup_style_t st = nt_ui_popup_style_defaults();
+    st.ease_speed = 0.0F;
+    nt_ui_popup_anchor_t anc = {.x = 100.0F, .y = 100.0F, .w = 40.0F, .h = 24.0F, .prefer_side = NT_UI_POPUP_BELOW};
+
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_state_used_slots(s_fx.ctx));
+    popup_frame(POP_A, &st, &anc, true, &(nt_ui_popup_result_t){0});
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_state_used_slots(s_fx.ctx));
+
+    nt_ui_popup_clear_state(s_fx.ctx, POP_A);
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_ui_state_used_slots(s_fx.ctx));
+}
+
 /* ---- Open/close tween clamp: t in [0,1], rises while open, decays after close; visible == (t>eps). ---- */
 static void popup_frame(uint32_t id, const nt_ui_popup_style_t *st, const nt_ui_popup_anchor_t *anc, bool open, nt_ui_popup_result_t *out) {
     nt_ui_begin(s_fx.ctx, VIEW_W, VIEW_H, 1.0F / 60.0F, &(nt_pointer_t){.active = true}, 1);
@@ -391,6 +407,7 @@ int main(void) {
     RUN_TEST(test_popup_outside_click_dismiss);
     RUN_TEST(test_popup_wrapper_clears_open);
     RUN_TEST(test_popup_no_dismiss_declares_no_catcher);
+    RUN_TEST(test_popup_clear_state_releases_retained_tween_cell);
     RUN_TEST(test_popup_tween_clamp);
     return UNITY_END();
 }


### PR DESCRIPTION
## Summary

Fixes #262.

Adds explicit cleanup hooks for popup/modal-owned retained UI state:

- `nt_ui_popup_clear_state(ctx, id)` clears the popup tween/open-edge state cell derived from the popup id.
- `nt_ui_modal_clear_state(ctx, id)` exposes the same cleanup at the modal layer.
- `test_ui_popup` now verifies that opening a popup allocates the retained tween cell and the cleanup hook releases it.

## Why

`nt_ui_state` is intentionally non-evicting and callers are expected to clear transient view state when a screen closes. Popup/modal tween state was stored under an internal derived id, so games could not clear it without duplicating private engine logic or clearing the entire UI state pool.

This keeps ownership explicit: engine clears engine-owned popup/modal state; callers still own child scroll/input/slider state inside the body.

## Review notes

The change is intentionally narrow. It does not add automatic eviction, lifecycle magic, or game-owned cleanup policy to the engine. The API only exposes the already-existing popup-owned retained state key through a public helper.

## Validation

- `cmake -S . -B C:\tmp\neotolis-engine-native-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug -DCMAKE_C_STANDARD=17 -DCMAKE_C_STANDARD_REQUIRED=ON -DCMAKE_C_COMPILER=clang -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DNT_UI_DEBUG_TOOLS=ON`
- `cmake --build C:\tmp\neotolis-engine-native-debug --target test_nt_ui_state test_ui_popup test_nt_ui_modal`
- `ctest --test-dir C:\tmp\neotolis-engine-native-debug -R "test_nt_ui_state|test_ui_popup|test_nt_ui_modal" --output-on-failure`
- `clang-format --dry-run --Werror engine\ui\nt_ui_popup.c engine\ui\nt_ui_popup.h engine\ui\nt_ui_modal.c engine\ui\nt_ui_modal.h tests\unit\test_ui_popup.c`
- `clang-tidy -p C:\tmp\neotolis-engine-native-debug engine\ui\nt_ui_popup.c engine\ui\nt_ui_modal.c tests\unit\test_ui_popup.c`
- `git diff --check`

Full default `cmake --build C:\tmp\neotolis-engine-native-debug` was not used as the final signal because this checkout currently requires a generated example asset pack at `build/examples/textured_quad/base.ntpack`; the relevant UI targets above pass.