### PR TITLE
ci: per-helper EM_JS_DEPS coverage + review-catalog rule (#275)

### DIFF
--- a/.claude/skills/reviewing-engine-code/references/principle-catalog.md
+++ b/.claude/skills/reviewing-engine-code/references/principle-catalog.md
@@ -25,6 +25,7 @@ smell**. Skip anything clang-format / clang-tidy / the size tracker already enfo
 10. Spec is source of truth
 11. Comments: short WHY only
 12. No gold-plating / speculative generality
+13. EM_JS_DEPS covers every referenced JS runtime helper
 
 ---
 
@@ -153,3 +154,17 @@ codebase.
 **Scope:** all engine code.
 ✅ a concrete function that does exactly what's needed now.
 ❌ a plugin registry / callback-vtable layer for a feature with a single call site.
+
+## 13. EM_JS_DEPS covers every referenced JS runtime helper — P1/P2
+
+**Rule:** every JS runtime helper referenced inside an `EM_JS`/`EM_ASM` body (`UTF8ToString`,
+`stringToNewUTF8`, `lengthBytesUTF8`, `wasmExports['x']`, …) must be declared by name in that
+TU's `EM_JS_DEPS`. A helper alive only through another dep's transitive `__deps` is an
+emscripten implementation detail, not a guarantee — it breaks silently in Closure wasm-release
+on an emsdk upgrade or a deps refactor, invisible to wasm-debug and native builds. P1 if no
+declared dep pulls the helper today (release is broken now); P2 if it currently survives
+transitively (latent).
+**Cite:** AGENTS.md §"Pre-commit checks" (EM_JS_DEPS gate) + `scripts/check_emjs_deps.sh` header.
+**Scope:** `engine/*/web/`, any TU with `EM_JS`/`EM_ASM`.
+✅ `EM_JS_DEPS(nt_http_web, "$UTF8ToString,malloc")` and the body uses exactly those.
+❌ body calls `lengthBytesUTF8(text)` while `EM_JS_DEPS` lists only `$stringToNewUTF8,$UTF8ToString`.

--- a/scripts/check_emjs_deps.sh
+++ b/scripts/check_emjs_deps.sh
@@ -1,25 +1,36 @@
 #!/usr/bin/env bash
-# Guard: an EM_JS / EM_ASM body that references a Closure-strippable JS runtime helper MUST self-declare
-# it via EM_JS_DEPS in the SAME translation unit. Otherwise the helper is invisible to Closure (the EM_JS
-# body is an opaque string), gets stripped in --closure release builds, and the call throws
-# "X is not defined" at runtime. The risk is release/Closure-only -> invisible to wasm-debug and to native,
-# so a plain build never catches it. This guard does, at lint time.
+# Guard: an EM_JS / EM_ASM body that references a Closure-strippable JS runtime helper MUST declare
+# THAT helper in an EM_JS_DEPS of the SAME translation unit. Presence of some EM_JS_DEPS is not
+# enough: a helper kept only via another dep's transitive __deps (an emscripten implementation
+# detail) breaks silently in --closure wasm-release on an emsdk upgrade or a deps refactor.
+# The risk is release/Closure-only -> invisible to wasm-debug and native builds.
+#
+# Method: strip C/JS comments (heuristic; also trims '//' inside string literals, which only ever
+# hides text after it on that line), collect helper references, and require each one, by name, in
+# the union of the TU's EM_JS_DEPS strings. JS-library helpers are declared with a '$' prefix
+# ($UTF8ToString); wasm exports referenced as wasmExports['x'] are declared bare (malloc).
 #
 # Trigger list: JS-side runtime helpers that only ever appear inside EM_JS/EM_ASM bodies (never in C),
 # so a match is a reliable signal the body marshals strings / reaches wasm exports.
 set -euo pipefail
 
-HELPERS='UTF8ToString|stringToNewUTF8|stringToUTF8|lengthBytesUTF8|allocateUTF8|intArrayFromString|wasmExports\['
+HELPERS='UTF8ToString|stringToNewUTF8|stringToUTF8|lengthBytesUTF8|allocateUTF8|intArrayFromString'
 
 fail=0
 while IFS= read -r -d '' f; do
     grep -Eq 'EM_JS\(|EM_ASM' "$f" 2>/dev/null || continue   # only TUs with an EM_JS/EM_ASM body
-    grep -Eq "$HELPERS" "$f" 2>/dev/null || continue          # ...that reference a strippable JS helper
-    if ! grep -q 'EM_JS_DEPS(' "$f" 2>/dev/null; then
+    stripped=$(perl -0777 -pe 's{/\*.*?\*/}{}gs; s{//[^\n]*}{}g' "$f")
+    required=$( { grep -oE "\b($HELPERS)\b" <<<"$stripped" || true;
+                  grep -oE "wasmExports\['[A-Za-z0-9_]+'\]" <<<"$stripped" | sed -E "s/wasmExports\['([A-Za-z0-9_]+)'\]/\1/" || true; } | sort -u)
+    [ -n "$required" ] || continue
+    declared=$(grep -oE 'EM_JS_DEPS\([A-Za-z0-9_]+[[:space:]]*,[[:space:]]*"[^"]*"' "$f" \
+               | sed -E 's/^[^"]*"//; s/"$//' | tr ',' '\n' | sed -E 's/^[[:space:]]*\$?//; s/[[:space:]]*$//' | sort -u)
+    missing=$(comm -23 <(echo "$required") <(echo "$declared"))
+    if [ -n "$missing" ]; then
         echo "EM_JS_DEPS GUARD FAIL: $f"
-        echo "  uses a Closure-strippable JS runtime helper inside an EM_JS/EM_ASM body but declares no EM_JS_DEPS(...)."
-        echo "  Add e.g.  EM_JS_DEPS(<tu_name>, \"\$UTF8ToString,...\")  so Closure keeps it in wasm-release."
-        grep -nE "$HELPERS" "$f" | head -5 | sed 's/^/     /'
+        echo "  EM_JS/EM_ASM body references helpers missing from this TU's EM_JS_DEPS:"
+        echo "$missing" | sed 's/^/     /'
+        echo "  Declare each one: JS-library helpers with '\$' (\$UTF8ToString), wasmExports['x'] bare (x)."
         fail=1
     fi
 done < <(find engine examples -name '*.c' -not -path '*/deps/*' -print0)
@@ -28,4 +39,4 @@ if [ "$fail" -ne 0 ]; then
     echo "EM_JS_DEPS GUARD: FAILED (see above)."
     exit 1
 fi
-echo "EM_JS_DEPS GUARD: ok -- every EM_JS/EM_ASM body using a JS runtime helper self-declares EM_JS_DEPS."
+echo "EM_JS_DEPS GUARD: ok -- every JS runtime helper used in an EM_JS/EM_ASM body is declared in its TU's EM_JS_DEPS."


### PR DESCRIPTION
Closes #275. Found by the #271 skill eval (seeded-bug recall run).

## What

- **`scripts/check_emjs_deps.sh`**: the gate previously only required that a TU with an `EM_JS`/`EM_ASM` body has *some* `EM_JS_DEPS(...)`. Now it strips C/JS comments, collects every referenced runtime helper (`$`-library helpers + `wasmExports['x']`), and requires each one **by name** in the union of the TU's `EM_JS_DEPS` strings. Catches helpers that survive Closure today only via another dep's transitive `__deps` (an emscripten implementation detail) and would break wasm-release silently on an emsdk upgrade or deps refactor — invisible to wasm-debug, native builds and tidy.
- **`reviewing-engine-code` principle catalog**: new rule 13 so the mandatory principle lens flags under-declared EM_JS deps (P1 active / P2 latent) instead of relying on the web lens noticing it.

## Validation

- On the #271 seeded branch the new gate fails on exactly the seeded `lengthBytesUTF8`-without-deps bug and nothing else; on master it passes clean (all existing web TUs are properly covered; `nt_devapi_web.c`'s comment mentioning `stringToNewUTF8` no longer false-positives thanks to comment stripping).
- 102/102 ctest, module-composition gates, emjs gate, doc-links gate: all green.
- Env caveat, stated explicitly: full `check.sh` build-all is blocked in this fresh worktree by the missing prebaked `sponza_full.ntpack` (pre-existing ~2h bake, clean baseline fails at the identical step); the diff is bash+md only, and tests/gates were run individually as listed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)