### PR TITLE
Define API contract naming style

### DIFF
--- a/docs/spec/assets/resource.md
+++ b/docs/spec/assets/resource.md
@@ -126,7 +126,7 @@ typedef void (*nt_post_resolve_fn)(const uint8_t *data, uint32_t size, nt_resour
 nt_resource_set_resolve_callbacks(asset_type, on_resolve, on_cleanup);
 nt_resource_set_post_resolve_callback(asset_type, on_post_resolve);
 nt_resource_set_behavior_flags(asset_type, flags);
-void *nt_resource_get_user_data(handle);
+void *nt_resource_peek_user_data(handle);
 ```
 
 Behavior flags:

--- a/docs/spec/assets/resource.md
+++ b/docs/spec/assets/resource.md
@@ -126,7 +126,7 @@ typedef void (*nt_post_resolve_fn)(const uint8_t *data, uint32_t size, nt_resour
 nt_resource_set_resolve_callbacks(asset_type, on_resolve, on_cleanup);
 nt_resource_set_post_resolve_callback(asset_type, on_post_resolve);
 nt_resource_set_behavior_flags(asset_type, flags);
-void *nt_resource_peek_user_data(handle);
+const void *nt_resource_peek_user_data(handle);
 ```
 
 Behavior flags:

--- a/docs/spec/core/api-contracts.md
+++ b/docs/spec/core/api-contracts.md
@@ -1,0 +1,148 @@
+# API Contract Style
+
+This chapter defines how Neotolis public C APIs spell ownership, pointer
+lifetime, nullability, and storage authority. It is a style contract for new
+APIs and for APIs touched during nearby work. It is not a new ownership system,
+and it does not change the engine/game boundary from
+[Principles](principles.md).
+
+Related: [Principles](principles.md), [Memory Policy](../runtime/memory.md),
+[Resource Registry](../assets/resource.md),
+[Logging, Errors, Debugging](../debug/logging-errors-debugging.md)
+
+## Scope
+
+- Apply this vocabulary to new public headers and to touched API comments.
+- Do not rename public symbols, fields, or typedefs only to match this chapter.
+- On a deliberate breaking-change branch, rename or reshape an actively
+  misleading API instead of explaining the mismatch with a comment.
+- Do not change behavior to make a lifetime easier to describe. If the current
+  behavior is bad, fix it through a focused behavior issue or ADR.
+- Do not duplicate every per-API lifetime here. Exact lifetimes stay next to
+  the API declaration or in the module chapter.
+- Do not introduce refcounting, smart-pointer layers, or heap copies in hot
+  paths for style compliance.
+
+This chapter was informed by established C/C++ API conventions: GLib
+transfer/scope annotations, Core Foundation Create/Get rules, Python C API
+new/borrowed/stolen references, SQLite static/transient binding policy, LLVM
+StringRef/ArrayRef views, C++ Core Guidelines owner/span/not_null, and optional
+SAL/Clang analyzer annotations. Neotolis borrows the intent, not their syntax.
+
+## Contract Checklist
+
+New public APIs, and existing APIs whose contract comments are touched, must
+make the relevant questions clear from the signature, name, or nearby comment
+when they expose a pointer, callback, handle, or pointer-carrying struct:
+
+- who allocates storage
+- who may mutate it
+- who frees it, and with which function
+- whether the callee may store the pointer
+- the exact invalidation event (`next call`, `next frame`,
+  `nt_mem_scratch_reset`, `unmount`, `destroy`, `shutdown`, etc.)
+- whether `NULL` is a valid public result or a programmer bug
+- which errors are recoverable return values and which are `NT_ASSERT`
+  contract violations
+
+Avoid vague words such as "temporary" or "owned" without the invalidation event
+or free path. A good contract says "valid until X" and "freed by Y".
+
+## Vocabulary
+
+| Word | Meaning |
+|---|---|
+| `init` / `shutdown` | Initializes or tears down module state or caller-provided storage. This does not imply heap ownership by itself. |
+| `create` / `destroy` | Creates a caller-owned handle/object with a documented destroy pair. Runtime hot paths should use this sparingly. |
+| `make` / `destroy` | Module-local synonym for create/destroy where already established, e.g. gfx resource creation. Do not rename to normalize. |
+| `copy` | Makes an owned deep copy. Input may die after the call returns unless the API says otherwise. |
+| `get` | Returns a current value or borrowed view. Caller must not free. Pointer lifetime must be stated. |
+| `find` | Pure lookup. It must not allocate or create a resource. Missing value is a normal result. |
+| `peek` | Borrowed pointer with a very short lifetime. Stronger warning than `get`: do not store. |
+| `take` / `consume` | Transfers ownership from caller to callee, or from callee to caller for `take_data`-style APIs. The success/failure transfer rule must be documented. |
+| `view` / `nt_*_view_t` | Non-owning pointer plus length/count, usually passed by value. No implicit NUL terminator. The backing lifetime must be stated. |
+| `pin` / `unpin` | Extends the lifetime of engine-owned backing storage without transferring free responsibility. Reserve for real pin semantics. |
+| `retain` / `release` | Reserve for real refcounted APIs only. Do not use as vague synonyms for `pin` or `destroy`. |
+| `out` / `out_*` | Caller-provided output storage. Pair pointer outputs with a count/capacity when applicable. |
+
+## Pointer Inputs
+
+Input pointers are borrowed for the duration of the call by default. If the
+callee stores a pointer or anything derived from it, the API must state one of:
+
+- copied now; caller may release its input after return
+- stored by reference until a named unregister, clear, destroy, or shutdown event
+- taken; caller must not free/use after the documented transfer point
+- pinned; backing storage stays engine-owned but the API extends its lifetime
+
+Do not silently store caller pointers. Stored-by-reference is allowed when it is
+the simplest and cheapest design, but the contract must say what must remain
+pointer-stable and for how long.
+
+## Pointer Returns
+
+Pointer returns fall into one of these shapes:
+
+- borrowed view into engine/module storage; caller never frees it
+- caller-owned allocation; caller frees through the documented function
+- caller buffer filled by the callee; caller owns the storage
+- optional result; `NULL` is a documented absence/failure result
+
+If a pointer return is non-NULL by contract, assert the invariant before
+returning rather than silently returning a null pointer. If absence is normal,
+use `NULL`, `false`, or `NT_ERR_*` as the public result and document it.
+
+## Views
+
+Use `nt_*_view_t` for borrowed pointer-plus-count snapshots such as SoA bulk
+component views. A view is not a container owner. It should normally be passed
+by value and should not be stored unless the API states the backing storage is
+stable for that use.
+
+When a view points into frame scratch, its lifetime is exactly until the next
+`nt_mem_scratch_reset()`, not generically "until next frame".
+
+## Callbacks And User Data
+
+For callbacks, treat `(fn, user_data)` as one registration unit. The API must
+state:
+
+- whether `user_data` is stored or only passed through during the call
+- how long stored `user_data` must remain valid
+- whether there is a destroy callback, and whether it runs exactly once
+- whether the callback may call back into the registering module
+
+Callback scope should use operational wording: "only during this call", "until
+unregister", "until context destroy", "until shutdown", or "until the destroy
+callback fires".
+
+## Handles
+
+Generational handles are values, not owned pointers. Passing a handle does not
+transfer ownership of the backing resource. An API that destroys, unregisters,
+invalidates, or releases backing state must say so explicitly.
+
+Virtual-resource APIs that publish a runtime handle do not automatically own or
+destroy the runtime object unless the function says that the handle is taken.
+
+## Hot Path Rule
+
+In hot paths, prefer handles, borrowed views, caller-provided output storage, or
+preallocated module storage. Allocation, deep copy, and ownership transfer
+belong in init, builder, loading/resolve, debug/devapi, or explicitly non-hot
+APIs. A style fix must not add heap work to a hot path.
+
+## Existing Canonical Examples
+
+- `nt_resource_find`: pure lookup naming.
+- `nt_resource_get_blob`: borrowed blob view wording.
+- `nt_resource_peek_user_data`: short-lived borrowed slot pointer naming.
+- `nt_ui_state`: retained UI view-state wording.
+- `nt_ui_probe_collect`: caller-buffer output with cap/truncation wording.
+- `nt_ui_probe_collect_owned`: context-owned scratch wording.
+- `nt_gfx_read_pixels`: caller-provided buffer with capacity wording.
+- Builder encode/bridge helpers: caller-owned heap output with module-free
+  wording.
+
+Use these as wording patterns, then keep the exact lifetime and invalidation
+event in the owning header or module chapter.

--- a/docs/spec/core/api-contracts.md
+++ b/docs/spec/core/api-contracts.md
@@ -1,10 +1,9 @@
 # API Contract Style
 
-This chapter defines how Neotolis public C APIs spell ownership, pointer
-lifetime, nullability, and storage authority. It is a style contract for new
-APIs and for APIs touched during nearby work. It is not a new ownership system,
-and it does not change the engine/game boundary from
-[Principles](principles.md).
+This chapter defines how Neotolis public C APIs spell storage ownership,
+pointer lifetime, nullability, and callback/user-data scope. It is a style
+contract, not a new ownership system, and it does not change the engine/game
+boundary from [Principles](principles.md).
 
 Related: [Principles](principles.md), [Memory Policy](../runtime/memory.md),
 [Resource Registry](../assets/resource.md),
@@ -23,98 +22,145 @@ Related: [Principles](principles.md), [Memory Policy](../runtime/memory.md),
 - Do not introduce refcounting, smart-pointer layers, or heap copies in hot
   paths for style compliance.
 
-This chapter was informed by established C/C++ API conventions: GLib
+This chapter borrows intent from established C/C++ conventions such as GLib
 transfer/scope annotations, Core Foundation Create/Get rules, Python C API
-new/borrowed/stolen references, SQLite static/transient binding policy, LLVM
-StringRef/ArrayRef views, C++ Core Guidelines owner/span/not_null, and optional
-SAL/Clang analyzer annotations. Neotolis borrows the intent, not their syntax.
+reference ownership, SQLite static/transient binding policy, LLVM
+StringRef/ArrayRef views, and C++ Core Guidelines owner/span/not_null. Neotolis
+uses plain C wording, not their syntax.
 
-## Contract Checklist
+## Required Contract
 
-New public APIs, and existing APIs whose contract comments are touched, must
-make the relevant questions clear from the signature, name, or nearby comment
-when they expose a pointer, callback, handle, or pointer-carrying struct:
+Public APIs in this chapter's scope that expose a pointer, callback, handle, or
+pointer-carrying struct must make the applicable questions clear from the
+signature, name, or nearby comment:
 
-- who allocates storage
-- who may mutate it
+- which storage backs pointer data: caller, module, frame scratch, pack blob,
+  external runtime object, or caller-provided output
+- who may mutate that storage
 - who frees it, and with which function
+- for containers, arrays, or pointer-carrying structs: whether ownership is
+  outer storage only, elements/subpointers only, both, or neither; name the
+  free path for each owned layer
 - whether the callee may store the pointer
-- the exact invalidation event (`next call`, `next frame`,
-  `nt_mem_scratch_reset`, `unmount`, `destroy`, `shutdown`, etc.)
-- whether `NULL` is a valid public result or a programmer bug
-- which errors are recoverable return values and which are `NT_ASSERT`
+- the exact invalidation event: next call, named mutation, next
+  `nt_mem_scratch_reset`, unmount, destroy, shutdown, etc.
+- whether `NULL` is a valid result/input or a programmer bug
+- which failures are recoverable return values and which are `NT_ASSERT`
   contract violations
 
 Avoid vague words such as "temporary" or "owned" without the invalidation event
 or free path. A good contract says "valid until X" and "freed by Y".
 
-## Vocabulary
+If the primary invalidation event cannot be named precisely, or the invalidating
+mutation set is open-ended, prefer a handle, caller-filled output, or explicit
+copy over returning a raw pointer. Multiple explicit events are OK when written
+as "until X or Y, whichever happens first."
 
-| Word | Meaning |
+## Contract Shapes
+
+Use the smallest shape that matches the real behavior.
+
+| Shape | Contract to state |
 |---|---|
-| `init` / `shutdown` | Initializes or tears down module state or caller-provided storage. This does not imply heap ownership by itself. |
-| `create` / `destroy` | Creates a caller-owned handle/object with a documented destroy pair. Runtime hot paths should use this sparingly. |
-| `make` / `destroy` | Module-local synonym for create/destroy where already established, e.g. gfx resource creation. Do not rename to normalize. |
-| `copy` | Makes an owned deep copy. Input may die after the call returns unless the API says otherwise. |
-| `get` | Returns a current value or borrowed view. Caller must not free. Pointer lifetime must be stated. |
-| `find` | Pure lookup. It must not allocate or create a resource. Missing value is a normal result. |
-| `peek` | Borrowed pointer with a very short lifetime. Stronger warning than `get`: do not store. |
-| `take` / `consume` | Transfers ownership from caller to callee, or from callee to caller for `take_data`-style APIs. The success/failure transfer rule must be documented. |
-| `view` / `nt_*_view_t` | Non-owning pointer plus length/count, usually passed by value. No implicit NUL terminator. The backing lifetime must be stated. |
-| `pin` / `unpin` | Extends the lifetime of engine-owned backing storage without transferring free responsibility. Reserve for real pin semantics. |
+| borrowed input | Default for input pointers: valid only during the call unless the API says it copies, stores, consumes, or pins it. |
+| stored-by-reference input | What must remain pointer-stable, and until which unregister, clear, destroy, or shutdown event. |
+| copied input | Callee copies the needed data before returning; caller may release the input after return. |
+| scratch-backed output | Backed by `nt_mem_scratch`; valid until next `nt_mem_scratch_reset()`; caller must not free or store it beyond that reset or in persistent state. |
+| borrowed module view | Backed by named module/owner storage; valid until the named mutation, destroy, or shutdown event. |
+| caller-owned output | Allocated or transferred to caller; comment names the free function. |
+| caller-filled output | Caller provides storage plus capacity; callee writes count/size and documents truncation or assert behavior. |
+| callback registration | Whether `(fn, user_data)` is stored, when it stops being called, and who frees `user_data`. |
+
+## Naming Rules
+
+| Word | Rule |
+|---|---|
+| `init` / `shutdown` | Initializes or tears down module state or caller-provided storage. Does not imply heap ownership by itself. |
+| `create` / `destroy` | Creates a new logical object, handle, or registry entry; the API must state who owns it and which teardown verb applies. If it returns a caller-owned object, document the destroy/free pair. Avoid in hot paths. |
+| `make` / `destroy` | Module-local synonym where already established, e.g. gfx resource creation. Do not rename only to normalize. |
+| `find` | Pure lookup. Must not allocate or create. Missing value is a normal result. |
+| `get` | Returns a current value or borrowed view with a named owner event. Caller must not free. |
+| `peek` | Returns a mutation-sensitive borrowed pointer. Caller must not store it. |
+| `view` / `nt_*_view_t` | Non-owning pointer plus length/count, passed by value. No implicit NUL terminator. Backing lifetime must be stated. |
+| `copy` | Makes an owned deep copy. Input may die after the call returns. |
+| `take` | Transfers ownership from callee to caller, e.g. `take_data`. Caller frees through the documented function. |
+| `consume` | Transfers ownership from caller to callee. Success and failure ownership rules must be documented. |
+| `pin` / `unpin` | Extends lifetime of engine-owned backing storage without transferring free responsibility. Reserve for real pin semantics. |
 | `retain` / `release` | Reserve for real refcounted APIs only. Do not use as vague synonyms for `pin` or `destroy`. |
-| `out` / `out_*` | Caller-provided output storage. Pair pointer outputs with a count/capacity when applicable. |
+| `out` / `out_*` | Caller-provided output storage. Pair pointer outputs with count/capacity where applicable. |
 
-## Pointer Inputs
+Use `peek` instead of `get` when the returned pointer is mutation-sensitive
+slot/module auxiliary state that must not be stored, such as a pointer
+invalidated by resource resolve/cleanup. Use `get` for borrowed data with a
+named owner event, such as pack-blob views valid until the resource slot
+publishes a different winner, blob eviction, unmount, destroy, or shutdown.
+Established `get_*` pointer APIs may keep their names when renaming would only
+normalize style, but their lifetime and invalidation events must be explicit.
 
-Input pointers are borrowed for the duration of the call by default. If the
-callee stores a pointer or anything derived from it, the API must state one of:
+Use `take` and `consume` only for real ownership transfer. If no ownership
+moves, do not use either word. Never write bare "takes ownership"; say from
+whom to whom, and name the free function or destroy event.
 
-- copied now; caller may release its input after return
-- stored by reference until a named unregister, clear, destroy, or shutdown event
-- taken; caller must not free/use after the documented transfer point
-- pinned; backing storage stays engine-owned but the API extends its lifetime
+Output pointers are not optional by default for APIs in this chapter's scope.
+For `out_*` parameters, state separately whether the output parameter pointer
+itself may be `NULL` to ignore the result, and whether the value written through
+it may be `NULL`. Do not use "nullable" without naming which pointer is
+nullable. Otherwise a `NULL` output parameter pointer is an `NT_ASSERT`
+contract violation. If an older untouched API accepts `NULL` for an output
+pointer but does not say so, fix the comment when that API is next touched.
 
-Do not silently store caller pointers. Stored-by-reference is allowed when it is
-the simplest and cheapest design, but the contract must say what must remain
-pointer-stable and for how long.
+For `nt_*_view_t`, state whether `data` is guaranteed non-NULL when `count > 0`.
+A zero-length view may use `NULL` data unless the API says otherwise.
 
-## Pointer Returns
+## Frame Scratch Storage
 
-Pointer returns fall into one of these shapes:
+`nt_mem_scratch` is engine-owned transient storage. A scratch allocation is not
+an owned object; it is caller-usable storage inside the frame arena. Callers must
+not free it, store it beyond the next reset or in persistent state, or return it
+from an API without documenting that the result is scratch-backed.
 
-- borrowed view into engine/module storage; caller never frees it
-- caller-owned allocation; caller frees through the documented function
-- caller buffer filled by the callee; caller owns the storage
-- optional result; `NULL` is a documented absence/failure result
+The invalidation event is exactly `nt_mem_scratch_reset()`. Do not describe
+scratch-backed pointers as valid "until end of frame": the reset placement is
+the contract, and tests may reset explicitly between simulated frames.
 
-If a pointer return is non-NULL by contract, assert the invariant before
-returning rather than silently returning a null pointer. If absence is normal,
-use `NULL`, `false`, or `NT_ERR_*` as the public result and document it.
+Use `scratch-backed` only for `nt_mem_scratch` storage. For per-context or
+module arenas, say `context-owned buffer`, `module-owned arena`, or another
+named owner, then name that owner-specific invalidation event.
 
-## Views
+Only the code that owns the top-level frame loop, or a test explicitly
+simulating that owner, may call `nt_mem_scratch_init`,
+`nt_mem_scratch_reset`, and `nt_mem_scratch_shutdown`. Modules may allocate
+scratch storage, but must not reset the arena. Public APIs that allocate into
+scratch must say whether they copy caller input into scratch or return a view
+into scratch.
 
-Use `nt_*_view_t` for borrowed pointer-plus-count snapshots such as SoA bulk
-component views. A view is not a container owner. It should normally be passed
-by value and should not be stored unless the API states the backing storage is
-stable for that use.
+Canonical wording:
 
-When a view points into frame scratch, its lifetime is exactly until the next
-`nt_mem_scratch_reset()`, not generically "until next frame".
+```c
+/* Returns a scratch-backed view. Valid until the next
+ * nt_mem_scratch_reset(); caller must not free or store beyond that reset. */
+```
 
 ## Callbacks And User Data
 
-For callbacks, treat `(fn, user_data)` as one registration unit. The API must
-state:
+Treat `(fn, user_data)` as one registration unit. The API must state:
 
 - whether `user_data` is stored or only passed through during the call
+- invocation scope: during this call, after registration until unregister,
+  until replaced, until destroy, or until shutdown
+- cardinality: zero, one, or many callback invocations
 - how long stored `user_data` must remain valid
-- whether there is a destroy callback, and whether it runs exactly once
-- whether the callback may call back into the registering module
+- whether each stored `user_data` value has a destroy callback, and whether
+  that callback runs exactly once for that value when it is replaced,
+  unregistered, destroyed, or shut down
+- replacement behavior and failed-registration ownership
+- if there is no destroy callback, that the engine never frees `user_data`
+- whether the callback may re-enter the module that invokes it, and which
+  mutating or accessor APIs are legal from that callback context
 
 Callback scope should use operational wording: "only during this call", "until
-unregister", "until context destroy", "until shutdown", or "until the destroy
-callback fires".
+unregister", "until replaced", "until context destroy", "until shutdown", or
+"until the destroy callback fires".
 
 ## Handles
 
@@ -123,26 +169,34 @@ transfer ownership of the backing resource. An API that destroys, unregisters,
 invalidates, or releases backing state must say so explicitly.
 
 Virtual-resource APIs that publish a runtime handle do not automatically own or
-destroy the runtime object unless the function says that the handle is taken.
+destroy the runtime object unless the function says it consumes ownership of the
+runtime object represented by that handle.
 
 ## Hot Path Rule
 
-In hot paths, prefer handles, borrowed views, caller-provided output storage, or
-preallocated module storage. Allocation, deep copy, and ownership transfer
-belong in init, builder, loading/resolve, debug/devapi, or explicitly non-hot
-APIs. A style fix must not add heap work to a hot path.
+In hot paths, prefer handles, borrowed views, scratch-backed temporaries,
+caller-filled output storage, or preallocated module storage. Heap allocation,
+persistent deep copy, and ownership transfer belong in init, builder, explicit
+load/activation boundaries, debug/devapi, or APIs documented as non-hot.
+Resource resolve runs from `nt_resource_step()` and is part of the hot path. Do
+not add resolve-time heap work as a style fix. The resource registry's current
+transient resolve-pass storage is an explicitly documented module-specific
+deviation, not a pattern; when touching that behavior, prefer preallocated
+module storage instead.
 
-## Existing Canonical Examples
+## Canonical Examples
 
 - `nt_resource_find`: pure lookup naming.
-- `nt_resource_get_blob`: borrowed blob view wording.
-- `nt_resource_peek_user_data`: short-lived borrowed slot pointer naming.
+- `nt_resource_get_blob`: borrowed pack-blob view wording.
+- `nt_resource_peek_user_data`: read-only, mutation-sensitive borrowed slot pointer.
+- `nt_fs_take_data` / `nt_http_take_data`: callee-to-caller ownership transfer.
 - `nt_ui_state`: retained UI view-state wording.
-- `nt_ui_probe_collect`: caller-buffer output with cap/truncation wording.
-- `nt_ui_probe_collect_owned`: context-owned scratch wording.
+- `nt_ui_probe_collect`: caller-filled output with cap/truncation wording.
+- `nt_ui_probe_collect_owned`: context-owned probe buffer wording.
 - `nt_gfx_read_pixels`: caller-provided buffer with capacity wording.
-- Builder encode/bridge helpers: caller-owned heap output with module-free
-  wording.
+- Builder encode/bridge helpers: caller-owned heap output with documented
+  `free()` or module free-function wording.
 
-Use these as wording patterns, then keep the exact lifetime and invalidation
-event in the owning header or module chapter.
+Use these as wording targets, not as blanket proof that older header comments
+already satisfy this chapter. Before copying a pattern, verify the owning header
+states the output optionality, invalidation event, and free path required above.

--- a/docs/spec/core/api-contracts.md
+++ b/docs/spec/core/api-contracts.md
@@ -1,9 +1,9 @@
 # API Contract Style
 
 This chapter defines how Neotolis public C APIs spell storage ownership,
-pointer lifetime, nullability, and callback/user-data scope. It is a style
-contract, not a new ownership system, and it does not change the engine/game
-boundary from [Principles](principles.md).
+pointer lifetime, nullability, callback/user-data scope, and output parameters.
+It is a style contract, not a new ownership system, and it does not change the
+engine/game boundary from [Principles](principles.md).
 
 Related: [Principles](principles.md), [Memory Policy](../runtime/memory.md),
 [Resource Registry](../assets/resource.md),
@@ -17,22 +17,16 @@ Related: [Principles](principles.md), [Memory Policy](../runtime/memory.md),
   misleading API instead of explaining the mismatch with a comment.
 - Do not change behavior to make a lifetime easier to describe. If the current
   behavior is bad, fix it through a focused behavior issue or ADR.
-- Do not duplicate every per-API lifetime here. Exact lifetimes stay next to
-  the API declaration or in the module chapter.
-- Do not introduce refcounting, smart-pointer layers, or heap copies in hot
-  paths for style compliance.
-
-This chapter borrows intent from established C/C++ conventions such as GLib
-transfer/scope annotations, Core Foundation Create/Get rules, Python C API
-reference ownership, SQLite static/transient binding policy, LLVM
-StringRef/ArrayRef views, and C++ Core Guidelines owner/span/not_null. Neotolis
-uses plain C wording, not their syntax.
+- Keep exact per-API lifetimes next to the API declaration or in the module
+  chapter; this chapter defines the shared vocabulary.
+- Do not introduce refcounting, smart-pointer layers, heap copies, or extra
+  indirection in hot paths for style compliance.
 
 ## Required Contract
 
-Public APIs in this chapter's scope that expose a pointer, callback, handle, or
-pointer-carrying struct must make the applicable questions clear from the
-signature, name, or nearby comment:
+Public APIs in this chapter's scope that expose a pointer, callback, handle,
+pointer-carrying struct, or output parameter must make the applicable questions
+clear from the signature, name, or nearby comment:
 
 - which storage backs pointer data: caller, module, frame scratch, pack blob,
   external runtime object, or caller-provided output
@@ -41,49 +35,44 @@ signature, name, or nearby comment:
 - for containers, arrays, or pointer-carrying structs: whether ownership is
   outer storage only, elements/subpointers only, both, or neither; name the
   free path for each owned layer
-- whether the callee may store the pointer
-- the exact invalidation event: next call, named mutation, next
+- whether the callee may store the pointer, and until which unregister, clear,
+  destroy, replacement, or shutdown event
+- the exact invalidation event: next call, named mutation,
   `nt_mem_scratch_reset`, unmount, destroy, shutdown, etc.
 - whether `NULL` is a valid result/input or a programmer bug
+- for output parameters, including `out_*`, size, count, progress, and data
+  pointers: whether the pointer itself may be `NULL`, what value is written on
+  success/failure, and whether the value written through it may be `NULL`; if
+  not stated, the output pointer is required
+- for pointer-plus-count views, whether `data` is guaranteed non-NULL when
+  `count > 0`
 - which failures are recoverable return values and which are `NT_ASSERT`
   contract violations
 
 Avoid vague words such as "temporary" or "owned" without the invalidation event
 or free path. A good contract says "valid until X" and "freed by Y".
 
+Input pointers are borrowed only for the duration of the call unless the API
+says it copies, stores, consumes, or pins them.
+
 If the primary invalidation event cannot be named precisely, or the invalidating
 mutation set is open-ended, prefer a handle, caller-filled output, or explicit
 copy over returning a raw pointer. Multiple explicit events are OK when written
 as "until X or Y, whichever happens first."
-
-## Contract Shapes
-
-Use the smallest shape that matches the real behavior.
-
-| Shape | Contract to state |
-|---|---|
-| borrowed input | Default for input pointers: valid only during the call unless the API says it copies, stores, consumes, or pins it. |
-| stored-by-reference input | What must remain pointer-stable, and until which unregister, clear, destroy, or shutdown event. |
-| copied input | Callee copies the needed data before returning; caller may release the input after return. |
-| scratch-backed output | Backed by `nt_mem_scratch`; valid until next `nt_mem_scratch_reset()`; caller must not free or store it beyond that reset or in persistent state. |
-| borrowed module view | Backed by named module/owner storage; valid until the named mutation, destroy, or shutdown event. |
-| caller-owned output | Allocated or transferred to caller; comment names the free function. |
-| caller-filled output | Caller provides storage plus capacity; callee writes count/size and documents truncation or assert behavior. |
-| callback registration | Whether `(fn, user_data)` is stored, when it stops being called, and who frees `user_data`. |
 
 ## Naming Rules
 
 | Word | Rule |
 |---|---|
 | `init` / `shutdown` | Initializes or tears down module state or caller-provided storage. Does not imply heap ownership by itself. |
-| `create` / `destroy` | Creates a new logical object, handle, or registry entry; the API must state who owns it and which teardown verb applies. If it returns a caller-owned object, document the destroy/free pair. Avoid in hot paths. |
+| `create` / `destroy` | Creates a logical object, handle, or registry entry; the API must state who owns it and which teardown verb applies. Avoid in hot paths. |
 | `make` / `destroy` | Module-local synonym where already established, e.g. gfx resource creation. Do not rename only to normalize. |
 | `find` | Pure lookup. Must not allocate or create. Missing value is a normal result. |
 | `get` | Returns a current value or borrowed view with a named owner event. Caller must not free. |
 | `peek` | Returns a mutation-sensitive borrowed pointer. Caller must not store it. |
 | `view` / `nt_*_view_t` | Non-owning pointer plus length/count, passed by value. No implicit NUL terminator. Backing lifetime must be stated. |
 | `copy` | Makes an owned deep copy. Input may die after the call returns. |
-| `take` | Transfers ownership from callee to caller, e.g. `take_data`. Caller frees through the documented function. |
+| `take` | Transfers ownership from callee to caller. Caller frees through the documented function. |
 | `consume` | Transfers ownership from caller to callee. Success and failure ownership rules must be documented. |
 | `pin` / `unpin` | Extends lifetime of engine-owned backing storage without transferring free responsibility. Reserve for real pin semantics. |
 | `retain` / `release` | Reserve for real refcounted APIs only. Do not use as vague synonyms for `pin` or `destroy`. |
@@ -91,68 +80,33 @@ Use the smallest shape that matches the real behavior.
 
 Use `peek` instead of `get` when the returned pointer is mutation-sensitive
 slot/module auxiliary state that must not be stored, such as a pointer
-invalidated by resource resolve/cleanup. Use `get` for borrowed data with a
-named owner event, such as pack-blob views valid until the resource slot
-publishes a different winner, blob eviction, unmount, destroy, or shutdown.
-Established `get_*` pointer APIs may keep their names when renaming would only
-normalize style, but their lifetime and invalidation events must be explicit.
+invalidated by resource resolve/cleanup. Established `get_*` pointer APIs may
+keep their names when renaming would only normalize style, but their lifetime
+and invalidation events must be explicit.
 
 Use `take` and `consume` only for real ownership transfer. If no ownership
 moves, do not use either word. Never write bare "takes ownership"; say from
 whom to whom, and name the free function or destroy event.
 
-Output pointers are not optional by default for APIs in this chapter's scope.
-For `out_*` parameters, state separately whether the output parameter pointer
-itself may be `NULL` to ignore the result, and whether the value written through
-it may be `NULL`. Do not use "nullable" without naming which pointer is
-nullable. Otherwise a `NULL` output parameter pointer is an `NT_ASSERT`
-contract violation. If an older untouched API accepts `NULL` for an output
-pointer but does not say so, fix the comment when that API is next touched.
+## Scratch-Backed Results
 
-For `nt_*_view_t`, state whether `data` is guaranteed non-NULL when `count > 0`.
-A zero-length view may use `NULL` data unless the API says otherwise.
-
-## Frame Scratch Storage
-
-`nt_mem_scratch` is engine-owned transient storage. A scratch allocation is not
-an owned object; it is caller-usable storage inside the frame arena. Callers must
-not free it, store it beyond the next reset or in persistent state, or return it
-from an API without documenting that the result is scratch-backed.
-
-The invalidation event is exactly `nt_mem_scratch_reset()`. Do not describe
-scratch-backed pointers as valid "until end of frame": the reset placement is
-the contract, and tests may reset explicitly between simulated frames.
-
-Use `scratch-backed` only for `nt_mem_scratch` storage. For per-context or
-module arenas, say `context-owned buffer`, `module-owned arena`, or another
-named owner, then name that owner-specific invalidation event.
-
-Only the code that owns the top-level frame loop, or a test explicitly
-simulating that owner, may call `nt_mem_scratch_init`,
-`nt_mem_scratch_reset`, and `nt_mem_scratch_shutdown`. Modules may allocate
-scratch storage, but must not reset the arena. Public APIs that allocate into
-scratch must say whether they copy caller input into scratch or return a view
-into scratch.
-
-Canonical wording:
-
-```c
-/* Returns a scratch-backed view. Valid until the next
- * nt_mem_scratch_reset(); caller must not free or store beyond that reset. */
-```
+Scratch-backed public results are backed by `nt_mem_scratch`, are valid exactly
+until the next `nt_mem_scratch_reset()`, and must not be freed or stored beyond
+that reset. Do not describe them as valid "until end of frame"; reset placement
+is the contract. Full scratch ownership rules live in
+[Memory Policy](../runtime/memory.md).
 
 ## Callbacks And User Data
 
 Treat `(fn, user_data)` as one registration unit. The API must state:
 
 - whether `user_data` is stored or only passed through during the call
-- invocation scope: during this call, after registration until unregister,
-  until replaced, until destroy, or until shutdown
+- invocation scope: during this call, until unregister, until replaced, until
+  destroy, or until shutdown
 - cardinality: zero, one, or many callback invocations
 - how long stored `user_data` must remain valid
 - whether each stored `user_data` value has a destroy callback, and whether
-  that callback runs exactly once for that value when it is replaced,
-  unregistered, destroyed, or shut down
+  that callback runs exactly once for that value
 - replacement behavior and failed-registration ownership
 - if there is no destroy callback, that the engine never frees `user_data`
 - whether the callback may re-enter the module that invokes it, and which
@@ -184,19 +138,22 @@ transient resolve-pass storage is an explicitly documented module-specific
 deviation, not a pattern; when touching that behavior, prefer preallocated
 module storage instead.
 
-## Canonical Examples
+## Wording Examples
 
-- `nt_resource_find`: pure lookup naming.
-- `nt_resource_get_blob`: borrowed pack-blob view wording.
-- `nt_resource_peek_user_data`: read-only, mutation-sensitive borrowed slot pointer.
-- `nt_fs_take_data` / `nt_http_take_data`: callee-to-caller ownership transfer.
-- `nt_ui_state`: retained UI view-state wording.
-- `nt_ui_probe_collect`: caller-filled output with cap/truncation wording.
-- `nt_ui_probe_collect_owned`: context-owned probe buffer wording.
-- `nt_gfx_read_pixels`: caller-provided buffer with capacity wording.
-- Builder encode/bridge helpers: caller-owned heap output with documented
-  `free()` or module free-function wording.
+Use these as wording targets; verify the owning header states exact optionality
+and invalidation events before copying a pattern.
 
-Use these as wording targets, not as blanket proof that older header comments
-already satisfy this chapter. Before copying a pattern, verify the owning header
-states the output optionality, invalidation event, and free path required above.
+```c
+/* Returns a scratch-backed view. Valid until the next nt_mem_scratch_reset();
+ * caller must not free or store beyond that reset. */
+```
+
+```c
+/* Transfers the completed buffer to the caller; caller frees with free().
+ * out_size may be NULL; when non-NULL it receives size or 0 on no transfer. */
+```
+
+```c
+/* Borrowed module view. Returns NULL when absent. Non-NULL data is valid until
+ * this slot publishes another winner, unmount, destroy, or shutdown. */
+```

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -39,6 +39,7 @@ no source-format parsers. The full picture is in
 | [core/principles.md](core/principles.md) | Design philosophy and the strict engine/game ownership boundary |
 | [core/scope.md](core/scope.md) | Baseline scope, explicit non-goals, and the `nt_ui` module note |
 | [core/module-layout.md](core/module-layout.md) | Module directory layout and interface/impl/stub composition |
+| [core/api-contracts.md](core/api-contracts.md) | Public API ownership, lifetime, and naming contract vocabulary |
 | [runtime/platform.md](runtime/platform.md) | Platform layer: Web/WASM target, responsibilities, canvas/DPR handling |
 | [runtime/frame-lifecycle.md](runtime/frame-lifecycle.md) | Frame order, game callbacks, fixed update loop |
 | [runtime/memory.md](runtime/memory.md) | Memory categories, frame scratch arena, capacity policy |
@@ -71,6 +72,10 @@ no source-format parsers. The full picture is in
 Source directories under `engine/` (and the builder under `tools/builder/`) mapped to
 the chapter that covers them:
 
+Any public-header/API contract change also reads
+[core/api-contracts.md](core/api-contracts.md) for the cross-cutting ownership,
+lifetime, and naming vocabulary.
+
 | Source dir | Chapter(s) |
 |---|---|
 | `engine/entity` | [data/entity.md](data/entity.md) |
@@ -94,7 +99,7 @@ the chapter that covers them:
 | `engine/app` | [debug/logging-errors-debugging.md](debug/logging-errors-debugging.md) (time & render control), [runtime/frame-lifecycle.md](runtime/frame-lifecycle.md) |
 | `engine/log`, `engine/devapi`, `engine/debug_overlay`, `engine/metrics`, `engine/introspect` | [debug/logging-errors-debugging.md](debug/logging-errors-debugging.md) |
 | `engine/memory`, `engine/pool` | [runtime/memory.md](runtime/memory.md) |
-| `engine/core` | [core/principles.md](core/principles.md); assert policy: [debug/logging-errors-debugging.md](debug/logging-errors-debugging.md) |
+| `engine/core` | [core/principles.md](core/principles.md), [core/api-contracts.md](core/api-contracts.md); assert policy: [debug/logging-errors-debugging.md](debug/logging-errors-debugging.md) |
 | `engine/clipboard` | [core/module-layout.md](core/module-layout.md) (stub semantics example) |
 | `engine/systems` | [runtime/frame-lifecycle.md](runtime/frame-lifecycle.md) (explicit system calls) |
 | `engine/basisu`, `engine/fpng` | [builder/builder.md](builder/builder.md) (texture encode), [debug/logging-errors-debugging.md](debug/logging-errors-debugging.md) (frame capture) |

--- a/engine/atlas/nt_atlas.c
+++ b/engine/atlas/nt_atlas.c
@@ -626,28 +626,28 @@ nt_result_t nt_atlas_init(void) {
 
 uint32_t nt_atlas_revision(nt_resource_t atlas) {
     NT_ASSERT(nt_resource_get_asset_type(atlas) == NT_ASSET_ATLAS && "nt_atlas_revision: handle is not an atlas resource");
-    nt_atlas_data_t *ad = (nt_atlas_data_t *)nt_resource_get_user_data(atlas);
+    nt_atlas_data_t *ad = (nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
     NT_ASSERT(ad != NULL && "nt_atlas_revision on unresolved atlas");
     return ad->revision;
 }
 
 uint32_t nt_atlas_region_count(nt_resource_t atlas) {
     NT_ASSERT(nt_resource_get_asset_type(atlas) == NT_ASSET_ATLAS && "nt_atlas_region_count: handle is not an atlas resource");
-    nt_atlas_data_t *ad = (nt_atlas_data_t *)nt_resource_get_user_data(atlas);
+    nt_atlas_data_t *ad = (nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
     NT_ASSERT(ad != NULL && "nt_atlas_region_count on unresolved atlas");
     return ad->region_count;
 }
 
 uint8_t nt_atlas_page_count(nt_resource_t atlas) {
     NT_ASSERT(nt_resource_get_asset_type(atlas) == NT_ASSET_ATLAS && "nt_atlas_page_count: handle is not an atlas resource");
-    nt_atlas_data_t *ad = (nt_atlas_data_t *)nt_resource_get_user_data(atlas);
+    nt_atlas_data_t *ad = (nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
     NT_ASSERT(ad != NULL && "nt_atlas_page_count on unresolved atlas");
     return ad->page_count;
 }
 
 uint32_t nt_atlas_find_region(nt_resource_t atlas, uint64_t name_hash) {
     NT_ASSERT(nt_resource_get_asset_type(atlas) == NT_ASSET_ATLAS && "nt_atlas_find_region: handle is not an atlas resource");
-    nt_atlas_data_t *ad = (nt_atlas_data_t *)nt_resource_get_user_data(atlas);
+    nt_atlas_data_t *ad = (nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
     NT_ASSERT(ad != NULL && "nt_atlas_find_region on unresolved atlas");
     if (ad->region_count == 0) {
         return NT_ATLAS_INVALID_REGION;
@@ -657,7 +657,7 @@ uint32_t nt_atlas_find_region(nt_resource_t atlas, uint64_t name_hash) {
 
 const nt_texture_region_t *nt_atlas_get_region(nt_resource_t atlas, uint32_t index) {
     NT_ASSERT(nt_resource_get_asset_type(atlas) == NT_ASSET_ATLAS && "nt_atlas_get_region: handle is not an atlas resource");
-    nt_atlas_data_t *ad = (nt_atlas_data_t *)nt_resource_get_user_data(atlas);
+    nt_atlas_data_t *ad = (nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
     NT_ASSERT(ad != NULL && "nt_atlas_get_region on unresolved atlas");
     NT_ASSERT(index < ad->region_count && "nt_atlas_get_region index out of range");
     return &ad->regions[index];
@@ -665,7 +665,7 @@ const nt_texture_region_t *nt_atlas_get_region(nt_resource_t atlas, uint32_t ind
 
 nt_resource_t nt_atlas_get_page_resource(nt_resource_t atlas, uint8_t page_index) {
     NT_ASSERT(nt_resource_get_asset_type(atlas) == NT_ASSET_ATLAS && "nt_atlas_get_page_resource: handle is not an atlas resource");
-    nt_atlas_data_t *ad = (nt_atlas_data_t *)nt_resource_get_user_data(atlas);
+    nt_atlas_data_t *ad = (nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
     NT_ASSERT(ad != NULL && "nt_atlas_get_page_resource on unresolved atlas");
     NT_ASSERT(page_index < ad->page_count && "page_index out of range");
     return ad->page_resources[page_index];
@@ -673,35 +673,35 @@ nt_resource_t nt_atlas_get_page_resource(nt_resource_t atlas, uint8_t page_index
 
 // #region cached projection accessors
 float nt_atlas_get_pixels_per_unit(nt_resource_t atlas) {
-    const nt_atlas_data_t *ad = (const nt_atlas_data_t *)nt_resource_get_user_data(atlas);
+    const nt_atlas_data_t *ad = (const nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
     NT_ASSERT(ad != NULL && "nt_atlas_get_pixels_per_unit on unresolved atlas");
     NT_ASSERT(ad->ipu > 0.0F && "atlas ipu must be set by atlas_on_post_resolve");
     return 1.0F / ad->ipu;
 }
 
 float nt_atlas_get_inverse_pixels_per_unit(nt_resource_t atlas) {
-    const nt_atlas_data_t *ad = (const nt_atlas_data_t *)nt_resource_get_user_data(atlas);
+    const nt_atlas_data_t *ad = (const nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
     NT_ASSERT(ad != NULL && "nt_atlas_get_inverse_pixels_per_unit on unresolved atlas");
     NT_ASSERT(ad->ipu > 0.0F && "atlas ipu must be set by atlas_on_post_resolve");
     return ad->ipu;
 }
 
 const float (*nt_atlas_get_region_cached_pos(nt_resource_t atlas, uint32_t region_index))[2] {
-    const nt_atlas_data_t *ad = (const nt_atlas_data_t *)nt_resource_get_user_data(atlas);
+    const nt_atlas_data_t *ad = (const nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
     NT_ASSERT(ad != NULL && "nt_atlas_get_region_cached_pos on unresolved atlas");
     NT_ASSERT(region_index < ad->region_count && "nt_atlas_get_region_cached_pos: region_index out of range");
     return (const float(*)[2]) & ad->cached_pos[ad->regions[region_index].vertex_start];
 }
 
 const nt_atlas_vertex_t *nt_atlas_get_region_raw_vertices(nt_resource_t atlas, uint32_t region_index) {
-    const nt_atlas_data_t *ad = (const nt_atlas_data_t *)nt_resource_get_user_data(atlas);
+    const nt_atlas_data_t *ad = (const nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
     NT_ASSERT(ad != NULL && "nt_atlas_get_region_raw_vertices on unresolved atlas");
     NT_ASSERT(region_index < ad->region_count && "nt_atlas_get_region_raw_vertices: region_index out of range");
     return &ad->vertices[ad->regions[region_index].vertex_start];
 }
 
 const uint16_t *nt_atlas_get_region_indices(nt_resource_t atlas, uint32_t region_index) {
-    const nt_atlas_data_t *ad = (const nt_atlas_data_t *)nt_resource_get_user_data(atlas);
+    const nt_atlas_data_t *ad = (const nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
     NT_ASSERT(ad != NULL && "nt_atlas_get_region_indices on unresolved atlas");
     NT_ASSERT(region_index < ad->region_count && "nt_atlas_get_region_indices: region_index out of range");
     return &ad->indices[ad->regions[region_index].index_start];
@@ -711,7 +711,7 @@ const uint16_t *nt_atlas_get_region_indices(nt_resource_t atlas, uint32_t region
 void nt_atlas_get_region_handles(nt_resource_t atlas, uint32_t region_index, nt_atlas_region_handles_t *out) {
     NT_ASSERT(out != NULL && "nt_atlas_get_region_handles: out must be non-NULL");
     NT_ASSERT(nt_resource_get_asset_type(atlas) == NT_ASSET_ATLAS && "nt_atlas_get_region_handles: handle is not an atlas resource");
-    const nt_atlas_data_t *ad = (const nt_atlas_data_t *)nt_resource_get_user_data(atlas);
+    const nt_atlas_data_t *ad = (const nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
     NT_ASSERT(ad != NULL && "nt_atlas_get_region_handles on unresolved atlas");
     NT_ASSERT(region_index < ad->region_count && "nt_atlas_get_region_handles: region_index out of range");
     NT_ASSERT(ad->ipu > 0.0F && "atlas ipu must be set by atlas_on_post_resolve");
@@ -731,7 +731,7 @@ void nt_atlas_get_region_handles(nt_resource_t atlas, uint32_t region_index, nt_
 // #region test access
 #ifdef NT_TEST_ACCESS
 
-const struct nt_atlas_data *nt_atlas_test_get_data(nt_resource_t atlas) { return (const nt_atlas_data_t *)nt_resource_get_user_data(atlas); }
+const struct nt_atlas_data *nt_atlas_test_get_data(nt_resource_t atlas) { return (const nt_atlas_data_t *)nt_resource_peek_user_data(atlas); }
 
 uint32_t nt_atlas_test_find_region_raw(const struct nt_atlas_data *ad, uint64_t name_hash) {
     NT_ASSERT(ad != NULL);

--- a/engine/atlas/nt_atlas.c
+++ b/engine/atlas/nt_atlas.c
@@ -626,28 +626,28 @@ nt_result_t nt_atlas_init(void) {
 
 uint32_t nt_atlas_revision(nt_resource_t atlas) {
     NT_ASSERT(nt_resource_get_asset_type(atlas) == NT_ASSET_ATLAS && "nt_atlas_revision: handle is not an atlas resource");
-    nt_atlas_data_t *ad = (nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
+    const nt_atlas_data_t *ad = (const nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
     NT_ASSERT(ad != NULL && "nt_atlas_revision on unresolved atlas");
     return ad->revision;
 }
 
 uint32_t nt_atlas_region_count(nt_resource_t atlas) {
     NT_ASSERT(nt_resource_get_asset_type(atlas) == NT_ASSET_ATLAS && "nt_atlas_region_count: handle is not an atlas resource");
-    nt_atlas_data_t *ad = (nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
+    const nt_atlas_data_t *ad = (const nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
     NT_ASSERT(ad != NULL && "nt_atlas_region_count on unresolved atlas");
     return ad->region_count;
 }
 
 uint8_t nt_atlas_page_count(nt_resource_t atlas) {
     NT_ASSERT(nt_resource_get_asset_type(atlas) == NT_ASSET_ATLAS && "nt_atlas_page_count: handle is not an atlas resource");
-    nt_atlas_data_t *ad = (nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
+    const nt_atlas_data_t *ad = (const nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
     NT_ASSERT(ad != NULL && "nt_atlas_page_count on unresolved atlas");
     return ad->page_count;
 }
 
 uint32_t nt_atlas_find_region(nt_resource_t atlas, uint64_t name_hash) {
     NT_ASSERT(nt_resource_get_asset_type(atlas) == NT_ASSET_ATLAS && "nt_atlas_find_region: handle is not an atlas resource");
-    nt_atlas_data_t *ad = (nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
+    const nt_atlas_data_t *ad = (const nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
     NT_ASSERT(ad != NULL && "nt_atlas_find_region on unresolved atlas");
     if (ad->region_count == 0) {
         return NT_ATLAS_INVALID_REGION;
@@ -657,7 +657,7 @@ uint32_t nt_atlas_find_region(nt_resource_t atlas, uint64_t name_hash) {
 
 const nt_texture_region_t *nt_atlas_get_region(nt_resource_t atlas, uint32_t index) {
     NT_ASSERT(nt_resource_get_asset_type(atlas) == NT_ASSET_ATLAS && "nt_atlas_get_region: handle is not an atlas resource");
-    nt_atlas_data_t *ad = (nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
+    const nt_atlas_data_t *ad = (const nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
     NT_ASSERT(ad != NULL && "nt_atlas_get_region on unresolved atlas");
     NT_ASSERT(index < ad->region_count && "nt_atlas_get_region index out of range");
     return &ad->regions[index];
@@ -665,7 +665,7 @@ const nt_texture_region_t *nt_atlas_get_region(nt_resource_t atlas, uint32_t ind
 
 nt_resource_t nt_atlas_get_page_resource(nt_resource_t atlas, uint8_t page_index) {
     NT_ASSERT(nt_resource_get_asset_type(atlas) == NT_ASSET_ATLAS && "nt_atlas_get_page_resource: handle is not an atlas resource");
-    nt_atlas_data_t *ad = (nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
+    const nt_atlas_data_t *ad = (const nt_atlas_data_t *)nt_resource_peek_user_data(atlas);
     NT_ASSERT(ad != NULL && "nt_atlas_get_page_resource on unresolved atlas");
     NT_ASSERT(page_index < ad->page_count && "page_index out of range");
     return ad->page_resources[page_index];

--- a/engine/atlas/nt_atlas.h
+++ b/engine/atlas/nt_atlas.h
@@ -176,11 +176,11 @@ struct nt_atlas_data;
  * Used by tests that DO drive the resource system end-to-end. */
 const struct nt_atlas_data *nt_atlas_test_get_data(nt_resource_t atlas);
 
-/* Bypass nt_resource_get_user_data and look up a region on a raw
+/* Bypass nt_resource_peek_user_data and look up a region on a raw
  * nt_atlas_data_t* directly. Mirrors nt_atlas_find_region(). */
 uint32_t nt_atlas_test_find_region_raw(const struct nt_atlas_data *ad, uint64_t name_hash);
 
-/* Bypass nt_resource_get_user_data and read a region array entry directly.
+/* Bypass nt_resource_peek_user_data and read a region array entry directly.
  * Mirrors nt_atlas_get_region(). */
 const nt_texture_region_t *nt_atlas_test_get_region_raw(const struct nt_atlas_data *ad, uint32_t index);
 

--- a/engine/devapi/nt_devapi.h
+++ b/engine/devapi/nt_devapi.h
@@ -24,7 +24,8 @@
 nt_result_t nt_devapi_init(void);
 void nt_devapi_shutdown(void);
 
-/* Register a command (copies all 7 descriptor strings). NT_ERR_INVALID_ARG if `method`
+/* Register a command. Copies all 7 descriptor strings; stores `user_data` by reference
+   and passes it to the handler until nt_devapi_shutdown(). NT_ERR_INVALID_ARG if `method`
    is already registered — the dup is rejected, not overwritten. */
 nt_result_t nt_devapi_register(const nt_devapi_command_desc *desc, nt_devapi_handler_fn handler, void *user_data);
 

--- a/engine/devapi/nt_devapi.h
+++ b/engine/devapi/nt_devapi.h
@@ -24,9 +24,11 @@
 nt_result_t nt_devapi_init(void);
 void nt_devapi_shutdown(void);
 
-/* Register a command. Copies all 7 descriptor strings; stores `user_data` by reference
-   and passes it to the handler until nt_devapi_shutdown(). NT_ERR_INVALID_ARG if `method`
-   is already registered — the dup is rejected, not overwritten. */
+/* Register a command. desc, handler, and all 7 descriptor strings must be non-NULL.
+   Copies the strings; user_data may be NULL. Non-NULL user_data is stored by
+   reference and passed to the handler until nt_devapi_shutdown(); caller owns it
+   and the engine never frees it. NT_ERR_INVALID_ARG if `method` is already registered —
+   the dup is rejected, not overwritten. */
 nt_result_t nt_devapi_register(const nt_devapi_command_desc *desc, nt_devapi_handler_fn handler, void *user_data);
 
 /* Submit one JSON request line → the JSON response line. The returned pointer is valid

--- a/engine/font/nt_font.c
+++ b/engine/font/nt_font.c
@@ -108,7 +108,7 @@ static void font_on_cleanup(void *user_data) {
 /* Read the winning resource's live blob through its pinned user_data holder
  * (never a raw pointer cached across frames). NULL when the provider is gone. */
 static const uint8_t *font_provider_blob(nt_resource_t resource, uint32_t *out_size) {
-    const nt_font_provider_t *p = (const nt_font_provider_t *)nt_resource_get_user_data(resource);
+    const nt_font_provider_t *p = (const nt_font_provider_t *)nt_resource_peek_user_data(resource);
     if (p == NULL || p->data == NULL) {
         if (out_size != NULL) {
             *out_size = 0;

--- a/engine/fs/nt_fs.h
+++ b/engine/fs/nt_fs.h
@@ -24,7 +24,10 @@ nt_result_t nt_fs_init(void);
 void nt_fs_shutdown(void);
 nt_fs_request_t nt_fs_read_file(const char *path);
 nt_fs_state_t nt_fs_state(nt_fs_request_t req);
+/* Transfers the completed buffer to the caller; caller frees with free().
+ * Returns NULL when the request is not DONE or was already taken. */
 uint8_t *nt_fs_take_data(nt_fs_request_t req, uint32_t *out_size);
+/* Releases the request slot and frees only data that was not taken. */
 void nt_fs_free(nt_fs_request_t req);
 
 #endif /* NT_FS_H */

--- a/engine/fs/nt_fs.h
+++ b/engine/fs/nt_fs.h
@@ -25,6 +25,7 @@ void nt_fs_shutdown(void);
 nt_fs_request_t nt_fs_read_file(const char *path);
 nt_fs_state_t nt_fs_state(nt_fs_request_t req);
 /* Transfers the completed buffer to the caller; caller frees with free().
+ * out_size may be NULL; when non-NULL it receives size or 0 on no transfer.
  * Returns NULL when the request is not DONE or was already taken. */
 uint8_t *nt_fs_take_data(nt_fs_request_t req, uint32_t *out_size);
 /* Releases the request slot and frees only data that was not taken. */

--- a/engine/http/nt_http.h
+++ b/engine/http/nt_http.h
@@ -26,7 +26,11 @@ void nt_http_shutdown(void);
 nt_http_request_t nt_http_request(const char *url);
 nt_http_state_t nt_http_state(nt_http_request_t req);
 void nt_http_progress(nt_http_request_t req, uint32_t *received, uint32_t *total);
+/* Transfers the completed response buffer to the caller; caller frees with free().
+ * Returns NULL with size 0 when the request is not DONE, has no completed
+ * buffer, or was already taken. */
 uint8_t *nt_http_take_data(nt_http_request_t req, uint32_t *out_size);
+/* Releases the request slot and frees only data that was not taken. */
 void nt_http_free(nt_http_request_t req);
 
 #endif /* NT_HTTP_H */

--- a/engine/http/nt_http.h
+++ b/engine/http/nt_http.h
@@ -27,6 +27,7 @@ nt_http_request_t nt_http_request(const char *url);
 nt_http_state_t nt_http_state(nt_http_request_t req);
 void nt_http_progress(nt_http_request_t req, uint32_t *received, uint32_t *total);
 /* Transfers the completed response buffer to the caller; caller frees with free().
+ * out_size may be NULL; when non-NULL it receives size or 0 on no transfer.
  * Returns NULL with size 0 when the request is not DONE, has no completed
  * buffer, or was already taken. */
 uint8_t *nt_http_take_data(nt_http_request_t req, uint32_t *out_size);

--- a/engine/resource/nt_resource.c
+++ b/engine/resource/nt_resource.c
@@ -1062,7 +1062,7 @@ uint32_t nt_resource_get(nt_resource_t handle) {
     return s_resource.slots[index].runtime_handle;
 }
 
-void *nt_resource_peek_user_data(nt_resource_t handle) {
+const void *nt_resource_peek_user_data(nt_resource_t handle) {
     if (handle.id == 0) {
         return NULL;
     }

--- a/engine/resource/nt_resource.c
+++ b/engine/resource/nt_resource.c
@@ -1062,7 +1062,7 @@ uint32_t nt_resource_get(nt_resource_t handle) {
     return s_resource.slots[index].runtime_handle;
 }
 
-void *nt_resource_get_user_data(nt_resource_t handle) {
+void *nt_resource_peek_user_data(nt_resource_t handle) {
     if (handle.id == 0) {
         return NULL;
     }

--- a/engine/resource/nt_resource.h
+++ b/engine/resource/nt_resource.h
@@ -55,7 +55,7 @@ static inline uint16_t nt_resource_generation(nt_resource_t r) { return (uint16_
 
 /* ---- Activator callback types ----
  * on_resolve/on_cleanup fire during resolve iteration — they must not call
- * resource API (mount/unmount/request/step/load/parse), because modifying
+ * mutating resource APIs (mount/unmount/request/step/load/parse), because modifying
  * resource state there is UB.
  *
  * on_post_resolve fires after the resolve iteration finishes. It may call
@@ -160,6 +160,10 @@ const void *nt_resource_get_meta(nt_resource_t handle, nt_hash64_t kind, uint32_
 
 /* ---- Virtual packs ---- */
 
+/* Virtual packs publish caller-created runtime handles. The resource system stores the
+ * handle value but does not own/destroy the runtime object; virtual unregister/unmount
+ * never call the asset deactivator. Resolve cleanup callbacks may still release
+ * per-slot user_data. */
 nt_result_t nt_resource_create_pack(nt_hash32_t pack_id, int16_t priority);
 nt_result_t nt_resource_register(nt_hash32_t pack_id, nt_hash64_t resource_id, uint8_t asset_type, uint32_t runtime_handle);
 void nt_resource_unregister(nt_hash32_t pack_id, nt_hash64_t resource_id);
@@ -182,7 +186,9 @@ void nt_resource_set_activator(uint8_t asset_type, nt_activate_fn activate, nt_d
 void nt_resource_set_resolve_callbacks(uint8_t asset_type, nt_resolve_fn on_resolve, nt_cleanup_fn on_cleanup);
 void nt_resource_set_post_resolve_callback(uint8_t asset_type, nt_post_resolve_fn on_post_resolve);
 void nt_resource_set_behavior_flags(uint8_t asset_type, uint8_t behavior_flags);
-void *nt_resource_get_user_data(nt_resource_t handle);
+/* Borrowed current slot aux pointer. Valid only until the next resource
+ * resolve/cleanup that changes this slot, or shutdown; caller must not free or store it. */
+void *nt_resource_peek_user_data(nt_resource_t handle);
 
 /* ---- Activation time budget ---- */
 

--- a/engine/resource/nt_resource.h
+++ b/engine/resource/nt_resource.h
@@ -54,9 +54,9 @@ static inline uint16_t nt_resource_slot_index(nt_resource_t r) { return (uint16_
 static inline uint16_t nt_resource_generation(nt_resource_t r) { return (uint16_t)(r.id >> 16); }
 
 /* ---- Activator callback types ----
- * on_resolve/on_cleanup fire during resolve iteration — they must not call
- * mutating resource APIs (mount/unmount/request/step/load/parse), because modifying
- * resource state there is UB.
+ * on_resolve/on_cleanup fire during resolve iteration. They may use callback
+ * args and APIs explicitly marked callback-safe, but must not request/get,
+ * mount/unmount/step/load/parse resource state; on_post_resolve is the stable read seam.
  *
  * on_post_resolve fires after the resolve iteration finishes. It may call
  * request/find/get-style resource accessors, but must not recurse into
@@ -147,15 +147,16 @@ uint8_t nt_resource_get_asset_type(nt_resource_t handle);
  * goes through resolve_pass and bumps the epoch normally. */
 uint32_t nt_resource_publication_epoch(void);
 
-/* Get raw blob data pointer (after NtBlobAssetHeader). Returns NULL if not ready or not a blob.
- * Returned pointer is a view into pack memory — valid until pack blob is evicted.
- * Caller must copy data if it needs to persist beyond the current frame. */
+/* Get raw blob data pointer (after NtBlobAssetHeader). Returns NULL if not ready,
+ * not a blob, or the current blob is absent; out_size may be NULL. Non-NULL data
+ * is the current published winner's pack-blob view, valid until this slot publishes
+ * another winner, the blob is evicted/unmounted, or shutdown. */
 const uint8_t *nt_resource_get_blob(nt_resource_t handle, uint32_t *out_size);
 
 /* Get metadata for a resource by kind hash. Returns pointer to metadata bytes
- * in resident pack memory, NULL if absent. Pointer valid until pack unmount.
- * kind = nt_hash64_str("tag") for example.
- * Returns NULL + size 0 for absent metadata. */
+ * in resident pack memory, NULL + size 0 if absent; out_size may be NULL.
+ * Non-NULL data is the current published winner's metadata view, valid until
+ * this slot publishes another winner, pack unmount, or shutdown. */
 const void *nt_resource_get_meta(nt_resource_t handle, nt_hash64_t kind, uint32_t *out_size);
 
 /* ---- Virtual packs ---- */
@@ -186,9 +187,11 @@ void nt_resource_set_activator(uint8_t asset_type, nt_activate_fn activate, nt_d
 void nt_resource_set_resolve_callbacks(uint8_t asset_type, nt_resolve_fn on_resolve, nt_cleanup_fn on_cleanup);
 void nt_resource_set_post_resolve_callback(uint8_t asset_type, nt_post_resolve_fn on_post_resolve);
 void nt_resource_set_behavior_flags(uint8_t asset_type, uint8_t behavior_flags);
-/* Borrowed current slot aux pointer. Valid only until the next resource
- * resolve/cleanup that changes this slot, or shutdown; caller must not free or store it. */
-void *nt_resource_peek_user_data(nt_resource_t handle);
+/* Borrowed current slot aux pointer. Returns NULL for invalid/stale handles or
+ * slots with no current aux data. Non-NULL is valid only until the next resource
+ * resolve/cleanup that changes this slot, or shutdown. Resolve/cleanup callbacks
+ * own mutation and freeing; caller must not free, mutate, or store it. */
+const void *nt_resource_peek_user_data(nt_resource_t handle);
 
 /* ---- Activation time budget ---- */
 

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -239,7 +239,8 @@ const nt_ui_element_data_t *nt_ui_make_element_data_xform(nt_ui_layer_t layer, v
 void nt_ui_set_atlas_white_region(nt_ui_context_t *ctx, nt_resource_t atlas, uint32_t white_region_idx);
 void nt_ui_set_sprite_material(nt_ui_context_t *ctx, nt_material_t sprite_material);
 void nt_ui_set_text_material(nt_ui_context_t *ctx, nt_material_t text_material);
-/* NULL fn silently skips CUSTOM commands. */
+/* NULL fn silently skips CUSTOM commands. `userdata` is stored by reference
+ * and passed to each CUSTOM call while the handler is installed. */
 void nt_ui_set_custom_handler(nt_ui_context_t *ctx, nt_ui_custom_handler_t fn, void *userdata);
 
 void nt_ui_module_init(void);

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -239,8 +239,9 @@ const nt_ui_element_data_t *nt_ui_make_element_data_xform(nt_ui_layer_t layer, v
 void nt_ui_set_atlas_white_region(nt_ui_context_t *ctx, nt_resource_t atlas, uint32_t white_region_idx);
 void nt_ui_set_sprite_material(nt_ui_context_t *ctx, nt_material_t sprite_material);
 void nt_ui_set_text_material(nt_ui_context_t *ctx, nt_material_t text_material);
-/* NULL fn silently skips CUSTOM commands. `userdata` is stored by reference
- * and passed to each CUSTOM call while the handler is installed. */
+/* NULL fn silently skips CUSTOM commands. userdata may be NULL. Non-NULL userdata
+ * is stored by reference and passed to each CUSTOM call until the handler is
+ * replaced; caller owns it and the UI context never frees it. */
 void nt_ui_set_custom_handler(nt_ui_context_t *ctx, nt_ui_custom_handler_t fn, void *userdata);
 
 void nt_ui_module_init(void);

--- a/tests/unit/test_resource.c
+++ b/tests/unit/test_resource.c
@@ -2586,7 +2586,7 @@ void test_peek_user_data_valid_handle(void) {
     nt_resource_t h = nt_resource_request(rid, NT_ASSET_MESH);
     nt_resource_step(); /* activate + resolve -> on_resolve sets user_data */
 
-    void *ud = nt_resource_peek_user_data(h);
+    const void *ud = nt_resource_peek_user_data(h);
     TEST_ASSERT_NOT_NULL(ud);
     TEST_ASSERT_EQUAL_PTR(s_last_resolve_user_data, ud);
 

--- a/tests/unit/test_resource.c
+++ b/tests/unit/test_resource.c
@@ -1657,18 +1657,18 @@ void test_blob_pin_unmount_severs_provider_synchronously(void) {
     nt_resource_step();
 
     /* Provider resolved into the live blob and pinned it. */
-    TEST_ASSERT_NOT_NULL(nt_resource_get_user_data(h));
+    TEST_ASSERT_NOT_NULL(nt_resource_peek_user_data(h));
     TEST_ASSERT_EQUAL_UINT32(1, nt_resource_test_pack_blob_pins(0));
 
     /* Unmount frees the blob; the provider view must be severed inline — NO intervening resolve/step —
      * so no read can dereference the freed blob. The published winner state is reconciled by the next
      * resolve pass (winner-loss + epoch bump), matching the pre-existing unmount contract. */
     nt_resource_unmount(pid);
-    TEST_ASSERT_NULL(nt_resource_get_user_data(h));
+    TEST_ASSERT_NULL(nt_resource_peek_user_data(h));
 
     /* Next resolve reconciles the dropped winner. */
     nt_resource_step();
-    TEST_ASSERT_NULL(nt_resource_get_user_data(h));
+    TEST_ASSERT_NULL(nt_resource_peek_user_data(h));
     TEST_ASSERT_FALSE(nt_resource_is_ready(h));
     TEST_ASSERT_EQUAL_UINT32(0, nt_resource_test_pack_blob_pins(0));
 
@@ -2492,7 +2492,7 @@ void test_aux_publish_waits_for_reload_when_no_usable_fallback_exists(void) {
     TEST_ASSERT_EQUAL_UINT8(NT_ASSET_STATE_LOADING, nt_resource_get_state(h));
     TEST_ASSERT_EQUAL(NT_PACK_STATE_NONE, nt_resource_pack_state(pid_b));
     TEST_ASSERT_EQUAL_UINT32(1, s_cleanup_call_count);
-    TEST_ASSERT_NULL(nt_resource_get_user_data(h));
+    TEST_ASSERT_NULL(nt_resource_peek_user_data(h));
 
     nt_resource_step(); /* re-download B and publish it again */
     if (nt_resource_pack_state(pid_b) == NT_PACK_STATE_REQUESTED) {
@@ -2503,7 +2503,7 @@ void test_aux_publish_waits_for_reload_when_no_usable_fallback_exists(void) {
     TEST_ASSERT_TRUE(nt_resource_is_ready(h));
     TEST_ASSERT_EQUAL_UINT32(handle_b, nt_resource_get(h));
     TEST_ASSERT_EQUAL_UINT32(3, s_resolve_call_count);
-    TEST_ASSERT_NOT_NULL(nt_resource_get_user_data(h));
+    TEST_ASSERT_NOT_NULL(nt_resource_peek_user_data(h));
 
     (void)remove("build/test_aux_reload_b.ntpack");
     (void)remove("build/test_aux_reload_a.ntpack");
@@ -2570,7 +2570,7 @@ void test_on_cleanup_fires_on_shutdown(void) {
     (void)remove("build/test_cleanup_shutdown.ntpack");
 }
 
-void test_get_user_data_valid_handle(void) {
+void test_peek_user_data_valid_handle(void) {
     reset_resolve_state();
     s_activate_call_count = 0;
     nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
@@ -2586,7 +2586,7 @@ void test_get_user_data_valid_handle(void) {
     nt_resource_t h = nt_resource_request(rid, NT_ASSET_MESH);
     nt_resource_step(); /* activate + resolve -> on_resolve sets user_data */
 
-    void *ud = nt_resource_get_user_data(h);
+    void *ud = nt_resource_peek_user_data(h);
     TEST_ASSERT_NOT_NULL(ud);
     TEST_ASSERT_EQUAL_PTR(s_last_resolve_user_data, ud);
 
@@ -2594,9 +2594,9 @@ void test_get_user_data_valid_handle(void) {
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-void test_get_user_data_invalid_handle(void) {
+void test_peek_user_data_invalid_handle(void) {
     /* Invalid zero handle */
-    TEST_ASSERT_NULL(nt_resource_get_user_data((nt_resource_t){0}));
+    TEST_ASSERT_NULL(nt_resource_peek_user_data((nt_resource_t){0}));
 
     /* Request a resource to get a valid handle, then shutdown+reinit (stale generation) */
     reset_resolve_state();
@@ -2615,13 +2615,13 @@ void test_get_user_data_invalid_handle(void) {
     nt_resource_step();
 
     /* Handle is valid now */
-    TEST_ASSERT_NOT_NULL(nt_resource_get_user_data(h));
+    TEST_ASSERT_NOT_NULL(nt_resource_peek_user_data(h));
 
     /* Shutdown + reinit: old handle becomes stale */
     nt_resource_shutdown();
     nt_resource_init(&s_desc);
 
-    TEST_ASSERT_NULL(nt_resource_get_user_data(h));
+    TEST_ASSERT_NULL(nt_resource_peek_user_data(h));
 
     (void)remove("build/test_ud_invalid.ntpack");
 }
@@ -2653,7 +2653,7 @@ void test_user_data_null_initially(void) {
     nt_hash64_t rid = nt_hash64_str("ud_null_initial");
     nt_resource_t h = nt_resource_request(rid, NT_ASSET_MESH);
 
-    TEST_ASSERT_NULL(nt_resource_get_user_data(h));
+    TEST_ASSERT_NULL(nt_resource_peek_user_data(h));
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
@@ -2969,8 +2969,8 @@ int main(void) {
     RUN_TEST(test_aux_publish_waits_for_reload_when_no_usable_fallback_exists);
     RUN_TEST(test_on_cleanup_fires_on_unmount);
     RUN_TEST(test_on_cleanup_fires_on_shutdown);
-    RUN_TEST(test_get_user_data_valid_handle);
-    RUN_TEST(test_get_user_data_invalid_handle);
+    RUN_TEST(test_peek_user_data_valid_handle);
+    RUN_TEST(test_peek_user_data_invalid_handle);
     RUN_TEST(test_no_on_resolve_without_registration);
     RUN_TEST(test_user_data_null_initially);
     RUN_TEST(test_on_resolve_fires_on_priority_change);


### PR DESCRIPTION
## Summary

- Add `docs/spec/core/api-contracts.md` as the cross-cutting naming/style contract for API ownership, lifetime, nullability, views, transfer, callbacks, and handles.
- Link the new chapter from the spec index and require public-header/API contract changes to read it.
- Apply a small example refactor: rename `nt_resource_get_user_data` to `nt_resource_peek_user_data` so the short-lived borrowed pointer contract is visible in the name.
- Add short header contracts where naming alone cannot express the lifetime: `take_data`, callback `user_data`, UI custom handler data, and virtual resource handles.

## Why

This follows #278. The intent is naming-first clarity, not an ownership framework. New public/module-boundary APIs should express ownership/lifetime through names and types first; comments are reserved for exact invalidation events or callback/user-data lifetimes that C signatures cannot encode.

This also opens the path for #279, which is a separate engine-wide audit/refactor epic. This PR is the style baseline plus one targeted example, not a mass old-API cleanup.

## Validation

- `git diff --check`
- `scripts/check.sh` via Git Bash login-shell
  - gates passed
  - native-debug build passed
  - `ctest`: 111/111 passed
  - clang-format passed
  - full clang-tidy passed on 253 project files

## Notes

`gh` is installed locally but could not read `C:\Users\ROG\AppData\Roaming\GitHub CLI\config.yml` due to access denied, so the PR was opened through the GitHub connector.