### PR TITLE
render: make batch keys renderer-owned

### DIFF
--- a/docs/spec/assets/resource.md
+++ b/docs/spec/assets/resource.md
@@ -130,6 +130,35 @@ Two consumption models exist for asset types that derive state from pack bytes:
 
 The per-asset pin (the published winner of a pinning slot) is exposed for diagnostics as `nt_resource_asset_info_t.blob_pins` and surfaced in the devapi `resource.list` group.
 
+## GPU context loss recovery
+
+`nt_gfx_begin_frame()` detects a restored context and sets
+`g_nt_gfx.context_restored` for that frame. Resource readiness, resolved runtime
+handles, and render items computed before that call still describe the previous
+GPU context. The game must discard them and skip dependent draws for the restored
+frame.
+
+When `context_restored` is true, the game:
+
+1. discards render decisions and draw lists prepared before
+   `nt_gfx_begin_frame()`
+2. calls `nt_resource_invalidate()` for each file-backed GPU asset type that it
+   uses
+3. destroys and recreates game-owned GPU objects, freeing their logical handle
+   slots before replacement
+4. calls the restore entry point of every active renderer
+
+`nt_resource_invalidate()` skips virtual packs. A game-owned GPU object published
+through a virtual pack must be destroyed, recreated from game-owned source data,
+and published again with `nt_resource_register()`.
+
+The frame's `nt_resource_step()` has already run before
+`nt_gfx_begin_frame()` discovers the restore. File-backed assets therefore
+reactivate and republish no earlier than a later resource step. The game rebuilds
+resource-dependent render state after that publication instead of reusing the
+discarded list. Render targets are recreated by `nt_gfx` from retained
+descriptors, but their pixel contents must be redrawn.
+
 ## Pack lifetime (mount / unmount)
 
 Asset lifetime is **explicit pack-level mount/unmount, owned by the developer** —

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -118,7 +118,7 @@ reverse direction, file → chapter):
 
 | Task | Entry points |
 |---|---|
-| Add/change a render item field | `engine/render/nt_render_defs.h` (16 B item, `_Static_assert`) → `nt_sort_by_key` → `nt_*_renderer_draw_list`. **The game builds items**, not the engine: reference `examples/bunnymark/main.c` |
+| Add/change a render item field | `engine/render/nt_render_defs.h` (16 B item, `_Static_assert`) → `nt_sort_by_key` / `nt_sort_by_key_then_batch` → renderer-owned batch-key helper → `nt_*_renderer_draw_list`. **The game builds items and chooses sort policy**, not the engine: reference `examples/bunnymark/main.c` |
 | Change UI text wrapping | Wrapping itself lives in vendored Clay (`deps/clay`, `CLAY_TEXT_WRAP_*`); the engine owns only the measure callback (`engine/ui/nt_ui.c` → `nt_font_measure_n`) and the wrap mode it passes. Rich text has its own solver: `engine/ui/nt_ui_rich_text.c` |
 | Touch the `.ntpack` format | Layout: `shared/include/nt_pack_format.h` (magic `NPAK`) → writer `nt_builder_finish_pack` (`tools/builder/nt_builder.c`) → reader `engine/resource/nt_resource.c` (header/version check) |
 | Add builder validation | Programmer/IO errors assert (`NT_BUILD_ASSERT`, e.g. `tools/builder/nt_builder_texture.c`); content errors of atlas sprites go to the graceful channel `nt_builder_get_errors` (`tools/builder/nt_builder_atlas.c`) |

--- a/docs/spec/render/items-sorting-batching.md
+++ b/docs/spec/render/items-sorting-batching.md
@@ -158,7 +158,7 @@ WebGL 2 provides native `drawArraysInstanced` / `drawElementsInstanced` — no e
 Sprite renderer: gather sorted sprite render items, resolve component SoA views
 once, pack sprite vertices into one dynamic vertex buffer per flush chunk, and
 draw recorded commands. The renderer owns atlas page correctness: `batch_key`
-is the renderer-defined material compatibility token, while SpriteRenderer
+is the renderer-defined material-and-page compatibility token, while SpriteRenderer
 verifies actual atlas page textures and splits commands when a run crosses
 pages.
 

--- a/docs/spec/render/items-sorting-batching.md
+++ b/docs/spec/render/items-sorting-batching.md
@@ -94,12 +94,15 @@ material and mesh bindings of that same `item.entity`; until
 alive, neither binding changes, and neither referenced live resource is
 destroyed or has its slot reused.
 
-`nt_sprite_renderer_batch_key(material)` returns material identity. The same
-entity/component/material lifetime rule applies through
-`nt_sprite_renderer_draw_list()`. SpriteRenderer separately resolves and checks
-the actual atlas page while emitting, so a page change inside one material run
-is supported and splits the command stream. Transform and drawable color may
-change after item construction because neither renderer's key encodes them.
+`nt_sprite_renderer_batch_key(material, page_resource)` packs the material's
+16-bit pool slot and the resolved atlas page resource's 16-bit slot. The page
+resource comes from the sprite component's resolved-region cache, so render-item
+construction does not search the atlas. The same bounded-lifetime rule applies
+through `nt_sprite_renderer_draw_list()`: the material binding and resolved page
+must not change. SpriteRenderer still checks the actual page while emitting, so
+a page mismatch inside a run splits safely; this does not relax the material-key
+contract. Transform and drawable color may change after item construction
+because neither renderer's key encodes them.
 
 ## Sorting Policy
 

--- a/docs/spec/render/items-sorting-batching.md
+++ b/docs/spec/render/items-sorting-batching.md
@@ -97,12 +97,14 @@ destroyed or has its slot reused.
 `nt_sprite_renderer_batch_key(material, page_resource)` packs the material's
 16-bit pool slot and the resolved atlas page resource's 16-bit slot. The page
 resource comes from the sprite component's resolved-region cache, so render-item
-construction does not search the atlas. The same bounded-lifetime rule applies
-through `nt_sprite_renderer_draw_list()`: the material binding and resolved page
-must not change. SpriteRenderer still checks the actual page while emitting, so
-a page mismatch inside a run splits safely; this does not relax the material-key
-contract. Transform and drawable color may change after item construction
-because neither renderer's key encodes them.
+construction does not search the atlas. The game excludes unresolved sprites and
+resolved tombstones before calling the helper; tombstones have no page resource.
+The same bounded-lifetime rule applies through
+`nt_sprite_renderer_draw_list()`: the material binding and resolved page must not
+change. SpriteRenderer still checks the actual page while emitting, so a page
+mismatch inside a run splits safely; this does not relax the material-key
+contract. Transform and drawable color may change after item construction because
+neither renderer's key encodes them.
 
 ## Sorting Policy
 

--- a/docs/spec/render/items-sorting-batching.md
+++ b/docs/spec/render/items-sorting-batching.md
@@ -50,11 +50,14 @@ Minimal render item — sorted draw record, not a fat data carrier. Renderer rea
 typedef struct nt_render_item_t {
     uint64_t sort_key;  // 8 bytes — encodes material+mesh for opaque, depth for transparent
     uint32_t entity;    // 4 bytes — raw entity id
-    uint32_t batch_key; // 4 bytes — state compatibility (same material+mesh = same key)
+    uint32_t batch_key; // 4 bytes — renderer-defined compatibility token
 } nt_render_item_t;     // 16 bytes, naturally aligned
 ```
 
-**batch_key vs sort_key:** sort_key controls draw order (can be anything: material, depth, layer). batch_key controls instancing compatibility (same material+mesh). These are independent — depth-sorted items still batch by material+mesh.
+**batch_key vs sort_key:** `sort_key` controls draw order and is pass-defined.
+`batch_key` identifies compatibility as defined by the renderer consuming the
+item. The two policies are independent: a depth/layer key may control order
+while the renderer's token identifies reusable state.
 
 **Why no inline world_matrix:** Instance packing reads world_matrix + color from component arrays via entity lookup (scattered access). Inlining them in the render item (96B) would make packing sequential, and a wider element costs proportionally more per sort pass. `nt_sort_by_key` is already the typed radix sort (`engine/render/nt_render_items.h`), so the remaining lever at 10K+ is an indirect sort over indices.
 
@@ -69,19 +72,51 @@ Sort key determines item order in the final draw sequence for a pass. It is pass
 
 ### Batch key / run detection
 
-`batch_key` encodes state compatibility (same material+mesh = same key). `sort_key` controls draw order. These are independent concerns — sort order can be anything (material, depth, layer) without affecting batch detection.
-
-Game fills `batch_key` via `nt_batch_key(material_id, mesh_id)`. Renderer compares consecutive batch_keys to detect instancing runs:
+The game fills `batch_key` through the helper owned by the concrete renderer.
+Renderers compare consecutive tokens to detect runs:
 
 ```c
 while (run_end < count && items[run_end].batch_key == items[run_start].batch_key) run_end++;
 ```
+
+Equality is authoritative: it allows the renderer to reuse state resolved from
+the run leader. Equal tokens for incompatible state violate the caller
+contract and may draw with the wrong state. Unequal tokens are always safe but
+may split compatible work. A game may therefore force a stronger boundary, but
+must not invent a weaker compatibility rule than the renderer helper.
+
+`nt_mesh_renderer_batch_key(material, mesh)` packs the two 16-bit pool slot
+indices as `material_slot << 16 | mesh_slot`. This is exact for simultaneously
+live handles without widening the render item. Generation bits are omitted
+because the list has a bounded lifetime: each key is built from the current
+material and mesh bindings of that same `item.entity`; until
+`nt_mesh_renderer_draw_list()` returns, the entity and required components stay
+alive, neither binding changes, and neither referenced live resource is
+destroyed or has its slot reused.
+
+`nt_sprite_renderer_batch_key(material)` returns material identity. The same
+entity/component/material lifetime rule applies through
+`nt_sprite_renderer_draw_list()`. SpriteRenderer separately resolves and checks
+the actual atlas page while emitting, so a page change inside one material run
+is supported and splits the command stream. Transform and drawable color may
+change after item construction because neither renderer's key encodes them.
 
 ## Sorting Policy
 
 ### Sort policy is pass-controlled
 
 The game decides sort mode for each pass. Typical modes: sort by material/state, sort by depth, no sort, custom order + tie-break.
+
+`nt_sort_by_key(items, count, scratch)` sorts ascending and stably by
+`sort_key` only. It deliberately ignores `batch_key`, so equal primary keys
+preserve the game's input order.
+
+`nt_sort_by_key_then_batch(items, count, scratch)` is the opt-in stable
+lexicographic policy: `sort_key` is primary and `batch_key` is secondary. It is
+useful when the primary key deliberately creates coarse ties and reordering
+inside a tie is permitted. Do not use it for transparent, UI, or other passes
+whose equal-key input order is semantically significant. Both functions use
+caller-provided separate scratch storage and allocate no heap memory.
 
 ### Depth sorting
 
@@ -118,8 +153,9 @@ WebGL 2 provides native `drawArraysInstanced` / `drawElementsInstanced` — no e
 Sprite renderer: gather sorted sprite render items, resolve component SoA views
 once, pack sprite vertices into one dynamic vertex buffer per flush chunk, and
 draw recorded commands. The renderer owns atlas page correctness: `batch_key`
-is a compatibility hint from the game, while SpriteRenderer verifies actual
-atlas page textures and splits commands when a run crosses pages.
+is the renderer-defined material compatibility token, while SpriteRenderer
+verifies actual atlas page textures and splits commands when a run crosses
+pages.
 
 Rect and polygon sprites use the same generic dynamic IBO path. The renderer
 does not keep a separate static-quad fast path unless measurements show a clear

--- a/docs/spec/render/items-sorting-batching.md
+++ b/docs/spec/render/items-sorting-batching.md
@@ -81,9 +81,9 @@ while (run_end < count && items[run_end].batch_key == items[run_start].batch_key
 
 Equality is authoritative: it allows the renderer to reuse state resolved from
 the run leader. Equal tokens for incompatible state violate the caller
-contract and may draw with the wrong state. Unequal tokens are always safe but
-may split compatible work. A game may therefore force a stronger boundary, but
-must not invent a weaker compatibility rule than the renderer helper.
+contract and may draw with the wrong state. Store renderer-helper tokens
+unchanged. To force a boundary between otherwise compatible items, split them
+across separate `draw_list()` calls.
 
 `nt_mesh_renderer_batch_key(material, mesh)` packs the two 16-bit pool slot
 indices as `material_slot << 16 | mesh_slot`. This is exact for simultaneously

--- a/docs/spec/render/render-components.md
+++ b/docs/spec/render/render-components.md
@@ -56,8 +56,8 @@ module behind the handle is described in [Material System](material.md).
 
 The sprite component is a SoA module — there is no monolithic `SpriteComponent`
 struct. Each sprite-bearing entity contributes one row across parallel dense
-arrays (atlas handle, region hash, cached region index, cached atlas revision,
-effective origin, flag bits). The module owns those arrays directly and
+arrays (atlas handle, region hash, cached resolved region data, cached atlas
+revision, effective origin, flag bits). The module owns those arrays directly and
 exposes them via per-entity accessors and a bulk view (see header
 `engine/sprite_comp/nt_sprite_comp.h` for the full API).
 
@@ -69,6 +69,8 @@ That pair survives atlas republish, hot reload, and region renumbering.
 The runtime additionally caches:
 
 - **Resolved region index** — `uint16_t` index into the atlas region table.
+- **Resolved region data** — atlas geometry pointers and the actual page
+  resource used by the renderer and its batch key.
 - **Atlas revision snapshot** — `uint32_t`, used to detect republish.
 - **Effective origin** — `float[2]`, either authored from the region or
   overridden by the game.

--- a/docs/spec/render/render-components.md
+++ b/docs/spec/render/render-components.md
@@ -100,11 +100,10 @@ Two ways to bind a sprite to a region, picked by what the game knows:
   moves; a dead region simply zero-draws.
 
 Game code is free to read back the cached region index for animation logic
-(e.g. cycle to the next frame). It is stable across atlas republish for
-surviving regions;
-the only failure mode — tombstoning — is observable via
-`is_resolved()`
-    .
+(e.g. cycle to the next frame). It is stable across atlas republish. A removed
+region remains `RESOLVED` at its tombstoned index so it can revive in place;
+`nt_sprite_resolved_region_has_geometry()` distinguishes it from a drawable
+resolved region.
 
 ### Origin override and flip
 
@@ -141,7 +140,7 @@ Resolution is explicit, not renderer-driven magic:
 - sync iterates dense sprite rows when the resource publication epoch
   advanced or any sprite was bound by hash since the last call; per-row
   early-out via cached atlas revision keeps stable frames cheap
-- sprite render-item build skips unresolved sprites
+- sprite render-item build skips unresolved sprites and resolved tombstones
 
 ### Bulk iteration
 

--- a/docs/spec/render/render-components.md
+++ b/docs/spec/render/render-components.md
@@ -97,13 +97,13 @@ Two ways to bind a sprite to a region, picked by what the game knows:
   atlas merge contract guarantees every region ever present keeps the same
   index for the atlas lifetime — removed regions are marked dead in place but
   keep their index and revive there if re-added — so the cached index never
-  moves; a dead region simply zero-draws.
+  moves; a dead region has zero geometry and no page resource.
 
 Game code is free to read back the cached region index for animation logic
 (e.g. cycle to the next frame). It is stable across atlas republish. A removed
 region remains `RESOLVED` at its tombstoned index so it can revive in place;
-`nt_sprite_resolved_region_has_geometry()` distinguishes it from a drawable
-resolved region.
+game-side render-item construction excludes it by checking
+`resolved.region->vertex_count != 0`.
 
 ### Origin override and flip
 

--- a/engine/render/nt_render_defs.h
+++ b/engine/render/nt_render_defs.h
@@ -42,7 +42,7 @@ _Static_assert(NT_COLOR_MODE_FLOAT4 == 2, "update s_instance_layouts if enum gro
 typedef struct {
     uint64_t sort_key;
     uint32_t entity;    /* raw entity id (not nt_entity_t) */
-    uint32_t batch_key; /* state compatibility: same material+mesh = same key, game fills this */
+    uint32_t batch_key; /* renderer-defined compatibility token, game fills this */
 } nt_render_item_t;
 
 _Static_assert(sizeof(nt_render_item_t) == 16, "render item must be 16 bytes");

--- a/engine/render/nt_render_items.c
+++ b/engine/render/nt_render_items.c
@@ -7,6 +7,7 @@
 
 /* ---- Instantiate typed radix sort for render items ---- */
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) -- generated radix sort includes assert expansion
 NT_SORT_DEFINE(nt_sort_by_key, nt_render_item_t)
 
 static void sort_by_batch_key(nt_render_item_t *items, uint32_t count, nt_render_item_t *scratch) {

--- a/engine/render/nt_render_items.c
+++ b/engine/render/nt_render_items.c
@@ -1,4 +1,5 @@
 #include "render/nt_render_items.h"
+#include "core/nt_assert.h"
 
 #include "entity/nt_entity.h"
 #include "sort/nt_sort.h"
@@ -7,6 +8,79 @@
 /* ---- Instantiate typed radix sort for render items ---- */
 
 NT_SORT_DEFINE(nt_sort_by_key, nt_render_item_t)
+
+static void sort_by_batch_key(nt_render_item_t *items, uint32_t count, nt_render_item_t *scratch) {
+    uint32_t histograms[4][256] = {{0}};
+    for (uint32_t i = 0; i < count; ++i) {
+        uint32_t key = items[i].batch_key;
+        ++histograms[0][(uint8_t)key];
+        ++histograms[1][(uint8_t)(key >> 8)];
+        ++histograms[2][(uint8_t)(key >> 16)];
+        ++histograms[3][(uint8_t)(key >> 24)];
+    }
+
+    bool active[4];
+    uint32_t active_count = 0;
+    for (uint32_t pass = 0; pass < 4; ++pass) {
+        active[pass] = true;
+        for (uint32_t bucket = 0; bucket < 256; ++bucket) {
+            if (histograms[pass][bucket] == count) {
+                active[pass] = false;
+                break;
+            }
+        }
+        if (active[pass]) {
+            ++active_count;
+        }
+    }
+    if (active_count == 0) {
+        return;
+    }
+
+    nt_render_item_t *src = items;
+    nt_render_item_t *dst = scratch;
+    if ((active_count & 1U) != 0) {
+        memcpy(scratch, items, (size_t)count * sizeof(*items));
+        src = scratch;
+        dst = items;
+    }
+
+    for (uint32_t pass = 0; pass < 4; ++pass) {
+        if (!active[pass]) {
+            continue;
+        }
+
+        uint32_t *histogram = histograms[pass];
+        uint32_t sum = 0;
+        for (uint32_t bucket = 0; bucket < 256; ++bucket) {
+            uint32_t bucket_count = histogram[bucket];
+            histogram[bucket] = sum;
+            sum += bucket_count;
+        }
+
+        uint32_t shift = pass * 8;
+        for (uint32_t i = 0; i < count; ++i) {
+            uint8_t digit = (uint8_t)(src[i].batch_key >> shift);
+            dst[histogram[digit]++] = src[i];
+        }
+
+        nt_render_item_t *tmp = src;
+        src = dst;
+        dst = tmp;
+    }
+}
+
+void nt_sort_by_key_then_batch(nt_render_item_t *items, uint32_t count, nt_render_item_t *scratch) {
+    if (count < 2) {
+        return;
+    }
+    NT_ASSERT(items != NULL);
+    NT_ASSERT(scratch != NULL);
+    NT_ASSERT(items != scratch);
+
+    sort_by_batch_key(items, count, scratch);
+    nt_sort_by_key(items, count, scratch);
+}
 
 /* ---- View depth calculation ---- */
 

--- a/engine/render/nt_render_items.h
+++ b/engine/render/nt_render_items.h
@@ -16,6 +16,12 @@
  */
 void nt_sort_by_key(nt_render_item_t *items, uint32_t count, nt_render_item_t *scratch);
 
+/**
+ * Sort render items by (sort_key, batch_key), ascending and stable.
+ * Uses the same separate-scratch contract as nt_sort_by_key().
+ */
+void nt_sort_by_key_then_batch(nt_render_item_t *items, uint32_t count, nt_render_item_t *scratch);
+
 /* ---- Sort key helpers (inline, no component knowledge) ---- */
 
 static inline uint64_t nt_sort_key_opaque(uint32_t material_id, uint32_t mesh_id) { return ((uint64_t)material_id << 32) | (uint64_t)mesh_id; }
@@ -47,10 +53,6 @@ static inline uint64_t nt_sort_key_z(float z) {
     }
     return (uint64_t)bits << 32;
 }
-
-/* ---- Batch key helper (material+mesh → state compatibility) ---- */
-
-static inline uint32_t nt_batch_key(uint32_t material_id, uint32_t mesh_id) { return (material_id * 0x9E3779B9U) ^ mesh_id; }
 
 /* ---- Declared functions (implemented in nt_render_items.c) ---- */
 

--- a/engine/render/nt_render_items.h
+++ b/engine/render/nt_render_items.h
@@ -4,7 +4,6 @@
 #include <string.h>
 
 #include "render/nt_render_defs.h"
-#include "sort/nt_sort.h"
 
 /* ---- Sort (typed radix sort for render items, defined in nt_render_items.c) ---- */
 

--- a/engine/renderers/nt_mesh_renderer.c
+++ b/engine/renderers/nt_mesh_renderer.c
@@ -341,6 +341,7 @@ void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count) {
     if (!s_mesh_renderer.initialized || count == 0) {
         return;
     }
+    NT_ASSERT(items != NULL);
 
     /* Reset per-frame tracking */
     s_mesh_renderer.frame_draw_calls = 0;

--- a/engine/renderers/nt_mesh_renderer.h
+++ b/engine/renderers/nt_mesh_renderer.h
@@ -1,9 +1,24 @@
 #ifndef NT_MESH_RENDERER_H
 #define NT_MESH_RENDERER_H
 
+#include "core/nt_assert.h"
 #include "core/nt_types.h"
 #include "graphics/nt_gfx.h"
+#include "material/nt_material.h"
+#include "pool/nt_pool.h"
 #include "render/nt_render_defs.h"
+
+_Static_assert(NT_POOL_SLOT_SHIFT == 16 && NT_POOL_SLOT_MASK == UINT16_MAX, "mesh batch key requires 16-bit pool slots");
+
+/* Handles must match the item's current bindings and stay live and unrebound
+ * until draw_list returns. Packing is exact for simultaneously live slots. */
+static inline uint32_t nt_mesh_renderer_batch_key(nt_material_t material, nt_mesh_t mesh) {
+    uint32_t material_slot = nt_pool_slot_index(material.id);
+    uint32_t mesh_slot = nt_pool_slot_index(mesh.id);
+    NT_ASSERT(material_slot != 0);
+    NT_ASSERT(mesh_slot != 0);
+    return (material_slot << NT_POOL_SLOT_SHIFT) | mesh_slot;
+}
 
 typedef struct {
     uint16_t max_instances; /* max per single instanced draw call, default: 4096 */
@@ -21,6 +36,8 @@ void nt_mesh_renderer_restore_gpu(void);
  * flag, color alpha, or entity-enabled state. Use nt_render_is_visible()
  * (engine/render/nt_render_util.h) as the canonical filter when building
  * the items array. */
+/* batch_key must come from each item's current material/mesh bindings. Entities,
+ * bindings, and referenced resources stay live and unchanged through this call. */
 void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count);
 
 // #region test_access

--- a/engine/renderers/nt_mesh_renderer.h
+++ b/engine/renderers/nt_mesh_renderer.h
@@ -38,6 +38,7 @@ void nt_mesh_renderer_restore_gpu(void);
  * the items array. */
 /* batch_key must come from each item's current material/mesh bindings. Entities,
  * bindings, and referenced resources stay live and unchanged through this call. */
+/* items may be NULL only when count is 0; otherwise it is borrowed for the call. */
 void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count);
 
 // #region test_access

--- a/engine/renderers/nt_mesh_renderer.h
+++ b/engine/renderers/nt_mesh_renderer.h
@@ -11,7 +11,8 @@
 _Static_assert(NT_POOL_SLOT_SHIFT == 16 && NT_POOL_SLOT_MASK == UINT16_MAX, "mesh batch key requires 16-bit pool slots");
 
 /* Handles must match the item's current bindings and stay live and unrebound
- * until draw_list returns. Packing is exact for simultaneously live slots. */
+ * until draw_list returns. Store the returned token unchanged; use separate
+ * draw_list calls for an explicit boundary. */
 static inline uint32_t nt_mesh_renderer_batch_key(nt_material_t material, nt_mesh_t mesh) {
     uint32_t material_slot = nt_pool_slot_index(material.id);
     uint32_t mesh_slot = nt_pool_slot_index(mesh.id);

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -651,7 +651,7 @@ static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *
 
     nt_resource_t atlas = sv->atlas[s_idx];
     const nt_sprite_resolved_region_t *resolved = &sv->resolved[s_idx];
-    if ((sv->flags[s_idx] & NT_SPRITE_FLAG_RESOLVED) == 0 || resolved->region == NULL || resolved->region->vertex_count == 0) {
+    if ((sv->flags[s_idx] & NT_SPRITE_FLAG_RESOLVED) == 0 || !nt_sprite_resolved_region_has_geometry(resolved)) {
         return; /* tombstone */
     }
     const nt_texture_region_t *r = resolved->region;

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -1246,6 +1246,7 @@ void nt_sprite_renderer_draw_list(const nt_render_item_t *items, uint32_t count)
     if (count == 0) {
         return;
     }
+    NT_ASSERT(items != NULL);
 
     s_sprite.last_draw_list_calls = 0;
     s_sprite.cur_custom_bytes = 0; /* ECS sprite path emits no custom attrs */

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -651,14 +651,14 @@ static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *
 
     nt_resource_t atlas = sv->atlas[s_idx];
     const nt_sprite_resolved_region_t *resolved = &sv->resolved[s_idx];
-    if ((sv->flags[s_idx] & NT_SPRITE_FLAG_RESOLVED) == 0 || !nt_sprite_resolved_region_has_geometry(resolved)) {
-        return; /* tombstone */
-    }
+    uint8_t flags = sv->flags[s_idx];
+    NT_ASSERT((flags & NT_SPRITE_FLAG_RESOLVED) != 0 && "sprite render item: sprite is unresolved");
+    NT_ASSERT(resolved->region != NULL && "sprite render item: resolved region is NULL");
+    NT_ASSERT(resolved->region->vertex_count != 0 && "sprite render item: region is tombstoned");
     const nt_texture_region_t *r = resolved->region;
     NT_ASSERT(resolved->cached_pos != NULL && resolved->raw_vertices != NULL && resolved->indices != NULL);
     uint32_t page_tex = nt_resource_get(resolved->page_resource);
 
-    uint8_t flags = sv->flags[s_idx];
     const float origin_x = (flags & NT_SPRITE_FLAG_ORIGIN_OV) ? sv->origin[s_idx][0] : r->origin_x;
     const float origin_y = (flags & NT_SPRITE_FLAG_ORIGIN_OV) ? sv->origin[s_idx][1] : r->origin_y;
     const uint8_t flip_bits = flags & (NT_SPRITE_FLAG_FLIP_X | NT_SPRITE_FLAG_FLIP_Y);

--- a/engine/renderers/nt_sprite_renderer.h
+++ b/engine/renderers/nt_sprite_renderer.h
@@ -4,8 +4,11 @@
 #include "core/nt_assert.h"
 #include "core/nt_types.h"
 #include "material/nt_material.h"
+#include "pool/nt_pool.h"
 #include "render/nt_render_defs.h"
 #include "resource/nt_resource.h"
+
+_Static_assert(NT_POOL_SLOT_SHIFT == 16 && NT_POOL_SLOT_MASK == UINT16_MAX, "sprite batch key requires 16-bit material slots");
 
 /* Staging buffers for one flush. uint16 indices cap MAX_VERTICES at 65536.
  * Default index ratio (9/4) sized for 8-vertex polygon worst case (18 idx /
@@ -67,11 +70,14 @@ static inline nt_sprite_renderer_desc_t nt_sprite_renderer_desc_defaults(void) {
     };
 }
 
-/* Material must match the item's current binding and stay live and unrebound
- * until draw_list returns. Atlas page compatibility is checked while emitting. */
-static inline uint32_t nt_sprite_renderer_batch_key(nt_material_t material) {
-    NT_ASSERT(material.id != 0);
-    return material.id;
+/* Handles must match the item's current bindings and stay live and unrebound
+ * until draw_list returns. Packing is exact for simultaneously live slots. */
+static inline uint32_t nt_sprite_renderer_batch_key(nt_material_t material, nt_resource_t page_resource) {
+    uint32_t material_slot = nt_pool_slot_index(material.id);
+    uint32_t page_slot = nt_resource_slot_index(page_resource);
+    NT_ASSERT(material_slot != 0);
+    NT_ASSERT(page_slot != 0);
+    return (material_slot << NT_POOL_SLOT_SHIFT) | page_slot;
 }
 
 /* ---- Lifecycle ---- */

--- a/engine/renderers/nt_sprite_renderer.h
+++ b/engine/renderers/nt_sprite_renderer.h
@@ -70,8 +70,8 @@ static inline nt_sprite_renderer_desc_t nt_sprite_renderer_desc_defaults(void) {
     };
 }
 
-/* Handles must match the item's current bindings and stay live and unrebound
- * until draw_list returns. Packing is exact for simultaneously live slots. */
+/* Only RESOLVED, non-tombstoned sprites have a page_resource. Handles must
+ * match current bindings and stay live and unrebound until draw_list returns. */
 static inline uint32_t nt_sprite_renderer_batch_key(nt_material_t material, nt_resource_t page_resource) {
     uint32_t material_slot = nt_pool_slot_index(material.id);
     uint32_t page_slot = nt_resource_slot_index(page_resource);
@@ -88,7 +88,8 @@ void nt_sprite_renderer_restore_gpu(void);
 
 /* Contracts:
  *   1. Atlas page texture binds to slot 0; material may override sampler.
- *   2. Caller pre-filters items by visibility; renderer draws every entry.
+ *   2. Caller pre-filters invisible, unresolved, and tombstoned sprites;
+ *      renderer draws every entry.
  *   3. Frame UBOs (e.g. view_proj) are shader-specific — register and bind
  *      them before draw_list; renderer does not touch UBOs.
  *   4. Entities, required components, and material bindings stay live and

--- a/engine/renderers/nt_sprite_renderer.h
+++ b/engine/renderers/nt_sprite_renderer.h
@@ -87,6 +87,7 @@ void nt_sprite_renderer_restore_gpu(void);
  *      them before draw_list; renderer does not touch UBOs.
  *   4. Entities, required components, and material bindings stay live and
  *      unchanged through draw_list. */
+/* items may be NULL only when count is 0; otherwise it is borrowed for the call. */
 void nt_sprite_renderer_draw_list(const nt_render_item_t *items, uint32_t count);
 
 /* INVARIANT for mid-frame callers: flush resets cmd_count to 0 and clears

--- a/engine/renderers/nt_sprite_renderer.h
+++ b/engine/renderers/nt_sprite_renderer.h
@@ -1,6 +1,7 @@
 #ifndef NT_SPRITE_RENDERER_H
 #define NT_SPRITE_RENDERER_H
 
+#include "core/nt_assert.h"
 #include "core/nt_types.h"
 #include "material/nt_material.h"
 #include "render/nt_render_defs.h"
@@ -66,6 +67,13 @@ static inline nt_sprite_renderer_desc_t nt_sprite_renderer_desc_defaults(void) {
     };
 }
 
+/* Material must match the item's current binding and stay live and unrebound
+ * until draw_list returns. Atlas page compatibility is checked while emitting. */
+static inline uint32_t nt_sprite_renderer_batch_key(nt_material_t material) {
+    NT_ASSERT(material.id != 0);
+    return material.id;
+}
+
 /* ---- Lifecycle ---- */
 
 nt_result_t nt_sprite_renderer_init(const nt_sprite_renderer_desc_t *desc);
@@ -76,7 +84,9 @@ void nt_sprite_renderer_restore_gpu(void);
  *   1. Atlas page texture binds to slot 0; material may override sampler.
  *   2. Caller pre-filters items by visibility; renderer draws every entry.
  *   3. Frame UBOs (e.g. view_proj) are shader-specific — register and bind
- *      them before draw_list; renderer does not touch UBOs. */
+ *      them before draw_list; renderer does not touch UBOs.
+ *   4. Entities, required components, and material bindings stay live and
+ *      unchanged through draw_list. */
 void nt_sprite_renderer_draw_list(const nt_render_item_t *items, uint32_t count);
 
 /* INVARIANT for mid-frame callers: flush resets cmd_count to 0 and clears

--- a/engine/renderers/nt_sprite_renderer.h
+++ b/engine/renderers/nt_sprite_renderer.h
@@ -71,7 +71,8 @@ static inline nt_sprite_renderer_desc_t nt_sprite_renderer_desc_defaults(void) {
 }
 
 /* Only RESOLVED, non-tombstoned sprites have a page_resource. Handles must
- * match current bindings and stay live and unrebound until draw_list returns. */
+ * match current bindings and stay live and unrebound until draw_list returns.
+ * Store the returned token unchanged; separate draw_list calls form barriers. */
 static inline uint32_t nt_sprite_renderer_batch_key(nt_material_t material, nt_resource_t page_resource) {
     uint32_t material_slot = nt_pool_slot_index(material.id);
     uint32_t page_slot = nt_resource_slot_index(page_resource);

--- a/engine/resource/nt_resource.h
+++ b/engine/resource/nt_resource.h
@@ -210,6 +210,8 @@ void nt_resource_set_blob_policy(nt_hash32_t pack_id, uint8_t policy, uint32_t t
 
 /* ---- Context loss recovery ---- */
 
+/* Invalidates non-virtual assets of one type for later reactivation. On
+ * context_restored, discard earlier render state and wait for a later resource_step. */
 void nt_resource_invalidate(uint8_t asset_type);
 
 /* ---- Debug: dump loaded pack contents to log ---- */

--- a/engine/sprite_comp/nt_sprite_comp.h
+++ b/engine/sprite_comp/nt_sprite_comp.h
@@ -95,9 +95,6 @@ typedef struct {
     nt_resource_t page_resource;
 } nt_sprite_resolved_region_t;
 
-/* RESOLVED tombstones keep their stable region index but have no geometry. */
-static inline bool nt_sprite_resolved_region_has_geometry(const nt_sprite_resolved_region_t *resolved) { return resolved != NULL && resolved->region != NULL && resolved->region->vertex_count != 0; }
-
 /* Bulk SoA view — pointers stable for module lifetime; values shift on add/remove.
  * Reads of region_index/origin/resolved require flags[i] & RESOLVED. */
 

--- a/engine/sprite_comp/nt_sprite_comp.h
+++ b/engine/sprite_comp/nt_sprite_comp.h
@@ -95,6 +95,9 @@ typedef struct {
     nt_resource_t page_resource;
 } nt_sprite_resolved_region_t;
 
+/* RESOLVED tombstones keep their stable region index but have no geometry. */
+static inline bool nt_sprite_resolved_region_has_geometry(const nt_sprite_resolved_region_t *resolved) { return resolved != NULL && resolved->region != NULL && resolved->region->vertex_count != 0; }
+
 /* Bulk SoA view — pointers stable for module lifetime; values shift on add/remove.
  * Reads of region_index/origin/resolved require flags[i] & RESOLVED. */
 

--- a/examples/atlas/main.c
+++ b/examples/atlas/main.c
@@ -171,13 +171,13 @@ static void frame(void) {
         nt_gfx_update_buffer(s_frame_ubo, 0, &uniforms, sizeof(uniforms));
         nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
 
-        uint32_t mesh_id = nt_resource_get(s_mesh_handle);
-        *nt_mesh_comp_handle(s_cube) = (nt_mesh_t){.id = mesh_id};
+        nt_mesh_t mesh = {.id = nt_resource_get(s_mesh_handle)};
+        *nt_mesh_comp_handle(s_cube) = mesh;
 
         nt_render_item_t items[1];
-        items[0].sort_key = nt_sort_key_opaque(s_material.id, mesh_id);
+        items[0].sort_key = nt_sort_key_opaque(s_material.id, mesh.id);
         items[0].entity = s_cube.id;
-        items[0].batch_key = nt_batch_key(s_material.id, mesh_id);
+        items[0].batch_key = nt_mesh_renderer_batch_key(s_material, mesh);
 
         nt_sort_by_key(items, 1, s_sort_scratch);
         nt_mesh_renderer_draw_list(items, 1);

--- a/examples/atlas/main.c
+++ b/examples/atlas/main.c
@@ -56,6 +56,20 @@ static const uint8_t s_checker_4x4[4 * 4 * 4] = {
 static nt_texture_t s_fallback_texture;
 static nt_buffer_t s_frame_ubo;
 
+static nt_texture_t make_fallback_texture(void) {
+    return nt_gfx_make_texture(&(nt_texture_desc_t){
+        .width = 4,
+        .height = 4,
+        .format = NT_TEXTURE_FORMAT_RGBA8,
+        .data = s_checker_4x4,
+        .min_filter = NT_FILTER_NEAREST,
+        .mag_filter = NT_FILTER_NEAREST,
+        .wrap_u = NT_WRAP_REPEAT,
+        .wrap_v = NT_WRAP_REPEAT,
+        .label = "fallback_checker",
+    });
+}
+
 /* ---- Resource handles ---- */
 
 static nt_hash32_t s_pack_id;
@@ -150,12 +164,16 @@ static void frame(void) {
     nt_gfx_begin_frame();
 
     if (g_nt_gfx.context_restored) {
+        can_render = false;
         nt_resource_invalidate(NT_ASSET_SHADER_CODE);
         nt_resource_invalidate(NT_ASSET_MESH);
         nt_resource_invalidate(NT_ASSET_TEXTURE);
 
+        nt_gfx_destroy_texture(s_fallback_texture);
+        s_fallback_texture = make_fallback_texture();
         nt_resource_register(nt_hash32_str("__fallback__"), nt_hash64_str("__fallback_checker__"), NT_ASSET_TEXTURE, s_fallback_texture.id);
 
+        nt_gfx_destroy_buffer(s_frame_ubo);
         s_frame_ubo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
             .type = NT_BUFFER_UNIFORM,
             .usage = NT_USAGE_DYNAMIC,
@@ -275,17 +293,7 @@ int main(void) {
     });
 
     /* Fallback checkerboard */
-    s_fallback_texture = nt_gfx_make_texture(&(nt_texture_desc_t){
-        .width = 4,
-        .height = 4,
-        .format = NT_TEXTURE_FORMAT_RGBA8,
-        .data = s_checker_4x4,
-        .min_filter = NT_FILTER_NEAREST,
-        .mag_filter = NT_FILTER_NEAREST,
-        .wrap_u = NT_WRAP_REPEAT,
-        .wrap_v = NT_WRAP_REPEAT,
-        .label = "fallback_checker",
-    });
+    s_fallback_texture = make_fallback_texture();
     nt_hash64_t checker_rid = nt_hash64_str("__fallback_checker__");
     nt_hash32_t checker_pid = nt_hash32_str("__fallback__");
     nt_resource_create_pack(checker_pid, 0);

--- a/examples/bunnymark/main.c
+++ b/examples/bunnymark/main.c
@@ -422,14 +422,19 @@ static void frame(void) {
         nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
 
         // #region build draw list
-        uint32_t sprite_batch_key = nt_sprite_renderer_batch_key(s_sprite_material);
+        nt_sprite_comp_view_t sprites = nt_sprite_comp_view();
+        uint32_t item_count = 0;
         for (uint32_t i = 0; i < s_bunny_count; i++) {
-            s_items[i].sort_key = 0; /* unsorted in Bunnymark; renderer ignores */
-            s_items[i].entity = s_entities[i].id;
-            /* SpriteRenderer validates the actual atlas page while emitting. */
-            s_items[i].batch_key = sprite_batch_key;
+            uint16_t sprite_idx = sprites.sparse_indices[nt_entity_index(s_entities[i])];
+            if (sprite_idx == UINT16_MAX || (sprites.flags[sprite_idx] & NT_SPRITE_FLAG_RESOLVED) == 0) {
+                continue;
+            }
+            s_items[item_count].sort_key = 0; /* unsorted in Bunnymark; renderer ignores */
+            s_items[item_count].entity = s_entities[i].id;
+            s_items[item_count].batch_key = nt_sprite_renderer_batch_key(s_sprite_material, sprites.resolved[sprite_idx].page_resource);
+            item_count++;
         }
-        nt_sprite_renderer_draw_list(s_items, s_bunny_count);
+        nt_sprite_renderer_draw_list(s_items, item_count);
         // #endregion
     }
 

--- a/examples/bunnymark/main.c
+++ b/examples/bunnymark/main.c
@@ -426,12 +426,16 @@ static void frame(void) {
         uint32_t item_count = 0;
         for (uint32_t i = 0; i < s_bunny_count; i++) {
             uint16_t sprite_idx = sprites.sparse_indices[nt_entity_index(s_entities[i])];
-            if (sprite_idx == UINT16_MAX || (sprites.flags[sprite_idx] & NT_SPRITE_FLAG_RESOLVED) == 0 || !nt_sprite_resolved_region_has_geometry(&sprites.resolved[sprite_idx])) {
+            if (sprite_idx == UINT16_MAX || (sprites.flags[sprite_idx] & NT_SPRITE_FLAG_RESOLVED) == 0) {
+                continue;
+            }
+            const nt_sprite_resolved_region_t *resolved = &sprites.resolved[sprite_idx];
+            if (resolved->region->vertex_count == 0) {
                 continue;
             }
             s_items[item_count].sort_key = 0; /* unsorted in Bunnymark; renderer ignores */
             s_items[item_count].entity = s_entities[i].id;
-            s_items[item_count].batch_key = nt_sprite_renderer_batch_key(s_sprite_material, sprites.resolved[sprite_idx].page_resource);
+            s_items[item_count].batch_key = nt_sprite_renderer_batch_key(s_sprite_material, resolved->page_resource);
             item_count++;
         }
         nt_sprite_renderer_draw_list(s_items, item_count);

--- a/examples/bunnymark/main.c
+++ b/examples/bunnymark/main.c
@@ -425,11 +425,8 @@ static void frame(void) {
         for (uint32_t i = 0; i < s_bunny_count; i++) {
             s_items[i].sort_key = 0; /* unsorted in Bunnymark; renderer ignores */
             s_items[i].entity = s_entities[i].id;
-            /* Coarse compatibility hint. The sprite renderer validates the
-             * actual atlas page while emitting and splits draw commands when a
-             * run crosses page textures, so the game no longer does per-bunny
-             * atlas/resource lookups just to build this key. */
-            s_items[i].batch_key = s_sprite_material.id;
+            /* SpriteRenderer validates the actual atlas page while emitting. */
+            s_items[i].batch_key = nt_sprite_renderer_batch_key(s_sprite_material);
         }
         nt_sprite_renderer_draw_list(s_items, s_bunny_count);
         // #endregion

--- a/examples/bunnymark/main.c
+++ b/examples/bunnymark/main.c
@@ -422,11 +422,12 @@ static void frame(void) {
         nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
 
         // #region build draw list
+        uint32_t sprite_batch_key = nt_sprite_renderer_batch_key(s_sprite_material);
         for (uint32_t i = 0; i < s_bunny_count; i++) {
             s_items[i].sort_key = 0; /* unsorted in Bunnymark; renderer ignores */
             s_items[i].entity = s_entities[i].id;
             /* SpriteRenderer validates the actual atlas page while emitting. */
-            s_items[i].batch_key = nt_sprite_renderer_batch_key(s_sprite_material);
+            s_items[i].batch_key = sprite_batch_key;
         }
         nt_sprite_renderer_draw_list(s_items, s_bunny_count);
         // #endregion

--- a/examples/bunnymark/main.c
+++ b/examples/bunnymark/main.c
@@ -426,7 +426,7 @@ static void frame(void) {
         uint32_t item_count = 0;
         for (uint32_t i = 0; i < s_bunny_count; i++) {
             uint16_t sprite_idx = sprites.sparse_indices[nt_entity_index(s_entities[i])];
-            if (sprite_idx == UINT16_MAX || (sprites.flags[sprite_idx] & NT_SPRITE_FLAG_RESOLVED) == 0) {
+            if (sprite_idx == UINT16_MAX || (sprites.flags[sprite_idx] & NT_SPRITE_FLAG_RESOLVED) == 0 || !nt_sprite_resolved_region_has_geometry(&sprites.resolved[sprite_idx])) {
                 continue;
             }
             s_items[item_count].sort_key = 0; /* unsorted in Bunnymark; renderer ignores */

--- a/examples/sponza/main.c
+++ b/examples/sponza/main.c
@@ -523,12 +523,12 @@ static void frame(void) {
             }
 
             /* Update mesh component handle */
-            uint32_t mesh_id = nt_resource_get(s_mesh_handles[i]);
-            *nt_mesh_comp_handle(s_entities[i]) = (nt_mesh_t){.id = mesh_id};
+            nt_mesh_t mesh = {.id = nt_resource_get(s_mesh_handles[i])};
+            *nt_mesh_comp_handle(s_entities[i]) = mesh;
 
-            items[item_count].sort_key = nt_sort_key_opaque(s_materials[i].id, mesh_id);
+            items[item_count].sort_key = nt_sort_key_opaque(s_materials[i].id, mesh.id);
             items[item_count].entity = s_entities[i].id;
-            items[item_count].batch_key = nt_batch_key(s_materials[i].id, mesh_id);
+            items[item_count].batch_key = nt_mesh_renderer_batch_key(s_materials[i], mesh);
             item_count++;
         }
 

--- a/examples/sponza/main.c
+++ b/examples/sponza/main.c
@@ -547,16 +547,19 @@ static void frame(void) {
 
     /* Restore GPU resources after WebGL context loss */
     if (g_nt_gfx.context_restored) {
+        item_count = 0;
         nt_resource_invalidate(NT_ASSET_SHADER_CODE);
         nt_resource_invalidate(NT_ASSET_MESH);
         nt_resource_invalidate(NT_ASSET_TEXTURE);
 
+        nt_gfx_destroy_buffer(s_frame_ubo);
         s_frame_ubo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
             .type = NT_BUFFER_UNIFORM,
             .usage = NT_USAGE_DYNAMIC,
             .size = sizeof(nt_frame_uniforms_t),
             .label = "frame_uniforms",
         });
+        nt_gfx_destroy_buffer(s_light_ubo);
         s_light_ubo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
             .type = NT_BUFFER_UNIFORM,
             .usage = NT_USAGE_DYNAMIC,

--- a/examples/text/main.c
+++ b/examples/text/main.c
@@ -288,13 +288,16 @@ static void frame(void) {
 
     /* ---- Render ---- */
 
+    bool can_render = true;
     nt_gfx_begin_frame();
 
     /* Restore GPU resources after WebGL context loss */
     if (g_nt_gfx.context_restored) {
+        can_render = false;
         nt_resource_invalidate(NT_ASSET_SHADER_CODE);
         nt_resource_invalidate(NT_ASSET_FONT);
 
+        nt_gfx_destroy_buffer(s_frame_ubo);
         s_frame_ubo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
             .type = NT_BUFFER_UNIFORM,
             .usage = NT_USAGE_DYNAMIC,
@@ -309,32 +312,34 @@ static void frame(void) {
         .clear_depth = 1.0F,
     });
 
-    /* Upload and bind frame UBO (slot 0) */
-    nt_gfx_update_buffer(s_frame_ubo, 0, &uniforms, sizeof(uniforms));
-    nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
-
     /* Step font system -- resolves pending resources, uploads GPU data */
     double t_font_step = nt_time_now();
     nt_font_step();
     t_font_step = (nt_time_now() - t_font_step) * 1000.0;
 
-    /* Draw text */
-    nt_text_renderer_set_material(s_text_material);
-    nt_text_renderer_set_font(s_font);
+    double t_draw = 0.0;
+    double t_flush = 0.0;
+    if (can_render) {
+        nt_gfx_update_buffer(s_frame_ubo, 0, &uniforms, sizeof(uniforms));
+        nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
 
-    double t_draw = nt_time_now();
-    draw_text_scene();
-    t_draw = (nt_time_now() - t_draw) * 1000.0;
+        nt_text_renderer_set_material(s_text_material);
+        nt_text_renderer_set_font(s_font);
+
+        t_draw = nt_time_now();
+        draw_text_scene();
+        t_draw = (nt_time_now() - t_draw) * 1000.0;
+
+        t_flush = nt_time_now();
+        nt_text_renderer_flush();
+        t_flush = (nt_time_now() - t_flush) * 1000.0;
+    }
 
     /* Track resize for trackball skip */
     if (resized) {
         s_prev_fb_w = g_nt_window.fb_width;
         s_prev_fb_h = g_nt_window.fb_height;
     }
-
-    double t_flush = nt_time_now();
-    nt_text_renderer_flush();
-    t_flush = (nt_time_now() - t_flush) * 1000.0;
 
     nt_gfx_end_pass();
     nt_gfx_end_frame();

--- a/examples/textured_quad/main.c
+++ b/examples/textured_quad/main.c
@@ -309,7 +309,7 @@ static void frame(void) {
         nt_gfx_update_buffer(s_frame_ubo, 0, &uniforms, sizeof(uniforms));
         nt_gfx_bind_uniform_buffer(s_frame_ubo, 0);
 
-        uint32_t mesh_id = nt_resource_get(s_mesh_handle);
+        nt_mesh_t mesh = {.id = nt_resource_get(s_mesh_handle)};
 
         /* ---- Collect: build render items from entities ---- */
         nt_render_item_t items[NUM_CUBES];
@@ -317,11 +317,11 @@ static void frame(void) {
 
         for (int i = 0; i < NUM_CUBES; i++) {
             /* Update mesh handle (may change when resource resolves) */
-            *nt_mesh_comp_handle(s_cubes[i]) = (nt_mesh_t){.id = mesh_id};
+            *nt_mesh_comp_handle(s_cubes[i]) = mesh;
 
-            items[item_count].sort_key = nt_sort_key_opaque(s_cube_material.id, mesh_id);
+            items[item_count].sort_key = nt_sort_key_opaque(s_cube_material.id, mesh.id);
             items[item_count].entity = s_cubes[i].id;
-            items[item_count].batch_key = nt_batch_key(s_cube_material.id, mesh_id);
+            items[item_count].batch_key = nt_mesh_renderer_batch_key(s_cube_material, mesh);
             item_count++;
         }
 

--- a/examples/textured_quad/main.c
+++ b/examples/textured_quad/main.c
@@ -69,6 +69,20 @@ static const uint8_t s_checker_4x4[4 * 4 * 4] = {
 static nt_texture_t s_fallback_texture;
 static nt_buffer_t s_frame_ubo;
 
+static nt_texture_t make_fallback_texture(void) {
+    return nt_gfx_make_texture(&(nt_texture_desc_t){
+        .width = 4,
+        .height = 4,
+        .format = NT_TEXTURE_FORMAT_RGBA8,
+        .data = s_checker_4x4,
+        .min_filter = NT_FILTER_NEAREST,
+        .mag_filter = NT_FILTER_NEAREST,
+        .wrap_u = NT_WRAP_REPEAT,
+        .wrap_v = NT_WRAP_REPEAT,
+        .label = "fallback_checker",
+    });
+}
+
 /* ---- Resource handles ---- */
 
 static nt_hash32_t s_base_pack_id;
@@ -284,15 +298,19 @@ static void frame(void) {
 
     /* Restore GPU resources after WebGL context loss */
     if (g_nt_gfx.context_restored) {
+        can_render = false;
         /* Invalidate all GFX-backed resources so they re-activate from blobs */
         nt_resource_invalidate(NT_ASSET_SHADER_CODE);
         nt_resource_invalidate(NT_ASSET_MESH);
         nt_resource_invalidate(NT_ASSET_TEXTURE);
 
         /* Re-register virtual pack resources (invalidate skips virtual packs) */
+        nt_gfx_destroy_texture(s_fallback_texture);
+        s_fallback_texture = make_fallback_texture();
         nt_resource_register(nt_hash32_str("__fallback__"), nt_hash64_str("__fallback_checker__"), NT_ASSET_TEXTURE, s_fallback_texture.id);
 
         /* Recreate game-owned GPU resources */
+        nt_gfx_destroy_buffer(s_frame_ubo);
         s_frame_ubo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
             .type = NT_BUFFER_UNIFORM,
             .usage = NT_USAGE_DYNAMIC,
@@ -458,17 +476,7 @@ int main(void) {
     });
 
     /* Fallback checkerboard texture */
-    s_fallback_texture = nt_gfx_make_texture(&(nt_texture_desc_t){
-        .width = 4,
-        .height = 4,
-        .format = NT_TEXTURE_FORMAT_RGBA8,
-        .data = s_checker_4x4,
-        .min_filter = NT_FILTER_NEAREST,
-        .mag_filter = NT_FILTER_NEAREST,
-        .wrap_u = NT_WRAP_REPEAT,
-        .wrap_v = NT_WRAP_REPEAT,
-        .label = "fallback_checker",
-    });
+    s_fallback_texture = make_fallback_texture();
     nt_hash64_t checker_rid = nt_hash64_str("__fallback_checker__");
     nt_hash32_t checker_pid = nt_hash32_str("__fallback__");
     nt_resource_create_pack(checker_pid, 0);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -965,13 +965,14 @@ if(NOT EMSCRIPTEN)
     nt_setup_test_target(test_meshwire_stub_off)
 
     # --- Mesh renderer tests ---
-    add_executable(test_mesh_renderer unit/test_mesh_renderer.c)
+    add_executable(test_mesh_renderer unit/test_mesh_renderer.c unit/test_helpers/nt_assert_trap.c)
     target_link_libraries(test_mesh_renderer PRIVATE
         nt_mesh_renderer nt_render nt_gfx_stub nt_basisu_transcoder_stub
         nt_entity nt_transform_comp nt_mesh_comp nt_material_comp nt_drawable_comp
         nt_material nt_resource nt_hash nt_http_stub nt_fs_stub nt_log_stub unity
      nt_meshwire_stub)
     target_compile_definitions(test_mesh_renderer PRIVATE _CRT_SECURE_NO_WARNINGS)
+    target_include_directories(test_mesh_renderer PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/unit")
     nt_set_warning_flags(test_mesh_renderer)
     nt_set_sanitizer_flags(test_mesh_renderer)
     set_target_properties(test_mesh_renderer PROPERTIES
@@ -980,7 +981,7 @@ if(NOT EMSCRIPTEN)
     add_test(NAME test_mesh_renderer COMMAND test_mesh_renderer)
 
     # --- Sprite renderer tests ---
-    add_executable(test_sprite_renderer unit/test_sprite_renderer.c)
+    add_executable(test_sprite_renderer unit/test_sprite_renderer.c unit/test_helpers/nt_assert_trap.c)
     target_link_libraries(test_sprite_renderer PRIVATE
         nt_sprite_renderer nt_atlas nt_sprite_comp nt_transform_comp
         nt_drawable_comp nt_material_comp nt_material nt_render
@@ -989,6 +990,7 @@ if(NOT EMSCRIPTEN)
     target_compile_definitions(test_sprite_renderer PRIVATE
         _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE
     )
+    target_include_directories(test_sprite_renderer PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/unit")
     nt_setup_test_target(test_sprite_renderer)
 
     # test_ui_radial registers in the nt_ui walker-test group below: it needs the

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -375,8 +375,9 @@ if(NOT EMSCRIPTEN)
     add_test(NAME test_components COMMAND test_components)
 
     # --- Render items tests ---
-    add_executable(test_render_items unit/test_render_items.c)
+    add_executable(test_render_items unit/test_render_items.c unit/test_helpers/nt_assert_trap.c)
     target_link_libraries(test_render_items PRIVATE nt_render nt_entity nt_drawable_comp nt_transform_comp nt_hash nt_gfx_stub nt_basisu_transcoder_stub nt_log_stub unity nt_meshwire_stub)
+    target_include_directories(test_render_items PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/unit")
     nt_set_warning_flags(test_render_items)
     nt_set_sanitizer_flags(test_render_items)
     set_target_properties(test_render_items PROPERTIES

--- a/tests/unit/test_mesh_renderer.c
+++ b/tests/unit/test_mesh_renderer.c
@@ -17,6 +17,7 @@
 #include "render/nt_render_items.h"
 #include "render/nt_render_defs.h"
 #include "graphics/nt_gfx_internal.h"
+#include "test_helpers/nt_assert_trap.h"
 #include "nt_mesh_format.h"
 #include "nt_pack_format.h"
 #include "unity.h"
@@ -236,6 +237,8 @@ void test_draw_list_empty(void) {
     nt_mesh_renderer_draw_list(NULL, 0);
     TEST_ASSERT_EQUAL_UINT32(0, nt_mesh_renderer_test_draw_call_count());
 }
+
+void test_draw_list_null_items_asserts_when_nonempty(void) { NT_TEST_EXPECT_ASSERT(nt_mesh_renderer_draw_list(NULL, 1)); }
 
 void test_batch_key_packs_material_and_mesh_slots(void) {
     nt_material_t material = {.id = 0x00010001U};
@@ -706,6 +709,7 @@ int main(void) {
 
     RUN_TEST(test_init_shutdown);
     RUN_TEST(test_draw_list_empty);
+    RUN_TEST(test_draw_list_null_items_asserts_when_nonempty);
     RUN_TEST(test_batch_key_packs_material_and_mesh_slots);
     RUN_TEST(test_batch_key_ignores_generation_bits);
     RUN_TEST(test_batch_key_distinguishes_old_hash_collision);

--- a/tests/unit/test_mesh_renderer.c
+++ b/tests/unit/test_mesh_renderer.c
@@ -237,6 +237,40 @@ void test_draw_list_empty(void) {
     TEST_ASSERT_EQUAL_UINT32(0, nt_mesh_renderer_test_draw_call_count());
 }
 
+void test_batch_key_packs_material_and_mesh_slots(void) {
+    nt_material_t material = {.id = 0x00010001U};
+    nt_mesh_t mesh = {.id = 0x00020001U};
+
+    TEST_ASSERT_EQUAL_HEX32(0x00010001U, nt_mesh_renderer_batch_key(material, mesh));
+}
+
+void test_batch_key_ignores_generation_bits(void) {
+    nt_material_t material_a = {.id = 0x00010001U};
+    nt_material_t material_b = {.id = 0xABCD0001U};
+    nt_mesh_t mesh_a = {.id = 0x00020002U};
+    nt_mesh_t mesh_b = {.id = 0xDCBA0002U};
+
+    TEST_ASSERT_EQUAL_HEX32(nt_mesh_renderer_batch_key(material_a, mesh_a), nt_mesh_renderer_batch_key(material_b, mesh_b));
+}
+
+void test_batch_key_distinguishes_old_hash_collision(void) {
+    nt_material_t material_a = {.id = 0x00010001U};
+    nt_mesh_t mesh_a = {.id = 0x00020001U};
+    nt_material_t material_b = {.id = 0x002D00CDU};
+    nt_mesh_t mesh_b = {.id = 0x0003009DU};
+
+    TEST_ASSERT_EQUAL_HEX32(0x00010001U, nt_mesh_renderer_batch_key(material_a, mesh_a));
+    TEST_ASSERT_EQUAL_HEX32(0x00CD009DU, nt_mesh_renderer_batch_key(material_b, mesh_b));
+    TEST_ASSERT_NOT_EQUAL(nt_mesh_renderer_batch_key(material_a, mesh_a), nt_mesh_renderer_batch_key(material_b, mesh_b));
+}
+
+void test_batch_key_supports_max_slots(void) {
+    nt_material_t material = {.id = 0x1234FFFFU};
+    nt_mesh_t mesh = {.id = 0x5678FFFFU};
+
+    TEST_ASSERT_EQUAL_HEX32(UINT32_MAX, nt_mesh_renderer_batch_key(material, mesh));
+}
+
 /* ---- Test 3: single item produces 1 draw call ---- */
 
 void test_draw_list_single_item(void) {
@@ -247,7 +281,7 @@ void test_draw_list_single_item(void) {
     nt_render_item_t items[1];
     items[0].sort_key = 0;
     items[0].entity = e.id;
-    items[0].batch_key = nt_batch_key(mat.id, mesh.id);
+    items[0].batch_key = nt_mesh_renderer_batch_key(mat, mesh);
 
     nt_mesh_renderer_draw_list(items, 1);
 
@@ -267,7 +301,7 @@ void test_mesh_renderer_forwards_material_blend_state(void) {
     nt_mesh_t mesh = create_test_mesh();
     nt_material_t mat = create_test_material_with_blend(blend);
     nt_entity_t e = create_test_entity(mesh, mat);
-    nt_render_item_t item = {.entity = e.id, .batch_key = nt_batch_key(mat.id, mesh.id)};
+    nt_render_item_t item = {.entity = e.id, .batch_key = nt_mesh_renderer_batch_key(mat, mesh)};
 
     nt_mesh_renderer_draw_list(&item, 1);
 
@@ -286,7 +320,7 @@ void test_draw_list_same_material_mesh_batching(void) {
     nt_entity_t e1 = create_test_entity(mesh, mat);
     nt_entity_t e2 = create_test_entity(mesh, mat);
 
-    uint32_t bk = nt_batch_key(mat.id, mesh.id);
+    uint32_t bk = nt_mesh_renderer_batch_key(mat, mesh);
     nt_render_item_t items[3];
     items[0].sort_key = 0;
     items[0].entity = e0.id;
@@ -317,10 +351,10 @@ void test_draw_list_different_materials(void) {
     nt_render_item_t items[2];
     items[0].sort_key = 0;
     items[0].entity = e0.id;
-    items[0].batch_key = nt_batch_key(mat_a.id, mesh.id);
+    items[0].batch_key = nt_mesh_renderer_batch_key(mat_a, mesh);
     items[1].sort_key = 1;
     items[1].entity = e1.id;
-    items[1].batch_key = nt_batch_key(mat_b.id, mesh.id);
+    items[1].batch_key = nt_mesh_renderer_batch_key(mat_b, mesh);
 
     nt_mesh_renderer_draw_list(items, 2);
 
@@ -339,8 +373,8 @@ void test_draw_list_alternating_materials(void) {
     nt_entity_t e1 = create_test_entity(mesh, mat_b);
     nt_entity_t e2 = create_test_entity(mesh, mat_a);
 
-    uint32_t bk_a = nt_batch_key(mat_a.id, mesh.id);
-    uint32_t bk_b = nt_batch_key(mat_b.id, mesh.id);
+    uint32_t bk_a = nt_mesh_renderer_batch_key(mat_a, mesh);
+    uint32_t bk_b = nt_mesh_renderer_batch_key(mat_b, mesh);
     nt_render_item_t items[3];
     items[0].sort_key = 0;
     items[0].entity = e0.id;
@@ -367,7 +401,7 @@ void test_pipeline_cache_reuse(void) {
     nt_render_item_t items[1];
     items[0].sort_key = 0;
     items[0].entity = e.id;
-    items[0].batch_key = nt_batch_key(mat.id, mesh.id);
+    items[0].batch_key = nt_mesh_renderer_batch_key(mat, mesh);
 
     /* First draw_list call */
     nt_mesh_renderer_draw_list(items, 1);
@@ -391,10 +425,10 @@ void test_pipeline_cache_different_layouts(void) {
     nt_render_item_t items[2];
     items[0].sort_key = 0;
     items[0].entity = e0.id;
-    items[0].batch_key = nt_batch_key(mat_a.id, mesh.id);
+    items[0].batch_key = nt_mesh_renderer_batch_key(mat_a, mesh);
     items[1].sort_key = 1;
     items[1].entity = e1.id;
-    items[1].batch_key = nt_batch_key(mat_b.id, mesh.id);
+    items[1].batch_key = nt_mesh_renderer_batch_key(mat_b, mesh);
 
     nt_mesh_renderer_draw_list(items, 2);
 
@@ -409,8 +443,8 @@ void test_pipeline_cache_different_material_attr_maps(void) {
     nt_entity_t e0 = create_test_entity(mesh, mat_a);
     nt_entity_t e1 = create_test_entity(mesh, mat_b);
     nt_render_item_t items[2] = {
-        {.sort_key = 0, .entity = e0.id, .batch_key = nt_batch_key(mat_a.id, mesh.id)},
-        {.sort_key = 1, .entity = e1.id, .batch_key = nt_batch_key(mat_b.id, mesh.id)},
+        {.sort_key = 0, .entity = e0.id, .batch_key = nt_mesh_renderer_batch_key(mat_a, mesh)},
+        {.sort_key = 1, .entity = e1.id, .batch_key = nt_mesh_renderer_batch_key(mat_b, mesh)},
     };
 
     nt_mesh_renderer_draw_list(items, 2);
@@ -429,7 +463,7 @@ void test_restore_gpu(void) {
     nt_render_item_t items[1];
     items[0].sort_key = 0;
     items[0].entity = e.id;
-    items[0].batch_key = nt_batch_key(mat.id, mesh.id);
+    items[0].batch_key = nt_mesh_renderer_batch_key(mat, mesh);
 
     /* Draw to populate cache */
     nt_mesh_renderer_draw_list(items, 1);
@@ -477,7 +511,7 @@ void test_draw_list_color_mode_float4(void) {
     nt_render_item_t items[1];
     items[0].sort_key = 0;
     items[0].entity = e.id;
-    items[0].batch_key = nt_batch_key(mat.id, mesh.id);
+    items[0].batch_key = nt_mesh_renderer_batch_key(mat, mesh);
 
     nt_mesh_renderer_draw_list(items, 1);
 
@@ -495,7 +529,7 @@ void test_draw_list_color_mode_rgba8(void) {
     nt_render_item_t items[1];
     items[0].sort_key = 0;
     items[0].entity = e.id;
-    items[0].batch_key = nt_batch_key(mat.id, mesh.id);
+    items[0].batch_key = nt_mesh_renderer_batch_key(mat, mesh);
 
     nt_mesh_renderer_draw_list(items, 1);
 
@@ -516,10 +550,10 @@ void test_pipeline_cache_different_color_modes(void) {
     nt_render_item_t items[2];
     items[0].sort_key = 0;
     items[0].entity = e0.id;
-    items[0].batch_key = nt_batch_key(mat_none.id, mesh.id);
+    items[0].batch_key = nt_mesh_renderer_batch_key(mat_none, mesh);
     items[1].sort_key = 1;
     items[1].entity = e1.id;
-    items[1].batch_key = nt_batch_key(mat_float4.id, mesh.id);
+    items[1].batch_key = nt_mesh_renderer_batch_key(mat_float4, mesh);
 
     nt_mesh_renderer_draw_list(items, 2);
 
@@ -540,10 +574,10 @@ void test_draw_list_mixed_color_modes(void) {
     nt_render_item_t items[2];
     items[0].sort_key = 0;
     items[0].entity = e0.id;
-    items[0].batch_key = nt_batch_key(mat_none.id, mesh.id);
+    items[0].batch_key = nt_mesh_renderer_batch_key(mat_none, mesh);
     items[1].sort_key = 1;
     items[1].entity = e1.id;
-    items[1].batch_key = nt_batch_key(mat_float4.id, mesh.id);
+    items[1].batch_key = nt_mesh_renderer_batch_key(mat_float4, mesh);
 
     nt_mesh_renderer_draw_list(items, 2);
 
@@ -570,7 +604,7 @@ void test_draw_list_mixed_color_modes_multi_instance(void) {
         entities[idx] = create_test_entity(mesh, mat_none);
         items[idx].sort_key = idx;
         items[idx].entity = entities[idx].id;
-        items[idx].batch_key = nt_batch_key(mat_none.id, mesh.id);
+        items[idx].batch_key = nt_mesh_renderer_batch_key(mat_none, mesh);
         idx++;
     }
     /* Run 1: 3x RGBA8 (stride 56) */
@@ -578,7 +612,7 @@ void test_draw_list_mixed_color_modes_multi_instance(void) {
         entities[idx] = create_test_entity(mesh, mat_rgba8);
         items[idx].sort_key = idx;
         items[idx].entity = entities[idx].id;
-        items[idx].batch_key = nt_batch_key(mat_rgba8.id, mesh.id);
+        items[idx].batch_key = nt_mesh_renderer_batch_key(mat_rgba8, mesh);
         idx++;
     }
     /* Run 2: 3x FLOAT4 (stride 64) */
@@ -586,7 +620,7 @@ void test_draw_list_mixed_color_modes_multi_instance(void) {
         entities[idx] = create_test_entity(mesh, mat_float4);
         items[idx].sort_key = idx;
         items[idx].entity = entities[idx].id;
-        items[idx].batch_key = nt_batch_key(mat_float4.id, mesh.id);
+        items[idx].batch_key = nt_mesh_renderer_batch_key(mat_float4, mesh);
         idx++;
     }
 
@@ -618,7 +652,7 @@ void test_ring_cursor_advances_and_wraps(void) {
     nt_render_item_t items[1];
     items[0].sort_key = 0;
     items[0].entity = e.id;
-    items[0].batch_key = nt_batch_key(mat.id, mesh.id);
+    items[0].batch_key = nt_mesh_renderer_batch_key(mat, mesh);
 
     nt_mesh_renderer_draw_list(items, 1);
     uint32_t delta = nt_mesh_renderer_test_ring_cursor();
@@ -652,7 +686,7 @@ void test_ring_upload_and_draw_base_agree(void) {
     nt_render_item_t items[1];
     items[0].sort_key = 0;
     items[0].entity = e.id;
-    items[0].batch_key = nt_batch_key(mat.id, mesh.id);
+    items[0].batch_key = nt_mesh_renderer_batch_key(mat, mesh);
 
     nt_mesh_renderer_draw_list(items, 1);
     uint32_t upload1 = nt_gfx_stub_test_last_update_buffer_offset();
@@ -672,6 +706,10 @@ int main(void) {
 
     RUN_TEST(test_init_shutdown);
     RUN_TEST(test_draw_list_empty);
+    RUN_TEST(test_batch_key_packs_material_and_mesh_slots);
+    RUN_TEST(test_batch_key_ignores_generation_bits);
+    RUN_TEST(test_batch_key_distinguishes_old_hash_collision);
+    RUN_TEST(test_batch_key_supports_max_slots);
     RUN_TEST(test_draw_list_single_item);
     RUN_TEST(test_mesh_renderer_forwards_material_blend_state);
     RUN_TEST(test_draw_list_same_material_mesh_batching);

--- a/tests/unit/test_render_items.c
+++ b/tests/unit/test_render_items.c
@@ -1,4 +1,5 @@
 #include <math.h>
+#include <stdlib.h>
 
 #include "drawable_comp/nt_drawable_comp.h"
 #include "entity/nt_entity.h"
@@ -6,6 +7,7 @@
 #include "render/nt_render_defs.h"
 #include "render/nt_render_items.h"
 #include "render/nt_render_util.h"
+#include "test_helpers/nt_assert_trap.h"
 #include "transform_comp/nt_transform_comp.h"
 #include "unity.h"
 
@@ -104,6 +106,15 @@ void test_sort_by_key_single(void) {
     nt_render_item_t scratch[1];
     nt_sort_by_key(&item, 1, scratch);
     TEST_ASSERT_EQUAL_UINT64(42, item.sort_key);
+}
+
+void test_sort_by_key_asserts_when_scratch_aliases_items(void) {
+    nt_render_item_t items[2] = {
+        {.sort_key = 2, .entity = 1},
+        {.sort_key = 1, .entity = 2},
+    };
+
+    NT_TEST_EXPECT_ASSERT(nt_sort_by_key(items, 2, items));
 }
 
 void test_sort_by_key_ignores_batch_key(void) {
@@ -319,6 +330,7 @@ int main(void) {
     RUN_TEST(test_sort_by_key_ascending);
     RUN_TEST(test_sort_by_key_empty);
     RUN_TEST(test_sort_by_key_single);
+    RUN_TEST(test_sort_by_key_asserts_when_scratch_aliases_items);
     RUN_TEST(test_sort_by_key_ignores_batch_key);
     RUN_TEST(test_sort_by_key_then_batch_lexicographic);
     RUN_TEST(test_sort_by_key_then_batch_primary_precedence_full_width);

--- a/tests/unit/test_render_items.c
+++ b/tests/unit/test_render_items.c
@@ -106,6 +106,115 @@ void test_sort_by_key_single(void) {
     TEST_ASSERT_EQUAL_UINT64(42, item.sort_key);
 }
 
+void test_sort_by_key_ignores_batch_key(void) {
+    nt_render_item_t items[3] = {
+        {.sort_key = 7, .entity = 1, .batch_key = 30},
+        {.sort_key = 7, .entity = 2, .batch_key = 10},
+        {.sort_key = 7, .entity = 3, .batch_key = 20},
+    };
+    nt_render_item_t scratch[3];
+
+    nt_sort_by_key(items, 3, scratch);
+
+    TEST_ASSERT_EQUAL_UINT32(1, items[0].entity);
+    TEST_ASSERT_EQUAL_UINT32(2, items[1].entity);
+    TEST_ASSERT_EQUAL_UINT32(3, items[2].entity);
+}
+
+void test_sort_by_key_then_batch_lexicographic(void) {
+    nt_render_item_t items[6] = {
+        {.sort_key = 2, .entity = 1, .batch_key = 3}, {.sort_key = 1, .entity = 2, .batch_key = 3}, {.sort_key = 2, .entity = 3, .batch_key = 1},
+        {.sort_key = 1, .entity = 4, .batch_key = 2}, {.sort_key = 2, .entity = 5, .batch_key = 2}, {.sort_key = 1, .entity = 6, .batch_key = 1},
+    };
+    nt_render_item_t scratch[6];
+
+    nt_sort_by_key_then_batch(items, 6, scratch);
+
+    const uint32_t expected[] = {6, 4, 2, 3, 5, 1};
+    for (uint32_t i = 0; i < 6; ++i) {
+        TEST_ASSERT_EQUAL_UINT32(expected[i], items[i].entity);
+    }
+}
+
+void test_sort_by_key_then_batch_primary_precedence_full_width(void) {
+    nt_render_item_t items[4] = {
+        {.sort_key = UINT64_MAX, .entity = 1, .batch_key = 0},
+        {.sort_key = 1, .entity = 2, .batch_key = UINT32_MAX},
+        {.sort_key = UINT64_MAX, .entity = 3, .batch_key = UINT32_MAX},
+        {.sort_key = 1, .entity = 4, .batch_key = 0},
+    };
+    nt_render_item_t scratch[4];
+
+    nt_sort_by_key_then_batch(items, 4, scratch);
+
+    const uint32_t expected[] = {4, 2, 1, 3};
+    for (uint32_t i = 0; i < 4; ++i) {
+        TEST_ASSERT_EQUAL_UINT32(expected[i], items[i].entity);
+    }
+}
+
+void test_sort_by_key_then_batch_stable_for_equal_pairs(void) {
+    nt_render_item_t items[4] = {
+        {.sort_key = 5, .entity = 1, .batch_key = 9},
+        {.sort_key = 5, .entity = 2, .batch_key = 3},
+        {.sort_key = 5, .entity = 3, .batch_key = 9},
+        {.sort_key = 5, .entity = 4, .batch_key = 9},
+    };
+    nt_render_item_t scratch[4];
+
+    nt_sort_by_key_then_batch(items, 4, scratch);
+
+    const uint32_t expected[] = {2, 1, 3, 4};
+    for (uint32_t i = 0; i < 4; ++i) {
+        TEST_ASSERT_EQUAL_UINT32(expected[i], items[i].entity);
+    }
+}
+
+void test_sort_by_key_then_batch_secondary_pass_parity(void) {
+    nt_render_item_t uniform[3] = {
+        {.sort_key = 3, .entity = 1, .batch_key = 7},
+        {.sort_key = 1, .entity = 2, .batch_key = 7},
+        {.sort_key = 2, .entity = 3, .batch_key = 7},
+    };
+    nt_render_item_t one_byte[3] = {
+        {.sort_key = 1, .entity = 1, .batch_key = 3},
+        {.sort_key = 1, .entity = 2, .batch_key = 1},
+        {.sort_key = 1, .entity = 3, .batch_key = 2},
+    };
+    nt_render_item_t two_bytes[3] = {
+        {.sort_key = 1, .entity = 1, .batch_key = 0x0101},
+        {.sort_key = 1, .entity = 2, .batch_key = 0x0002},
+        {.sort_key = 1, .entity = 3, .batch_key = 0x0100},
+    };
+    nt_render_item_t scratch[3];
+
+    nt_sort_by_key_then_batch(uniform, 3, scratch);
+    TEST_ASSERT_EQUAL_UINT32(2, uniform[0].entity);
+    TEST_ASSERT_EQUAL_UINT32(3, uniform[1].entity);
+    TEST_ASSERT_EQUAL_UINT32(1, uniform[2].entity);
+
+    nt_sort_by_key_then_batch(one_byte, 3, scratch);
+    TEST_ASSERT_EQUAL_UINT32(2, one_byte[0].entity);
+    TEST_ASSERT_EQUAL_UINT32(3, one_byte[1].entity);
+    TEST_ASSERT_EQUAL_UINT32(1, one_byte[2].entity);
+
+    nt_sort_by_key_then_batch(two_bytes, 3, scratch);
+    TEST_ASSERT_EQUAL_UINT32(2, two_bytes[0].entity);
+    TEST_ASSERT_EQUAL_UINT32(3, two_bytes[1].entity);
+    TEST_ASSERT_EQUAL_UINT32(1, two_bytes[2].entity);
+}
+
+void test_sort_by_key_then_batch_empty_and_single(void) {
+    nt_render_item_t item = {.sort_key = 42, .entity = 1, .batch_key = 7};
+    nt_render_item_t scratch[1];
+
+    nt_sort_by_key_then_batch(NULL, 0, NULL);
+    nt_sort_by_key_then_batch(&item, 1, scratch);
+
+    TEST_ASSERT_EQUAL_UINT64(42, item.sort_key);
+    TEST_ASSERT_EQUAL_UINT32(7, item.batch_key);
+}
+
 /* ---- Calc view depth ---- */
 
 void test_calc_view_depth_positive(void) {
@@ -210,6 +319,12 @@ int main(void) {
     RUN_TEST(test_sort_by_key_ascending);
     RUN_TEST(test_sort_by_key_empty);
     RUN_TEST(test_sort_by_key_single);
+    RUN_TEST(test_sort_by_key_ignores_batch_key);
+    RUN_TEST(test_sort_by_key_then_batch_lexicographic);
+    RUN_TEST(test_sort_by_key_then_batch_primary_precedence_full_width);
+    RUN_TEST(test_sort_by_key_then_batch_stable_for_equal_pairs);
+    RUN_TEST(test_sort_by_key_then_batch_secondary_pass_parity);
+    RUN_TEST(test_sort_by_key_then_batch_empty_and_single);
     /* View depth */
     RUN_TEST(test_calc_view_depth_positive);
     /* Visibility */

--- a/tests/unit/test_sprite_comp.c
+++ b/tests/unit/test_sprite_comp.c
@@ -518,6 +518,9 @@ void test_sprite_sync_keeps_resolved_when_region_removed(void) {
     nt_sprite_comp_sync_resources();
     TEST_ASSERT_TRUE(nt_sprite_comp_is_resolved(e));
     const uint16_t r1_idx = *nt_sprite_comp_region_index(e);
+    nt_sprite_comp_view_t before = nt_sprite_comp_view();
+    uint16_t before_idx = before.sparse_indices[nt_entity_index(e)];
+    TEST_ASSERT_TRUE(nt_sprite_resolved_region_has_geometry(&before.resolved[before_idx]));
 
     uint8_t atlas_blob[1024];
     uint32_t atlas_blob_size = build_fixture_atlas_blob_r0_only(atlas_blob, sizeof(atlas_blob));
@@ -539,6 +542,9 @@ void test_sprite_sync_keeps_resolved_when_region_removed(void) {
     const nt_texture_region_t *region = nt_atlas_get_region(s_atlas_res, *nt_sprite_comp_region_index(e));
     TEST_ASSERT_NOT_NULL(region);
     TEST_ASSERT_EQUAL_UINT8(0, region->vertex_count); /* dead → zero-draw */
+    nt_sprite_comp_view_t after = nt_sprite_comp_view();
+    uint16_t after_idx = after.sparse_indices[nt_entity_index(e)];
+    TEST_ASSERT_FALSE(nt_sprite_resolved_region_has_geometry(&after.resolved[after_idx]));
 }
 
 /* ---- Test 13: set_flip sets bits correctly and isolates from other flags ---- */

--- a/tests/unit/test_sprite_comp.c
+++ b/tests/unit/test_sprite_comp.c
@@ -518,9 +518,6 @@ void test_sprite_sync_keeps_resolved_when_region_removed(void) {
     nt_sprite_comp_sync_resources();
     TEST_ASSERT_TRUE(nt_sprite_comp_is_resolved(e));
     const uint16_t r1_idx = *nt_sprite_comp_region_index(e);
-    nt_sprite_comp_view_t before = nt_sprite_comp_view();
-    uint16_t before_idx = before.sparse_indices[nt_entity_index(e)];
-    TEST_ASSERT_TRUE(nt_sprite_resolved_region_has_geometry(&before.resolved[before_idx]));
 
     uint8_t atlas_blob[1024];
     uint32_t atlas_blob_size = build_fixture_atlas_blob_r0_only(atlas_blob, sizeof(atlas_blob));
@@ -544,7 +541,7 @@ void test_sprite_sync_keeps_resolved_when_region_removed(void) {
     TEST_ASSERT_EQUAL_UINT8(0, region->vertex_count); /* dead → zero-draw */
     nt_sprite_comp_view_t after = nt_sprite_comp_view();
     uint16_t after_idx = after.sparse_indices[nt_entity_index(e)];
-    TEST_ASSERT_FALSE(nt_sprite_resolved_region_has_geometry(&after.resolved[after_idx]));
+    TEST_ASSERT_EQUAL_UINT32(0, after.resolved[after_idx].page_resource.id);
 }
 
 /* ---- Test 13: set_flip sets bits correctly and isolates from other flags ---- */

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -633,35 +633,10 @@ void test_sprite_renderer_batch_grouping(void) {
     TEST_ASSERT_EQUAL_UINT32(2, nt_sprite_renderer_test_draw_call_count());
 }
 
-/* ---- Test: an explicit stronger batch boundary is honored ---- */
-void test_sprite_renderer_explicit_batch_boundary(void) {
-    nt_sprite_renderer_desc_t desc = nt_sprite_renderer_desc_defaults();
-    TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&desc));
-
-    s_atlas_res = register_test_atlas(0xA3ULL);
-    nt_material_t mat = create_test_material();
-    nt_entity_t e0 = create_sprite_entity(s_atlas_res, FIXTURE_R0_HASH, mat);
-    nt_entity_t e1 = create_sprite_entity(s_atlas_res, FIXTURE_R0_HASH, mat);
-
-    uint32_t canonical_key = sprite_batch_key(e0, mat);
-    nt_render_item_t items[2];
-    items[0].sort_key = 0;
-    items[0].entity = e0.id;
-    items[0].batch_key = canonical_key;
-    items[1].sort_key = 1;
-    items[1].entity = e1.id;
-    items[1].batch_key = canonical_key ^ 0x80000000U;
-
-    nt_sprite_renderer_draw_list(items, 2);
-    TEST_ASSERT_EQUAL_UINT32(2, nt_sprite_renderer_test_draw_call_count());
-}
-
-/* ---- Test: actual atlas page splits a coarse batch_key run ----
+/* ---- Defensive test: actual atlas page splits a malformed batch_key run ----
  *
- * The game-level batch_key is a compatibility hint, not the texture source of
- * truth. If two adjacent sprites share a key but resolve to different atlas
- * pages, the renderer must split the command stream before drawing the second
- * sprite. */
+ * This deliberately violates the caller contract by reusing page 0's key for a
+ * page 1 sprite. The renderer still splits commands to avoid a wrong texture. */
 void test_sprite_renderer_splits_run_on_actual_page_change(void) {
     nt_sprite_renderer_desc_t desc = nt_sprite_renderer_desc_defaults();
     TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&desc));
@@ -1177,7 +1152,6 @@ int main(void) {
     RUN_TEST(test_sprite_renderer_pipeline_cache);
     RUN_TEST(test_sprite_renderer_forwards_material_blend_state);
     RUN_TEST(test_sprite_renderer_batch_grouping);
-    RUN_TEST(test_sprite_renderer_explicit_batch_boundary);
     RUN_TEST(test_sprite_renderer_splits_run_on_actual_page_change);
     RUN_TEST(test_sprite_renderer_polygon_emit);
     RUN_TEST(test_sprite_renderer_extended_layout_from_attr_map);

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -529,6 +529,28 @@ void test_sprite_renderer_draw_list_null_items_asserts_when_nonempty(void) {
     NT_TEST_EXPECT_ASSERT(nt_sprite_renderer_draw_list(NULL, 1));
 }
 
+void test_sprite_renderer_draw_list_asserts_on_unresolved_sprite_item(void) {
+    nt_sprite_renderer_desc_t desc = nt_sprite_renderer_desc_defaults();
+    TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&desc));
+
+    s_atlas_res = register_test_atlas(0xA0ULL);
+    nt_material_t material = create_test_material();
+    nt_entity_t entity = nt_entity_create();
+    nt_transform_comp_add(entity);
+    nt_drawable_comp_add(entity);
+    nt_material_comp_add(entity);
+    nt_sprite_comp_add(entity);
+    *nt_material_comp_handle(entity) = material;
+
+    nt_resource_t page_resource = nt_atlas_get_page_resource(s_atlas_res, 0);
+    nt_render_item_t item = {
+        .entity = entity.id,
+        .batch_key = nt_sprite_renderer_batch_key(material, page_resource),
+    };
+
+    NT_TEST_EXPECT_ASSERT(nt_sprite_renderer_draw_list(&item, 1));
+}
+
 /* ---- Test: pipeline cache reuse + miss-creates-new ---- */
 
 void test_sprite_renderer_pipeline_cache(void) {
@@ -1151,6 +1173,7 @@ int main(void) {
     RUN_TEST(test_sprite_renderer_batch_key_ignores_handle_generations);
     RUN_TEST(test_sprite_renderer_batch_key_distinguishes_page_slots);
     RUN_TEST(test_sprite_renderer_draw_list_null_items_asserts_when_nonempty);
+    RUN_TEST(test_sprite_renderer_draw_list_asserts_on_unresolved_sprite_item);
     RUN_TEST(test_sprite_renderer_pipeline_cache);
     RUN_TEST(test_sprite_renderer_forwards_material_blend_state);
     RUN_TEST(test_sprite_renderer_batch_grouping);

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -24,6 +24,7 @@
 #include "renderers/nt_sprite_renderer.h"
 #include "resource/nt_resource.h"
 #include "sprite_comp/nt_sprite_comp.h"
+#include "test_helpers/nt_assert_trap.h"
 #include "transform_comp/nt_transform_comp.h"
 #include "unity.h"
 /* clang-format on */
@@ -488,6 +489,13 @@ void test_sprite_renderer_init_shutdown(void) {
  * This runtime test mirrors the assertion in case the static check is ever
  * accidentally relaxed (it would still catch the breakage in CI). */
 void test_sprite_renderer_vertex_size_assert(void) { TEST_ASSERT_EQUAL_size_t(20, sizeof(nt_sprite_vertex_t)); }
+
+void test_sprite_renderer_draw_list_null_items_asserts_when_nonempty(void) {
+    nt_sprite_renderer_desc_t desc = nt_sprite_renderer_desc_defaults();
+    TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&desc));
+
+    NT_TEST_EXPECT_ASSERT(nt_sprite_renderer_draw_list(NULL, 1));
+}
 
 /* ---- Test: pipeline cache reuse + miss-creates-new ---- */
 
@@ -1107,6 +1115,7 @@ int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_sprite_renderer_init_shutdown);
     RUN_TEST(test_sprite_renderer_vertex_size_assert);
+    RUN_TEST(test_sprite_renderer_draw_list_null_items_asserts_when_nonempty);
     RUN_TEST(test_sprite_renderer_pipeline_cache);
     RUN_TEST(test_sprite_renderer_forwards_material_blend_state);
     RUN_TEST(test_sprite_renderer_batch_grouping);

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -504,10 +504,10 @@ void test_sprite_renderer_pipeline_cache(void) {
     nt_render_item_t items[2];
     items[0].sort_key = 0;
     items[0].entity = e0.id;
-    items[0].batch_key = nt_batch_key(mat_a.id, (uint32_t)FIXTURE_R0_HASH);
+    items[0].batch_key = nt_sprite_renderer_batch_key(mat_a);
     items[1].sort_key = 1;
     items[1].entity = e1.id;
-    items[1].batch_key = nt_batch_key(mat_b.id, (uint32_t)FIXTURE_R0_HASH);
+    items[1].batch_key = nt_sprite_renderer_batch_key(mat_b);
 
     nt_sprite_renderer_draw_list(items, 2);
     TEST_ASSERT_EQUAL_UINT32(2, nt_sprite_renderer_test_pipeline_cache_count());
@@ -529,7 +529,7 @@ void test_sprite_renderer_forwards_material_blend_state(void) {
     s_atlas_res = register_test_atlas(0xB1ULL);
     nt_material_t mat = create_test_material_with_blend(blend);
     nt_entity_t entity = create_sprite_entity(s_atlas_res, FIXTURE_R0_HASH, mat);
-    nt_render_item_t item = {.entity = entity.id, .batch_key = nt_batch_key(mat.id, (uint32_t)FIXTURE_R0_HASH)};
+    nt_render_item_t item = {.entity = entity.id, .batch_key = nt_sprite_renderer_batch_key(mat)};
     nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
 
     nt_sprite_renderer_draw_list(&item, 1);
@@ -553,8 +553,8 @@ void test_sprite_renderer_batch_grouping(void) {
     nt_entity_t e1 = create_sprite_entity(s_atlas_res, FIXTURE_R0_HASH, mat_a);
     nt_entity_t e2 = create_sprite_entity(s_atlas_res, FIXTURE_R0_HASH, mat_b);
 
-    uint32_t bk_a = nt_batch_key(mat_a.id, (uint32_t)FIXTURE_R0_HASH);
-    uint32_t bk_b = nt_batch_key(mat_b.id, (uint32_t)FIXTURE_R0_HASH);
+    uint32_t bk_a = nt_sprite_renderer_batch_key(mat_a);
+    uint32_t bk_b = nt_sprite_renderer_batch_key(mat_b);
     nt_render_item_t items[3];
     items[0].sort_key = 0;
     items[0].entity = e0.id;
@@ -571,12 +571,8 @@ void test_sprite_renderer_batch_grouping(void) {
     TEST_ASSERT_EQUAL_UINT32(2, nt_sprite_renderer_test_draw_call_count());
 }
 
-/* ---- Test: batch_key-driven boundaries ----
- *
- * When the batch_key changes between consecutive items, a flush is triggered
- * even if the underlying material id matches — the renderer trusts batch_key
- * as the abstraction (atlas page id is folded in by the game). */
-void test_sprite_renderer_batch_key_atlas_change(void) {
+/* ---- Test: an explicit stronger batch boundary is honored ---- */
+void test_sprite_renderer_explicit_batch_boundary(void) {
     nt_sprite_renderer_desc_t desc = nt_sprite_renderer_desc_defaults();
     TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&desc));
 
@@ -585,16 +581,14 @@ void test_sprite_renderer_batch_key_atlas_change(void) {
     nt_entity_t e0 = create_sprite_entity(s_atlas_res, FIXTURE_R0_HASH, mat);
     nt_entity_t e1 = create_sprite_entity(s_atlas_res, FIXTURE_R1_HASH, mat);
 
-    /* Two distinct batch_keys (game encodes atlas page id into the key). The
-     * renderer flushes between groups, even though the cached pipeline is
-     * the same — exercising the batch_key boundary contract. */
+    uint32_t canonical_key = nt_sprite_renderer_batch_key(mat);
     nt_render_item_t items[2];
     items[0].sort_key = 0;
     items[0].entity = e0.id;
-    items[0].batch_key = nt_batch_key(mat.id, 0xAAU);
+    items[0].batch_key = canonical_key;
     items[1].sort_key = 1;
     items[1].entity = e1.id;
-    items[1].batch_key = nt_batch_key(mat.id, 0xBBU);
+    items[1].batch_key = canonical_key ^ 0x80000000U;
 
     nt_sprite_renderer_draw_list(items, 2);
     TEST_ASSERT_EQUAL_UINT32(2, nt_sprite_renderer_test_draw_call_count());
@@ -615,7 +609,7 @@ void test_sprite_renderer_splits_run_on_actual_page_change(void) {
     nt_entity_t e0 = create_sprite_entity(s_atlas_res, FIXTURE_R0_HASH, mat);
     nt_entity_t e1 = create_sprite_entity(s_atlas_res, FIXTURE_R1_HASH, mat);
 
-    uint32_t coarse_key = nt_batch_key(mat.id, 0xCAFEU);
+    uint32_t coarse_key = nt_sprite_renderer_batch_key(mat);
     nt_render_item_t items[2];
     items[0].sort_key = 0;
     items[0].entity = e0.id;
@@ -644,7 +638,7 @@ void test_sprite_renderer_polygon_emit(void) {
     nt_render_item_t items[1];
     items[0].sort_key = 0;
     items[0].entity = e.id;
-    items[0].batch_key = nt_batch_key(mat.id, (uint32_t)FIXTURE_RPOLY_HASH);
+    items[0].batch_key = nt_sprite_renderer_batch_key(mat);
 
     nt_sprite_renderer_draw_list(items, 1);
 
@@ -764,7 +758,7 @@ void test_sprite_renderer_flip_mirrors_around_pivot(void) {
     nt_render_item_t items[1];
     items[0].sort_key = 0;
     items[0].entity = e.id;
-    items[0].batch_key = nt_batch_key(mat.id, (uint32_t)FIXTURE_R0_HASH);
+    items[0].batch_key = nt_sprite_renderer_batch_key(mat);
 
     /* Region r0: 64x64 source, origin (0.5, 0.5) → pivot at source (32, 32).
      * 4 verts at source-space (i*10, i*20) for i=0..3 = (0,0),(10,20),(20,40),(30,60).
@@ -822,7 +816,7 @@ void test_sprite_renderer_restore_gpu_cycle(void) {
     nt_render_item_t items[1];
     items[0].sort_key = 0;
     items[0].entity = e.id;
-    items[0].batch_key = nt_batch_key(mat.id, (uint32_t)FIXTURE_R0_HASH);
+    items[0].batch_key = nt_sprite_renderer_batch_key(mat);
 
     nt_sprite_renderer_draw_list(items, 1);
     TEST_ASSERT_EQUAL_UINT32(1, nt_sprite_renderer_test_pipeline_cache_count());
@@ -857,10 +851,10 @@ void test_sprite_renderer_pipeline_cache_capacity(void) {
     nt_render_item_t items[2];
     items[0].sort_key = 0;
     items[0].entity = e0.id;
-    items[0].batch_key = nt_batch_key(mat_a.id, (uint32_t)FIXTURE_R0_HASH);
+    items[0].batch_key = nt_sprite_renderer_batch_key(mat_a);
     items[1].sort_key = 1;
     items[1].entity = e1.id;
-    items[1].batch_key = nt_batch_key(mat_b.id, (uint32_t)FIXTURE_R0_HASH);
+    items[1].batch_key = nt_sprite_renderer_batch_key(mat_b);
 
     nt_sprite_renderer_draw_list(items, 2);
     TEST_ASSERT_EQUAL_UINT32(2, nt_sprite_renderer_test_pipeline_cache_count());
@@ -933,10 +927,10 @@ void test_sprite_renderer_sampler_override_does_not_stick(void) {
     nt_render_item_t items[2];
     items[0].sort_key = 0;
     items[0].entity = e_a.id;
-    items[0].batch_key = nt_batch_key(mat_override.id, (uint32_t)FIXTURE_R0_HASH);
+    items[0].batch_key = nt_sprite_renderer_batch_key(mat_override);
     items[1].sort_key = 1;
     items[1].entity = e_b.id;
-    items[1].batch_key = nt_batch_key(mat_plain.id, (uint32_t)FIXTURE_R0_HASH);
+    items[1].batch_key = nt_sprite_renderer_batch_key(mat_plain);
 
     nt_gfx_stub_test_reset();
     nt_sprite_renderer_draw_list(items, 2);
@@ -1047,7 +1041,7 @@ void test_sprite_comp_slice9_scale_affects_emit_position(void) {
     nt_render_item_t items[1];
     items[0].sort_key = 0;
     items[0].entity = e.id;
-    items[0].batch_key = nt_batch_key(mat.id, (uint32_t)FIXTURE_RS9_HASH);
+    items[0].batch_key = nt_sprite_renderer_batch_key(mat);
     nt_sprite_renderer_draw_list(items, 1);
 
     /* rs9: 100×100 src, slice9=16, origin (0,0) → local lxs[1] = 16 × scale = 32. */
@@ -1116,7 +1110,7 @@ int main(void) {
     RUN_TEST(test_sprite_renderer_pipeline_cache);
     RUN_TEST(test_sprite_renderer_forwards_material_blend_state);
     RUN_TEST(test_sprite_renderer_batch_grouping);
-    RUN_TEST(test_sprite_renderer_batch_key_atlas_change);
+    RUN_TEST(test_sprite_renderer_explicit_batch_boundary);
     RUN_TEST(test_sprite_renderer_splits_run_on_actual_page_change);
     RUN_TEST(test_sprite_renderer_polygon_emit);
     RUN_TEST(test_sprite_renderer_extended_layout_from_attr_map);

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -408,6 +408,14 @@ static nt_entity_t create_sprite_entity(nt_resource_t atlas, uint64_t region_has
     return e;
 }
 
+static uint32_t sprite_batch_key(nt_entity_t entity, nt_material_t material) {
+    nt_sprite_comp_view_t sprites = nt_sprite_comp_view();
+    uint16_t dense_idx = sprites.sparse_indices[nt_entity_index(entity)];
+    TEST_ASSERT_NOT_EQUAL_UINT16(UINT16_MAX, dense_idx);
+    TEST_ASSERT_BITS_HIGH(NT_SPRITE_FLAG_RESOLVED, sprites.flags[dense_idx]);
+    return nt_sprite_renderer_batch_key(material, sprites.resolved[dense_idx].page_resource);
+}
+
 /* ---- setUp / tearDown ---- */
 
 void setUp(void) {
@@ -490,6 +498,30 @@ void test_sprite_renderer_init_shutdown(void) {
  * accidentally relaxed (it would still catch the breakage in CI). */
 void test_sprite_renderer_vertex_size_assert(void) { TEST_ASSERT_EQUAL_size_t(20, sizeof(nt_sprite_vertex_t)); }
 
+void test_sprite_renderer_batch_key_packs_material_and_page_slots(void) {
+    nt_material_t material = {.id = 0xABCD1234U};
+    nt_resource_t page_resource = {.id = 0x43215678U};
+
+    TEST_ASSERT_EQUAL_HEX32(0x12345678U, nt_sprite_renderer_batch_key(material, page_resource));
+}
+
+void test_sprite_renderer_batch_key_ignores_handle_generations(void) {
+    nt_material_t material_a = {.id = 0x00011234U};
+    nt_material_t material_b = {.id = 0xFFFF1234U};
+    nt_resource_t page_a = {.id = 0x00015678U};
+    nt_resource_t page_b = {.id = 0xFFFF5678U};
+
+    TEST_ASSERT_EQUAL_HEX32(nt_sprite_renderer_batch_key(material_a, page_a), nt_sprite_renderer_batch_key(material_b, page_b));
+}
+
+void test_sprite_renderer_batch_key_distinguishes_page_slots(void) {
+    nt_material_t material = {.id = 0x00010001U};
+    nt_resource_t page_a = {.id = 0x00010001U};
+    nt_resource_t page_b = {.id = 0x00010002U};
+
+    TEST_ASSERT_NOT_EQUAL(nt_sprite_renderer_batch_key(material, page_a), nt_sprite_renderer_batch_key(material, page_b));
+}
+
 void test_sprite_renderer_draw_list_null_items_asserts_when_nonempty(void) {
     nt_sprite_renderer_desc_t desc = nt_sprite_renderer_desc_defaults();
     TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&desc));
@@ -512,10 +544,10 @@ void test_sprite_renderer_pipeline_cache(void) {
     nt_render_item_t items[2];
     items[0].sort_key = 0;
     items[0].entity = e0.id;
-    items[0].batch_key = nt_sprite_renderer_batch_key(mat_a);
+    items[0].batch_key = sprite_batch_key(e0, mat_a);
     items[1].sort_key = 1;
     items[1].entity = e1.id;
-    items[1].batch_key = nt_sprite_renderer_batch_key(mat_b);
+    items[1].batch_key = sprite_batch_key(e1, mat_b);
 
     nt_sprite_renderer_draw_list(items, 2);
     TEST_ASSERT_EQUAL_UINT32(2, nt_sprite_renderer_test_pipeline_cache_count());
@@ -537,7 +569,7 @@ void test_sprite_renderer_forwards_material_blend_state(void) {
     s_atlas_res = register_test_atlas(0xB1ULL);
     nt_material_t mat = create_test_material_with_blend(blend);
     nt_entity_t entity = create_sprite_entity(s_atlas_res, FIXTURE_R0_HASH, mat);
-    nt_render_item_t item = {.entity = entity.id, .batch_key = nt_sprite_renderer_batch_key(mat)};
+    nt_render_item_t item = {.entity = entity.id, .batch_key = sprite_batch_key(entity, mat)};
     nt_sprite_renderer_init(&(nt_sprite_renderer_desc_t){.max_pipelines = 4});
 
     nt_sprite_renderer_draw_list(&item, 1);
@@ -561,8 +593,8 @@ void test_sprite_renderer_batch_grouping(void) {
     nt_entity_t e1 = create_sprite_entity(s_atlas_res, FIXTURE_R0_HASH, mat_a);
     nt_entity_t e2 = create_sprite_entity(s_atlas_res, FIXTURE_R0_HASH, mat_b);
 
-    uint32_t bk_a = nt_sprite_renderer_batch_key(mat_a);
-    uint32_t bk_b = nt_sprite_renderer_batch_key(mat_b);
+    uint32_t bk_a = sprite_batch_key(e0, mat_a);
+    uint32_t bk_b = sprite_batch_key(e2, mat_b);
     nt_render_item_t items[3];
     items[0].sort_key = 0;
     items[0].entity = e0.id;
@@ -587,9 +619,9 @@ void test_sprite_renderer_explicit_batch_boundary(void) {
     s_atlas_res = register_test_atlas(0xA3ULL);
     nt_material_t mat = create_test_material();
     nt_entity_t e0 = create_sprite_entity(s_atlas_res, FIXTURE_R0_HASH, mat);
-    nt_entity_t e1 = create_sprite_entity(s_atlas_res, FIXTURE_R1_HASH, mat);
+    nt_entity_t e1 = create_sprite_entity(s_atlas_res, FIXTURE_R0_HASH, mat);
 
-    uint32_t canonical_key = nt_sprite_renderer_batch_key(mat);
+    uint32_t canonical_key = sprite_batch_key(e0, mat);
     nt_render_item_t items[2];
     items[0].sort_key = 0;
     items[0].entity = e0.id;
@@ -617,7 +649,7 @@ void test_sprite_renderer_splits_run_on_actual_page_change(void) {
     nt_entity_t e0 = create_sprite_entity(s_atlas_res, FIXTURE_R0_HASH, mat);
     nt_entity_t e1 = create_sprite_entity(s_atlas_res, FIXTURE_R1_HASH, mat);
 
-    uint32_t coarse_key = nt_sprite_renderer_batch_key(mat);
+    uint32_t coarse_key = sprite_batch_key(e0, mat);
     nt_render_item_t items[2];
     items[0].sort_key = 0;
     items[0].entity = e0.id;
@@ -646,7 +678,7 @@ void test_sprite_renderer_polygon_emit(void) {
     nt_render_item_t items[1];
     items[0].sort_key = 0;
     items[0].entity = e.id;
-    items[0].batch_key = nt_sprite_renderer_batch_key(mat);
+    items[0].batch_key = sprite_batch_key(e, mat);
 
     nt_sprite_renderer_draw_list(items, 1);
 
@@ -766,7 +798,7 @@ void test_sprite_renderer_flip_mirrors_around_pivot(void) {
     nt_render_item_t items[1];
     items[0].sort_key = 0;
     items[0].entity = e.id;
-    items[0].batch_key = nt_sprite_renderer_batch_key(mat);
+    items[0].batch_key = sprite_batch_key(e, mat);
 
     /* Region r0: 64x64 source, origin (0.5, 0.5) → pivot at source (32, 32).
      * 4 verts at source-space (i*10, i*20) for i=0..3 = (0,0),(10,20),(20,40),(30,60).
@@ -824,7 +856,7 @@ void test_sprite_renderer_restore_gpu_cycle(void) {
     nt_render_item_t items[1];
     items[0].sort_key = 0;
     items[0].entity = e.id;
-    items[0].batch_key = nt_sprite_renderer_batch_key(mat);
+    items[0].batch_key = sprite_batch_key(e, mat);
 
     nt_sprite_renderer_draw_list(items, 1);
     TEST_ASSERT_EQUAL_UINT32(1, nt_sprite_renderer_test_pipeline_cache_count());
@@ -859,10 +891,10 @@ void test_sprite_renderer_pipeline_cache_capacity(void) {
     nt_render_item_t items[2];
     items[0].sort_key = 0;
     items[0].entity = e0.id;
-    items[0].batch_key = nt_sprite_renderer_batch_key(mat_a);
+    items[0].batch_key = sprite_batch_key(e0, mat_a);
     items[1].sort_key = 1;
     items[1].entity = e1.id;
-    items[1].batch_key = nt_sprite_renderer_batch_key(mat_b);
+    items[1].batch_key = sprite_batch_key(e1, mat_b);
 
     nt_sprite_renderer_draw_list(items, 2);
     TEST_ASSERT_EQUAL_UINT32(2, nt_sprite_renderer_test_pipeline_cache_count());
@@ -935,10 +967,10 @@ void test_sprite_renderer_sampler_override_does_not_stick(void) {
     nt_render_item_t items[2];
     items[0].sort_key = 0;
     items[0].entity = e_a.id;
-    items[0].batch_key = nt_sprite_renderer_batch_key(mat_override);
+    items[0].batch_key = sprite_batch_key(e_a, mat_override);
     items[1].sort_key = 1;
     items[1].entity = e_b.id;
-    items[1].batch_key = nt_sprite_renderer_batch_key(mat_plain);
+    items[1].batch_key = sprite_batch_key(e_b, mat_plain);
 
     nt_gfx_stub_test_reset();
     nt_sprite_renderer_draw_list(items, 2);
@@ -1049,7 +1081,7 @@ void test_sprite_comp_slice9_scale_affects_emit_position(void) {
     nt_render_item_t items[1];
     items[0].sort_key = 0;
     items[0].entity = e.id;
-    items[0].batch_key = nt_sprite_renderer_batch_key(mat);
+    items[0].batch_key = sprite_batch_key(e, mat);
     nt_sprite_renderer_draw_list(items, 1);
 
     /* rs9: 100×100 src, slice9=16, origin (0,0) → local lxs[1] = 16 × scale = 32. */
@@ -1115,6 +1147,9 @@ int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_sprite_renderer_init_shutdown);
     RUN_TEST(test_sprite_renderer_vertex_size_assert);
+    RUN_TEST(test_sprite_renderer_batch_key_packs_material_and_page_slots);
+    RUN_TEST(test_sprite_renderer_batch_key_ignores_handle_generations);
+    RUN_TEST(test_sprite_renderer_batch_key_distinguishes_page_slots);
     RUN_TEST(test_sprite_renderer_draw_list_null_items_asserts_when_nonempty);
     RUN_TEST(test_sprite_renderer_pipeline_cache);
     RUN_TEST(test_sprite_renderer_forwards_material_blend_state);


### PR DESCRIPTION
## Summary

Make `batch_key` an exact renderer-owned compatibility contract while preserving the universal 16-byte `nt_render_item_t`.

Closes #350.

## Changes

- remove the generic probabilistic `nt_batch_key()`;
- add `nt_mesh_renderer_batch_key(material, mesh)` with exact 16+16 live pool-slot packing;
- add `nt_sprite_renderer_batch_key(material)`, while SpriteRenderer keeps validating actual atlas pages;
- add opt-in stable lexicographic `nt_sort_by_key_then_batch()`;
- preserve stable sort-by-`sort_key`-only behavior in `nt_sort_by_key()`;
- migrate all current examples and renderer tests;
- document the renderer-specific key and item-build-to-draw lifetime contracts.

## Verification

- [x] RED: new tests failed on the absent sort and MeshRenderer helper APIs
- [x] Targeted render-item, MeshRenderer, and SpriteRenderer tests: 3/3 passed
- [x] Native atlas, textured_quad, sponza, and bunnymark consumers built
- [x] `scripts/format_and_check.sh`
- [x] `scripts/check.sh --push`
- [x] WASM debug and release builds
- [x] Submodule consumption test
- [x] No remaining `nt_batch_key` references

## Key Decisions

- `sort_key` remains the primary game-owned ordering policy.
- Secondary batching order is opt-in because transparent/UI ties may be order-sensitive.
- Mesh keys omit generation bits under the explicit item-build-to-draw liveness and no-rebind contract.
- False key equality is invalid; false inequality is safe but may split a batch.

## TDD Audit

| Test evidence | Impl commit | gate_status |
|---|---|---|
| RED compile failure captured before implementation | `9d47c051` | missing |

The implementation followed the TDD skill, but the commit predates adding a `gate_status:` trailer.

gate_status: skill=0, fallback=0, exempt=0, missing=1