### PR TITLE
gfx: offset in update_buffer + ring-allocated instance uploads

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -128,7 +128,7 @@ Environment differences a local Windows host cannot reproduce:
 - **emsdk pin skew** — CI installs `.emsdk-version`; if local `emcc --version` differs, wasm-release/Closure can false-green locally. Compare versions before trusting it.
 - **clang-tidy skips `#if defined(__linux__)` blocks off-Linux** — reason about platform-`#if` code as Linux code or add `NOLINT` defensively.
 - **Browser Smoke runs under LeakSanitizer, headless** — skip `glfwInit` when neither `DISPLAY` nor `WAYLAND_DISPLAY` is set.
-- **CI ctest must stay serial** — the real-GL tests share one xvfb display; parallel ctest there fails `glfwInit`. Local `-j` is safe (desktop GL); the two GL tests hold `RESOURCE_LOCK gl_display`.
+- **CI ctest must stay serial** — the real-GL tests share one xvfb display; parallel ctest there fails `glfwInit`. Local `-j` is safe (desktop GL); the real-GL tests hold `RESOURCE_LOCK gl_display` (list in `cmake/test_target.cmake`).
 - **CI native-release passes a global `-DNT_ASSERT_MODE`** — a per-target `-D` collides (`-Wmacro-redefined` under `-Werror`). Force a different assert mode via a wrapper TU with `#undef`/`#define` (pattern: `tests/unit/test_helpers/nt_atlas_assert_off_tu.c`).
 - **Local tidy can false-green NEW files** — before pushing new test/tool files run `clang-tidy -p build/_cmake/tidy-ci <file>` directly (the devapi-enabled DB check.sh creates; plain native-debug lacks devapi TUs); that reproduces CI.
 

--- a/cmake/test_target.cmake
+++ b/cmake/test_target.cmake
@@ -35,7 +35,7 @@ function(nt_setup_test_target target_name)
     set_tests_properties(${target_name} PROPERTIES TIMEOUT ${ARG_TIMEOUT})
     # Display-touching tests (real GLFW/GL) share one xvfb display on headless
     # runners: never run two concurrently.
-    if(target_name MATCHES "^(test_window_native|test_nt_gfx_render_target_native|test_clipboard)$")
+    if(target_name MATCHES "^(test_window_native|test_nt_gfx_render_target_native|test_shape_renderer_ring_native|test_clipboard)$")
         set_tests_properties(${target_name} PROPERTIES RESOURCE_LOCK gl_display)
     endif()
 endfunction()

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -129,7 +129,7 @@ or a shadow-map system.
 
 Not all renderers carry the same weight. The engine ships three classes; copying patterns across classes is a common mistake.
 
-**Building blocks** — direct GPU primitives (`nt_gfx_draw_indexed`, `nt_mesh_renderer`). Single pipeline, fixed pattern, one instanced draw per batch_key run (see items-sorting-batching.md). Use for 3D meshes, custom geometry, anything where the game owns batching strategy. Stay minimal.
+**Building blocks** — direct GPU primitives (`nt_gfx_draw_indexed`, `nt_mesh_renderer`). Single pipeline, fixed pattern, one or more instanced draws per batch_key run — split at max_instances chunk boundaries (see items-sorting-batching.md). Use for 3D meshes, custom geometry, anything where the game owns batching strategy. Stay minimal.
 
 **Batched dynamic** — high-throughput accumulation renderers (`nt_sprite_renderer`; future particles). Cmd queue, state-delta tracking, overflow recovery via snapshot/replay, multi-page atlas resolution, SIMD path. Optimized for many small draws per frame (1k–60k items). Complex by necessity — the 580 LOC of `nt_sprite_renderer.c` are paid for by measured throughput on bunnymark. Don't simplify away the cmd queue or snapshot recovery without a measured replacement plan.
 

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -129,7 +129,7 @@ or a shadow-map system.
 
 Not all renderers carry the same weight. The engine ships three classes; copying patterns across classes is a common mistake.
 
-**Building blocks** — direct GPU primitives (`nt_gfx_draw_indexed`, `nt_mesh_renderer`). Single pipeline, fixed pattern, one draw call per item. Use for 3D meshes, custom geometry, anything where the game owns batching strategy. Stay minimal.
+**Building blocks** — direct GPU primitives (`nt_gfx_draw_indexed`, `nt_mesh_renderer`). Single pipeline, fixed pattern, one instanced draw per batch_key run (see items-sorting-batching.md). Use for 3D meshes, custom geometry, anything where the game owns batching strategy. Stay minimal.
 
 **Batched dynamic** — high-throughput accumulation renderers (`nt_sprite_renderer`; future particles). Cmd queue, state-delta tracking, overflow recovery via snapshot/replay, multi-page atlas resolution, SIMD path. Optimized for many small draws per frame (1k–60k items). Complex by necessity — the 580 LOC of `nt_sprite_renderer.c` are paid for by measured throughput on bunnymark. Don't simplify away the cmd queue or snapshot recovery without a measured replacement plan.
 

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -1179,7 +1179,7 @@ void nt_gfx_backend_bind_index_buffer(uint32_t backend_handle) {
     glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, buf);
 }
 
-void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle) {
+void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle, uint32_t byte_offset) {
     if (backend_handle == 0 || backend_handle > s_init_desc.max_buffers) {
         return;
     }
@@ -1197,7 +1197,7 @@ void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle) {
             GLboolean normalized;
             get_format_params(attr->format, &size, &type, &normalized);
             glVertexAttribPointer(attr->location, size, type, normalized, (GLsizei)layout->stride,
-                                  (void *)(uintptr_t)attr->offset); // NOLINT(performance-no-int-to-ptr)
+                                  (void *)(uintptr_t)(attr->offset + byte_offset)); // NOLINT(performance-no-int-to-ptr)
         }
     }
 }

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -114,7 +114,6 @@ static GLuint *s_buffer_gl;               /* GL buffer names, indexed by slot */
 static GLenum *s_buffer_targets;          /* GL_ARRAY_BUFFER or GL_ELEMENT_ARRAY_BUFFER */
 static GLuint *s_texture_gl;              /* GL texture names, indexed by slot */
 static nt_gfx_gl_render_target_t *s_render_targets;
-static GLuint s_instance_gl_buf; /* GL name of last bound instance buffer */
 static GLuint s_bound_framebuffer;
 
 static nt_gfx_desc_t s_init_desc; /* resolved desc: defaults applied, used everywhere */
@@ -224,7 +223,6 @@ static void nt_gfx_gl_cache_reset(void) {
     s_gl_cache.po_units = 0.0F;
     s_gl_cache.active_texture = GL_TEXTURE0;
     memset(s_gl_cache.bound_textures, 0, sizeof(s_gl_cache.bound_textures));
-    s_instance_gl_buf = 0;
 }
 
 /* ---- Helpers: enum mapping ---- */
@@ -1184,7 +1182,6 @@ void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle, uint32_t byte_
         return;
     }
     GLuint buf = s_buffer_gl[backend_handle];
-    s_instance_gl_buf = buf;
     glBindBuffer(GL_ARRAY_BUFFER, buf);
 
     /* Re-apply instance attribute pointers from the currently bound pipeline. */
@@ -1199,25 +1196,6 @@ void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle, uint32_t byte_
             glVertexAttribPointer(attr->location, size, type, normalized, (GLsizei)layout->stride,
                                   (void *)(uintptr_t)(attr->offset + byte_offset)); // NOLINT(performance-no-int-to-ptr)
         }
-    }
-}
-
-void nt_gfx_backend_set_instance_offset(uint32_t byte_offset) {
-    NT_ASSERT(s_instance_gl_buf != 0); /* must call bind_instance_buffer first */
-    if (s_bound_pipeline_slot == 0 || s_bound_pipeline_slot > s_init_desc.max_pipelines) {
-        return;
-    }
-    /* Re-bind instance buffer so glVertexAttribPointer captures the right source */
-    glBindBuffer(GL_ARRAY_BUFFER, s_instance_gl_buf);
-    const nt_vertex_layout_t *layout = &s_pipelines[s_bound_pipeline_slot].instance_layout;
-    for (uint8_t i = 0; i < layout->attr_count; i++) {
-        const nt_vertex_attr_t *attr = &layout->attrs[i];
-        GLint size;
-        GLenum type;
-        GLboolean normalized;
-        get_format_params(attr->format, &size, &type, &normalized);
-        glVertexAttribPointer(attr->location, size, type, normalized, (GLsizei)layout->stride,
-                              (void *)(uintptr_t)(attr->offset + byte_offset)); // NOLINT(performance-no-int-to-ptr)
     }
 }
 

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -1122,14 +1122,14 @@ void nt_gfx_backend_destroy_buffer(uint32_t backend_handle) {
     s_buffer_targets[backend_handle] = 0;
 }
 
-void nt_gfx_backend_update_buffer(uint32_t backend_handle, const void *data, uint32_t size) {
+void nt_gfx_backend_update_buffer(uint32_t backend_handle, uint32_t offset, const void *data, uint32_t size) {
     if (backend_handle == 0 || backend_handle > s_init_desc.max_buffers) {
         return;
     }
     GLuint buf = s_buffer_gl[backend_handle];
     GLenum target = s_buffer_targets[backend_handle];
     glBindBuffer(target, buf);
-    glBufferSubData(target, 0, (GLsizeiptr)size, data);
+    glBufferSubData(target, (GLintptr)offset, (GLsizeiptr)size, data);
 }
 
 void nt_gfx_backend_orphan_buffer(uint32_t backend_handle, const void *data, uint32_t size) {

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -1475,6 +1475,7 @@ void nt_gfx_draw_indexed_instanced(uint32_t first_index, uint32_t num_indices, u
 
 /* ---- Instance buffer ---- */
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) — NT_ASSERT expansion, not real branching
 void nt_gfx_bind_instance_buffer(nt_buffer_t buf, uint32_t byte_offset) {
     if (g_nt_gfx.context_lost) {
         return;
@@ -1490,6 +1491,7 @@ void nt_gfx_bind_instance_buffer(nt_buffer_t buf, uint32_t byte_offset) {
         return;
     }
     NT_ASSERT(byte_offset <= s_gfx.buffer_metas[slot].size && "bind_instance_buffer: offset exceeds buffer capacity");
+    NT_ASSERT((byte_offset & 3U) == 0 && "bind_instance_buffer: offset must be 4-byte aligned (WebGL2 attrib rule)");
     NT_ASSERT(s_gfx.bound_pipeline != 0 && "bind_instance_buffer: requires a bound pipeline");
     if (s_gfx.bound_pipeline == 0) {
         NT_LOG_ERROR("bind_instance_buffer: no pipeline bound");

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -1490,14 +1490,12 @@ void nt_gfx_bind_instance_buffer(nt_buffer_t buf, uint32_t byte_offset) {
         return;
     }
     NT_ASSERT(byte_offset <= s_gfx.buffer_metas[slot].size && "bind_instance_buffer: offset exceeds buffer capacity");
-    nt_gfx_backend_bind_instance_buffer(s_gfx.buffer_backends[slot], byte_offset);
-}
-
-void nt_gfx_set_instance_offset(uint32_t byte_offset) {
-    if (g_nt_gfx.context_lost) {
+    NT_ASSERT(s_gfx.bound_pipeline != 0 && "bind_instance_buffer: requires a bound pipeline");
+    if (s_gfx.bound_pipeline == 0) {
+        NT_LOG_ERROR("bind_instance_buffer: no pipeline bound");
         return;
     }
-    nt_gfx_backend_set_instance_offset(byte_offset);
+    nt_gfx_backend_bind_instance_buffer(s_gfx.buffer_backends[slot], byte_offset);
 }
 
 void nt_gfx_set_vertex_attrib_default(uint8_t location, float x, float y, float z, float w) {
@@ -1540,6 +1538,7 @@ void nt_gfx_set_uniform_block(nt_pipeline_t pip, const char *block_name, uint32_
 
 /* ---- Buffer update ---- */
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) — NT_ASSERT expansion, not real branching
 void nt_gfx_update_buffer(nt_buffer_t buf, uint32_t offset, const void *data, uint32_t size) {
     if (g_nt_gfx.context_lost) {
         return;
@@ -1550,6 +1549,7 @@ void nt_gfx_update_buffer(nt_buffer_t buf, uint32_t offset, const void *data, ui
     }
     uint32_t slot = nt_pool_slot_index(buf.id);
     NT_ASSERT(s_gfx.buffer_metas[slot].usage != NT_USAGE_IMMUTABLE && "update_buffer: cannot update immutable buffer");
+    NT_ASSERT((data != NULL || size == 0) && "update_buffer: NULL data with nonzero size");
     NT_ASSERT(offset <= s_gfx.buffer_metas[slot].size && "update_buffer: offset exceeds buffer capacity");
     NT_ASSERT(size <= s_gfx.buffer_metas[slot].size - offset && "update_buffer: offset + size exceeds buffer capacity");
     nt_gfx_backend_update_buffer(s_gfx.buffer_backends[slot], offset, data, size);

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -1475,7 +1475,7 @@ void nt_gfx_draw_indexed_instanced(uint32_t first_index, uint32_t num_indices, u
 
 /* ---- Instance buffer ---- */
 
-void nt_gfx_bind_instance_buffer(nt_buffer_t buf) {
+void nt_gfx_bind_instance_buffer(nt_buffer_t buf, uint32_t byte_offset) {
     if (g_nt_gfx.context_lost) {
         return;
     }
@@ -1489,7 +1489,8 @@ void nt_gfx_bind_instance_buffer(nt_buffer_t buf) {
         NT_LOG_ERROR("bind_instance_buffer: buffer is not vertex type");
         return;
     }
-    nt_gfx_backend_bind_instance_buffer(s_gfx.buffer_backends[slot]);
+    NT_ASSERT(byte_offset <= s_gfx.buffer_metas[slot].size && "bind_instance_buffer: offset exceeds buffer capacity");
+    nt_gfx_backend_bind_instance_buffer(s_gfx.buffer_backends[slot], byte_offset);
 }
 
 void nt_gfx_set_instance_offset(uint32_t byte_offset) {

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -497,6 +497,9 @@ void nt_gfx_begin_frame(void) {
     }
     s_gfx.render_state = NT_GFX_STATE_FRAME;
     memset(&g_nt_gfx.frame_stats, 0, sizeof(g_nt_gfx.frame_stats));
+    /* Backend resets its pipeline cache per frame; mirror it so the
+     * bound-pipeline asserts stay truthful across frame boundaries. */
+    s_gfx.bound_pipeline = 0;
     nt_gfx_backend_begin_frame();
 }
 

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -1539,7 +1539,7 @@ void nt_gfx_set_uniform_block(nt_pipeline_t pip, const char *block_name, uint32_
 
 /* ---- Buffer update ---- */
 
-void nt_gfx_update_buffer(nt_buffer_t buf, const void *data, uint32_t size) {
+void nt_gfx_update_buffer(nt_buffer_t buf, uint32_t offset, const void *data, uint32_t size) {
     if (g_nt_gfx.context_lost) {
         return;
     }
@@ -1549,8 +1549,9 @@ void nt_gfx_update_buffer(nt_buffer_t buf, const void *data, uint32_t size) {
     }
     uint32_t slot = nt_pool_slot_index(buf.id);
     NT_ASSERT(s_gfx.buffer_metas[slot].usage != NT_USAGE_IMMUTABLE && "update_buffer: cannot update immutable buffer");
-    NT_ASSERT(size <= s_gfx.buffer_metas[slot].size && "update_buffer: size exceeds buffer capacity");
-    nt_gfx_backend_update_buffer(s_gfx.buffer_backends[slot], data, size);
+    NT_ASSERT(offset <= s_gfx.buffer_metas[slot].size && "update_buffer: offset exceeds buffer capacity");
+    NT_ASSERT(size <= s_gfx.buffer_metas[slot].size - offset && "update_buffer: offset + size exceeds buffer capacity");
+    nt_gfx_backend_update_buffer(s_gfx.buffer_backends[slot], offset, data, size);
 }
 
 void nt_gfx_begin_segment(const char *name) {

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -440,11 +440,9 @@ bool nt_gfx_read_pixels(int x, int y, int w, int h, uint8_t *out, uint32_t out_c
 
 /* ---- Instance buffer ---- */
 
-/* Bind applies instance attrib pointers at byte_offset in one pass (requires a
- * bound pipeline). set_instance_offset re-points them for later draws from the
- * same buffer without re-binding. */
+/* Applies the bound pipeline's instance attrib pointers at byte_offset —
+ * a pipeline must be bound first (asserted). Re-bind per draw to re-point. */
 void nt_gfx_bind_instance_buffer(nt_buffer_t buf, uint32_t byte_offset);
-void nt_gfx_set_instance_offset(uint32_t byte_offset);
 void nt_gfx_set_vertex_attrib_default(uint8_t location, float x, float y, float z, float w);
 
 /* ---- Uniform buffer ---- */
@@ -453,9 +451,10 @@ void nt_gfx_bind_uniform_buffer(nt_buffer_t buf, uint32_t slot);
 void nt_gfx_set_uniform_block(nt_pipeline_t pip, const char *block_name, uint32_t slot);
 
 /* update_buffer = glBufferSubData at byte offset (offset + size must fit the
- * buffer). Disjoint offsets let several writes per frame share one buffer
- * without the driver copying in-flight data. orphan_buffer = glBufferData
- * with DYNAMIC_DRAW hint, for streaming geometry replaced every frame. */
+ * buffer; data must point to size bytes, NULL only with size 0). Disjoint
+ * offsets let several writes per frame share one buffer without the driver
+ * copying in-flight data. orphan_buffer = glBufferData with DYNAMIC_DRAW
+ * hint, for streaming geometry replaced every frame. */
 void nt_gfx_update_buffer(nt_buffer_t buf, uint32_t offset, const void *data, uint32_t size);
 void nt_gfx_orphan_buffer(nt_buffer_t buf, const void *data, uint32_t size);
 

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -450,11 +450,9 @@ void nt_gfx_set_vertex_attrib_default(uint8_t location, float x, float y, float 
 void nt_gfx_bind_uniform_buffer(nt_buffer_t buf, uint32_t slot);
 void nt_gfx_set_uniform_block(nt_pipeline_t pip, const char *block_name, uint32_t slot);
 
-/* update_buffer = glBufferSubData at byte offset (offset + size must fit the
- * buffer; data must point to size bytes, NULL only with size 0). Disjoint
- * offsets let several writes per frame share one buffer without the driver
- * copying in-flight data. orphan_buffer = glBufferData with DYNAMIC_DRAW
- * hint, for streaming geometry replaced every frame. */
+/* update_buffer = glBufferSubData at byte offset; offset + size must fit the
+ * buffer, data must point to size bytes (NULL only with size 0). Disjoint
+ * offsets keep in-flight data untouched. orphan_buffer = glBufferData. */
 void nt_gfx_update_buffer(nt_buffer_t buf, uint32_t offset, const void *data, uint32_t size);
 void nt_gfx_orphan_buffer(nt_buffer_t buf, const void *data, uint32_t size);
 

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -440,7 +440,10 @@ bool nt_gfx_read_pixels(int x, int y, int w, int h, uint8_t *out, uint32_t out_c
 
 /* ---- Instance buffer ---- */
 
-void nt_gfx_bind_instance_buffer(nt_buffer_t buf);
+/* Bind applies instance attrib pointers at byte_offset in one pass (requires a
+ * bound pipeline). set_instance_offset re-points them for later draws from the
+ * same buffer without re-binding. */
+void nt_gfx_bind_instance_buffer(nt_buffer_t buf, uint32_t byte_offset);
 void nt_gfx_set_instance_offset(uint32_t byte_offset);
 void nt_gfx_set_vertex_attrib_default(uint8_t location, float x, float y, float z, float w);
 

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -440,8 +440,9 @@ bool nt_gfx_read_pixels(int x, int y, int w, int h, uint8_t *out, uint32_t out_c
 
 /* ---- Instance buffer ---- */
 
-/* Applies the bound pipeline's instance attrib pointers at byte_offset —
- * a pipeline must be bound first (asserted). Re-bind per draw to re-point. */
+/* Applies the bound pipeline's instance attrib pointers at byte_offset — a
+ * pipeline must be bound first and the offset 4-byte aligned (WebGL2 rejects
+ * unaligned attrib offsets); both asserted. Re-bind per draw to re-point. */
 void nt_gfx_bind_instance_buffer(nt_buffer_t buf, uint32_t byte_offset);
 void nt_gfx_set_vertex_attrib_default(uint8_t location, float x, float y, float z, float w);
 

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -449,9 +449,11 @@ void nt_gfx_set_vertex_attrib_default(uint8_t location, float x, float y, float 
 void nt_gfx_bind_uniform_buffer(nt_buffer_t buf, uint32_t slot);
 void nt_gfx_set_uniform_block(nt_pipeline_t pip, const char *block_name, uint32_t slot);
 
-/* update_buffer = glBufferSubData (partial). orphan_buffer = glBufferData
+/* update_buffer = glBufferSubData at byte offset (offset + size must fit the
+ * buffer). Disjoint offsets let several writes per frame share one buffer
+ * without the driver copying in-flight data. orphan_buffer = glBufferData
  * with DYNAMIC_DRAW hint, for streaming geometry replaced every frame. */
-void nt_gfx_update_buffer(nt_buffer_t buf, const void *data, uint32_t size);
+void nt_gfx_update_buffer(nt_buffer_t buf, uint32_t offset, const void *data, uint32_t size);
 void nt_gfx_orphan_buffer(nt_buffer_t buf, const void *data, uint32_t size);
 
 /* Named GPU TIME_ELAPSED segments. Pairs must be sequential (no nesting —

--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -53,7 +53,7 @@ void nt_gfx_backend_bind_sampler(uint32_t backend_handle, uint32_t slot);
 void nt_gfx_backend_bind_pipeline(uint32_t backend_handle);
 void nt_gfx_backend_bind_vertex_buffer(uint32_t backend_handle);
 void nt_gfx_backend_bind_index_buffer(uint32_t backend_handle);
-void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle);
+void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle, uint32_t byte_offset);
 void nt_gfx_backend_set_instance_offset(uint32_t byte_offset);
 void nt_gfx_backend_set_vertex_attrib_default(uint8_t location, float x, float y, float z, float w);
 
@@ -135,6 +135,8 @@ void nt_gfx_stub_test_fail_next_backend_restore(void);
 void nt_gfx_stub_test_fail_next_render_target_create(void);
 void nt_gfx_stub_test_fail_next_render_target_resize(void);
 void nt_gfx_stub_test_set_context_lost(bool lost);
+uint32_t nt_gfx_stub_test_last_update_buffer_offset(void);
+uint32_t nt_gfx_stub_test_last_instance_offset(void);
 void nt_gfx_stub_test_reset(void);
 #endif
 

--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -32,7 +32,7 @@ void nt_gfx_backend_destroy_pipeline(uint32_t backend_handle);
 
 uint32_t nt_gfx_backend_create_buffer(const nt_buffer_desc_t *desc);
 void nt_gfx_backend_destroy_buffer(uint32_t backend_handle);
-void nt_gfx_backend_update_buffer(uint32_t backend_handle, const void *data, uint32_t size);
+void nt_gfx_backend_update_buffer(uint32_t backend_handle, uint32_t offset, const void *data, uint32_t size);
 void nt_gfx_backend_orphan_buffer(uint32_t backend_handle, const void *data, uint32_t size);
 
 uint32_t nt_gfx_backend_create_texture(const nt_texture_desc_t *desc);

--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -54,7 +54,6 @@ void nt_gfx_backend_bind_pipeline(uint32_t backend_handle);
 void nt_gfx_backend_bind_vertex_buffer(uint32_t backend_handle);
 void nt_gfx_backend_bind_index_buffer(uint32_t backend_handle);
 void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle, uint32_t byte_offset);
-void nt_gfx_backend_set_instance_offset(uint32_t byte_offset);
 void nt_gfx_backend_set_vertex_attrib_default(uint8_t location, float x, float y, float z, float w);
 
 /* Scissor and viewport (see nt_gfx.h for convention).

--- a/engine/graphics/stub/nt_gfx_stub.c
+++ b/engine/graphics/stub/nt_gfx_stub.c
@@ -377,14 +377,6 @@ void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle, uint32_t byte_
 #endif
 }
 
-void nt_gfx_backend_set_instance_offset(uint32_t byte_offset) {
-#ifdef NT_TEST_ACCESS
-    s_stub_last_instance_offset = byte_offset;
-#else
-    (void)byte_offset;
-#endif
-}
-
 void nt_gfx_backend_set_vertex_attrib_default(uint8_t location, float x, float y, float z, float w) {
     (void)location;
     (void)x;

--- a/engine/graphics/stub/nt_gfx_stub.c
+++ b/engine/graphics/stub/nt_gfx_stub.c
@@ -33,6 +33,8 @@ static bool s_stub_fail_next_texture_create;
 static bool s_stub_fail_next_backend_restore;
 static bool s_stub_fail_next_render_target_create;
 static bool s_stub_fail_next_render_target_resize;
+static uint32_t s_stub_last_update_buffer_offset;
+static uint32_t s_stub_last_instance_offset;
 
 uint32_t nt_gfx_stub_test_last_sampler(uint32_t slot) {
     if (slot >= NT_GFX_STUB_MAX_SLOTS) {
@@ -64,6 +66,8 @@ void nt_gfx_stub_test_fail_next_render_target_resize(void) { s_stub_fail_next_re
 void nt_gfx_stub_test_fail_next_texture_create(void) { s_stub_fail_next_texture_create = true; }
 void nt_gfx_stub_test_fail_next_backend_restore(void) { s_stub_fail_next_backend_restore = true; }
 void nt_gfx_stub_test_set_context_lost(bool lost) { s_stub_context_lost = lost; }
+uint32_t nt_gfx_stub_test_last_update_buffer_offset(void) { return s_stub_last_update_buffer_offset; }
+uint32_t nt_gfx_stub_test_last_instance_offset(void) { return s_stub_last_instance_offset; }
 
 void nt_gfx_stub_test_reset(void) {
     for (uint32_t i = 0; i < NT_GFX_STUB_MAX_SLOTS; i++) {
@@ -86,6 +90,8 @@ void nt_gfx_stub_test_reset(void) {
     s_stub_last_texture_desc = (nt_texture_desc_t){0};
     s_stub_last_depth_texture_backend = 0;
     s_stub_next_texture_backend = 0;
+    s_stub_last_update_buffer_offset = 0;
+    s_stub_last_instance_offset = 0;
     s_stub_context_lost = false;
     s_stub_backend_missing = false;
     s_stub_fail_next_texture_create = false;
@@ -293,9 +299,13 @@ void nt_gfx_backend_bind_texture(uint32_t backend_handle, uint32_t slot) {
 
 void nt_gfx_backend_update_buffer(uint32_t backend_handle, uint32_t offset, const void *data, uint32_t size) {
     (void)backend_handle;
-    (void)offset;
     (void)data;
     (void)size;
+#ifdef NT_TEST_ACCESS
+    s_stub_last_update_buffer_offset = offset;
+#else
+    (void)offset;
+#endif
 }
 
 void nt_gfx_backend_orphan_buffer(uint32_t backend_handle, const void *data, uint32_t size) {
@@ -358,9 +368,22 @@ void nt_gfx_backend_bind_vertex_buffer(uint32_t backend_handle) { (void)backend_
 
 void nt_gfx_backend_bind_index_buffer(uint32_t backend_handle) { (void)backend_handle; }
 
-void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle) { (void)backend_handle; }
+void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle, uint32_t byte_offset) {
+    (void)backend_handle;
+#ifdef NT_TEST_ACCESS
+    s_stub_last_instance_offset = byte_offset;
+#else
+    (void)byte_offset;
+#endif
+}
 
-void nt_gfx_backend_set_instance_offset(uint32_t byte_offset) { (void)byte_offset; }
+void nt_gfx_backend_set_instance_offset(uint32_t byte_offset) {
+#ifdef NT_TEST_ACCESS
+    s_stub_last_instance_offset = byte_offset;
+#else
+    (void)byte_offset;
+#endif
+}
 
 void nt_gfx_backend_set_vertex_attrib_default(uint8_t location, float x, float y, float z, float w) {
     (void)location;

--- a/engine/graphics/stub/nt_gfx_stub.c
+++ b/engine/graphics/stub/nt_gfx_stub.c
@@ -291,8 +291,9 @@ void nt_gfx_backend_bind_texture(uint32_t backend_handle, uint32_t slot) {
 #endif
 }
 
-void nt_gfx_backend_update_buffer(uint32_t backend_handle, const void *data, uint32_t size) {
+void nt_gfx_backend_update_buffer(uint32_t backend_handle, uint32_t offset, const void *data, uint32_t size) {
     (void)backend_handle;
+    (void)offset;
     (void)data;
     (void)size;
 }

--- a/engine/renderers/nt_mesh_renderer.c
+++ b/engine/renderers/nt_mesh_renderer.c
@@ -30,6 +30,7 @@ static struct {
 
     uint8_t *instance_data; /* CPU staging byte buffer [max_instances * NT_INSTANCE_STRIDE_MAX] */
     uint16_t max_instances;
+    uint32_t ring_cursor; /* next free byte in instance_buf; disjoint writes avoid driver copies of in-flight data */
 
     /* Per-frame tracking for test accessors */
     uint32_t frame_draw_calls;
@@ -379,7 +380,7 @@ void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count) {
 
         /* ---- Pack all instances in this chunk into byte buffer ---- */
         /* First pass: pack at variable stride per draw group */
-        uint32_t byte_offset = 0;
+        uint32_t packed_size = 0;
         uint32_t scan = chunk_start;
         while (scan < chunk_end) {
             uint32_t run_end = scan + 1;
@@ -397,7 +398,7 @@ void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count) {
 
             for (uint32_t i = scan; i < run_end; i++) {
                 nt_entity_t e = {.id = items[i].entity};
-                uint8_t *dst = s_mesh_renderer.instance_data + byte_offset;
+                uint8_t *dst = s_mesh_renderer.instance_data + packed_size;
 
                 const float *world = nt_transform_comp_world_matrix(e);
                 pack_mat4x3((float *)dst, world);
@@ -411,18 +412,24 @@ void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count) {
                 }
                 /* NONE: nothing after the 48 bytes */
 
-                byte_offset += stride;
+                packed_size += stride;
             }
             scan = run_end;
         }
 
-        /* ---- Single GPU upload for packed byte data ---- */
-        nt_gfx_update_buffer(s_mesh_renderer.instance_buf, s_mesh_renderer.instance_data, byte_offset);
+        /* ---- Single GPU upload for packed byte data, ring-allocated ---- */
+        uint32_t capacity = (uint32_t)s_mesh_renderer.max_instances * (uint32_t)NT_INSTANCE_STRIDE_MAX;
+        if (s_mesh_renderer.ring_cursor + packed_size > capacity) {
+            s_mesh_renderer.ring_cursor = 0; /* wrap: may overlap in-flight data once, driver copies */
+        }
+        uint32_t ring_base = s_mesh_renderer.ring_cursor;
+        s_mesh_renderer.ring_cursor = ring_base + packed_size;
+        nt_gfx_update_buffer(s_mesh_renderer.instance_buf, ring_base, s_mesh_renderer.instance_data, packed_size);
         nt_gfx_bind_instance_buffer(s_mesh_renderer.instance_buf);
 
         /* ---- Draw runs within this chunk ---- */
         uint32_t run_start = chunk_start;
-        uint32_t draw_byte_offset = 0;
+        uint32_t draw_byte_offset = ring_base;
 
         while (run_start < chunk_end) {
             nt_entity_t entity = {.id = items[run_start].entity};
@@ -507,3 +514,5 @@ uint32_t nt_mesh_renderer_test_pipeline_cache_count(void) { return s_mesh_render
 uint32_t nt_mesh_renderer_test_draw_call_count(void) { return s_mesh_renderer.frame_draw_calls; }
 
 uint32_t nt_mesh_renderer_test_instance_total(void) { return s_mesh_renderer.frame_instance_total; }
+
+uint32_t nt_mesh_renderer_test_ring_cursor(void) { return s_mesh_renderer.ring_cursor; }

--- a/engine/renderers/nt_mesh_renderer.c
+++ b/engine/renderers/nt_mesh_renderer.c
@@ -286,7 +286,7 @@ nt_result_t nt_mesh_renderer_init(const nt_mesh_renderer_desc_t *desc) {
         return NT_ERR_INIT_FAILED;
     }
 
-    /* Create instance buffer (STREAM: rewritten every frame) */
+    /* Create instance buffer (STREAM: ring-suballocated, refilled every frame) */
     s_mesh_renderer.instance_buf = nt_gfx_make_buffer(&(nt_buffer_desc_t){
         .type = NT_BUFFER_VERTEX,
         .usage = NT_USAGE_STREAM,

--- a/engine/renderers/nt_mesh_renderer.c
+++ b/engine/renderers/nt_mesh_renderer.c
@@ -425,7 +425,6 @@ void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count) {
         uint32_t ring_base = s_mesh_renderer.ring_cursor;
         s_mesh_renderer.ring_cursor = ring_base + packed_size;
         nt_gfx_update_buffer(s_mesh_renderer.instance_buf, ring_base, s_mesh_renderer.instance_data, packed_size);
-        nt_gfx_bind_instance_buffer(s_mesh_renderer.instance_buf, ring_base);
 
         /* ---- Draw runs within this chunk ---- */
         uint32_t run_start = chunk_start;
@@ -488,7 +487,7 @@ void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count) {
                 prev_mesh = run_mesh;
             }
 
-            nt_gfx_set_instance_offset(draw_byte_offset);
+            nt_gfx_bind_instance_buffer(s_mesh_renderer.instance_buf, draw_byte_offset);
 
             if (mesh_info->index_count > 0) {
                 nt_gfx_draw_indexed_instanced(0, mesh_info->index_count, mesh_info->vertex_count, instance_count);

--- a/engine/renderers/nt_mesh_renderer.c
+++ b/engine/renderers/nt_mesh_renderer.c
@@ -420,12 +420,12 @@ void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count) {
         /* ---- Single GPU upload for packed byte data, ring-allocated ---- */
         uint32_t capacity = (uint32_t)s_mesh_renderer.max_instances * (uint32_t)NT_INSTANCE_STRIDE_MAX;
         if (s_mesh_renderer.ring_cursor + packed_size > capacity) {
-            s_mesh_renderer.ring_cursor = 0; /* wrap: may overlap in-flight data once, driver copies */
+            s_mesh_renderer.ring_cursor = 0; /* wrap overlaps in-flight data (every alloc once a frame fills capacity); driver copies */
         }
         uint32_t ring_base = s_mesh_renderer.ring_cursor;
         s_mesh_renderer.ring_cursor = ring_base + packed_size;
         nt_gfx_update_buffer(s_mesh_renderer.instance_buf, ring_base, s_mesh_renderer.instance_data, packed_size);
-        nt_gfx_bind_instance_buffer(s_mesh_renderer.instance_buf);
+        nt_gfx_bind_instance_buffer(s_mesh_renderer.instance_buf, ring_base);
 
         /* ---- Draw runs within this chunk ---- */
         uint32_t run_start = chunk_start;

--- a/engine/renderers/nt_mesh_renderer.h
+++ b/engine/renderers/nt_mesh_renderer.h
@@ -28,6 +28,7 @@ void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count);
 uint32_t nt_mesh_renderer_test_pipeline_cache_count(void);
 uint32_t nt_mesh_renderer_test_draw_call_count(void);
 uint32_t nt_mesh_renderer_test_instance_total(void);
+uint32_t nt_mesh_renderer_test_ring_cursor(void);
 #endif
 // #endregion
 

--- a/engine/renderers/nt_shape_renderer.c
+++ b/engine/renderers/nt_shape_renderer.c
@@ -782,7 +782,7 @@ void nt_shape_renderer_flush(void) {
         uint32_t inst_bytes = cnt * (uint32_t)sizeof(nt_shape_instance_t);
         uint32_t inst_capacity = NT_SHAPE_RENDERER_MAX_INSTANCES * (uint32_t)sizeof(nt_shape_instance_t);
         if (s_shape.inst_ring_cursor + inst_bytes > inst_capacity) {
-            s_shape.inst_ring_cursor = 0; /* wrap: may overlap in-flight data once, driver copies */
+            s_shape.inst_ring_cursor = 0; /* wrap overlaps in-flight data (every alloc once a frame fills capacity); driver copies */
         }
         uint32_t inst_base = s_shape.inst_ring_cursor;
         s_shape.inst_ring_cursor = inst_base + inst_bytes;
@@ -790,15 +790,16 @@ void nt_shape_renderer_flush(void) {
         nt_gfx_bind_pipeline(t == NT_SHAPE_CAPSULE ? s_shape.cap_inst_pip_active : s_shape.inst_pip_active);
         nt_gfx_bind_vertex_buffer(s_shape.templates[t].vbo);
         nt_gfx_bind_index_buffer(s_shape.templates[t].ibo);
-        nt_gfx_bind_instance_buffer(s_shape.inst_buf);
-        nt_gfx_set_instance_offset(inst_base);
+        nt_gfx_bind_instance_buffer(s_shape.inst_buf, inst_base);
         nt_gfx_set_uniform_mat4("u_vp", s_shape.vp);
 
         nt_gfx_draw_indexed_instanced(0, s_shape.templates[t].num_indices, s_shape.templates[t].num_vertices, cnt);
         s_shape.inst_counts[t] = 0;
     }
 
-    /* Flush CPU-batched shapes (triangle, mesh) */
+    /* Flush CPU-batched shapes (triangle, mesh). Batch vbo/ibo stay at offset 0:
+     * the non-instanced draw path has no read-side offset plumbing, so the
+     * in-flight rewrite (driver copy) is accepted here. */
     if (s_shape.index_count > 0) {
         nt_gfx_update_buffer(s_shape.batch_vbo, 0, s_shape.vertices, s_shape.vertex_count * (uint32_t)sizeof(nt_shape_renderer_vertex_t));
         nt_gfx_update_buffer(s_shape.batch_ibo, 0, s_shape.indices, s_shape.index_count * (uint32_t)sizeof(nt_shape_index_t));
@@ -819,7 +820,7 @@ void nt_shape_renderer_flush(void) {
         uint32_t line_bytes = s_shape.line_count * (uint32_t)sizeof(nt_shape_line_instance_t);
         uint32_t line_capacity = NT_SHAPE_RENDERER_MAX_LINES * (uint32_t)sizeof(nt_shape_line_instance_t);
         if (s_shape.line_ring_cursor + line_bytes > line_capacity) {
-            s_shape.line_ring_cursor = 0; /* wrap: may overlap in-flight data once, driver copies */
+            s_shape.line_ring_cursor = 0; /* wrap overlaps in-flight data (every alloc once a frame fills capacity); driver copies */
         }
         uint32_t line_base = s_shape.line_ring_cursor;
         s_shape.line_ring_cursor = line_base + line_bytes;
@@ -828,8 +829,7 @@ void nt_shape_renderer_flush(void) {
         nt_gfx_bind_pipeline(s_shape.line_pip_active);
         nt_gfx_bind_vertex_buffer(s_shape.line_template_vbo);
         nt_gfx_bind_index_buffer(s_shape.line_template_ibo);
-        nt_gfx_bind_instance_buffer(s_shape.line_instance_buf);
-        nt_gfx_set_instance_offset(line_base);
+        nt_gfx_bind_instance_buffer(s_shape.line_instance_buf, line_base);
         nt_gfx_set_uniform_mat4("u_vp", s_shape.vp);
         float cp4[4] = {s_shape.cam_pos[0], s_shape.cam_pos[1], s_shape.cam_pos[2], 0.0F};
         nt_gfx_set_uniform_vec4("u_cam_pos", cp4);
@@ -1437,6 +1437,8 @@ void nt_shape_renderer_mesh_wire(const float *positions, uint32_t num_vertices, 
 /* ---- Test accessors (always compiled; header guards visibility) ---- */
 
 uint32_t nt_shape_renderer_test_instance_count(int type) { return s_shape.inst_counts[type]; }
+
+uint32_t nt_shape_renderer_test_instance_capacity(void) { return NT_SHAPE_RENDERER_MAX_INSTANCES; }
 uint32_t nt_shape_renderer_test_vertex_count(void) { return s_shape.vertex_count; }
 uint32_t nt_shape_renderer_test_index_count(void) { return s_shape.index_count; }
 uint32_t nt_shape_renderer_test_line_count(void) { return s_shape.line_count; }

--- a/engine/renderers/nt_shape_renderer.c
+++ b/engine/renderers/nt_shape_renderer.c
@@ -186,7 +186,8 @@ static struct {
     nt_pipeline_t inst_pip_depth;
     nt_pipeline_t inst_pip_overlay;
     nt_pipeline_t inst_pip_active;
-    nt_buffer_t inst_buf; /* shared GPU instance buffer, reused per type */
+    nt_buffer_t inst_buf;      /* shared GPU instance buffer, reused per type */
+    uint32_t inst_ring_cursor; /* next free byte; disjoint writes avoid driver copies of in-flight data */
     nt_shape_template_t templates[NT_SHAPE_TYPE_COUNT];
     nt_shape_instance_t inst_data[NT_SHAPE_TYPE_COUNT][NT_SHAPE_RENDERER_MAX_INSTANCES];
     uint32_t inst_counts[NT_SHAPE_TYPE_COUNT];
@@ -205,6 +206,7 @@ static struct {
     nt_buffer_t line_template_vbo;
     nt_buffer_t line_template_ibo;
     nt_buffer_t line_instance_buf;
+    uint32_t line_ring_cursor;
     nt_shape_line_instance_t lines[NT_SHAPE_RENDERER_MAX_LINES];
     uint32_t line_count;
 
@@ -777,11 +779,19 @@ void nt_shape_renderer_flush(void) {
         if (cnt == 0) {
             continue;
         }
-        nt_gfx_update_buffer(s_shape.inst_buf, s_shape.inst_data[t], cnt * (uint32_t)sizeof(nt_shape_instance_t));
+        uint32_t inst_bytes = cnt * (uint32_t)sizeof(nt_shape_instance_t);
+        uint32_t inst_capacity = NT_SHAPE_RENDERER_MAX_INSTANCES * (uint32_t)sizeof(nt_shape_instance_t);
+        if (s_shape.inst_ring_cursor + inst_bytes > inst_capacity) {
+            s_shape.inst_ring_cursor = 0; /* wrap: may overlap in-flight data once, driver copies */
+        }
+        uint32_t inst_base = s_shape.inst_ring_cursor;
+        s_shape.inst_ring_cursor = inst_base + inst_bytes;
+        nt_gfx_update_buffer(s_shape.inst_buf, inst_base, s_shape.inst_data[t], inst_bytes);
         nt_gfx_bind_pipeline(t == NT_SHAPE_CAPSULE ? s_shape.cap_inst_pip_active : s_shape.inst_pip_active);
         nt_gfx_bind_vertex_buffer(s_shape.templates[t].vbo);
         nt_gfx_bind_index_buffer(s_shape.templates[t].ibo);
         nt_gfx_bind_instance_buffer(s_shape.inst_buf);
+        nt_gfx_set_instance_offset(inst_base);
         nt_gfx_set_uniform_mat4("u_vp", s_shape.vp);
 
         nt_gfx_draw_indexed_instanced(0, s_shape.templates[t].num_indices, s_shape.templates[t].num_vertices, cnt);
@@ -790,8 +800,8 @@ void nt_shape_renderer_flush(void) {
 
     /* Flush CPU-batched shapes (triangle, mesh) */
     if (s_shape.index_count > 0) {
-        nt_gfx_update_buffer(s_shape.batch_vbo, s_shape.vertices, s_shape.vertex_count * (uint32_t)sizeof(nt_shape_renderer_vertex_t));
-        nt_gfx_update_buffer(s_shape.batch_ibo, s_shape.indices, s_shape.index_count * (uint32_t)sizeof(nt_shape_index_t));
+        nt_gfx_update_buffer(s_shape.batch_vbo, 0, s_shape.vertices, s_shape.vertex_count * (uint32_t)sizeof(nt_shape_renderer_vertex_t));
+        nt_gfx_update_buffer(s_shape.batch_ibo, 0, s_shape.indices, s_shape.index_count * (uint32_t)sizeof(nt_shape_index_t));
 
         nt_gfx_bind_pipeline(s_shape.batch_pip_active);
         nt_gfx_bind_vertex_buffer(s_shape.batch_vbo);
@@ -806,12 +816,20 @@ void nt_shape_renderer_flush(void) {
 
     /* Flush instanced lines */
     if (s_shape.line_count > 0) {
-        nt_gfx_update_buffer(s_shape.line_instance_buf, s_shape.lines, s_shape.line_count * (uint32_t)sizeof(nt_shape_line_instance_t));
+        uint32_t line_bytes = s_shape.line_count * (uint32_t)sizeof(nt_shape_line_instance_t);
+        uint32_t line_capacity = NT_SHAPE_RENDERER_MAX_LINES * (uint32_t)sizeof(nt_shape_line_instance_t);
+        if (s_shape.line_ring_cursor + line_bytes > line_capacity) {
+            s_shape.line_ring_cursor = 0; /* wrap: may overlap in-flight data once, driver copies */
+        }
+        uint32_t line_base = s_shape.line_ring_cursor;
+        s_shape.line_ring_cursor = line_base + line_bytes;
+        nt_gfx_update_buffer(s_shape.line_instance_buf, line_base, s_shape.lines, line_bytes);
 
         nt_gfx_bind_pipeline(s_shape.line_pip_active);
         nt_gfx_bind_vertex_buffer(s_shape.line_template_vbo);
         nt_gfx_bind_index_buffer(s_shape.line_template_ibo);
         nt_gfx_bind_instance_buffer(s_shape.line_instance_buf);
+        nt_gfx_set_instance_offset(line_base);
         nt_gfx_set_uniform_mat4("u_vp", s_shape.vp);
         float cp4[4] = {s_shape.cam_pos[0], s_shape.cam_pos[1], s_shape.cam_pos[2], 0.0F};
         nt_gfx_set_uniform_vec4("u_cam_pos", cp4);

--- a/engine/renderers/nt_shape_renderer.h
+++ b/engine/renderers/nt_shape_renderer.h
@@ -118,6 +118,7 @@ enum {
 };
 
 uint32_t nt_shape_renderer_test_instance_count(int type);
+uint32_t nt_shape_renderer_test_instance_capacity(void);
 uint32_t nt_shape_renderer_test_vertex_count(void);
 uint32_t nt_shape_renderer_test_index_count(void);
 uint32_t nt_shape_renderer_test_line_count(void);

--- a/examples/atlas/main.c
+++ b/examples/atlas/main.c
@@ -168,7 +168,7 @@ static void frame(void) {
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_color = {0.1F, 0.1F, 0.15F, 1.0F}, .clear_depth = 1.0F});
 
     if (can_render) {
-        nt_gfx_update_buffer(s_frame_ubo, &uniforms, sizeof(uniforms));
+        nt_gfx_update_buffer(s_frame_ubo, 0, &uniforms, sizeof(uniforms));
         nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
 
         uint32_t mesh_id = nt_resource_get(s_mesh_handle);

--- a/examples/bunnymark/main.c
+++ b/examples/bunnymark/main.c
@@ -418,7 +418,7 @@ static void frame(void) {
     nt_font_step();
 
     if (can_render) {
-        nt_gfx_update_buffer(s_frame_ubo, &uniforms, sizeof(uniforms));
+        nt_gfx_update_buffer(s_frame_ubo, 0, &uniforms, sizeof(uniforms));
         nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
 
         // #region build draw list

--- a/examples/rtt_showcase/main.c
+++ b/examples/rtt_showcase/main.c
@@ -386,7 +386,7 @@ static void draw_ui_overlay(void) {
     uniforms.resolution[3] = (fb_h > 0.0F) ? (1.0F / fb_h) : 0.0F;
     uniforms.near_far[0] = -1.0F;
     uniforms.near_far[1] = 1.0F;
-    nt_gfx_update_buffer(s_frame_ubo, &uniforms, sizeof(uniforms));
+    nt_gfx_update_buffer(s_frame_ubo, 0, &uniforms, sizeof(uniforms));
     nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
 
     char zoom_text[32];
@@ -460,7 +460,7 @@ static void draw_textured_quad(nt_texture_t texture, float x0, float y0, float x
     rtt_quad_vertex_t verts[6] = {
         {{x0, y0}, {0.0F, 0.0F}}, {{x1, y0}, {1.0F, 0.0F}}, {{x1, y1}, {1.0F, 1.0F}}, {{x0, y0}, {0.0F, 0.0F}}, {{x1, y1}, {1.0F, 1.0F}}, {{x0, y1}, {0.0F, 1.0F}},
     };
-    nt_gfx_update_buffer(s_demo.quad_vbo, verts, sizeof(verts));
+    nt_gfx_update_buffer(s_demo.quad_vbo, 0, verts, sizeof(verts));
     nt_gfx_bind_pipeline(s_demo.quad_pipeline);
     nt_gfx_bind_vertex_buffer(s_demo.quad_vbo);
     nt_gfx_bind_texture(texture, 0);

--- a/examples/slice9_demo/main.c
+++ b/examples/slice9_demo/main.c
@@ -419,7 +419,7 @@ static void frame(void) {
     const bool can_render = s_atlas_bound && s_font_bound && sprite_info && sprite_info->ready && text_info && text_info->ready;
 
     if (can_render) {
-        nt_gfx_update_buffer(s_frame_ubo, &uniforms, sizeof(uniforms));
+        nt_gfx_update_buffer(s_frame_ubo, 0, &uniforms, sizeof(uniforms));
         nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
 
         /* Pass the RAW device pointer; the ctx converts it via the scale-derived viewport. */

--- a/examples/sponza/main.c
+++ b/examples/sponza/main.c
@@ -573,7 +573,7 @@ static void frame(void) {
 
     if (item_count > 0) {
         /* Upload and bind frame UBO (slot 0) */
-        nt_gfx_update_buffer(s_frame_ubo, &uniforms, sizeof(uniforms));
+        nt_gfx_update_buffer(s_frame_ubo, 0, &uniforms, sizeof(uniforms));
         nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
 
         /* Upload and bind lighting UBO (slot 1) */
@@ -582,7 +582,7 @@ static void frame(void) {
             .light_color = {1.0F, 0.95F, 0.9F, 1.2F}, /* warm white, intensity 1.2 */
             .ambient = {0.6F, 0.65F, 0.8F, 0.3F},     /* cool ambient, intensity 0.3 */
         };
-        nt_gfx_update_buffer(s_light_ubo, &lighting, sizeof(lighting));
+        nt_gfx_update_buffer(s_light_ubo, 0, &lighting, sizeof(lighting));
         nt_gfx_bind_uniform_buffer(s_light_ubo, 1);
 
         /* Draw all render items */

--- a/examples/text/main.c
+++ b/examples/text/main.c
@@ -310,7 +310,7 @@ static void frame(void) {
     });
 
     /* Upload and bind frame UBO (slot 0) */
-    nt_gfx_update_buffer(s_frame_ubo, &uniforms, sizeof(uniforms));
+    nt_gfx_update_buffer(s_frame_ubo, 0, &uniforms, sizeof(uniforms));
     nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
 
     /* Step font system -- resolves pending resources, uploads GPU data */

--- a/examples/textured_quad/main.c
+++ b/examples/textured_quad/main.c
@@ -306,7 +306,7 @@ static void frame(void) {
 
     if (can_render) {
         /* Upload frame uniforms and bind to slot 0 */
-        nt_gfx_update_buffer(s_frame_ubo, &uniforms, sizeof(uniforms));
+        nt_gfx_update_buffer(s_frame_ubo, 0, &uniforms, sizeof(uniforms));
         nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
 
         uint32_t mesh_id = nt_resource_get(s_mesh_handle);

--- a/examples/ui_3d_demo/main.c
+++ b/examples/ui_3d_demo/main.c
@@ -883,7 +883,7 @@ static void frame(void) {
     const bool ui_can_render = s_atlas_bound && s_font_bound && sprite_info && sprite_info->ready && text_info && text_info->ready;
 
     if (ui_can_render) {
-        nt_gfx_update_buffer(s_frame_ubo, &uniforms_3d, sizeof uniforms_3d);
+        nt_gfx_update_buffer(s_frame_ubo, 0, &uniforms_3d, sizeof uniforms_3d);
         nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
 
         const nt_pointer_t mouse_phys = g_nt_input.pointers[0];
@@ -926,7 +926,7 @@ static void frame(void) {
 
     /* HUD: ortho VP. */
     if (text_info && text_info->ready) {
-        nt_gfx_update_buffer(s_frame_ubo, &uniforms_2d, sizeof uniforms_2d);
+        nt_gfx_update_buffer(s_frame_ubo, 0, &uniforms_2d, sizeof uniforms_2d);
         nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
         draw_hud(fb_w, fb_h);
         nt_text_renderer_flush();
@@ -934,7 +934,7 @@ static void frame(void) {
 
     if (ui_can_render && nt_ui_inspector_is_active(s_ctx)) {
         /* Sidebar tree is its own screen-space pass (ortho). */
-        nt_gfx_update_buffer(s_frame_ubo, &uniforms_2d, sizeof uniforms_2d);
+        nt_gfx_update_buffer(s_frame_ubo, 0, &uniforms_2d, sizeof uniforms_2d);
         nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
         nt_ui_debug_inspector_walk(s_ctx, &target);
         nt_sprite_renderer_flush();
@@ -942,7 +942,7 @@ static void frame(void) {
 
         /* Highlight overlay emits the element's world geometry in 3D ctx → bind the perspective VP
          * so it lands on the panel; the depth-off inspector materials keep it on top. */
-        nt_gfx_update_buffer(s_frame_ubo, &uniforms_3d, sizeof uniforms_3d);
+        nt_gfx_update_buffer(s_frame_ubo, 0, &uniforms_3d, sizeof uniforms_3d);
         nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
         nt_ui_inspector_overlay_draw(s_ctx, &target, s_font, 16.0F);
         nt_sprite_renderer_flush();

--- a/examples/ui_showcase/main.c
+++ b/examples/ui_showcase/main.c
@@ -3735,7 +3735,7 @@ static void frame(void) {
     const bool can_render = s_atlas_bound && s_font_bound && sprite_info && sprite_info->ready && text_info && text_info->ready;
 
     if (can_render) {
-        nt_gfx_update_buffer(s_frame_ubo, &uniforms, sizeof(uniforms));
+        nt_gfx_update_buffer(s_frame_ubo, 0, &uniforms, sizeof(uniforms));
         nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
 
         ensure_ids();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -279,6 +279,12 @@ if(NOT EMSCRIPTEN)
     nt_setup_test_target(test_nt_gfx_render_target_native)
     set_tests_properties(test_nt_gfx_render_target_native PROPERTIES LABELS "native")
 
+    # Real OpenGL shape-renderer ring: multi-flush uploads at ring offsets render pixel-correct.
+    add_executable(test_shape_renderer_ring_native unit/test_shape_renderer_ring_native.c)
+    target_link_libraries(test_shape_renderer_ring_native PRIVATE nt_shape_renderer nt_gfx nt_window nt_input_stub nt_log unity glad)
+    nt_setup_test_target(test_shape_renderer_ring_native)
+    set_tests_properties(test_shape_renderer_ring_native PROPERTIES LABELS "native")
+
     # --- Post-FX blur tests ---
     add_executable(test_nt_postfx_blur unit/test_nt_postfx_blur.c unit/test_helpers/nt_assert_trap.c)
     target_link_libraries(test_nt_postfx_blur PRIVATE nt_postfx_blur nt_gfx_stub nt_log_stub unity)

--- a/tests/browser/app/main.c
+++ b/tests/browser/app/main.c
@@ -287,7 +287,7 @@ static void frame(void) {
     const bool can_render = s_atlas_bound && s_font_bound && s_rich_font_bound && sprite_info && sprite_info->ready && text_info && text_info->ready;
 
     if (can_render) {
-        nt_gfx_update_buffer(s_frame_ubo, &uniforms, sizeof(uniforms));
+        nt_gfx_update_buffer(s_frame_ubo, 0, &uniforms, sizeof(uniforms));
         nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
 
         nt_ui_begin(s_ctx, scale.logical_w, scale.logical_h, g_nt_app.dt, &g_nt_input.pointers[0], 1);

--- a/tests/unit/test_gfx.c
+++ b/tests/unit/test_gfx.c
@@ -719,6 +719,7 @@ void test_update_buffer_rejects_out_of_range(void) {
     EXPECT_ASSERT(nt_gfx_update_buffer(buf, 257, data, 0));          /* offset past capacity */
     EXPECT_ASSERT(nt_gfx_update_buffer(buf, 224, data, 64));         /* offset + size past capacity */
     EXPECT_ASSERT(nt_gfx_update_buffer(buf, 0xFFFFFFFFU, data, 64)); /* overflow-prone pair */
+    EXPECT_ASSERT(nt_gfx_update_buffer(buf, 0, NULL, 64));           /* NULL data, nonzero size */
     nt_gfx_destroy_buffer(buf);
 }
 

--- a/tests/unit/test_gfx.c
+++ b/tests/unit/test_gfx.c
@@ -689,7 +689,21 @@ void test_update_uniform_buffer(void) {
     TEST_ASSERT_NOT_EQUAL_UINT32(0, buf.id);
     uint8_t data[256];
     memset(data, 0xAB, sizeof(data));
-    nt_gfx_update_buffer(buf, data, 256);
+    nt_gfx_update_buffer(buf, 0, data, 256);
+    nt_gfx_destroy_buffer(buf);
+}
+
+void test_update_buffer_at_offset(void) {
+    nt_buffer_t buf = nt_gfx_make_buffer(&(nt_buffer_desc_t){
+        .type = NT_BUFFER_VERTEX,
+        .usage = NT_USAGE_STREAM,
+        .size = 256,
+    });
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, buf.id);
+    uint8_t data[128];
+    memset(data, 0xCD, sizeof(data));
+    /* offset + size == capacity: must pass the range assert */
+    nt_gfx_update_buffer(buf, 128, data, 128);
     nt_gfx_destroy_buffer(buf);
 }
 
@@ -987,6 +1001,7 @@ int main(void) {
     RUN_TEST(test_make_uniform_buffer);
     RUN_TEST(test_bind_uniform_buffer);
     RUN_TEST(test_update_uniform_buffer);
+    RUN_TEST(test_update_buffer_at_offset);
     RUN_TEST(test_destroy_uniform_buffer);
     /* Global block registration tests */
     RUN_TEST(test_register_global_block);

--- a/tests/unit/test_gfx.c
+++ b/tests/unit/test_gfx.c
@@ -731,10 +731,12 @@ void test_bind_instance_buffer_rejects_unaligned_offset(void) {
         .fragment_shader = fs,
         .layout = {.attr_count = 1, .stride = 12, .attrs = {{.location = 0, .format = NT_FORMAT_FLOAT3}}},
     });
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, pip.id);
     nt_gfx_bind_pipeline(pip);
     nt_buffer_t buf = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 256});
-    nt_gfx_bind_instance_buffer(buf, 4);                /* aligned: passes */
-    EXPECT_ASSERT(nt_gfx_bind_instance_buffer(buf, 1)); /* WebGL2 rejects unaligned attrib offsets */
+    nt_gfx_bind_instance_buffer(buf, 4);
+    TEST_ASSERT_EQUAL_UINT32(4, nt_gfx_stub_test_last_instance_offset()); /* aligned offset reached the backend */
+    EXPECT_ASSERT(nt_gfx_bind_instance_buffer(buf, 1));                   /* WebGL2 rejects unaligned attrib offsets */
     nt_gfx_destroy_buffer(buf);
     nt_gfx_destroy_pipeline(pip);
     nt_gfx_destroy_shader(vs);

--- a/tests/unit/test_gfx.c
+++ b/tests/unit/test_gfx.c
@@ -743,6 +743,34 @@ void test_bind_instance_buffer_rejects_unaligned_offset(void) {
     nt_gfx_destroy_shader(fs);
 }
 
+void test_bind_instance_buffer_requires_pipeline_each_frame(void) {
+    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "v"});
+    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "f"});
+    nt_pipeline_t pip = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
+        .vertex_shader = vs,
+        .fragment_shader = fs,
+        .layout = {.attr_count = 1, .stride = 12, .attrs = {{.location = 0, .format = NT_FORMAT_FLOAT3}}},
+    });
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, pip.id);
+    nt_buffer_t buf = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 256});
+
+    nt_gfx_begin_frame();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_instance_buffer(buf, 0); /* bound this frame: passes */
+    nt_gfx_end_frame();
+
+    /* Backend drops its pipeline cache per frame — a bind without re-binding
+     * the pipeline must trap, not silently skip attrib setup. */
+    nt_gfx_begin_frame();
+    EXPECT_ASSERT(nt_gfx_bind_instance_buffer(buf, 0));
+    nt_gfx_end_frame();
+
+    nt_gfx_destroy_buffer(buf);
+    nt_gfx_destroy_pipeline(pip);
+    nt_gfx_destroy_shader(vs);
+    nt_gfx_destroy_shader(fs);
+}
+
 void test_update_buffer_rejects_immutable(void) {
     uint8_t initial[64] = {0};
     nt_buffer_t buf = nt_gfx_make_buffer(&(nt_buffer_desc_t){
@@ -1054,6 +1082,7 @@ int main(void) {
     RUN_TEST(test_update_buffer_rejects_out_of_range);
     RUN_TEST(test_update_buffer_rejects_immutable);
     RUN_TEST(test_bind_instance_buffer_rejects_unaligned_offset);
+    RUN_TEST(test_bind_instance_buffer_requires_pipeline_each_frame);
     RUN_TEST(test_destroy_uniform_buffer);
     /* Global block registration tests */
     RUN_TEST(test_register_global_block);

--- a/tests/unit/test_gfx.c
+++ b/tests/unit/test_gfx.c
@@ -707,6 +707,34 @@ void test_update_buffer_at_offset(void) {
     nt_gfx_destroy_buffer(buf);
 }
 
+void test_update_buffer_rejects_out_of_range(void) {
+    nt_buffer_t buf = nt_gfx_make_buffer(&(nt_buffer_desc_t){
+        .type = NT_BUFFER_VERTEX,
+        .usage = NT_USAGE_STREAM,
+        .size = 256,
+    });
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, buf.id);
+    uint8_t data[64];
+    memset(data, 0xEF, sizeof(data));
+    EXPECT_ASSERT(nt_gfx_update_buffer(buf, 257, data, 0));          /* offset past capacity */
+    EXPECT_ASSERT(nt_gfx_update_buffer(buf, 224, data, 64));         /* offset + size past capacity */
+    EXPECT_ASSERT(nt_gfx_update_buffer(buf, 0xFFFFFFFFU, data, 64)); /* overflow-prone pair */
+    nt_gfx_destroy_buffer(buf);
+}
+
+void test_update_buffer_rejects_immutable(void) {
+    uint8_t initial[64] = {0};
+    nt_buffer_t buf = nt_gfx_make_buffer(&(nt_buffer_desc_t){
+        .type = NT_BUFFER_VERTEX,
+        .usage = NT_USAGE_IMMUTABLE,
+        .size = 64,
+        .data = initial,
+    });
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, buf.id);
+    EXPECT_ASSERT(nt_gfx_update_buffer(buf, 0, initial, 64));
+    nt_gfx_destroy_buffer(buf);
+}
+
 void test_destroy_uniform_buffer(void) {
     nt_buffer_t buf1 = nt_gfx_make_buffer(&(nt_buffer_desc_t){
         .type = NT_BUFFER_UNIFORM,
@@ -1002,6 +1030,8 @@ int main(void) {
     RUN_TEST(test_bind_uniform_buffer);
     RUN_TEST(test_update_uniform_buffer);
     RUN_TEST(test_update_buffer_at_offset);
+    RUN_TEST(test_update_buffer_rejects_out_of_range);
+    RUN_TEST(test_update_buffer_rejects_immutable);
     RUN_TEST(test_destroy_uniform_buffer);
     /* Global block registration tests */
     RUN_TEST(test_register_global_block);

--- a/tests/unit/test_gfx.c
+++ b/tests/unit/test_gfx.c
@@ -723,6 +723,24 @@ void test_update_buffer_rejects_out_of_range(void) {
     nt_gfx_destroy_buffer(buf);
 }
 
+void test_bind_instance_buffer_rejects_unaligned_offset(void) {
+    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "v"});
+    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "f"});
+    nt_pipeline_t pip = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
+        .vertex_shader = vs,
+        .fragment_shader = fs,
+        .layout = {.attr_count = 1, .stride = 12, .attrs = {{.location = 0, .format = NT_FORMAT_FLOAT3}}},
+    });
+    nt_gfx_bind_pipeline(pip);
+    nt_buffer_t buf = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 256});
+    nt_gfx_bind_instance_buffer(buf, 4);                /* aligned: passes */
+    EXPECT_ASSERT(nt_gfx_bind_instance_buffer(buf, 1)); /* WebGL2 rejects unaligned attrib offsets */
+    nt_gfx_destroy_buffer(buf);
+    nt_gfx_destroy_pipeline(pip);
+    nt_gfx_destroy_shader(vs);
+    nt_gfx_destroy_shader(fs);
+}
+
 void test_update_buffer_rejects_immutable(void) {
     uint8_t initial[64] = {0};
     nt_buffer_t buf = nt_gfx_make_buffer(&(nt_buffer_desc_t){
@@ -1033,6 +1051,7 @@ int main(void) {
     RUN_TEST(test_update_buffer_at_offset);
     RUN_TEST(test_update_buffer_rejects_out_of_range);
     RUN_TEST(test_update_buffer_rejects_immutable);
+    RUN_TEST(test_bind_instance_buffer_rejects_unaligned_offset);
     RUN_TEST(test_destroy_uniform_buffer);
     /* Global block registration tests */
     RUN_TEST(test_register_global_block);

--- a/tests/unit/test_mesh_renderer.c
+++ b/tests/unit/test_mesh_renderer.c
@@ -560,6 +560,44 @@ void test_draw_list_mixed_color_modes_multi_instance(void) {
     TEST_ASSERT_EQUAL_UINT32(3, nt_mesh_renderer_test_pipeline_cache_count());
 }
 
+/* ---- Ring allocation: cursor advances per draw_list call, wraps at capacity ---- */
+
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+void test_ring_cursor_advances_and_wraps(void) {
+    /* Re-init with a tiny buffer so wrap is reachable: capacity = 4 * 64 = 256 bytes */
+    nt_mesh_renderer_shutdown();
+    nt_mesh_renderer_desc_t small = {.max_instances = 4, .max_pipelines = 8};
+    TEST_ASSERT_EQUAL_INT(0, (int)nt_mesh_renderer_init(&small));
+
+    nt_mesh_t mesh = create_test_mesh();
+    nt_material_t mat = create_test_material();
+    nt_entity_t e = create_test_entity(mesh, mat);
+
+    nt_render_item_t items[1];
+    items[0].sort_key = 0;
+    items[0].entity = e.id;
+    items[0].batch_key = nt_batch_key(mat.id, mesh.id);
+
+    nt_mesh_renderer_draw_list(items, 1);
+    uint32_t delta = nt_mesh_renderer_test_ring_cursor();
+    TEST_ASSERT_TRUE(delta > 0); /* first call starts at 0, advances by packed size */
+
+    uint32_t capacity = 4 * 64; /* max_instances * NT_INSTANCE_STRIDE_MAX */
+    uint32_t fit = capacity / delta;
+    for (uint32_t i = 1; i < fit; i++) {
+        nt_mesh_renderer_draw_list(items, 1);
+        TEST_ASSERT_EQUAL_UINT32((i + 1) * delta, nt_mesh_renderer_test_ring_cursor());
+    }
+    /* Buffer full: next call wraps to 0 and writes there */
+    nt_mesh_renderer_draw_list(items, 1);
+    TEST_ASSERT_EQUAL_UINT32(delta, nt_mesh_renderer_test_ring_cursor());
+
+    /* Restore defaults for tearDown */
+    nt_mesh_renderer_shutdown();
+    nt_mesh_renderer_desc_t desc = nt_mesh_renderer_desc_defaults();
+    nt_mesh_renderer_init(&desc);
+}
+
 /* ---- main ---- */
 
 int main(void) {
@@ -580,6 +618,7 @@ int main(void) {
     RUN_TEST(test_pipeline_cache_different_color_modes);
     RUN_TEST(test_draw_list_mixed_color_modes);
     RUN_TEST(test_draw_list_mixed_color_modes_multi_instance);
+    RUN_TEST(test_ring_cursor_advances_and_wraps);
     /* Stream format mapping */
     RUN_TEST(test_stream_to_format_float32);
     RUN_TEST(test_stream_to_format_float16);

--- a/tests/unit/test_mesh_renderer.c
+++ b/tests/unit/test_mesh_renderer.c
@@ -15,6 +15,8 @@
 #include "resource/nt_resource.h"
 #include "hash/nt_hash.h"
 #include "render/nt_render_items.h"
+#include "render/nt_render_defs.h"
+#include "graphics/nt_gfx_internal.h"
 #include "nt_mesh_format.h"
 #include "nt_pack_format.h"
 #include "unity.h"
@@ -564,11 +566,47 @@ void test_draw_list_mixed_color_modes_multi_instance(void) {
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_ring_cursor_advances_and_wraps(void) {
-    /* Re-init with a tiny buffer so wrap is reachable: capacity = 4 * 64 = 256 bytes */
+    /* Tiny buffer so wrap is reachable. FLOAT4 material -> stride equals
+     * NT_INSTANCE_STRIDE_MAX, so per-call delta divides capacity exactly and
+     * the exact-fit boundary (cursor == capacity must NOT wrap early) is hit. */
     nt_mesh_renderer_shutdown();
     nt_mesh_renderer_desc_t small = {.max_instances = 4, .max_pipelines = 8};
     TEST_ASSERT_EQUAL_INT(0, (int)nt_mesh_renderer_init(&small));
 
+    nt_mesh_t mesh = create_test_mesh();
+    nt_material_t mat = create_test_material_ex(NT_COLOR_MODE_FLOAT4);
+    nt_entity_t e = create_test_entity(mesh, mat);
+
+    nt_render_item_t items[1];
+    items[0].sort_key = 0;
+    items[0].entity = e.id;
+    items[0].batch_key = nt_batch_key(mat.id, mesh.id);
+
+    nt_mesh_renderer_draw_list(items, 1);
+    uint32_t delta = nt_mesh_renderer_test_ring_cursor();
+    TEST_ASSERT_EQUAL_UINT32(NT_INSTANCE_STRIDE_MAX, delta); /* FLOAT4 packs at max stride */
+
+    uint32_t capacity = 4U * NT_INSTANCE_STRIDE_MAX;
+    uint32_t fit = capacity / delta;
+    for (uint32_t i = 1; i < fit; i++) {
+        nt_mesh_renderer_draw_list(items, 1);
+        TEST_ASSERT_EQUAL_UINT32((i + 1) * delta, nt_mesh_renderer_test_ring_cursor());
+    }
+    /* Exact fit: cursor sits AT capacity without having wrapped */
+    TEST_ASSERT_EQUAL_UINT32(capacity, nt_mesh_renderer_test_ring_cursor());
+    /* Buffer full: next call wraps to 0 and writes there */
+    nt_mesh_renderer_draw_list(items, 1);
+    TEST_ASSERT_EQUAL_UINT32(delta, nt_mesh_renderer_test_ring_cursor());
+
+    /* Restore defaults for tearDown */
+    nt_mesh_renderer_shutdown();
+    nt_mesh_renderer_desc_t desc = nt_mesh_renderer_desc_defaults();
+    nt_mesh_renderer_init(&desc);
+}
+
+/* ---- Ring upload base and draw base must agree (stub records both) ---- */
+
+void test_ring_upload_and_draw_base_agree(void) {
     nt_mesh_t mesh = create_test_mesh();
     nt_material_t mat = create_test_material();
     nt_entity_t e = create_test_entity(mesh, mat);
@@ -579,23 +617,14 @@ void test_ring_cursor_advances_and_wraps(void) {
     items[0].batch_key = nt_batch_key(mat.id, mesh.id);
 
     nt_mesh_renderer_draw_list(items, 1);
-    uint32_t delta = nt_mesh_renderer_test_ring_cursor();
-    TEST_ASSERT_TRUE(delta > 0); /* first call starts at 0, advances by packed size */
+    uint32_t upload1 = nt_gfx_stub_test_last_update_buffer_offset();
+    TEST_ASSERT_EQUAL_UINT32(upload1, nt_gfx_stub_test_last_instance_offset());
 
-    uint32_t capacity = 4 * 64; /* max_instances * NT_INSTANCE_STRIDE_MAX */
-    uint32_t fit = capacity / delta;
-    for (uint32_t i = 1; i < fit; i++) {
-        nt_mesh_renderer_draw_list(items, 1);
-        TEST_ASSERT_EQUAL_UINT32((i + 1) * delta, nt_mesh_renderer_test_ring_cursor());
-    }
-    /* Buffer full: next call wraps to 0 and writes there */
+    /* Second call must advance BOTH bases together, not just the upload */
     nt_mesh_renderer_draw_list(items, 1);
-    TEST_ASSERT_EQUAL_UINT32(delta, nt_mesh_renderer_test_ring_cursor());
-
-    /* Restore defaults for tearDown */
-    nt_mesh_renderer_shutdown();
-    nt_mesh_renderer_desc_t desc = nt_mesh_renderer_desc_defaults();
-    nt_mesh_renderer_init(&desc);
+    uint32_t upload2 = nt_gfx_stub_test_last_update_buffer_offset();
+    TEST_ASSERT_TRUE(upload2 > upload1);
+    TEST_ASSERT_EQUAL_UINT32(upload2, nt_gfx_stub_test_last_instance_offset());
 }
 
 /* ---- main ---- */
@@ -619,6 +648,7 @@ int main(void) {
     RUN_TEST(test_draw_list_mixed_color_modes);
     RUN_TEST(test_draw_list_mixed_color_modes_multi_instance);
     RUN_TEST(test_ring_cursor_advances_and_wraps);
+    RUN_TEST(test_ring_upload_and_draw_base_agree);
     /* Stream format mapping */
     RUN_TEST(test_stream_to_format_float32);
     RUN_TEST(test_stream_to_format_float16);

--- a/tests/unit/test_mesh_renderer.c
+++ b/tests/unit/test_mesh_renderer.c
@@ -560,6 +560,8 @@ void test_draw_list_mixed_color_modes_multi_instance(void) {
     TEST_ASSERT_EQUAL_UINT32(9, nt_mesh_renderer_test_instance_total());
     /* 3 different color modes = 3 pipelines */
     TEST_ASSERT_EQUAL_UINT32(3, nt_mesh_renderer_test_pipeline_cache_count());
+    /* Last run's bind offset = upload base + preceding runs (3x NONE + 3x RGBA8) */
+    TEST_ASSERT_EQUAL_UINT32(nt_gfx_stub_test_last_update_buffer_offset() + (3 * NT_INSTANCE_STRIDE_NONE) + (3 * NT_INSTANCE_STRIDE_RGBA8), nt_gfx_stub_test_last_instance_offset());
 }
 
 /* ---- Ring allocation: cursor advances per draw_list call, wraps at capacity ---- */

--- a/tests/unit/test_shape_renderer_ring_native.c
+++ b/tests/unit/test_shape_renderer_ring_native.c
@@ -1,8 +1,6 @@
-/* Real-GL proof that ring-allocated instance uploads land where the draws read:
- * several shape flushes in one frame write disjoint buffer ranges (nonzero
- * offsets after the first), and every shape still renders at its position.
- * Renders into a fixed-size offscreen target — the window framebuffer scales
- * with the host DPI and would shift every sample point. */
+/* Real-GL proof that ring-allocated instance uploads land where the draws
+ * read: multi-flush frames write disjoint ranges yet render pixel-correct.
+ * Fixed-size offscreen target — the window framebuffer scales with host DPI. */
 
 #include "graphics/nt_gfx.h"
 #include "renderers/nt_shape_renderer.h"

--- a/tests/unit/test_shape_renderer_ring_native.c
+++ b/tests/unit/test_shape_renderer_ring_native.c
@@ -1,0 +1,144 @@
+/* Real-GL proof that ring-allocated instance uploads land where the draws read:
+ * several shape flushes in one frame write disjoint buffer ranges (nonzero
+ * offsets after the first), and every shape still renders at its position.
+ * Renders into a fixed-size offscreen target — the window framebuffer scales
+ * with the host DPI and would shift every sample point. */
+
+#include "graphics/nt_gfx.h"
+#include "renderers/nt_shape_renderer.h"
+#include "unity.h"
+#include "window/nt_window.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#define GLFW_INCLUDE_NONE
+#include <GLFW/glfw3.h>
+#include <glad/gl.h>
+
+enum { RT_W = 64, RT_H = 64 };
+
+static const float k_identity_vp[16] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
+
+static nt_render_target_t s_target;
+
+void setUp(void) {
+    TEST_ASSERT_TRUE_MESSAGE(glfwInit(), "glfwInit failed");
+    glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
+    g_nt_window = (nt_window_t){
+        .max_dpr = 1.0F,
+        .resizable = false,
+        .width = RT_W,
+        .height = RT_H,
+    };
+    nt_window_init();
+
+    nt_gfx_desc_t desc = nt_gfx_desc_defaults();
+    nt_gfx_init(&desc);
+    TEST_ASSERT_TRUE(g_nt_gfx.initialized);
+
+    s_target = nt_gfx_make_render_target(&(nt_render_target_desc_t){
+        .width = RT_W,
+        .height = RT_H,
+        .color_format = NT_TEXTURE_FORMAT_RGBA8,
+        .color_min_filter = NT_FILTER_NEAREST,
+        .color_mag_filter = NT_FILTER_NEAREST,
+        .color_wrap_u = NT_WRAP_CLAMP_TO_EDGE,
+        .color_wrap_v = NT_WRAP_CLAMP_TO_EDGE,
+        .depth_storage = NT_RT_DEPTH_BUFFER,
+        .depth_format = NT_TEXTURE_FORMAT_DEPTH24,
+        .label = "shape_ring_rt",
+    });
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, s_target.id);
+    TEST_ASSERT_TRUE(nt_gfx_render_target_ready(s_target));
+
+    nt_shape_renderer_init();
+    nt_shape_renderer_set_vp(k_identity_vp);
+    nt_shape_renderer_set_depth(false);
+}
+
+void tearDown(void) {
+    nt_shape_renderer_shutdown();
+    nt_gfx_destroy_render_target(s_target);
+    nt_gfx_shutdown();
+    nt_window_shutdown();
+}
+
+/* Sample one pixel from a top-left-oriented full-frame readback. */
+static const uint8_t *pixel_at(const uint8_t *frame, int x, int y_top) { return &frame[(((size_t)y_top * RT_W) + (size_t)x) * 4U]; }
+
+static void assert_pixel(const uint8_t *frame, int x, int y_top, uint8_t r, uint8_t g, uint8_t b) {
+    const uint8_t *p = pixel_at(frame, x, y_top);
+    TEST_ASSERT_UINT8_WITHIN(1, r, p[0]);
+    TEST_ASSERT_UINT8_WITHIN(1, g, p[1]);
+    TEST_ASSERT_UINT8_WITHIN(1, b, p[2]);
+}
+
+static void test_multi_flush_ring_offsets_render_correctly(void) {
+    const float red[4] = {1, 0, 0, 1};
+    const float green[4] = {0, 1, 0, 1};
+    const float blue[4] = {0, 0, 1, 1};
+
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.target = s_target, .clear_color = {0, 0, 0, 1}, .clear_depth = 1.0F});
+
+    /* Flush 1: two instance types -> two ring writes within one flush.
+     * Red rect covers the left half; green cube sits center-right (the circle
+     * template lies in XZ — edge-on under the identity VP — so cube it is). */
+    nt_shape_renderer_rect((float[3]){-0.5F, 0.0F, 0.0F}, (float[2]){1.0F, 2.0F}, red);
+    nt_shape_renderer_cube((float[3]){0.5F, 0.0F, 0.0F}, (float[3]){0.5F, 0.5F, 0.5F}, green);
+    nt_shape_renderer_flush();
+
+    /* Flush 2: rect again — its upload starts at a nonzero ring offset.
+     * Blue rect in the top-right quadrant (clip x [0.2,0.8], y [0.4,0.8]). */
+    nt_shape_renderer_rect((float[3]){0.5F, 0.6F, 0.0F}, (float[2]){0.6F, 0.4F}, blue);
+    nt_shape_renderer_flush();
+
+    uint8_t frame[RT_W * RT_H * 4U] = {0};
+    TEST_ASSERT_TRUE(nt_gfx_read_pixels(0, 0, RT_W, RT_H, frame, sizeof(frame)));
+
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    assert_pixel(frame, 16, 32, 255, 0, 0); /* left half: red rect (flush 1, write 1) */
+    assert_pixel(frame, 48, 32, 0, 255, 0); /* cube center: green (flush 1, write 2 at nonzero offset) */
+    assert_pixel(frame, 48, 13, 0, 0, 255); /* top-right quadrant: blue rect (flush 2 at nonzero offset) */
+    assert_pixel(frame, 56, 56, 0, 0, 0);   /* bottom-right corner untouched: background */
+}
+
+/* Wrap: many flushes exceed instance-buffer capacity; after the cursor wraps
+ * to 0 the newest shape must still render (no stale data drawn). */
+static void test_ring_wrap_still_renders(void) {
+    const float red[4] = {1, 0, 0, 1};
+    const float green[4] = {0, 1, 0, 1};
+
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.target = s_target, .clear_color = {0, 0, 0, 1}, .clear_depth = 1.0F});
+
+    /* Each flush advances the ring; enough iterations to force >= 1 wrap
+     * regardless of NT_SHAPE_RENDERER_MAX_INSTANCES sizing. */
+    for (int i = 0; i < 64; i++) {
+        for (int j = 0; j < 256; j++) {
+            nt_shape_renderer_rect((float[3]){-0.5F, 0.0F, 0.0F}, (float[2]){1.0F, 2.0F}, red);
+        }
+        nt_shape_renderer_flush();
+    }
+    nt_shape_renderer_rect((float[3]){0.5F, 0.0F, 0.0F}, (float[2]){1.0F, 2.0F}, green);
+    nt_shape_renderer_flush();
+
+    uint8_t frame[RT_W * RT_H * 4U] = {0};
+    TEST_ASSERT_TRUE(nt_gfx_read_pixels(0, 0, RT_W, RT_H, frame, sizeof(frame)));
+
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    assert_pixel(frame, 16, 32, 255, 0, 0); /* left half still red */
+    assert_pixel(frame, 48, 32, 0, 255, 0); /* post-wrap green rect renders */
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_multi_flush_ring_offsets_render_correctly);
+    RUN_TEST(test_ring_wrap_still_renders);
+    return UNITY_END();
+}

--- a/tests/unit/test_shape_renderer_ring_native.c
+++ b/tests/unit/test_shape_renderer_ring_native.c
@@ -115,9 +115,10 @@ static void test_ring_wrap_still_renders(void) {
     nt_gfx_begin_frame();
     nt_gfx_begin_pass(&(nt_pass_desc_t){.target = s_target, .clear_color = {0, 0, 0, 1}, .clear_depth = 1.0F});
 
-    /* Each flush advances the ring; enough iterations to force >= 1 wrap
-     * regardless of NT_SHAPE_RENDERER_MAX_INSTANCES sizing. */
-    for (int i = 0; i < 64; i++) {
+    /* Each flush advances the ring by 256 instances; flush count is derived
+     * from the actual capacity so >= 2 wraps happen at any configured size. */
+    uint32_t flushes = ((nt_shape_renderer_test_instance_capacity() / 256U) * 2U) + 1U;
+    for (uint32_t i = 0; i < flushes; i++) {
         for (int j = 0; j < 256; j++) {
             nt_shape_renderer_rect((float[3]){-0.5F, 0.0F, 0.0F}, (float[2]){1.0F, 2.0F}, red);
         }

--- a/tests/unit/test_shape_renderer_ring_native.c
+++ b/tests/unit/test_shape_renderer_ring_native.c
@@ -113,11 +113,13 @@ static void test_ring_wrap_still_renders(void) {
     nt_gfx_begin_frame();
     nt_gfx_begin_pass(&(nt_pass_desc_t){.target = s_target, .clear_color = {0, 0, 0, 1}, .clear_depth = 1.0F});
 
-    /* Each flush advances the ring by 256 instances; flush count is derived
-     * from the actual capacity so >= 2 wraps happen at any configured size. */
-    uint32_t flushes = ((nt_shape_renderer_test_instance_capacity() / 256U) * 2U) + 1U;
+    /* Flush count derived from the actual capacity: >= 2 wraps at any
+     * configured size (per-flush count clamped so small caps still cycle). */
+    uint32_t cap = nt_shape_renderer_test_instance_capacity();
+    uint32_t per = cap < 256U ? cap : 256U;
+    uint32_t flushes = ((cap / per) * 2U) + 1U;
     for (uint32_t i = 0; i < flushes; i++) {
-        for (int j = 0; j < 256; j++) {
+        for (uint32_t j = 0; j < per; j++) {
             nt_shape_renderer_rect((float[3]){-0.5F, 0.0F, 0.0F}, (float[2]){1.0F, 2.0F}, red);
         }
         nt_shape_renderer_flush();


### PR DESCRIPTION
Closes #322.

## What

- `nt_gfx_update_buffer(buf, offset, data, size)` — byte offset for partial writes (`glBufferSubData` offset was hard-coded 0). Range-asserted against buffer capacity, overflow-safe. All existing call sites pass 0.
- `nt_mesh_renderer`: instance uploads ring-allocate inside the existing 256 KB STREAM buffer — the 3-6 `draw_list` calls of a frame write disjoint ranges; draws start at the ring base via the existing `nt_gfx_set_instance_offset` plumbing.
- `nt_shape_renderer`: same ring for the shared per-type instance buffer (up to 7 rewrites per flush before) and the line instance buffer. The CPU-batched triangle/mesh path keeps offset 0 (no read-side offset plumbing; out of scope).
- Wrap policy: a write that does not fit the tail restarts at 0 — one potential driver copy per wrap instead of one per write.

## Why

WebGL is the primary target: each rewrite of an in-flight buffer forces ANGLE to ghost (allocate + full copy). Disjoint ranges remove that per-write. Research trail with browser-engineer sources in #322. Not a correctness fix — GL guarantees draw-time snapshots — scheduled hygiene per the issue discussion.

## Tests

- New real-GL test `test_shape_renderer_ring_native` (RESOURCE_LOCK gl_display): multi-flush ring offsets render pixel-correct into a fixed-size offscreen target; wrap still renders. Both PASS.
- Stub tests: ring cursor advance + wrap bookkeeping (`test_ring_cursor_advances_and_wraps`), offset-range write (`test_update_buffer_at_offset`).
- `check.sh --push` PASS (native + wasm-debug + wasm-release + submodule consumption).

Game repo needs the mechanical `, 0` update at its 6 `nt_gfx_update_buffer` call sites on the next submodule bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)