### PR TITLE
gfx: depth-compare sampling on sampler objects (#316)

### DIFF
--- a/docs/spec/core/api-contracts.md
+++ b/docs/spec/core/api-contracts.md
@@ -135,8 +135,8 @@ and `DEPTH32F` require the same, plus `data == NULL` and no mipmaps.
 A separately bound sampler must obey the same format restrictions; it cannot
 replace the explicit texture state with an incompatible filter. Depth comparison
 is the one documented exception, and it is sampler state only: `DEPTH*` accepts
-`LINEAR` from a sampler whose `depth_compare` is set, because the filtering then
-applies to comparison results rather than to raw depth. The texture keeps
+`LINEAR` from a sampler whose `compare_func` is not `NONE`, because the filtering
+then applies to comparison results rather than to raw depth. The texture keeps
 `NEAREST` either way, and the same descriptor field is rejected on non-depth
 storage.
 

--- a/docs/spec/core/api-contracts.md
+++ b/docs/spec/core/api-contracts.md
@@ -130,10 +130,15 @@ runtime object represented by that handle.
 
 `nt_texture_desc_t.format` is required and names the real storage format.
 `RG16UI` requires `NEAREST` minification and magnification. `DEPTH16`, `DEPTH24`,
-and `DEPTH32F` additionally require `data == NULL` and no mipmaps until comparison
-sampling exists. A separately bound sampler must obey the same format
-restrictions; it cannot replace the explicit texture state with an incompatible
-filter.
+and `DEPTH32F` require the same, plus `data == NULL` and no mipmaps.
+
+A separately bound sampler must obey the same format restrictions; it cannot
+replace the explicit texture state with an incompatible filter. Depth comparison
+is the one documented exception, and it is sampler state only: `DEPTH*` accepts
+`LINEAR` from a sampler whose `depth_compare` is set, because the filtering then
+applies to comparison results rather than to raw depth. The texture keeps
+`NEAREST` either way, and the same descriptor field is rejected on non-depth
+storage.
 
 ### Render-target handles
 
@@ -178,7 +183,8 @@ choose attachment formats or sampler defaults.
 
 Invalid render-target descriptors include mismatched color/depth format classes,
 a missing or extraneous depth format for the selected storage, invalid sampler
-values, and non-`NEAREST` depth filtering without comparison mode. These cases,
+values, and non-`NEAREST` depth filtering — comparison is sampler state and
+never reaches this descriptor. These cases,
 exhausted configured target capacity, stale handles, direct mutation of owned
 attachments, and render-target lifecycle calls inside an active pass are
 developer errors and assert. Backend allocation, framebuffer completeness,

--- a/docs/spec/core/api-contracts.md
+++ b/docs/spec/core/api-contracts.md
@@ -184,10 +184,10 @@ choose attachment formats or sampler defaults.
 Invalid render-target descriptors include mismatched color/depth format classes,
 a missing or extraneous depth format for the selected storage, invalid sampler
 values, and non-`NEAREST` depth filtering — comparison is sampler state and
-never reaches this descriptor. These cases,
-exhausted configured target capacity, stale handles, direct mutation of owned
-attachments, and render-target lifecycle calls inside an active pass are
-developer errors and assert. Backend allocation, framebuffer completeness,
+never reaches this descriptor. These cases, exhausted configured target
+capacity, stale handles, direct mutation of owned attachments, and
+render-target lifecycle calls inside an active pass are developer errors and
+assert. Backend allocation, framebuffer completeness,
 resize, and context-restore failures remain runtime failures reported through
 invalid handles, `false`, or readiness queries.
 

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -94,14 +94,16 @@ magnification: WebGL 2 texture completeness rejects filtered depth unless
 comparison is enabled, and comparison is not texture state. Wrap state remains
 explicit and may use clamp, repeat, or mirrored repeat.
 
-Depth comparison lives on the sampler object (`nt_sampler_desc_t.depth_compare`
-plus `compare_func`), not on the texture, because one depth target is read two
-ways: through a comparison sampler for the shadow lookup, and through a plain
-sampler for a raw-depth debug view. Sampler state supersedes texture state, so a
+Depth comparison lives on the sampler object (`nt_sampler_desc_t.compare_func`),
+not on the texture, because one depth target is read two ways: through a
+comparison sampler for the shadow lookup, and through a plain sampler for a
+raw-depth debug view. The field is a single tri-state — `NONE`, `LEQUAL`,
+`LESS` — so a zero-filled descriptor is a plain sampler and there is exactly one
+spelling of "no comparison". Sampler state supersedes texture state, so a
 comparison sampler makes `LINEAR` legal on that binding while the attachment
-description is untouched. A sampler with comparison enabled is rejected on
-non-depth storage, where the comparison would make every lookup undefined; a
-sampler without it still cannot filter depth.
+description is untouched. A comparison sampler is rejected on non-depth storage,
+where the comparison would make every lookup undefined; a sampler without one
+still cannot filter depth.
 
 Sampler binds follow the texture bind for a unit, because
 `nt_gfx_bind_texture` installs the texture's own default sampler and discards

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -88,11 +88,28 @@ returns invalid — the fallback path a caller needs regardless. The capability
 bit exists so a caller can choose its format without paying for a failed
 attempt.
 
-The supported depth formats are `DEPTH16`, `DEPTH24`, and `DEPTH32F`. The current
-sampler contract has no depth-comparison mode, so WebGL 2 texture completeness
-requires `NEAREST` minification and magnification for depth textures. Wrap state
-remains explicit and may use clamp, repeat, or mirrored repeat. Binding a
-separate sampler does not relax the depth filtering restriction.
+The supported depth formats are `DEPTH16`, `DEPTH24`, and `DEPTH32F`. A depth
+attachment's own texture state stays `NEAREST` for minification and
+magnification: WebGL 2 texture completeness rejects filtered depth unless
+comparison is enabled, and comparison is not texture state. Wrap state remains
+explicit and may use clamp, repeat, or mirrored repeat.
+
+Depth comparison lives on the sampler object (`nt_sampler_desc_t.depth_compare`
+plus `compare_func`), not on the texture, because one depth target is read two
+ways: through a comparison sampler for the shadow lookup, and through a plain
+sampler for a raw-depth debug view. Sampler state supersedes texture state, so a
+comparison sampler makes `LINEAR` legal on that binding while the attachment
+description is untouched. A sampler with comparison enabled is rejected on
+non-depth storage, where the comparison would make every lookup undefined; a
+sampler without it still cannot filter depth.
+
+With comparison on, `LINEAR` filters the 0/1 comparison results instead of the
+raw depths — the ordering a shadow edge needs, since averaging depths first
+compares against a depth that exists in no texel. Both the desktop GL and the
+GLES specifications leave the blend implementation-dependent and promise only a
+value proportional to the passing comparisons, so consumers may rely on the
+proportionality but not on specific weights. Comparison itself is core in
+GLES 3.0, WebGL 2, and desktop GL 3.0+, so it needs no capability bit.
 
 Sampler overrides with a mipmap minification filter require complete mip
 storage for the bound texture. A 1x1 base level is already a complete chain.

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -103,6 +103,11 @@ description is untouched. A sampler with comparison enabled is rejected on
 non-depth storage, where the comparison would make every lookup undefined; a
 sampler without it still cannot filter depth.
 
+Sampler binds follow the texture bind for a unit, because
+`nt_gfx_bind_texture` installs the texture's own default sampler and discards
+whatever the unit held. A comparison sampler bound to a unit with no live
+texture is therefore rejected rather than silently replaced.
+
 With comparison on, `LINEAR` filters the 0/1 comparison results instead of the
 raw depths — the ordering a shadow edge needs, since averaging depths first
 compares against a depth that exists in no texel. Both the desktop GL and the

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -381,11 +381,13 @@ static GLenum map_texture_filter(nt_texture_filter_t f) {
 
 static GLenum map_compare_func(nt_compare_func_t f) {
     switch (f) {
-    case NT_COMPARE_LEQUAL:
-        return GL_LEQUAL;
     case NT_COMPARE_LESS:
         return GL_LESS;
+    case NT_COMPARE_NONE:
+    case NT_COMPARE_LEQUAL:
     default:
+        /* GL keeps a comparison function even with the mode off; LEQUAL is its
+         * own default, so an unused slot reads back as untouched state. */
         return GL_LEQUAL;
     }
 }
@@ -1820,7 +1822,7 @@ uint32_t nt_gfx_backend_create_sampler(const nt_sampler_desc_t *desc) {
     glSamplerParameteri(s, GL_TEXTURE_WRAP_T, (GLint)map_texture_wrap(desc->wrap_v));
     /* Set unconditionally rather than relying on the object's default NONE —
      * sampler state stays fully described by the descriptor. */
-    glSamplerParameteri(s, GL_TEXTURE_COMPARE_MODE, desc->depth_compare ? GL_COMPARE_REF_TO_TEXTURE : GL_NONE);
+    glSamplerParameteri(s, GL_TEXTURE_COMPARE_MODE, desc->compare_func != NT_COMPARE_NONE ? GL_COMPARE_REF_TO_TEXTURE : GL_NONE);
     glSamplerParameteri(s, GL_TEXTURE_COMPARE_FUNC, (GLint)map_compare_func(desc->compare_func));
     return (uint32_t)s;
 }

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -379,6 +379,17 @@ static GLenum map_texture_filter(nt_texture_filter_t f) {
     }
 }
 
+static GLenum map_compare_func(nt_compare_func_t f) {
+    switch (f) {
+    case NT_COMPARE_LEQUAL:
+        return GL_LEQUAL;
+    case NT_COMPARE_LESS:
+        return GL_LESS;
+    default:
+        return GL_LEQUAL;
+    }
+}
+
 static GLenum map_texture_wrap(nt_texture_wrap_t w) {
     switch (w) {
     case NT_WRAP_CLAMP_TO_EDGE:
@@ -1807,6 +1818,10 @@ uint32_t nt_gfx_backend_create_sampler(const nt_sampler_desc_t *desc) {
     glSamplerParameteri(s, GL_TEXTURE_MAG_FILTER, (GLint)map_texture_filter(desc->mag_filter));
     glSamplerParameteri(s, GL_TEXTURE_WRAP_S, (GLint)map_texture_wrap(desc->wrap_u));
     glSamplerParameteri(s, GL_TEXTURE_WRAP_T, (GLint)map_texture_wrap(desc->wrap_v));
+    /* Set unconditionally rather than relying on the object's default NONE —
+     * sampler state stays fully described by the descriptor. */
+    glSamplerParameteri(s, GL_TEXTURE_COMPARE_MODE, desc->depth_compare ? GL_COMPARE_REF_TO_TEXTURE : GL_NONE);
+    glSamplerParameteri(s, GL_TEXTURE_COMPARE_FUNC, (GLint)map_compare_func(desc->compare_func));
     return (uint32_t)s;
 }
 

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -1187,13 +1187,10 @@ static inline uint32_t sampler_pack_key(const nt_sampler_desc_t *desc) {
     uint32_t mn = ((uint32_t)desc->min_filter) & 0x7U;
     uint32_t wu = ((uint32_t)desc->wrap_u) & 0x3U;
     uint32_t wv = ((uint32_t)desc->wrap_v) & 0x3U;
-    /* compare_func is normalized the same way the backend clamps it, not
-     * masked: a masked out-of-range value would key one function and build
-     * another. It also drops out with comparison off, so both spellings of
-     * "no comparison" share one cache slot. */
-    uint32_t cmp = desc->depth_compare ? 1U : 0U;
-    uint32_t fn = (cmp != 0U && desc->compare_func == NT_COMPARE_LESS) ? 1U : 0U;
-    return mn | (mag << 3) | (wu << 4) | (wv << 6) | (cmp << 8) | (fn << 9);
+    /* compare_func is normalized the way the backend clamps it, not masked: a
+     * masked out-of-range value would key one function and build another. */
+    uint32_t cmp = (desc->compare_func <= NT_COMPARE_LESS) ? (uint32_t)desc->compare_func : (uint32_t)NT_COMPARE_NONE;
+    return mn | (mag << 3) | (wu << 4) | (wv << 6) | (cmp << 8);
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity) — cache hit / miss / lazy-recreate paths
@@ -1238,12 +1235,13 @@ static bool texture_has_complete_mip_chain(const nt_gfx_texture_meta_t *meta) {
 }
 
 static bool bound_texture_sampler_compatible(uint32_t slot, const nt_sampler_desc_t *desc) {
+    bool compares = desc->compare_func != NT_COMPARE_NONE;
     uint32_t texture_id = s_gfx.bound_texture_ids[slot];
     if (!nt_pool_valid(&s_gfx.texture_pool, texture_id)) {
         /* Comparison needs depth storage to check against, and nt_gfx_bind_texture
          * reinstalls the texture's own sampler — so a comparison sampler on an
          * empty slot can only be a bind-order mistake. */
-        return !desc->depth_compare;
+        return !compares;
     }
     uint32_t texture_slot = nt_pool_slot_index(texture_id);
     const nt_gfx_texture_meta_t *meta = &s_gfx.texture_metas[texture_slot];
@@ -1251,13 +1249,13 @@ static bool bound_texture_sampler_compatible(uint32_t slot, const nt_sampler_des
     bool depth = format >= (uint8_t)NT_TEXTURE_FORMAT_DEPTH16;
     /* Comparison against a non-depth texture makes every lookup undefined in
      * GL, whichever sampler type the shader declares. */
-    if (desc->depth_compare && !depth) {
+    if (compares && !depth) {
         return false;
     }
     /* Filtering raw depth averages texels into a depth that exists in none of
      * them; with comparison on, LINEAR blends the 0/1 comparison results
      * instead. Integer storage has no such escape and stays NEAREST. */
-    bool nearest_only = format == (uint8_t)NT_TEXTURE_FORMAT_RG16UI || (depth && !desc->depth_compare);
+    bool nearest_only = format == (uint8_t)NT_TEXTURE_FORMAT_RG16UI || (depth && !compares);
     if (nearest_only && (desc->min_filter != NT_FILTER_NEAREST || desc->mag_filter != NT_FILTER_NEAREST)) {
         return false;
     }

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -1179,27 +1179,48 @@ void nt_gfx_test_viewport_rect(int out[4]) {
 
 /* ---- Sampler (deduplicated cache) ---- */
 
-static inline uint32_t sampler_pack_key(const nt_sampler_desc_t *desc) {
-    /* Explicit clamp on mag_filter — only NEAREST/LINEAR are legal there.
-     * If asserts get compiled out (NT_ASSERT OFF mode for production), a
-     * bad input would otherwise silently collide with another sampler. */
-    uint32_t mag = (desc->mag_filter == NT_FILTER_LINEAR) ? 1U : 0U;
-    uint32_t mn = ((uint32_t)desc->min_filter) & 0x7U;
-    uint32_t wu = ((uint32_t)desc->wrap_u) & 0x3U;
-    uint32_t wv = ((uint32_t)desc->wrap_v) & 0x3U;
-    /* compare_func is normalized the way the backend clamps it, not masked: a
-     * masked out-of-range value would key one function and build another. */
-    uint32_t cmp = (desc->compare_func <= NT_COMPARE_LESS) ? (uint32_t)desc->compare_func : (uint32_t)NT_COMPARE_NONE;
-    return mn | (mag << 3) | (wu << 4) | (wv << 6) | (cmp << 8);
+/* Single clamp site for the whole sampler path: the dedupe key, the GL object
+ * and the recorded desc all derive from the result, so they cannot describe
+ * different samplers. Out of range maps to the zero value every backend mapper
+ * already falls back to; pack headers cast straight into these enums, so the
+ * input is not always a caller. */
+static inline nt_sampler_desc_t sampler_normalize(const nt_sampler_desc_t *desc) {
+    nt_sampler_desc_t out = *desc;
+    if ((uint32_t)out.min_filter > (uint32_t)NT_FILTER_LINEAR_MIPMAP_LINEAR) {
+        out.min_filter = NT_FILTER_NEAREST;
+    }
+    if ((uint32_t)out.mag_filter > (uint32_t)NT_FILTER_LINEAR) {
+        out.mag_filter = NT_FILTER_NEAREST;
+    }
+    if ((uint32_t)out.wrap_u > (uint32_t)NT_WRAP_MIRRORED_REPEAT) {
+        out.wrap_u = NT_WRAP_CLAMP_TO_EDGE;
+    }
+    if ((uint32_t)out.wrap_v > (uint32_t)NT_WRAP_MIRRORED_REPEAT) {
+        out.wrap_v = NT_WRAP_CLAMP_TO_EDGE;
+    }
+    if ((uint32_t)out.compare_func > (uint32_t)NT_COMPARE_LESS) {
+        out.compare_func = NT_COMPARE_NONE;
+    }
+    return out;
 }
+
+/* Normalized descs only: equal key must mean an identical GL sampler. */
+static inline uint32_t sampler_pack_key(const nt_sampler_desc_t *desc) {
+    return (uint32_t)desc->min_filter | ((uint32_t)desc->mag_filter << 3) | ((uint32_t)desc->wrap_u << 4) | ((uint32_t)desc->wrap_v << 6) | ((uint32_t)desc->compare_func << 8);
+}
+_Static_assert(NT_FILTER_LINEAR_MIPMAP_LINEAR < 8 && NT_FILTER_LINEAR < 2 && NT_WRAP_MIRRORED_REPEAT < 4 && NT_COMPARE_LESS < 4,
+               "sampler_pack_key field widths — a new enum value would overlap the next field");
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity) — cache hit / miss / lazy-recreate paths
 nt_sampler_t nt_gfx_make_sampler(const nt_sampler_desc_t *desc) {
     NT_ASSERT(desc != NULL);
-    NT_ASSERT(desc->mag_filter <= NT_FILTER_LINEAR && "sampler mag_filter must be NEAREST or LINEAR");
-    NT_ASSERT(desc->compare_func <= NT_COMPARE_LESS && "sampler compare_func out of range");
+    /* Unsigned: nt_compare_func_t and nt_texture_filter_t are signed under the
+     * MSVC ABI, where a negative cast would pass an upper-bound-only check. */
+    NT_ASSERT((uint32_t)desc->mag_filter <= NT_FILTER_LINEAR && "sampler mag_filter must be NEAREST or LINEAR");
+    NT_ASSERT((uint32_t)desc->compare_func <= NT_COMPARE_LESS && "sampler compare_func out of range");
 
-    uint32_t key = sampler_pack_key(desc);
+    nt_sampler_desc_t normalized = sampler_normalize(desc);
+    uint32_t key = sampler_pack_key(&normalized);
 
     for (uint32_t i = 0; i < s_gfx.sampler_count; i++) {
         if (s_gfx.sampler_cache[i].key == key) {
@@ -1212,7 +1233,7 @@ nt_sampler_t nt_gfx_make_sampler(const nt_sampler_desc_t *desc) {
     }
 
     NT_ASSERT(s_gfx.sampler_count < NT_GFX_MAX_SAMPLERS && "sampler cache full; raise NT_GFX_MAX_SAMPLERS");
-    uint32_t backend = nt_gfx_backend_create_sampler(desc);
+    uint32_t backend = nt_gfx_backend_create_sampler(&normalized);
     if (backend == 0) {
         NT_LOG_ERROR("make_sampler: backend failed");
         return NT_SAMPLER_INVALID;
@@ -1220,7 +1241,7 @@ nt_sampler_t nt_gfx_make_sampler(const nt_sampler_desc_t *desc) {
     uint32_t slot = s_gfx.sampler_count++;
     s_gfx.sampler_cache[slot].key = key;
     s_gfx.sampler_cache[slot].backend = backend;
-    s_gfx.sampler_cache[slot].desc = *desc;
+    s_gfx.sampler_cache[slot].desc = normalized;
     return (nt_sampler_t){.id = slot + 1};
 }
 

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -1187,10 +1187,12 @@ static inline uint32_t sampler_pack_key(const nt_sampler_desc_t *desc) {
     uint32_t mn = ((uint32_t)desc->min_filter) & 0x7U;
     uint32_t wu = ((uint32_t)desc->wrap_u) & 0x3U;
     uint32_t wv = ((uint32_t)desc->wrap_v) & 0x3U;
-    /* compare_func has no effect with comparison off; drop it from the key so
-     * both spellings of "no comparison" share one cache slot. */
+    /* compare_func is normalized the same way the backend clamps it, not
+     * masked: a masked out-of-range value would key one function and build
+     * another. It also drops out with comparison off, so both spellings of
+     * "no comparison" share one cache slot. */
     uint32_t cmp = desc->depth_compare ? 1U : 0U;
-    uint32_t fn = cmp * (((uint32_t)desc->compare_func) & 0x1U);
+    uint32_t fn = (cmp != 0U && desc->compare_func == NT_COMPARE_LESS) ? 1U : 0U;
     return mn | (mag << 3) | (wu << 4) | (wv << 6) | (cmp << 8) | (fn << 9);
 }
 
@@ -1238,7 +1240,10 @@ static bool texture_has_complete_mip_chain(const nt_gfx_texture_meta_t *meta) {
 static bool bound_texture_sampler_compatible(uint32_t slot, const nt_sampler_desc_t *desc) {
     uint32_t texture_id = s_gfx.bound_texture_ids[slot];
     if (!nt_pool_valid(&s_gfx.texture_pool, texture_id)) {
-        return true;
+        /* Comparison needs depth storage to check against, and nt_gfx_bind_texture
+         * reinstalls the texture's own sampler — so a comparison sampler on an
+         * empty slot can only be a bind-order mistake. */
+        return !desc->depth_compare;
     }
     uint32_t texture_slot = nt_pool_slot_index(texture_id);
     const nt_gfx_texture_meta_t *meta = &s_gfx.texture_metas[texture_slot];

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -1179,11 +1179,9 @@ void nt_gfx_test_viewport_rect(int out[4]) {
 
 /* ---- Sampler (deduplicated cache) ---- */
 
-/* Single clamp site for the whole sampler path: the dedupe key, the GL object
- * and the recorded desc all derive from the result, so they cannot describe
- * different samplers. Out of range maps to the zero value every backend mapper
- * already falls back to; pack headers cast straight into these enums, so the
- * input is not always a caller. */
+/* One clamp for the whole sampler path: key, GL object and recorded desc derive
+ * from the result, so they cannot disagree. Pack headers cast raw bytes into
+ * these enums, so out of range takes the zero value the backend maps it to. */
 static inline nt_sampler_desc_t sampler_normalize(const nt_sampler_desc_t *desc) {
     nt_sampler_desc_t out = *desc;
     if ((uint32_t)out.min_filter > (uint32_t)NT_FILTER_LINEAR_MIPMAP_LINEAR) {

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -65,7 +65,7 @@ static uint32_t s_global_block_count;
  * Lifetime = engine. desc is preserved across context loss so backend can be
  * lazily recreated without invalidating material-side sampler.id handles. */
 typedef struct {
-    uint32_t key;           /* hash of (min, mag, wrap_u, wrap_v); 0 = empty slot */
+    uint32_t key;           /* hash of (min, mag, wrap_u, wrap_v, compare) */
     uint32_t backend;       /* GL sampler object handle; 0 after context loss */
     nt_sampler_desc_t desc; /* recorded for context-loss recreate */
 } nt_gfx_sampler_entry_t;
@@ -1187,13 +1187,18 @@ static inline uint32_t sampler_pack_key(const nt_sampler_desc_t *desc) {
     uint32_t mn = ((uint32_t)desc->min_filter) & 0x7U;
     uint32_t wu = ((uint32_t)desc->wrap_u) & 0x3U;
     uint32_t wv = ((uint32_t)desc->wrap_v) & 0x3U;
-    return mn | (mag << 3) | (wu << 4) | (wv << 6);
+    /* compare_func has no effect with comparison off; drop it from the key so
+     * both spellings of "no comparison" share one cache slot. */
+    uint32_t cmp = desc->depth_compare ? 1U : 0U;
+    uint32_t fn = cmp * (((uint32_t)desc->compare_func) & 0x1U);
+    return mn | (mag << 3) | (wu << 4) | (wv << 6) | (cmp << 8) | (fn << 9);
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity) — cache hit / miss / lazy-recreate paths
 nt_sampler_t nt_gfx_make_sampler(const nt_sampler_desc_t *desc) {
     NT_ASSERT(desc != NULL);
     NT_ASSERT(desc->mag_filter <= NT_FILTER_LINEAR && "sampler mag_filter must be NEAREST or LINEAR");
+    NT_ASSERT(desc->compare_func <= NT_COMPARE_LESS && "sampler compare_func out of range");
 
     uint32_t key = sampler_pack_key(desc);
 
@@ -1238,7 +1243,16 @@ static bool bound_texture_sampler_compatible(uint32_t slot, const nt_sampler_des
     uint32_t texture_slot = nt_pool_slot_index(texture_id);
     const nt_gfx_texture_meta_t *meta = &s_gfx.texture_metas[texture_slot];
     uint8_t format = meta->format;
-    bool nearest_only = format == (uint8_t)NT_TEXTURE_FORMAT_RG16UI || format >= (uint8_t)NT_TEXTURE_FORMAT_DEPTH16;
+    bool depth = format >= (uint8_t)NT_TEXTURE_FORMAT_DEPTH16;
+    /* Comparison against a non-depth texture makes every lookup undefined in
+     * GL, whichever sampler type the shader declares. */
+    if (desc->depth_compare && !depth) {
+        return false;
+    }
+    /* Filtering raw depth averages texels into a depth that exists in none of
+     * them; with comparison on, LINEAR blends the 0/1 comparison results
+     * instead. Integer storage has no such escape and stays NEAREST. */
+    bool nearest_only = format == (uint8_t)NT_TEXTURE_FORMAT_RG16UI || (depth && !desc->depth_compare);
     if (nearest_only && (desc->min_filter != NT_FILTER_NEAREST || desc->mag_filter != NT_FILTER_NEAREST)) {
         return false;
     }

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -59,7 +59,7 @@ typedef struct {
  * return the same handle. Most apps use 3-10 unique configs. */
 /* 128 is headroom, not coverage: the descriptor space is larger
  * (min×mag×wrap_u×wrap_v×compare = 324) and creation never inspects a texture,
- * so every combination is constructible. Cost: ~4.5 KB BSS (not binary —
+ * so every combination is constructible. Cost: ~4 KB BSS (not binary —
  * zero-init in WASM linear memory / native .bss). Linear scan in
  * nt_gfx_make_sampler iterates sampler_count, not capacity, so size is free
  * for the hot path. */

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -54,15 +54,10 @@ typedef struct {
 
 #define NT_GFX_MAX_GLOBAL_BLOCKS 8
 
-/* Sampler cache size — samplers are deduplicated by their (filter/wrap/compare)
- * descriptor so repeated nt_gfx_make_sampler calls with the same desc
- * return the same handle. Most apps use 3-10 unique configs. */
-/* 128 is headroom, not coverage: the descriptor space is larger
- * (min×mag×wrap_u×wrap_v×compare = 324) and creation never inspects a texture,
- * so every combination is constructible. Cost: ~4 KB BSS (not binary —
- * zero-init in WASM linear memory / native .bss). Linear scan in
- * nt_gfx_make_sampler iterates sampler_count, not capacity, so size is free
- * for the hot path. */
+/* Samplers are deduplicated by their (filter/wrap/compare) descriptor; most apps
+ * use 3-10 unique configs. 128 is headroom, not coverage — all 324 combinations
+ * are constructible. Costs ~4 KB of BSS, not binary size; the linear scan
+ * iterates sampler_count, not capacity, so capacity is free for the hot path. */
 #define NT_GFX_MAX_SAMPLERS 128
 
 typedef struct {

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -54,14 +54,15 @@ typedef struct {
 
 #define NT_GFX_MAX_GLOBAL_BLOCKS 8
 
-/* Sampler cache size — samplers are deduplicated by their (filter/wrap)
+/* Sampler cache size — samplers are deduplicated by their (filter/wrap/compare)
  * descriptor so repeated nt_gfx_make_sampler calls with the same desc
  * return the same handle. Most apps use 3-10 unique configs. */
-/* 128 covers all theoretically possible combinations of (min×mag×wrap_u×wrap_v)
- * = 6×2×3×3 = 108, with a small safety margin. Cost: ~3.5 KB BSS (not binary
- * — zero-init in WASM linear memory / native .bss). Linear scan in
- * nt_gfx_make_sampler iterates sampler_count, not capacity, so size is free
- * for the hot path. */
+/* 128 no longer covers every theoretical combination (min×mag×wrap_u×wrap_v ×
+ * compare = 108×3 = 324) — comparison is only legal on DEPTH* textures, so the
+ * reachable set stays far below this. Overflow asserts rather than corrupting.
+ * Cost: ~4.5 KB BSS (not binary — zero-init in WASM linear memory / native
+ * .bss). Linear scan in nt_gfx_make_sampler iterates sampler_count, not
+ * capacity, so size is free for the hot path. */
 #define NT_GFX_MAX_SAMPLERS 128
 
 typedef struct {
@@ -157,6 +158,14 @@ typedef enum {
     NT_WRAP_MIRRORED_REPEAT,
 } nt_texture_wrap_t;
 
+/* Depth-compare function for sampler objects. LEQUAL is zero so a zero-filled
+ * descriptor matches the GL default and the shadow-map convention: a receiver
+ * at exactly the stored depth stays lit instead of shadowing itself. */
+typedef enum {
+    NT_COMPARE_LEQUAL = 0,
+    NT_COMPARE_LESS,
+} nt_compare_func_t;
+
 typedef enum {
     NT_RT_DEPTH_NONE = 0,
     NT_RT_DEPTH_BUFFER,
@@ -247,6 +256,11 @@ typedef struct {
     nt_texture_filter_t mag_filter; /* default: NT_FILTER_LINEAR (NEAREST or LINEAR only) */
     nt_texture_wrap_t wrap_u;       /* default: NT_WRAP_CLAMP_TO_EDGE */
     nt_texture_wrap_t wrap_v;       /* default: NT_WRAP_CLAMP_TO_EDGE */
+    /* Comparison lives on the sampler, not the texture: one depth target reads
+     * through a comparison sampler for the shadow lookup and through a plain
+     * sampler for a raw-depth view. DEPTH* textures only. */
+    bool depth_compare;
+    nt_compare_func_t compare_func; /* ignored unless depth_compare; default LEQUAL */
     const char *label;              /* debug name; static storage */
 } nt_sampler_desc_t;
 
@@ -260,8 +274,8 @@ typedef struct {
     nt_texture_wrap_t color_wrap_v;
     nt_render_target_depth_t depth_storage;
     nt_texture_format_t depth_format;             /* INVALID for NONE; DEPTH* otherwise */
-    nt_texture_filter_t depth_texture_min_filter; /* TEXTURE only; NEAREST without compare mode */
-    nt_texture_filter_t depth_texture_mag_filter; /* TEXTURE only; NEAREST without compare mode */
+    nt_texture_filter_t depth_texture_min_filter; /* TEXTURE only; NEAREST — comparison is sampler state */
+    nt_texture_filter_t depth_texture_mag_filter; /* TEXTURE only; NEAREST — comparison is sampler state */
     nt_texture_wrap_t depth_texture_wrap_u;       /* TEXTURE only */
     nt_texture_wrap_t depth_texture_wrap_v;       /* TEXTURE only */
     const char *label;                            /* debug name; static storage */
@@ -384,8 +398,9 @@ void nt_gfx_bind_vertex_buffer(nt_buffer_t buf);
 void nt_gfx_bind_index_buffer(nt_buffer_t buf);
 void nt_gfx_bind_texture(nt_texture_t tex, uint32_t slot);
 /* Bind sampler to texture unit `slot`. Pass NT_SAMPLER_INVALID to fall back
- * to texture state. RG16UI/DEPTH* require NEAREST min/mag. Mipmap min filters
- * require a complete chain; a 1x1 base level is already complete. */
+ * to texture state. RG16UI requires NEAREST min/mag, and so does DEPTH* unless
+ * depth_compare is set; depth_compare requires a DEPTH* texture. Mipmap min
+ * filters require a complete chain; a 1x1 base level is already complete. */
 void nt_gfx_bind_sampler(nt_sampler_t s, uint32_t slot);
 
 /* ---- Scissor and viewport ----

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -57,12 +57,12 @@ typedef struct {
 /* Sampler cache size — samplers are deduplicated by their (filter/wrap/compare)
  * descriptor so repeated nt_gfx_make_sampler calls with the same desc
  * return the same handle. Most apps use 3-10 unique configs. */
-/* 128 no longer covers every theoretical combination (min×mag×wrap_u×wrap_v ×
- * compare = 108×3 = 324) — comparison is only legal on DEPTH* textures, so the
- * reachable set stays far below this. Overflow asserts rather than corrupting.
- * Cost: ~4.5 KB BSS (not binary — zero-init in WASM linear memory / native
- * .bss). Linear scan in nt_gfx_make_sampler iterates sampler_count, not
- * capacity, so size is free for the hot path. */
+/* 128 is headroom, not coverage: the descriptor space is larger
+ * (min×mag×wrap_u×wrap_v×compare = 324) and creation never inspects a texture,
+ * so every combination is constructible. Cost: ~4.5 KB BSS (not binary —
+ * zero-init in WASM linear memory / native .bss). Linear scan in
+ * nt_gfx_make_sampler iterates sampler_count, not capacity, so size is free
+ * for the hot path. */
 #define NT_GFX_MAX_SAMPLERS 128
 
 typedef struct {
@@ -397,10 +397,12 @@ void nt_gfx_bind_pipeline(nt_pipeline_t pip);
 void nt_gfx_bind_vertex_buffer(nt_buffer_t buf);
 void nt_gfx_bind_index_buffer(nt_buffer_t buf);
 void nt_gfx_bind_texture(nt_texture_t tex, uint32_t slot);
-/* Bind sampler to texture unit `slot`. Pass NT_SAMPLER_INVALID to fall back
- * to texture state. RG16UI requires NEAREST min/mag, and so does DEPTH* unless
- * depth_compare is set; depth_compare requires a DEPTH* texture. Mipmap min
- * filters require a complete chain; a 1x1 base level is already complete. */
+/* Bind sampler to texture unit `slot`, after nt_gfx_bind_texture for that slot —
+ * bind_texture installs the texture's own default sampler and discards this one.
+ * Pass NT_SAMPLER_INVALID to fall back to texture state. RG16UI requires NEAREST
+ * min/mag, and so does DEPTH* unless depth_compare is set; depth_compare requires
+ * a bound DEPTH* texture. Mipmap min filters require a complete chain; a 1x1 base
+ * level is already complete. */
 void nt_gfx_bind_sampler(nt_sampler_t s, uint32_t slot);
 
 /* ---- Scissor and viewport ----

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -158,11 +158,12 @@ typedef enum {
     NT_WRAP_MIRRORED_REPEAT,
 } nt_texture_wrap_t;
 
-/* Depth-compare function for sampler objects. LEQUAL is zero so a zero-filled
- * descriptor matches the GL default and the shadow-map convention: a receiver
- * at exactly the stored depth stays lit instead of shadowing itself. */
+/* Depth comparison on sampler objects. NONE is zero so a zero-filled descriptor
+ * is a plain sampler; enabling comparison names its function, since LEQUAL and
+ * LESS differ exactly on a receiver at its own stored depth. */
 typedef enum {
-    NT_COMPARE_LEQUAL = 0,
+    NT_COMPARE_NONE = 0,
+    NT_COMPARE_LEQUAL,
     NT_COMPARE_LESS,
 } nt_compare_func_t;
 
@@ -258,10 +259,9 @@ typedef struct {
     nt_texture_wrap_t wrap_v;       /* default: NT_WRAP_CLAMP_TO_EDGE */
     /* Comparison lives on the sampler, not the texture: one depth target reads
      * through a comparison sampler for the shadow lookup and through a plain
-     * sampler for a raw-depth view. DEPTH* textures only. */
-    bool depth_compare;
-    nt_compare_func_t compare_func; /* ignored unless depth_compare; default LEQUAL */
-    const char *label;              /* debug name; static storage */
+     * sampler for a raw-depth view. Non-NONE requires DEPTH* storage. */
+    nt_compare_func_t compare_func;
+    const char *label; /* debug name; static storage */
 } nt_sampler_desc_t;
 
 typedef struct {
@@ -400,9 +400,9 @@ void nt_gfx_bind_texture(nt_texture_t tex, uint32_t slot);
 /* Bind sampler to texture unit `slot`, after nt_gfx_bind_texture for that slot —
  * bind_texture installs the texture's own default sampler and discards this one.
  * Pass NT_SAMPLER_INVALID to fall back to texture state. RG16UI requires NEAREST
- * min/mag, and so does DEPTH* unless depth_compare is set; depth_compare requires
- * a bound DEPTH* texture. Mipmap min filters require a complete chain; a 1x1 base
- * level is already complete. */
+ * min/mag, and so does DEPTH* unless compare_func is set; a set compare_func
+ * requires a bound DEPTH* texture. Mipmap min filters require a complete chain;
+ * a 1x1 base level is already complete. */
 void nt_gfx_bind_sampler(nt_sampler_t s, uint32_t slot);
 
 /* ---- Scissor and viewport ----

--- a/tests/unit/test_nt_gfx_render_target.c
+++ b/tests/unit/test_nt_gfx_render_target.c
@@ -381,6 +381,89 @@ static void test_integer_texture_rejects_linear_sampler_override(void) {
     NT_TEST_EXPECT_ASSERT(nt_gfx_bind_sampler(linear, 0));
 }
 
+static nt_sampler_t make_comparison_sampler(void) {
+    return nt_gfx_make_sampler(&(nt_sampler_desc_t){
+        .min_filter = NT_FILTER_LINEAR,
+        .mag_filter = NT_FILTER_LINEAR,
+        .wrap_u = NT_WRAP_CLAMP_TO_EDGE,
+        .wrap_v = NT_WRAP_CLAMP_TO_EDGE,
+        .depth_compare = true,
+        .compare_func = NT_COMPARE_LEQUAL,
+    });
+}
+
+static void test_depth_texture_accepts_linear_comparison_sampler(void) {
+    nt_render_target_desc_t desc = rt_desc(NT_RT_DEPTH_TEXTURE);
+    nt_render_target_t rt = nt_gfx_make_render_target(&desc);
+    nt_sampler_t comparison = make_comparison_sampler();
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, comparison.id);
+
+    nt_gfx_bind_texture(nt_gfx_render_target_depth(rt), 0);
+    nt_gfx_bind_sampler(comparison, 0);
+
+    nt_gfx_destroy_render_target(rt);
+}
+
+/* Comparison against non-depth storage is undefined in GL, so the same sampler
+ * that is legal on the depth attachment must be rejected on the colour one. */
+static void test_color_texture_rejects_comparison_sampler(void) {
+    nt_render_target_desc_t desc = rt_desc(NT_RT_DEPTH_TEXTURE);
+    nt_render_target_t rt = nt_gfx_make_render_target(&desc);
+    nt_sampler_t comparison = make_comparison_sampler();
+
+    nt_gfx_bind_texture(nt_gfx_render_target_color(rt), 0);
+    NT_TEST_EXPECT_ASSERT(nt_gfx_bind_sampler(comparison, 0));
+
+    nt_gfx_destroy_render_target(rt);
+}
+
+static void test_integer_texture_rejects_comparison_sampler(void) {
+    nt_texture_t integer = nt_gfx_make_texture(&(nt_texture_desc_t){
+        .width = 1,
+        .height = 1,
+        .format = NT_TEXTURE_FORMAT_RG16UI,
+        .min_filter = NT_FILTER_NEAREST,
+        .mag_filter = NT_FILTER_NEAREST,
+        .wrap_u = NT_WRAP_CLAMP_TO_EDGE,
+        .wrap_v = NT_WRAP_CLAMP_TO_EDGE,
+    });
+    nt_sampler_t comparison = make_comparison_sampler();
+
+    nt_gfx_bind_texture(integer, 0);
+    NT_TEST_EXPECT_ASSERT(nt_gfx_bind_sampler(comparison, 0));
+
+    nt_gfx_destroy_texture(integer);
+}
+
+/* The dedupe key must separate comparison state, or the shadow lookup and the
+ * raw-depth debug view would collapse onto one GL sampler object. */
+static void test_comparison_state_participates_in_sampler_dedupe(void) {
+    nt_sampler_desc_t plain = {
+        .min_filter = NT_FILTER_LINEAR,
+        .mag_filter = NT_FILTER_LINEAR,
+        .wrap_u = NT_WRAP_CLAMP_TO_EDGE,
+        .wrap_v = NT_WRAP_CLAMP_TO_EDGE,
+    };
+    nt_sampler_desc_t leq = plain;
+    leq.depth_compare = true;
+    nt_sampler_desc_t less = leq;
+    less.compare_func = NT_COMPARE_LESS;
+
+    nt_sampler_t a = nt_gfx_make_sampler(&plain);
+    nt_sampler_t b = nt_gfx_make_sampler(&leq);
+    nt_sampler_t c = nt_gfx_make_sampler(&less);
+
+    TEST_ASSERT_NOT_EQUAL_UINT32(a.id, b.id);
+    TEST_ASSERT_NOT_EQUAL_UINT32(b.id, c.id);
+    TEST_ASSERT_EQUAL_UINT32(b.id, nt_gfx_make_sampler(&leq).id);
+
+    /* compare_func is inert while comparison is off; both spellings of "no
+     * comparison" must land on the same cache slot. */
+    nt_sampler_desc_t plain_other_func = plain;
+    plain_other_func.compare_func = NT_COMPARE_LESS;
+    TEST_ASSERT_EQUAL_UINT32(a.id, nt_gfx_make_sampler(&plain_other_func).id);
+}
+
 static nt_sampler_t make_mipmap_sampler(void) {
     return nt_gfx_make_sampler(&(nt_sampler_desc_t){
         .min_filter = NT_FILTER_LINEAR_MIPMAP_LINEAR,
@@ -694,6 +777,10 @@ int main(void) {
     RUN_TEST(test_make_render_target_rejects_invalid_sampler_modes);
     RUN_TEST(test_depth_texture_rejects_linear_sampler_override);
     RUN_TEST(test_integer_texture_rejects_linear_sampler_override);
+    RUN_TEST(test_depth_texture_accepts_linear_comparison_sampler);
+    RUN_TEST(test_color_texture_rejects_comparison_sampler);
+    RUN_TEST(test_integer_texture_rejects_comparison_sampler);
+    RUN_TEST(test_comparison_state_participates_in_sampler_dedupe);
     RUN_TEST(test_render_target_color_rejects_mipmap_sampler_override);
     RUN_TEST(test_one_pixel_texture_accepts_mipmap_sampler_override);
     RUN_TEST(test_invalid_render_target_lifecycle_arguments_assert);

--- a/tests/unit/test_nt_gfx_render_target.c
+++ b/tests/unit/test_nt_gfx_render_target.c
@@ -387,7 +387,6 @@ static nt_sampler_t make_comparison_sampler(void) {
         .mag_filter = NT_FILTER_LINEAR,
         .wrap_u = NT_WRAP_CLAMP_TO_EDGE,
         .wrap_v = NT_WRAP_CLAMP_TO_EDGE,
-        .depth_compare = true,
         .compare_func = NT_COMPARE_LEQUAL,
     });
 }
@@ -434,7 +433,7 @@ static void test_integer_texture_rejects_comparison_sampler(void) {
         .mag_filter = NT_FILTER_NEAREST,
         .wrap_u = NT_WRAP_CLAMP_TO_EDGE,
         .wrap_v = NT_WRAP_CLAMP_TO_EDGE,
-        .depth_compare = true,
+        .compare_func = NT_COMPARE_LEQUAL,
     });
 
     nt_gfx_bind_texture(integer, 0);
@@ -453,8 +452,8 @@ static void test_comparison_state_participates_in_sampler_dedupe(void) {
         .wrap_v = NT_WRAP_CLAMP_TO_EDGE,
     };
     nt_sampler_desc_t leq = plain;
-    leq.depth_compare = true;
-    nt_sampler_desc_t less = leq;
+    leq.compare_func = NT_COMPARE_LEQUAL;
+    nt_sampler_desc_t less = plain;
     less.compare_func = NT_COMPARE_LESS;
 
     nt_sampler_t a = nt_gfx_make_sampler(&plain);
@@ -465,12 +464,6 @@ static void test_comparison_state_participates_in_sampler_dedupe(void) {
     TEST_ASSERT_NOT_EQUAL_UINT32(b.id, c.id);
     TEST_ASSERT_NOT_EQUAL_UINT32(a.id, c.id);
     TEST_ASSERT_EQUAL_UINT32(b.id, nt_gfx_make_sampler(&leq).id);
-
-    /* compare_func is inert while comparison is off; both spellings of "no
-     * comparison" must land on the same cache slot. */
-    nt_sampler_desc_t plain_other_func = plain;
-    plain_other_func.compare_func = NT_COMPARE_LESS;
-    TEST_ASSERT_EQUAL_UINT32(a.id, nt_gfx_make_sampler(&plain_other_func).id);
 }
 
 static nt_sampler_t make_mipmap_sampler(void) {

--- a/tests/unit/test_nt_gfx_render_target.c
+++ b/tests/unit/test_nt_gfx_render_target.c
@@ -426,8 +426,8 @@ static void test_integer_texture_rejects_comparison_sampler(void) {
         .wrap_u = NT_WRAP_CLAMP_TO_EDGE,
         .wrap_v = NT_WRAP_CLAMP_TO_EDGE,
     });
-    /* NEAREST, so the pre-existing integer filter rule cannot be what rejects
-     * this — only the comparison guard can. */
+    /* NEAREST, so the integer filter rule cannot be what rejects this — only
+     * the comparison guard can. */
     nt_sampler_t comparison = nt_gfx_make_sampler(&(nt_sampler_desc_t){
         .min_filter = NT_FILTER_NEAREST,
         .mag_filter = NT_FILTER_NEAREST,

--- a/tests/unit/test_nt_gfx_render_target.c
+++ b/tests/unit/test_nt_gfx_render_target.c
@@ -466,6 +466,28 @@ static void test_comparison_state_participates_in_sampler_dedupe(void) {
     TEST_ASSERT_EQUAL_UINT32(b.id, nt_gfx_make_sampler(&leq).id);
 }
 
+/* Pack headers cast raw bytes into these enums, so an out-of-range value has to
+ * key the sampler the backend actually builds — otherwise it takes over the
+ * cache slot of a valid, different one. */
+static void test_out_of_range_sampler_state_keys_what_the_backend_builds(void) {
+    nt_sampler_desc_t clamped = {
+        .min_filter = NT_FILTER_NEAREST,
+        .mag_filter = NT_FILTER_NEAREST,
+        .wrap_u = NT_WRAP_CLAMP_TO_EDGE,
+        .wrap_v = NT_WRAP_CLAMP_TO_EDGE,
+    };
+    nt_sampler_desc_t garbage = clamped;
+    // NOLINTNEXTLINE(clang-analyzer-optin.core.EnumCastOutOfRange) — the out-of-range value is the subject of the test
+    garbage.wrap_u = (nt_texture_wrap_t)9;
+    nt_sampler_desc_t repeat = clamped;
+    repeat.wrap_u = NT_WRAP_REPEAT;
+
+    nt_sampler_t from_garbage = nt_gfx_make_sampler(&garbage);
+
+    TEST_ASSERT_EQUAL_UINT32(nt_gfx_make_sampler(&clamped).id, from_garbage.id);
+    TEST_ASSERT_NOT_EQUAL_UINT32(nt_gfx_make_sampler(&repeat).id, from_garbage.id);
+}
+
 static nt_sampler_t make_mipmap_sampler(void) {
     return nt_gfx_make_sampler(&(nt_sampler_desc_t){
         .min_filter = NT_FILTER_LINEAR_MIPMAP_LINEAR,
@@ -783,6 +805,7 @@ int main(void) {
     RUN_TEST(test_color_texture_rejects_comparison_sampler);
     RUN_TEST(test_integer_texture_rejects_comparison_sampler);
     RUN_TEST(test_comparison_state_participates_in_sampler_dedupe);
+    RUN_TEST(test_out_of_range_sampler_state_keys_what_the_backend_builds);
     RUN_TEST(test_render_target_color_rejects_mipmap_sampler_override);
     RUN_TEST(test_one_pixel_texture_accepts_mipmap_sampler_override);
     RUN_TEST(test_invalid_render_target_lifecycle_arguments_assert);

--- a/tests/unit/test_nt_gfx_render_target.c
+++ b/tests/unit/test_nt_gfx_render_target.c
@@ -427,7 +427,15 @@ static void test_integer_texture_rejects_comparison_sampler(void) {
         .wrap_u = NT_WRAP_CLAMP_TO_EDGE,
         .wrap_v = NT_WRAP_CLAMP_TO_EDGE,
     });
-    nt_sampler_t comparison = make_comparison_sampler();
+    /* NEAREST, so the pre-existing integer filter rule cannot be what rejects
+     * this — only the comparison guard can. */
+    nt_sampler_t comparison = nt_gfx_make_sampler(&(nt_sampler_desc_t){
+        .min_filter = NT_FILTER_NEAREST,
+        .mag_filter = NT_FILTER_NEAREST,
+        .wrap_u = NT_WRAP_CLAMP_TO_EDGE,
+        .wrap_v = NT_WRAP_CLAMP_TO_EDGE,
+        .depth_compare = true,
+    });
 
     nt_gfx_bind_texture(integer, 0);
     NT_TEST_EXPECT_ASSERT(nt_gfx_bind_sampler(comparison, 0));
@@ -455,6 +463,7 @@ static void test_comparison_state_participates_in_sampler_dedupe(void) {
 
     TEST_ASSERT_NOT_EQUAL_UINT32(a.id, b.id);
     TEST_ASSERT_NOT_EQUAL_UINT32(b.id, c.id);
+    TEST_ASSERT_NOT_EQUAL_UINT32(a.id, c.id);
     TEST_ASSERT_EQUAL_UINT32(b.id, nt_gfx_make_sampler(&leq).id);
 
     /* compare_func is inert while comparison is off; both spellings of "no

--- a/tests/unit/test_nt_gfx_render_target_native.c
+++ b/tests/unit/test_nt_gfx_render_target_native.c
@@ -253,7 +253,6 @@ static void test_depth_comparison_sampler_blends_comparison_results(void) {
         .mag_filter = NT_FILTER_LINEAR,
         .wrap_u = NT_WRAP_CLAMP_TO_EDGE,
         .wrap_v = NT_WRAP_CLAMP_TO_EDGE,
-        .depth_compare = true,
         .compare_func = NT_COMPARE_LEQUAL,
     });
     nt_sampler_t raw = nt_gfx_make_sampler(&(nt_sampler_desc_t){

--- a/tests/unit/test_nt_gfx_render_target_native.c
+++ b/tests/unit/test_nt_gfx_render_target_native.c
@@ -130,6 +130,195 @@ static void test_depth_texture_uses_explicit_format_and_wrap(void) {
     nt_gfx_destroy_render_target(target);
 }
 
+/* Depth step written by geometry: the left texel keeps the pass clear, the
+   right one takes the quad's depth. */
+static const char *s_depth_vs = "layout(location = 0) in vec3 a_position;\n"
+                                "void main() { gl_Position = vec4(a_position, 1.0); }\n";
+static const char *s_depth_fs = "precision mediump float;\n"
+                                "out vec4 frag_color;\n"
+                                "void main() { frag_color = vec4(1.0); }\n";
+static const char *s_fullscreen_vs = "layout(location = 0) in vec2 a_position;\n"
+                                     "layout(location = 3) in vec2 a_uv;\n"
+                                     "out vec2 v_uv;\n"
+                                     "void main() {\n"
+                                     "    v_uv = a_uv;\n"
+                                     "    gl_Position = vec4(a_position, 0.0, 1.0);\n"
+                                     "}\n";
+static const char *s_shadow_fs = "precision highp float;\n"
+                                 "uniform highp sampler2DShadow u_shadow;\n"
+                                 "uniform float u_ref;\n"
+                                 "in vec2 v_uv;\n"
+                                 "out vec4 frag_color;\n"
+                                 "void main() {\n"
+                                 "    float lit = texture(u_shadow, vec3(v_uv, u_ref));\n"
+                                 "    frag_color = vec4(lit, lit, lit, 1.0);\n"
+                                 "}\n";
+static const char *s_raw_fs = "precision highp float;\n"
+                              "uniform highp sampler2D u_depth;\n"
+                              "in vec2 v_uv;\n"
+                              "out vec4 frag_color;\n"
+                              "void main() {\n"
+                              "    float d = texture(u_depth, v_uv).r;\n"
+                              "    frag_color = vec4(d, d, d, 1.0);\n"
+                              "}\n";
+
+typedef struct {
+    float pos[2];
+    float uv[2];
+} fullscreen_vertex_t;
+
+/* The window framebuffer is whatever the OS grants a hidden window, so the
+   shadow passes pin their own width and sample the ramp at fixed columns. */
+#define RAMP_WIDTH 64
+#define RAMP_NEAR 4
+#define RAMP_EDGE 32
+#define RAMP_FAR 60
+
+static uint8_t ramp_at(const uint8_t *row, int column) { return row[(size_t)(unsigned)column * 4U]; }
+
+static nt_pipeline_t make_test_pipeline(const char *vs_src, const char *fs_src, bool depth_write, const nt_vertex_layout_t *layout) {
+    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = vs_src});
+    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = fs_src});
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, vs.id);
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, fs.id);
+    nt_pipeline_t pip = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
+        .vertex_shader = vs,
+        .fragment_shader = fs,
+        .layout = *layout,
+        .depth_test = depth_write,
+        .depth_write = depth_write,
+        .depth_func = NT_DEPTH_ALWAYS,
+    });
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, pip.id);
+    return pip;
+}
+
+/* Hardware comparison filters the 0/1 comparison results, so the shadow edge
+   lands between them. Both specs leave the blend implementation-dependent and
+   only promise a value proportional to the passing comparisons — hence the
+   bounds check rather than an exact midpoint. */
+static void test_depth_comparison_sampler_blends_comparison_results(void) {
+    nt_render_target_t shadow_map = nt_gfx_make_render_target(&(nt_render_target_desc_t){
+        .width = 2,
+        .height = 1,
+        .color_format = NT_TEXTURE_FORMAT_RGBA8,
+        .color_min_filter = NT_FILTER_NEAREST,
+        .color_mag_filter = NT_FILTER_NEAREST,
+        .color_wrap_u = NT_WRAP_CLAMP_TO_EDGE,
+        .color_wrap_v = NT_WRAP_CLAMP_TO_EDGE,
+        .depth_storage = NT_RT_DEPTH_TEXTURE,
+        .depth_format = NT_TEXTURE_FORMAT_DEPTH24,
+        .depth_texture_min_filter = NT_FILTER_NEAREST,
+        .depth_texture_mag_filter = NT_FILTER_NEAREST,
+        .depth_texture_wrap_u = NT_WRAP_CLAMP_TO_EDGE,
+        .depth_texture_wrap_v = NT_WRAP_CLAMP_TO_EDGE,
+        .label = "shadow_map_probe",
+    });
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, shadow_map.id);
+    TEST_ASSERT_TRUE(nt_gfx_render_target_ready(shadow_map));
+
+    /* z_ndc 0.6 maps to window depth 0.8; the pass clear leaves 0.2 on the left. */
+    static const float right_half_quad[18] = {
+        0.0F, -1.0F, 0.6F, 1.0F, -1.0F, 0.6F, 1.0F, 1.0F, 0.6F, 0.0F, -1.0F, 0.6F, 1.0F, 1.0F, 0.6F, 0.0F, 1.0F, 0.6F,
+    };
+    static const fullscreen_vertex_t fullscreen_tri[3] = {
+        {{-1.0F, -1.0F}, {0.0F, 0.0F}},
+        {{3.0F, -1.0F}, {2.0F, 0.0F}},
+        {{-1.0F, 3.0F}, {0.0F, 2.0F}},
+    };
+    nt_vertex_layout_t depth_layout = {
+        .stride = sizeof(float) * 3,
+        .attr_count = 1,
+        .attrs = {{.location = NT_ATTR_POSITION, .format = NT_FORMAT_FLOAT3, .offset = 0}},
+    };
+    nt_vertex_layout_t fullscreen_layout = {
+        .stride = sizeof(fullscreen_vertex_t),
+        .attr_count = 2,
+        .attrs =
+            {
+                {.location = NT_ATTR_POSITION, .format = NT_FORMAT_FLOAT2, .offset = 0},
+                {.location = NT_ATTR_TEXCOORD0, .format = NT_FORMAT_FLOAT2, .offset = 8},
+            },
+    };
+    nt_buffer_t depth_vbo = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_IMMUTABLE, .data = right_half_quad, .size = sizeof(right_half_quad)});
+    nt_buffer_t fullscreen_vbo = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_IMMUTABLE, .data = fullscreen_tri, .size = sizeof(fullscreen_tri)});
+    nt_pipeline_t depth_pip = make_test_pipeline(s_depth_vs, s_depth_fs, true, &depth_layout);
+    nt_pipeline_t shadow_pip = make_test_pipeline(s_fullscreen_vs, s_shadow_fs, false, &fullscreen_layout);
+    nt_pipeline_t raw_pip = make_test_pipeline(s_fullscreen_vs, s_raw_fs, false, &fullscreen_layout);
+
+    nt_sampler_t comparison = nt_gfx_make_sampler(&(nt_sampler_desc_t){
+        .min_filter = NT_FILTER_LINEAR,
+        .mag_filter = NT_FILTER_LINEAR,
+        .wrap_u = NT_WRAP_CLAMP_TO_EDGE,
+        .wrap_v = NT_WRAP_CLAMP_TO_EDGE,
+        .depth_compare = true,
+        .compare_func = NT_COMPARE_LEQUAL,
+    });
+    nt_sampler_t raw = nt_gfx_make_sampler(&(nt_sampler_desc_t){
+        .min_filter = NT_FILTER_NEAREST,
+        .mag_filter = NT_FILTER_NEAREST,
+        .wrap_u = NT_WRAP_CLAMP_TO_EDGE,
+        .wrap_v = NT_WRAP_CLAMP_TO_EDGE,
+    });
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, comparison.id);
+    TEST_ASSERT_NOT_EQUAL_UINT32(comparison.id, raw.id);
+
+    nt_texture_t depth_tex = nt_gfx_render_target_depth(shadow_map);
+
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.target = shadow_map, .clear_color = {0, 0, 0, 1}, .clear_depth = 0.2F});
+    nt_gfx_bind_pipeline(depth_pip);
+    nt_gfx_bind_vertex_buffer(depth_vbo);
+    nt_gfx_draw(0, 6);
+    nt_gfx_end_pass();
+
+    /* The fullscreen triangle spreads v_uv.x across the viewport, so one row
+       readback carries the whole shadow ramp. */
+    uint8_t row[RAMP_WIDTH * 4] = {0};
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_color = {0, 0, 0, 1}, .clear_depth = 1.0F});
+    nt_gfx_set_viewport(0, 0, RAMP_WIDTH, (int)g_nt_window.fb_height);
+    nt_gfx_bind_pipeline(shadow_pip);
+    nt_gfx_bind_vertex_buffer(fullscreen_vbo);
+    nt_gfx_bind_texture(depth_tex, 0);
+    nt_gfx_bind_sampler(comparison, 0);
+    nt_gfx_set_uniform_int("u_shadow", 0);
+    nt_gfx_set_uniform_float("u_ref", 0.5F);
+    nt_gfx_draw(0, 3);
+    TEST_ASSERT_TRUE(nt_gfx_read_pixels(0, 0, RAMP_WIDTH, 1, row, sizeof(row)));
+    nt_gfx_end_pass();
+
+    GLint sampler_binding = 0;
+    glGetIntegerv(GL_SAMPLER_BINDING, &sampler_binding);
+    GLint compare_state = 0;
+    glGetSamplerParameteriv((GLuint)sampler_binding, GL_TEXTURE_COMPARE_MODE, &compare_state);
+    TEST_ASSERT_EQUAL_INT(GL_COMPARE_REF_TO_TEXTURE, compare_state);
+    glGetSamplerParameteriv((GLuint)sampler_binding, GL_TEXTURE_COMPARE_FUNC, &compare_state);
+    TEST_ASSERT_EQUAL_INT(GL_LEQUAL, compare_state);
+
+    /* u < 0.25 samples only the near texel, u > 0.75 only the far one. */
+    TEST_ASSERT_EQUAL_UINT8(0, ramp_at(row, RAMP_NEAR));
+    TEST_ASSERT_EQUAL_UINT8(255, ramp_at(row, RAMP_FAR));
+    TEST_ASSERT_TRUE_MESSAGE(ramp_at(row, RAMP_EDGE) > 0 && ramp_at(row, RAMP_EDGE) < 255, "shadow edge did not blend comparison results");
+
+    /* Same texture, plain sampler: raw depth for a debug view. */
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_color = {0, 0, 0, 1}, .clear_depth = 1.0F});
+    nt_gfx_set_viewport(0, 0, RAMP_WIDTH, (int)g_nt_window.fb_height);
+    nt_gfx_bind_pipeline(raw_pip);
+    nt_gfx_bind_vertex_buffer(fullscreen_vbo);
+    nt_gfx_bind_texture(depth_tex, 0);
+    nt_gfx_bind_sampler(raw, 0);
+    nt_gfx_set_uniform_int("u_depth", 0);
+    nt_gfx_draw(0, 3);
+    TEST_ASSERT_TRUE(nt_gfx_read_pixels(0, 0, RAMP_WIDTH, 1, row, sizeof(row)));
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    TEST_ASSERT_UINT8_WITHIN(2, 51, ramp_at(row, RAMP_NEAR));
+    TEST_ASSERT_UINT8_WITHIN(2, 204, ramp_at(row, RAMP_FAR));
+
+    nt_gfx_destroy_render_target(shadow_map);
+}
+
 /* An over-range clear must survive the round trip — clamping to white would
    mean the target has no headroom and only the format name changed. */
 static void test_half_float_target_is_complete_and_keeps_values_above_one(void) {
@@ -257,6 +446,7 @@ int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_render_target_resize_without_spare_texture_slots);
     RUN_TEST(test_depth_texture_uses_explicit_format_and_wrap);
+    RUN_TEST(test_depth_comparison_sampler_blends_comparison_results);
     RUN_TEST(test_half_float_target_is_complete_and_keeps_values_above_one);
     RUN_TEST(test_depth_buffer_uses_explicit_format);
     RUN_TEST(test_begin_pass_clears_depth_after_depth_writes_were_disabled);

--- a/tests/unit/test_nt_gfx_render_target_native.c
+++ b/tests/unit/test_nt_gfx_render_target_native.c
@@ -193,10 +193,9 @@ static nt_pipeline_t make_test_pipeline(const char *vs_src, const char *fs_src, 
     return pip;
 }
 
-/* Hardware comparison filters the 0/1 comparison results, so the shadow edge
-   lands between them. Both specs leave the blend implementation-dependent and
-   only promise a value proportional to the passing comparisons — hence the
-   bounds check rather than an exact midpoint. */
+/* Hardware comparison filters the 0/1 results, so the shadow edge lands between
+   them. The blend weights are implementation-dependent, hence a bounds check
+   rather than an exact midpoint. */
 static void test_depth_comparison_sampler_blends_comparison_results(void) {
     nt_render_target_t shadow_map = nt_gfx_make_render_target(&(nt_render_target_desc_t){
         .width = 2,

--- a/tests/unit/test_nt_gfx_render_target_native.c
+++ b/tests/unit/test_nt_gfx_render_target_native.c
@@ -216,6 +216,8 @@ static void test_depth_comparison_sampler_blends_comparison_results(void) {
     });
     TEST_ASSERT_NOT_EQUAL_UINT32(0, shadow_map.id);
     TEST_ASSERT_TRUE(nt_gfx_render_target_ready(shadow_map));
+    /* Reading outside the drawable is undefined, so refuse to guess its width. */
+    TEST_ASSERT_TRUE_MESSAGE(g_nt_window.fb_width >= RAMP_WIDTH, "drawable narrower than the sampled ramp");
 
     /* z_ndc 0.6 maps to window depth 0.8; the pass clear leaves 0.2 on the left. */
     static const float right_half_quad[18] = {
@@ -298,7 +300,8 @@ static void test_depth_comparison_sampler_blends_comparison_results(void) {
     /* u < 0.25 samples only the near texel, u > 0.75 only the far one. */
     TEST_ASSERT_EQUAL_UINT8(0, ramp_at(row, RAMP_NEAR));
     TEST_ASSERT_EQUAL_UINT8(255, ramp_at(row, RAMP_FAR));
-    TEST_ASSERT_TRUE_MESSAGE(ramp_at(row, RAMP_EDGE) > 0 && ramp_at(row, RAMP_EDGE) < 255, "shadow edge did not blend comparison results");
+    TEST_ASSERT_TRUE_MESSAGE(ramp_at(row, RAMP_EDGE) > 0 && ramp_at(row, RAMP_EDGE) < 255,
+                             "shadow edge did not blend comparison results — both specs allow a driver to compare a single texel, so suspect driver latitude before the sampler path");
 
     /* Same texture, plain sampler: raw depth for a debug view. */
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_color = {0, 0, 0, 1}, .clear_depth = 1.0F});


### PR DESCRIPTION
Closes #316.

Adds depth comparison to `nt_sampler_desc_t` so a game can run a hardware-PCF shadow lookup on the existing render-target API. Comparison is sampler state, never texture state, so one depth attachment serves both the shadow lookup (comparison sampler, `LINEAR`) and a raw-depth debug view (plain sampler, `NEAREST`) — the pairing that sampling one texture as both `sampler2D` and `sampler2DShadow` cannot express.

`nt_render_target_desc_t`, its validators and `nt_gfx_make_texture` are unchanged in behaviour; depth attachments stay `NEAREST`.

## Change

- `nt_compare_func_t` (`LEQUAL = 0`, `LESS`) plus `depth_compare` / `compare_func` on `nt_sampler_desc_t`. `LEQUAL` is zero so a zero-filled descriptor matches both the GL default and the shadow-map convention — a receiver at exactly the stored depth stays lit instead of shadowing itself.
- `bound_texture_sampler_compatible()` splits the depth case from the integer case: `LINEAR` on `DEPTH*` is legal only with comparison on, `RG16UI` keeps its unconditional `NEAREST` requirement, and a comparison sampler is now rejected on non-depth storage.
- The GL backend emits `GL_TEXTURE_COMPARE_MODE` and `GL_TEXTURE_COMPARE_FUNC` on every sampler rather than only when comparison is on, so sampler state stays fully described by the descriptor.
- Comparison state joins the dedupe key. `compare_func` is normalised out of the key while comparison is off, so both spellings of "no comparison" share one cache slot; the func bits are masked for the same `NT_ASSERT_MODE=OFF` reason the existing `mag_filter` clamp documents.
- `NT_GFX_MAX_SAMPLERS` stays 128. Its comment no longer claims to cover every theoretical descriptor combination — comparison is only reachable on `DEPTH*`, and overflow already asserts.

Only two comparison functions are exposed. `nt_depth_func_t` carries just `LESS`/`LEQUAL`/`ALWAYS`, so the engine cannot build a reversed-Z pipeline; `GREATER`/`GEQUAL` would be comparison modes the depth test has no way to pair with.

## Scope beyond the issue

The issue's proposal covered the completeness relaxation only. ES 3.0 §3.8.15.1 makes three lookup combinations undefined, and the symmetric one was unguarded: a comparison-enabled sampler on a non-depth texture. That half is now rejected. The engine cannot see the shader-side mismatch (`sampler2D` vs `sampler2DShadow`), but the texture-side half is exactly what `bound_texture_sampler_compatible()` already guards.

## Support

Comparison sampling is core in GLES 3.0, therefore core in WebGL 2, and core in desktop GL 3.0+. No capability bit, no extension probe. `GL_TEXTURE_COMPARE_MODE`, `GL_TEXTURE_COMPARE_FUNC` and `GL_COMPARE_REF_TO_TEXTURE` are already present in both `deps/glad/include/glad/gl.h` and emsdk's `GLES3/gl3.h`, so unlike the timer-query constants in the same file this needs no inline `#ifndef` shim.

## What the filtering actually guarantees

OpenGL 4.6 core §8.23.1 and OpenGL ES 3.0.6 §3.8.15.1 carry the same sentence: with a non-`NEAREST` filter, `r` *may* be computed from more than one depth value, the details are **implementation-dependent**, and only the proportionality to passing comparisons is promised. Desktop GL guarantees no more here than WebGL 2 does — the WebGL 2 note about `LINEAR` possibly degrading to `NEAREST` restates that GLES underspecification rather than adding a browser restriction.

The native test therefore asserts `0` well inside, `255` well outside, and *strictly between* on the edge, rather than a specific fraction. A standalone WebGL 2 probe run before writing the code found four backends all producing the blend — ANGLE over SwiftShader, D3D11 (Intel UHD), OpenGL 4.5 (Intel), and Vulkan (RTX 4080) returned 128/128/128/127 at the texel midpoint. Full numbers are in the issue comment; note that 127 already rules out an exact-midpoint assertion.

## Verification

- `scripts/check.sh --push` — PASS (native-debug, ctest, clang-format, clang-tidy, wasm-debug, wasm-release, submodule consumption).
- `test_nt_gfx_render_target` (stub, 41 tests): comparison sampler accepted on depth storage; plain `LINEAR` still rejected on depth; comparison rejected on both `RGBA8` and `RG16UI`; dedupe separates comparison and function while collapsing the inert-func case.
- `test_nt_gfx_render_target_native` (real GL, 6 tests): renders a two-texel depth step into a `DEPTH24` target, samples it through `sampler2DShadow` with the comparison sampler, and reads back the ramp; also reads the same texture through a plain `NEAREST` sampler as `sampler2D` and gets the raw 0.2 / 0.8 depths, which is the debug-view half of the requirement. GL sampler state is read back with `glGetSamplerParameteriv` to confirm the mode and function reached the object.

The new native test pins its own viewport: the hidden GLFW window here was handed a 176x64 framebuffer rather than the requested 64x64, which silently skewed the first version's uv mapping. Existing tests in that file did not expose it because they read from render targets, not the default framebuffer.

## Unverified

CI runs the real-GL tests under xvfb on software Mesa, which the probe host could not reach. Mesa is expected to compare-then-filter, but the edge assertion's first proof is this PR's CI run. If llvmpipe turns out to be `NEAREST`-only, the edge bound drops and only the `0` / `255` assertions stay.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LNfFP4ER3rvQ6cSseFV4ub
