### PR TITLE
CI: docs-link workflow for broken relative links in docs/ (#269)

### DIFF
--- a/.github/workflows/docs-link.yml
+++ b/.github/workflows/docs-link.yml
@@ -1,0 +1,33 @@
+name: Docs Links
+
+# Standalone from ci.yml on purpose: ci.yml's top-level paths-ignore skips the
+# whole workflow for docs-only changes, so broken relative links in docs/ would
+# ship unchecked. This workflow does the opposite — it runs ONLY on doc/md
+# changes and does nothing but the fast link check (no build).
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docs/**'
+      - '**/*.md'
+      - 'scripts/check_doc_links.sh'
+      - '.github/workflows/docs-link.yml'
+  pull_request:
+    paths:
+      - 'docs/**'
+      - '**/*.md'
+      - 'scripts/check_doc_links.sh'
+      - '.github/workflows/docs-link.yml'
+
+concurrency:
+  group: docs-link-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docs-link:
+    name: Doc Links
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Check documentation links resolve
+        run: bash scripts/check_doc_links.sh

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -147,6 +147,10 @@ if [ "$MODE" = "full" ]; then
     bash scripts/check_link_failure_loud.sh
     bash scripts/check_emjs_deps.sh
     ok
+
+    step "doc links"
+    bash scripts/check_doc_links.sh
+    ok
 else
     step "clang-format (changed files)"
     if [ -n "$FORMAT_FILES" ]; then

--- a/scripts/check_doc_links.sh
+++ b/scripts/check_doc_links.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# Gate: every relative link in the docs tree must resolve to an existing file
+# (and, when present, an existing heading anchor). docs/** is in ci.yml's
+# paths-ignore, so a docs-only PR runs no other CI — a broken spec link would
+# otherwise ship unchecked. The .github/workflows/docs-link.yml workflow runs
+# this on doc/md changes; scripts/check.sh --full runs it locally.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR/.."
+
+python3 - <<'PY'
+import os, re, sys
+
+DOC_DIRS = ["docs"]
+EXTRA_FILES = ["AGENTS.md", "README.md"]  # root docs that link into docs/
+LINK_RE = re.compile(r"\[[^\]]*\]\(([^)]+)\)")
+
+def slugify(text):
+    s = text.strip().lower()
+    s = re.sub(r"[^\w\s-]", "", s)   # GitHub drops punctuation
+    s = re.sub(r"\s+", "-", s)
+    return s
+
+_heading_cache = {}
+def heading_slugs(path):
+    if path not in _heading_cache:
+        slugs = set()
+        try:
+            with open(path, encoding="utf-8") as fh:
+                for line in fh:
+                    m = re.match(r"#{1,6}\s+(.*)", line)
+                    if m:
+                        slugs.add(slugify(m.group(1)))
+        except OSError:
+            pass
+        _heading_cache[path] = slugs
+    return _heading_cache[path]
+
+md_files = []
+for d in DOC_DIRS:
+    for dirpath, _, files in os.walk(d):
+        md_files += [os.path.join(dirpath, f) for f in files if f.endswith(".md")]
+md_files += [f for f in EXTRA_FILES if os.path.isfile(f)]
+
+broken = []
+for src in md_files:
+    base = os.path.dirname(src)
+    with open(src, encoding="utf-8") as fh:
+        text = fh.read()
+    for target in LINK_RE.findall(text):
+        target = target.strip()
+        if target.startswith(("http://", "https://", "mailto:", "#")):
+            continue  # external or in-page-only
+        path_part, _, anchor = target.partition("#")
+        if not path_part:
+            continue
+        resolved = os.path.normpath(os.path.join(base, path_part))
+        if not os.path.exists(resolved):
+            broken.append((src, target, "missing file"))
+        elif anchor and resolved.endswith(".md") and slugify(anchor) not in heading_slugs(resolved):
+            broken.append((src, target, f"no heading anchor #{anchor}"))
+
+if broken:
+    print(f"check_doc_links: FAILED -- {len(broken)} broken link(s):")
+    for src, target, why in broken:
+        print(f"  {src} -> {target}  ({why})")
+    sys.exit(1)
+print(f"check_doc_links: ok ({len(md_files)} markdown files scanned, all relative links resolve)")
+PY


### PR DESCRIPTION
`docs/**` sits in ci.yml's top-level `paths-ignore`, so docs-only PRs (spec edits included) trigger **no** CI — broken relative links in `docs/spec/` ship unchecked. The #264 spec split has 95 internal relative links held together only by hand.

**Adds:**
- `scripts/check_doc_links.sh` — a Python link parser: every relative markdown link under `docs/` (+ root `AGENTS.md`/`README.md`) must resolve to an existing file; `#anchors` are validated against the target file's headings (GitHub slug rules). Prints the broken list, exits 1.
- `.github/workflows/docs-link.yml` — a **standalone** workflow, the inverse of ci.yml's ignore: it runs **only** on `docs/**` / `**/*.md` changes, does nothing but the link check (~10s, no build). Heavy ci.yml keeps ignoring docs.
- Wired into `scripts/check.sh --full` for local runs.

Tested locally: clean pass (33 files), catches a planted broken file link and a broken anchor (exit 1), valid anchors don't false-fail.

Closes #269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RFmSJF1E6ZHsZaot8QLity