### PR TITLE
gfx: half-float colour render targets for the HDR path

### DIFF
--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -67,7 +67,14 @@ private to the concrete graphics implementation.
 
 `nt_render_target_desc_t` explicitly selects the color format and default sampler
 state, plus depth storage (`NONE`, `BUFFER`, or `TEXTURE`) and depth format. The
-current render-target color format is `RGBA8`. `NONE`
+supported render-target color formats are `RGBA8` and `RGBA16F`. Half-float is
+the HDR path: it holds values above 1.0 so a tone-mapping or bright-pass stage
+has headroom to work with, and it stays filterable in WebGL 2 core, so `LINEAR`
+sampling of the attachment remains valid. Creation does not consult
+`gpu_caps.has_float_render_target` — a device that cannot render to half-float
+fails the backend completeness check and creation returns invalid. The cap bit
+is there so a caller can choose its format without paying for a failed attempt.
+`NONE`
 requires `NT_TEXTURE_FORMAT_INVALID`; `BUFFER` creates a non-sampleable
 renderbuffer in the requested depth format; `TEXTURE` creates a sampleable
 texture in the requested depth format with its own filter and wrap state. The

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -67,20 +67,26 @@ private to the concrete graphics implementation.
 
 `nt_render_target_desc_t` explicitly selects the color format and default sampler
 state, plus depth storage (`NONE`, `BUFFER`, or `TEXTURE`) and depth format. The
-supported render-target color formats are `RGBA8` and `RGBA16F`. Half-float is
-the HDR path: it holds values above 1.0 so a tone-mapping or bright-pass stage
-has headroom to work with, and it stays filterable in WebGL 2 core, so `LINEAR`
-sampling of the attachment remains valid. Creation does not consult
-`gpu_caps.has_float_render_target` — a device that cannot render to half-float
-fails the backend completeness check and creation returns invalid. The cap bit
-is there so a caller can choose its format without paying for a failed attempt.
-`NONE`
+supported render-target color formats are `RGBA8` and `RGBA16F`. `NONE`
 requires `NT_TEXTURE_FORMAT_INVALID`; `BUFFER` creates a non-sampleable
 renderbuffer in the requested depth format; `TEXTURE` creates a sampleable
 texture in the requested depth format with its own filter and wrap state. The
 descriptor is retained as the single source for creation, resize, and context
 restore. A backend must not substitute its own attachment format or default
 sampler state.
+
+`RGBA16F` is the HDR color path: it carries values above 1.0, so a tone-mapping
+or bright-pass stage has headroom instead of a buffer already clamped at write
+time. It stays filterable in WebGL 2 core, so `LINEAR` on the color attachment
+remains valid. `RGBA32F` is not supported for render targets — it additionally
+needs `OES_texture_float_linear` to be filtered and `EXT_float_blend` to be
+blended into, and both are absent on roughly half of iOS devices.
+
+Creation does not consult `gpu_caps.has_float_render_target`. A device that
+cannot render to half-float fails the backend completeness check, and creation
+returns invalid — the fallback path a caller needs regardless. The capability
+bit exists so a caller can choose its format without paying for a failed
+attempt.
 
 The supported depth formats are `DEPTH16`, `DEPTH24`, and `DEPTH32F`. The current
 sampler contract has no depth-comparison mode, so WebGL 2 texture completeness

--- a/engine/graphics/gl/nt_gfx_gl_ctx_native.c
+++ b/engine/graphics/gl/nt_gfx_gl_ctx_native.c
@@ -44,6 +44,8 @@ nt_gfx_gpu_caps_t nt_gfx_gl_ctx_detect_gpu_caps(void) {
     if (gl_ver >= 43) {
         caps.has_etc2 = true;
     }
+    /* Float colour attachments are core in GL 3.0+; the engine already requires 3.3. */
+    caps.has_float_render_target = gl_ver >= 30;
 
     GLint max_tex_size = 0;
     glGetIntegerv(GL_MAX_TEXTURE_SIZE, &max_tex_size);

--- a/engine/graphics/gl/nt_gfx_gl_ctx_native.c
+++ b/engine/graphics/gl/nt_gfx_gl_ctx_native.c
@@ -44,7 +44,7 @@ nt_gfx_gpu_caps_t nt_gfx_gl_ctx_detect_gpu_caps(void) {
     if (gl_ver >= 43) {
         caps.has_etc2 = true;
     }
-    /* Float colour attachments are core in GL 3.0+; the engine already requires 3.3. */
+    /* Float colour attachments are core in GL 3.0+ — no extension needed */
     caps.has_float_render_target = gl_ver >= 30;
 
     GLint max_tex_size = 0;

--- a/engine/graphics/gl/nt_gfx_gl_ctx_web.c
+++ b/engine/graphics/gl/nt_gfx_gl_ctx_web.c
@@ -42,9 +42,7 @@ bool nt_gfx_gl_ctx_is_lost(void) { return s_gl_context <= 0 || emscripten_is_web
 
 /* Detect GPU capability extensions via JavaScript.
  * gl.getExtension() both checks AND enables the extension.
- * Bit 0 = ASTC, Bit 1 = BC7/BPTC, Bit 2 = ETC2, Bit 3 = float colour attachments.
- * EXT_color_buffer_float is what makes RGBA16F renderable in WebGL2; without it
- * a half-float target only fails later, at the framebuffer completeness check. */
+ * Bit 0 = ASTC, Bit 1 = BC7/BPTC, Bit 2 = ETC2, Bit 3 = float colour attachments. */
 // clang-format off
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wextra-semi"

--- a/engine/graphics/gl/nt_gfx_gl_ctx_web.c
+++ b/engine/graphics/gl/nt_gfx_gl_ctx_web.c
@@ -40,9 +40,11 @@ void nt_gfx_gl_ctx_destroy(void) {
 
 bool nt_gfx_gl_ctx_is_lost(void) { return s_gl_context <= 0 || emscripten_is_webgl_context_lost(s_gl_context) != 0; }
 
-/* Detect GPU compressed texture extensions via JavaScript.
+/* Detect GPU capability extensions via JavaScript.
  * gl.getExtension() both checks AND enables the extension.
- * Bit 0 = ASTC, Bit 1 = BC7/BPTC, Bit 2 = ETC2 */
+ * Bit 0 = ASTC, Bit 1 = BC7/BPTC, Bit 2 = ETC2, Bit 3 = float colour attachments.
+ * EXT_color_buffer_float is what makes RGBA16F renderable in WebGL2; without it
+ * a half-float target only fails later, at the framebuffer completeness check. */
 // clang-format off
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wextra-semi"
@@ -53,6 +55,7 @@ EM_JS(int, nt_gfx_js_detect_gpu_caps, (void), {
     if (gl.getExtension('WEBGL_compressed_texture_astc')) caps |= 1;
     if (gl.getExtension('EXT_texture_compression_bptc')) caps |= 2;
     if (gl.getExtension('WEBGL_compressed_texture_etc')) caps |= 4;
+    if (gl.getExtension('EXT_color_buffer_float')) caps |= 8;
     return caps;
 });
 #pragma clang diagnostic pop
@@ -75,6 +78,7 @@ nt_gfx_gpu_caps_t nt_gfx_gl_ctx_detect_gpu_caps(void) {
     caps.has_astc = (bits & 1) != 0;
     caps.has_bc7 = (bits & 2) != 0;
     caps.has_etc2 = (bits & 4) != 0;
+    caps.has_float_render_target = (bits & 8) != 0;
     caps.max_texture_size = (uint32_t)nt_gfx_js_max_texture_size();
     return caps;
 }

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -842,8 +842,13 @@ nt_render_target_t nt_gfx_make_render_target(const nt_render_target_desc_t *desc
         NT_LOG_ERROR("make_render_target: zero dimension");
         return result;
     }
-    NT_ASSERT(desc->color_format == NT_TEXTURE_FORMAT_RGBA8 && "make_render_target: unsupported color format");
-    if (desc->color_format != NT_TEXTURE_FORMAT_RGBA8) {
+    /* RGBA16F is accepted without consulting gpu_caps: a device that cannot
+       render to it fails the backend completeness check and creation returns
+       invalid, which is the fallback path a caller needs either way. The cap
+       bit exists so a caller can pick its format before paying for the try. */
+    bool color_format_valid = desc->color_format == NT_TEXTURE_FORMAT_RGBA8 || desc->color_format == NT_TEXTURE_FORMAT_RGBA16F;
+    NT_ASSERT(color_format_valid && "make_render_target: unsupported color format");
+    if (!color_format_valid) {
         NT_LOG_ERROR("make_render_target: unsupported color format");
         return result;
     }

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -842,10 +842,8 @@ nt_render_target_t nt_gfx_make_render_target(const nt_render_target_desc_t *desc
         NT_LOG_ERROR("make_render_target: zero dimension");
         return result;
     }
-    /* RGBA16F is accepted without consulting gpu_caps: a device that cannot
-       render to it fails the backend completeness check and creation returns
-       invalid, which is the fallback path a caller needs either way. The cap
-       bit exists so a caller can pick its format before paying for the try. */
+    /* Deliberately not gated on gpu_caps.has_float_render_target: the backend
+       completeness check is the real gate, and it already returns invalid. */
     bool color_format_valid = desc->color_format == NT_TEXTURE_FORMAT_RGBA8 || desc->color_format == NT_TEXTURE_FORMAT_RGBA16F;
     NT_ASSERT(color_format_valid && "make_render_target: unsupported color format");
     if (!color_format_valid) {

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -285,17 +285,14 @@ typedef struct {
     uint32_t instances; /* total objects drawn via instanced calls */
 } nt_gfx_frame_stats_t;
 
-/* ---- GPU compressed texture format capabilities ---- */
+/* ---- GPU format capabilities ---- */
 
 typedef struct {
-    bool has_astc; /* ASTC 4x4 LDR (WEBGL_compressed_texture_astc / KHR_texture_compression_astc_ldr) */
-    bool has_bc7;  /* BC7 / BPTC (EXT_texture_compression_bptc / ARB_texture_compression_bptc) */
-    bool has_etc2; /* ETC2 + EAC (WEBGL_compressed_texture_etc / core GL 4.3+) */
-    /* RGBA16F usable as a colour attachment (EXT_color_buffer_float / core GL 3.0+).
-       Half-float is filterable in ES 3.0 core, so LINEAR sampling stays valid; RGBA32F
-       is not covered by this bit and remains rejected for render targets. */
-    bool has_float_render_target;
-    uint32_t max_texture_size; /* GL_MAX_TEXTURE_SIZE, queried at init */
+    bool has_astc;                /* ASTC 4x4 LDR (WEBGL_compressed_texture_astc / KHR_texture_compression_astc_ldr) */
+    bool has_bc7;                 /* BC7 / BPTC (EXT_texture_compression_bptc / ARB_texture_compression_bptc) */
+    bool has_etc2;                /* ETC2 + EAC (WEBGL_compressed_texture_etc / core GL 4.3+) */
+    bool has_float_render_target; /* RGBA16F as a colour attachment (EXT_color_buffer_float / core GL 3.0+) */
+    uint32_t max_texture_size;    /* GL_MAX_TEXTURE_SIZE, queried at init */
 } nt_gfx_gpu_caps_t;
 
 /* ---- Global state ---- */
@@ -335,7 +332,7 @@ void nt_gfx_get_global_blocks(const nt_global_block_t **blocks, uint32_t *count)
 void nt_gfx_init(const nt_gfx_desc_t *desc);
 void nt_gfx_shutdown(void);
 
-/* GPU compressed format capabilities (valid after nt_gfx_init) */
+/* GPU format capabilities (valid after nt_gfx_init) */
 const nt_gfx_gpu_caps_t *nt_gfx_gpu_caps(void);
 
 /* ---- Frame / Pass ---- */

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -288,9 +288,13 @@ typedef struct {
 /* ---- GPU compressed texture format capabilities ---- */
 
 typedef struct {
-    bool has_astc;             /* ASTC 4x4 LDR (WEBGL_compressed_texture_astc / KHR_texture_compression_astc_ldr) */
-    bool has_bc7;              /* BC7 / BPTC (EXT_texture_compression_bptc / ARB_texture_compression_bptc) */
-    bool has_etc2;             /* ETC2 + EAC (WEBGL_compressed_texture_etc / core GL 4.3+) */
+    bool has_astc; /* ASTC 4x4 LDR (WEBGL_compressed_texture_astc / KHR_texture_compression_astc_ldr) */
+    bool has_bc7;  /* BC7 / BPTC (EXT_texture_compression_bptc / ARB_texture_compression_bptc) */
+    bool has_etc2; /* ETC2 + EAC (WEBGL_compressed_texture_etc / core GL 4.3+) */
+    /* RGBA16F usable as a colour attachment (EXT_color_buffer_float / core GL 3.0+).
+       Half-float is filterable in ES 3.0 core, so LINEAR sampling stays valid; RGBA32F
+       is not covered by this bit and remains rejected for render targets. */
+    bool has_float_render_target;
     uint32_t max_texture_size; /* GL_MAX_TEXTURE_SIZE, queried at init */
 } nt_gfx_gpu_caps_t;
 

--- a/engine/graphics/stub/nt_gfx_stub.c
+++ b/engine/graphics/stub/nt_gfx_stub.c
@@ -441,5 +441,5 @@ nt_gfx_gpu_caps_t nt_gfx_gl_ctx_detect_gpu_caps(void) {
 #ifdef NT_TEST_ACCESS
     s_stub_gpu_caps_probe_count++;
 #endif
-    return (nt_gfx_gpu_caps_t){.max_texture_size = 4096};
+    return (nt_gfx_gpu_caps_t){.max_texture_size = 4096, .has_float_render_target = true};
 }

--- a/tests/unit/test_nt_gfx_render_target.c
+++ b/tests/unit/test_nt_gfx_render_target.c
@@ -296,6 +296,28 @@ static void test_make_render_target_rejects_invalid_formats(void) {
     NT_TEST_EXPECT_ASSERT(nt_gfx_make_render_target(&desc));
 }
 
+static void test_make_render_target_accepts_half_float_color(void) {
+    nt_render_target_desc_t desc = rt_desc(NT_RT_DEPTH_NONE);
+    desc.color_format = NT_TEXTURE_FORMAT_RGBA16F;
+
+    nt_render_target_t rt = nt_gfx_make_render_target(&desc);
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, rt.id);
+    TEST_ASSERT_TRUE(nt_gfx_render_target_ready(rt));
+
+    /* The attachment carries the requested format, not a silently substituted one. */
+    nt_texture_t color = nt_gfx_render_target_color(rt);
+    TEST_ASSERT_EQUAL_INT(NT_TEXTURE_FORMAT_RGBA16F, nt_gfx_texture_format(color));
+
+    nt_gfx_destroy_render_target(rt);
+}
+
+static void test_make_render_target_still_rejects_full_float_color(void) {
+    nt_render_target_desc_t desc = rt_desc(NT_RT_DEPTH_NONE);
+    desc.color_format = NT_TEXTURE_FORMAT_RGBA32F;
+
+    NT_TEST_EXPECT_ASSERT(nt_gfx_make_render_target(&desc));
+}
+
 static void test_make_render_target_rejects_invalid_sampler_modes(void) {
     nt_render_target_desc_t desc = rt_desc(NT_RT_DEPTH_NONE);
 
@@ -667,6 +689,8 @@ int main(void) {
     RUN_TEST(test_update_rejects_render_target_owned_texture);
     RUN_TEST(test_make_render_target_rejects_null_and_zero_dimensions);
     RUN_TEST(test_make_render_target_rejects_invalid_formats);
+    RUN_TEST(test_make_render_target_accepts_half_float_color);
+    RUN_TEST(test_make_render_target_still_rejects_full_float_color);
     RUN_TEST(test_make_render_target_rejects_invalid_sampler_modes);
     RUN_TEST(test_depth_texture_rejects_linear_sampler_override);
     RUN_TEST(test_integer_texture_rejects_linear_sampler_override);

--- a/tests/unit/test_nt_gfx_render_target_native.c
+++ b/tests/unit/test_nt_gfx_render_target_native.c
@@ -130,8 +130,8 @@ static void test_depth_texture_uses_explicit_format_and_wrap(void) {
     nt_gfx_destroy_render_target(target);
 }
 
-/* The value of a half-float target is headroom above 1.0, so the proof is that
-   an over-range clear survives the round trip instead of clamping to white. */
+/* An over-range clear must survive the round trip — clamping to white would
+   mean the target has no headroom and only the format name changed. */
 static void test_half_float_target_is_complete_and_keeps_values_above_one(void) {
     TEST_ASSERT_TRUE(g_nt_gfx.gpu_caps.has_float_render_target);
 

--- a/tests/unit/test_nt_gfx_render_target_native.c
+++ b/tests/unit/test_nt_gfx_render_target_native.c
@@ -130,6 +130,44 @@ static void test_depth_texture_uses_explicit_format_and_wrap(void) {
     nt_gfx_destroy_render_target(target);
 }
 
+/* The value of a half-float target is headroom above 1.0, so the proof is that
+   an over-range clear survives the round trip instead of clamping to white. */
+static void test_half_float_target_is_complete_and_keeps_values_above_one(void) {
+    TEST_ASSERT_TRUE(g_nt_gfx.gpu_caps.has_float_render_target);
+
+    nt_render_target_t target = nt_gfx_make_render_target(&(nt_render_target_desc_t){
+        .width = 4,
+        .height = 4,
+        .color_format = NT_TEXTURE_FORMAT_RGBA16F,
+        .color_min_filter = NT_FILTER_LINEAR,
+        .color_mag_filter = NT_FILTER_LINEAR,
+        .color_wrap_u = NT_WRAP_CLAMP_TO_EDGE,
+        .color_wrap_v = NT_WRAP_CLAMP_TO_EDGE,
+        .depth_storage = NT_RT_DEPTH_NONE,
+        .depth_format = NT_TEXTURE_FORMAT_INVALID,
+    });
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, target.id);
+    TEST_ASSERT_TRUE(nt_gfx_render_target_ready(target));
+
+    nt_gfx_bind_texture(nt_gfx_render_target_color(target), 0);
+    GLint internal_format = 0;
+    glGetTexLevelParameteriv(GL_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT, &internal_format);
+    TEST_ASSERT_EQUAL_INT(GL_RGBA16F, internal_format);
+
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.target = target, .clear_color = {3.5F, 0.25F, 0.0F, 1.0F}, .clear_depth = 1.0F});
+    float pixels[4 * 4 * 4] = {0};
+    glReadPixels(0, 0, 4, 4, GL_RGBA, GL_FLOAT, pixels);
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    /* Unity float asserts are disabled in this build; compare in millis. */
+    TEST_ASSERT_INT_WITHIN(10, 3500, (int)(pixels[0] * 1000.0F));
+    TEST_ASSERT_INT_WITHIN(10, 250, (int)(pixels[1] * 1000.0F));
+
+    nt_gfx_destroy_render_target(target);
+}
+
 static void test_depth_buffer_uses_explicit_format(void) {
     nt_render_target_t target = nt_gfx_make_render_target(&(nt_render_target_desc_t){
         .width = 4,
@@ -219,6 +257,7 @@ int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_render_target_resize_without_spare_texture_slots);
     RUN_TEST(test_depth_texture_uses_explicit_format_and_wrap);
+    RUN_TEST(test_half_float_target_is_complete_and_keeps_values_above_one);
     RUN_TEST(test_depth_buffer_uses_explicit_format);
     RUN_TEST(test_begin_pass_clears_depth_after_depth_writes_were_disabled);
     return UNITY_END();


### PR DESCRIPTION
Closes #314.

## What changed

`nt_gfx_make_render_target` now accepts `NT_TEXTURE_FORMAT_RGBA16F` as well as `RGBA8`, and `nt_gfx_gpu_caps_t` gains `has_float_render_target`.

The change is small because most of the stack was already in place — `RGBA16F` is a public enum value, `nt_gfx_make_texture` accepts it, and the GL backend maps it to `GL_RGBA16F / GL_HALF_FLOAT`. Only the frontend validation gate made it unreachable, and it did so on every platform including native.

| file | change |
| --- | --- |
| `engine/graphics/nt_gfx.c` | accept `RGBA8` or `RGBA16F` as render-target colour format |
| `engine/graphics/nt_gfx.h` | `has_float_render_target` on `nt_gfx_gpu_caps_t` |
| `engine/graphics/gl/nt_gfx_gl_ctx_native.c` | cap derived from GL version (float attachments are core in 3.0+) |
| `engine/graphics/gl/nt_gfx_gl_ctx_web.c` | cap probed via `EXT_color_buffer_float`, bit 3 of the existing caps word |
| `engine/graphics/stub/nt_gfx_stub.c` | stub reports the cap so unit tests can exercise the format |
| `docs/spec/render/architecture.md` | the render-target format paragraph, which claimed `RGBA8` was the only option |

## Two design decisions worth reviewing

**Creation does not consult the capability bit.** A device that cannot render to half-float already fails `glCheckFramebufferStatus` in `nt_gfx_gl_build_render_target`, which logs and returns false, and `nt_gfx_make_render_target` returns invalid. That is the fallback path a caller needs regardless, so gating on the cap up front would add a second rejection route without adding safety — and it would turn an unsupported device into a debug-build assert rather than a graceful fallback. The cap bit is advisory: it lets a renderer pick its buffer format at init without paying for a failed attempt.

**`RGBA32F` stays rejected.** Half-float is what HDR post-processing actually wants, and it is texture-filterable in WebGL 2 / ES 3.0 core so `NT_FILTER_LINEAR` on the attachment stays valid. Full float would additionally need `OES_texture_float_linear` to be sampled with anything but `NEAREST`, which is a separate contract.

## Web support

`EXT_color_buffer_float` is what makes `RGBA16F` renderable in WebGL2. Emscripten already enables it: `GL.initExtensions` calls `getExtension` on every entry of `getEmscriptenSupportedExtensions()` except `lose_context`/`debug*`, `EXT_color_buffer_float` is in that list, and `nt_gfx_gl_ctx_create` never sets `enableExtensionsByDefault` to false. The explicit probe added here is therefore a *detect* for the caps bit, matching how the compressed-texture caps already work — not an enable.

Device support among WebGL2-capable hardware is 99.74% overall, 100% on iOS, Safari, Edge, Opera and Samsung Internet ([web3dsurvey](https://web3dsurvey.com/webgl2/extensions/EXT_color_buffer_float)). Available across browsers since September 2021.

## Tests

Three added:

- `test_make_render_target_accepts_half_float_color` (stub) — creation succeeds and the attachment reports `RGBA16F` rather than a silently substituted format.
- `test_make_render_target_still_rejects_full_float_color` (stub) — `RGBA32F` still asserts.
- `test_half_float_target_is_complete_and_keeps_values_above_one` (native, real GL) — the target is complete, the GL internal format is `GL_RGBA16F`, and a clear of `3.5` reads back as `3.5` instead of clamping to white. That last assertion is the actual point of the feature; a format that merely links proves nothing.

Verified on Windows / native-debug-test:

```
test_gfx                          61 Tests 0 Failures  OK
test_gfx_read_pixels               4 Tests 0 Failures  OK
test_nt_gfx_scissor                4 Tests 0 Failures  OK
test_nt_postfx_blur               15 Tests 0 Failures  OK
test_nt_gfx_render_target         37 Tests 0 Failures  OK
test_nt_gfx_render_target_native   5 Tests 0 Failures  OK
```

`scripts/check.sh` gates all pass (module composition, EM_JS_DEPS, doc links + spec index, CRT pins, test registration, tidy). Its `build (native-debug)` step fails on a missing `examples/textured_quad/base.ntpack` — reproduced identically on unmodified `master` in the same clone, so it is a fresh-clone bootstrap requirement (example packs must be generated first), not a regression from this change. `clang-format --dry-run --Werror` is clean on all seven touched files.

Not verified by me: the web path. The caps probe is a one-line `getExtension` in the existing EM_JS body, but I have not run a wasm build against a browser.
