### PR TITLE
Ignore Serena local tooling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,9 @@ package-lock.json
 # GSD planning
 .planning/
 
+# Serena local agent tooling
+.serena/
+
 #codex branch diff
 branch_diff.patch
 diff.txt


### PR DESCRIPTION
## What changed

- ignore the project-local `.serena/` directory
- keep Serena MCP configuration, caches, and logs out of version control

## Why

This allows Claude Code and Codex to use the same local Serena project configuration without polluting the repository or affecting other developers.

## Impact

No runtime, builder, API, or build-system behavior changes. The local Serena installation and client MCP registrations are user-specific and are not included in this PR.

## Validation

- `scripts/check.sh --push`
- 119/119 native tests passed
- wasm-debug and wasm-release builds passed
- submodule consumption test passed