### PR TITLE
gfx: widen mesh layout_hash to 64 bits

### DIFF
--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -64,6 +64,14 @@ per-stream type/count/normalized, duplicate name hashes, and misaligned
 offsets/strides before any pipeline exists. Pipelines are cached, so the
 asserts are off the hot path.
 
+**Pipeline cache identity.** Renderers key their pipeline caches on a 64-bit
+hash of the full pipeline signature — vertex layout, shader pair, render state
+— and treat that hash as identity: descriptors are never compared on a hit.
+The hashed population is distinct layouts and material states, tens of values
+in a real game, so a 64-bit collision is not a practical risk, and a fixed
+array with a linear scan stays cheaper than a hash map at that scale. Every
+`nt_pipeline_desc_t` field a renderer varies must be folded into its key.
+
 ### Render targets
 
 Render targets are a general backend capability for offscreen passes, not a

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -2185,7 +2185,7 @@ uint32_t nt_gfx_activate_mesh(const uint8_t *data, uint32_t size) {
     s_gfx.mesh_table[slot].stride = stride;
 
     /* Compute layout_hash from stream descriptors for pipeline cache keying */
-    s_gfx.mesh_table[slot].layout_hash = nt_hash32(src_streams, (uint32_t)hdr->stream_count * (uint32_t)sizeof(NtStreamDesc)).value;
+    s_gfx.mesh_table[slot].layout_hash = nt_hash64(src_streams, (uint32_t)hdr->stream_count * (uint32_t)sizeof(NtStreamDesc)).value;
 
     return mesh_id;
 }

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -77,7 +77,7 @@ typedef struct {
     uint8_t index_type;                        /* 0=none, 1=uint16, 2=uint32 */
     NtStreamDesc streams[NT_MESH_MAX_STREAMS]; /* copied from pack data at activation */
     uint16_t stride;                           /* total vertex size in bytes */
-    uint32_t layout_hash;                      /* hash of stream descriptors for pipeline cache key */
+    uint64_t layout_hash;                      /* stream-descriptor hash; serves as pipeline-cache identity, hence 64-bit */
 } nt_gfx_mesh_info_t;
 
 /* ---- Enums ---- */

--- a/engine/renderers/nt_mesh_renderer.c
+++ b/engine/renderers/nt_mesh_renderer.c
@@ -154,7 +154,9 @@ static uint16_t stream_byte_size(const NtStreamDesc *s) { return (uint16_t)(nt_s
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static nt_pipeline_t find_or_create_pipeline(const nt_material_info_t *mat_info, const nt_gfx_mesh_info_t *mesh_info) {
 
-    /* Full pipeline signature: layout + shaders + render state. */
+    /* Full pipeline signature: layout + shaders + render state. The 64-bit hash
+     * IS the cache identity -- descriptors are never compared on a hit, so every
+     * nt_pipeline_desc_t field this renderer varies must be folded in here. */
     uint64_t key = mesh_info->layout_hash;
     key = key * 0x9E3779B97F4A7C15ULL + mat_info->resolved_vs;
     key = key * 0x9E3779B97F4A7C15ULL + mat_info->resolved_fs;


### PR DESCRIPTION
Closes #347.

## What

`nt_gfx_mesh_info_t.layout_hash` becomes `uint64_t`, computed with `nt_hash64`
instead of `nt_hash32`. Nothing else about the cache changes — the key
construction, the linear scan, and the mesh stream validator are untouched.

## Why

The mesh pipeline cache treats its key as identity: entries are matched by key
equality alone and descriptors are never compared on a hit. Every other
ingredient of that key is already 64-bit (`resolved_vs`/`resolved_fs`,
`render_state_hash`); `layout_hash` was the one dimension silently narrowed to
32 bits.

That width was never a considered choice. The original key packed
`(layout_hash << 32) | program_handle`, so the hash was sized to fit beside a
32-bit handle. The key later became a rolling hash over vs/fs/render state/
attr_map, the packing disappeared, and the 32-bit width stayed behind.

Two vertex layouts colliding in 32 bits would silently share a pipeline and
bind the wrong attribute setup, with no diagnostic. The practical risk was
already small — the hashed population is *distinct vertex layouts*, tens of
values in a real game, so a collision sits around 1e-6 even at a hundred
layouts. This is an alignment with the rest of the key, not a bug fix. It is
worth doing only because it is nearly free: the hash is computed once at mesh
activation, so there is no per-frame cost, and `nt_gfx_mesh_info_t` grows from
88 to 96 bytes (~1 KB at the default `max_meshes = 128`).

## Documentation

A 64-bit hash serving as identity with no descriptor comparison is a
deliberate design choice that reads like an oversight, so it is now written
down in two places: a comment at the key construction and a
`Pipeline cache identity` paragraph in `docs/spec/render/architecture.md`.
Both carry the maintenance rule that comes with it — every
`nt_pipeline_desc_t` field a renderer varies has to be folded into its key.

## Rejected alternatives

- **Exact descriptor comparison on a hash hit** (the other remedy #347
  proposed). It removes the collision class entirely, but costs ~29 KB of heap
  for the stored descriptors and moves descriptor construction onto every
  pipeline bind. That reverses the cache's founding decision — the layout hash
  is precomputed at activation specifically so there is no per-frame hashing —
  and buys protection against an event that does not occur at this population
  size. Engines that do compare (ANGLE, Filament, Dawn, Unreal) get it for free
  from a hash map; engines with our shape (fixed array, linear scan, no
  allocation) use a 64-bit hash as identity.
- **Canonicalizing or validating `_pad` / `normalized`** (item 2 of #347).
  Unreachable: `tools/builder/nt_builder_mesh.c:542-543` writes `_pad = 0` and
  `normalized ? 1 : 0`. The consequence would have been a duplicate pipeline,
  not a wrong render.

## Verification

`bash scripts/check.sh --push` — PASS (gates, native-debug, clang-format,
clang-tidy, ctest, wasm-debug, wasm-release, submodule consumption).
`test_gfx` and `test_mesh_renderer`, which exercise mesh activation and the
pipeline cache, pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Spzm9XcsFN53pcHxY4SXPc