### PR TITLE
build: NT_HYBRID_HPG opts hybrid-GPU Windows laptops onto the discrete GPU

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ If code and spec diverge, flag it explicitly in the response. Do not silently "n
 - **Standard**: C17
 - **Why C17**: broader compiler, Emscripten toolchain, and build environment support
 - **NT_STATIC_CRT** (CMake option, default ON): pins the static release CRT on Windows. Consumers embedding builder + runtime in one exe set OFF to inherit their own `CMAKE_MSVC_RUNTIME_LIBRARY`. All pinning goes through `nt_set_static_crt(_cxx)` — never raw `-U_DLL` (gated by `scripts/check_crt_pins.sh`).
+- **NT_HYBRID_HPG** (CMake option, default ON): exe exports the NVIDIA/AMD hint symbols so hybrid-GPU Windows laptops run games on the discrete GPU. OFF for battery-friendly games/tools; the user's per-app Windows graphics preference always overrides the hint.
 
 If specific build, check, or run commands appear in the repo, keep them up to date in this file.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,11 @@ set(NT_WASM_SIMD_WASM_PATH "" CACHE STRING "Alternate SIMD wasm path injected in
 # OFF lets an exe that embeds both builder and runtime pick its own CRT (see nt_set_static_crt).
 option(NT_STATIC_CRT "Pin the static release CRT on Windows targets; OFF inherits the embedding project's CRT." ON)
 
+# ON exports NvOptimusEnablement/AmdPowerXpressRequestHighPerformance from the exe so hybrid-GPU
+# Windows laptops pick the discrete GPU; OFF for battery-friendly games/tools. Build-time only,
+# no runtime engine code — the user's per-app Windows graphics preference still overrides it.
+option(NT_HYBRID_HPG "Prefer the discrete GPU on hybrid-GPU Windows systems." ON)
+
 # Web counterpart to the native KHR_debug callback. ONE flag enables Emscripten GL_ASSERTIONS (validate
 # GL call params) + GL_DEBUG (log every GL call). OFF by default EVEN in debug: GL_DEBUG logs every GL
 # call, so it is opt-in for active GL bug-hunts only. Inert on native builds (warned below).
@@ -149,6 +154,16 @@ if(NOT EMSCRIPTEN)
     set(GLFW_BUILD_TESTS OFF CACHE BOOL "" FORCE)
     set(GLFW_BUILD_EXAMPLES OFF CACHE BOOL "" FORCE)
     set(GLFW_INSTALL OFF CACHE BOOL "" FORCE)
+    set(GLFW_USE_HYBRID_HPG ${NT_HYBRID_HPG} CACHE BOOL "" FORCE)
+    # The GPU hint symbols must live in the exe's export table — in a glfw DLL Windows
+    # ignores them. Directory-scoped set (no CACHE FORCE): outside the hint's contract
+    # the consumer's BUILD_SHARED_LIBS / GLFW_LIBRARY_TYPE choice stays untouched.
+    # Pre-create the cache entry so glfw's own set(CACHE) never persists our STATIC
+    # override — otherwise an ON configure would stick after switching to OFF.
+    set(GLFW_LIBRARY_TYPE "${GLFW_LIBRARY_TYPE}" CACHE STRING "GLFW library type override")
+    if(WIN32 AND NT_HYBRID_HPG)
+        set(GLFW_LIBRARY_TYPE "STATIC")
+    endif()
     add_subdirectory(deps/glfw EXCLUDE_FROM_ALL)
     add_subdirectory(deps/glad EXCLUDE_FROM_ALL)
     add_subdirectory(deps/cgltf EXCLUDE_FROM_ALL)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -210,6 +210,7 @@ if(NOT EMSCRIPTEN)
     # --- Native window smoke test (real GLFW, hidden window) ---
     add_executable(test_window_native unit/test_window_native.c)
     target_link_libraries(test_window_native PRIVATE nt_window nt_input_stub nt_log unity)
+    target_compile_definitions(test_window_native PRIVATE NT_TEST_HYBRID_HPG=$<BOOL:${NT_HYBRID_HPG}>)
     nt_setup_test_target(test_window_native)
     set_tests_properties(test_window_native PROPERTIES LABELS "native")
 

--- a/tests/unit/test_window_native.c
+++ b/tests/unit/test_window_native.c
@@ -102,8 +102,38 @@ void test_native_set_vsync(void) {
     nt_window_shutdown();
 }
 
+#if defined(_WIN32)
+#define WIN32_LEAN_AND_MEAN
+/* stdnoreturn.h (pulled in above) defines noreturn -> _Noreturn, which breaks
+   winnt.h's __declspec(noreturn). */
+#undef noreturn
+#include <stdint.h>
+#include <windows.h>
+
+/* NT_HYBRID_HPG contract: the exe's export table carries the GPU hint symbols with
+   value 1 (prefer dGPU). A glfw DLL or a dropped define silently loses them. */
+void test_native_hybrid_hpg_exports(void) {
+    HMODULE self = GetModuleHandleW(NULL);
+    FARPROC nv = GetProcAddress(self, "NvOptimusEnablement");
+    FARPROC amd = GetProcAddress(self, "AmdPowerXpressRequestHighPerformance");
+#if NT_TEST_HYBRID_HPG
+    TEST_ASSERT_NOT_NULL(nv);
+    TEST_ASSERT_NOT_NULL(amd);
+    /* uintptr_t hop: a direct FARPROC->object-pointer cast trips -Wpedantic */
+    TEST_ASSERT_EQUAL_UINT32(1U, *(const DWORD *)(uintptr_t)nv); // NOLINT(performance-no-int-to-ptr)
+    TEST_ASSERT_EQUAL_INT(1, *(const int *)(uintptr_t)amd);      // NOLINT(performance-no-int-to-ptr)
+#else
+    TEST_ASSERT_NULL(nv);
+    TEST_ASSERT_NULL(amd);
+#endif
+}
+#endif
+
 int main(void) {
     UNITY_BEGIN();
+#if defined(_WIN32)
+    RUN_TEST(test_native_hybrid_hpg_exports);
+#endif
     RUN_TEST(test_native_window_creates);
     RUN_TEST(test_native_window_shutdown_cleans_up);
     RUN_TEST(test_native_should_close_initially_false);


### PR DESCRIPTION
## Problem

On hybrid-GPU Windows laptops every engine exe lands on the power-saving iGPU: Windows assigns the integrated adapter by default and the exe exports no opt-out (#320).

## Fix

New CMake option **NT_HYBRID_HPG** (default ON, same pattern as NT_STATIC_CRT) maps to GLFW's `GLFW_USE_HYBRID_HPG`, so win32 exes export `NvOptimusEnablement` / `AmdPowerXpressRequestHighPerformance`. OFF is available for battery-friendly games/tools. The user's per-app Windows graphics preference still overrides the hint. No-op on other platforms (GLFW gates the option on WIN32). Documented next to NT_STATIC_CRT in AGENTS.md.

## Verification

- `llvm-readobj --coff-exports` on `spinning_cube.exe`: 2 hint symbols with ON, none with OFF (and none before the change).
- On a hybrid Intel UHD + RTX 4080 laptop, `nvidia-smi` shows `bunnymark_demo.exe` running on the RTX (31% util) after the fix.
- `check.sh --push` PASS.

Fixes #320

🤖 Generated with [Claude Code](https://claude.com/claude-code)