### PR TITLE
site: rename hello promo title to Hello

### DIFF
--- a/examples/hello/site_promo/index.md
+++ b/examples/hello/site_promo/index.md
@@ -1,5 +1,5 @@
 ---
-title: Hello Triangle
+title: Hello
 description: Minimal WASM example demonstrating engine initialization and WebGL canvas setup.
 ---
 


### PR DESCRIPTION
Closes #336.

The site promo for `examples/hello` was titled "Hello Triangle", but the example links no gfx module and draws nothing — it demos engine init, window, input and timing. Renamed the promo title to "Hello" so the site matches the example.

Checks: `format_and_check.sh` PASS (doc-links gate included). `check.sh --push` not run — change is a single site_promo markdown title, wasm builds don't consume it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)