### PR TITLE
text: cache pipelines per material instead of rebuilding one on every switch

### DIFF
--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -126,6 +126,7 @@ uint32_t nt_gfx_stub_test_render_target_resize_count(void);
 uint32_t nt_gfx_stub_test_render_target_destroy_count(void);
 uint32_t nt_gfx_stub_test_texture_create_count(void);
 uint32_t nt_gfx_stub_test_program_create_count(void);
+uint32_t nt_gfx_stub_test_pipeline_create_count(void);
 uint32_t nt_gfx_stub_test_uniform_int_count(void);
 const char *nt_gfx_stub_test_uniform_int_name_at(uint32_t index);
 int nt_gfx_stub_test_uniform_int_value_at(uint32_t index);

--- a/engine/graphics/stub/nt_gfx_stub.c
+++ b/engine/graphics/stub/nt_gfx_stub.c
@@ -19,6 +19,7 @@ static uint32_t s_stub_render_target_resize_count;
 static uint32_t s_stub_render_target_destroy_count;
 static uint32_t s_stub_texture_create_count;
 static uint32_t s_stub_program_create_count;
+static uint32_t s_stub_pipeline_create_count;
 #define NT_GFX_STUB_UNIFORM_NAMES 16
 static const char *s_stub_uniform_int_names[NT_GFX_STUB_UNIFORM_NAMES];
 static int s_stub_uniform_int_values[NT_GFX_STUB_UNIFORM_NAMES];
@@ -62,6 +63,7 @@ uint32_t nt_gfx_stub_test_render_target_resize_count(void) { return s_stub_rende
 uint32_t nt_gfx_stub_test_render_target_destroy_count(void) { return s_stub_render_target_destroy_count; }
 uint32_t nt_gfx_stub_test_texture_create_count(void) { return s_stub_texture_create_count; }
 uint32_t nt_gfx_stub_test_program_create_count(void) { return s_stub_program_create_count; }
+uint32_t nt_gfx_stub_test_pipeline_create_count(void) { return s_stub_pipeline_create_count; }
 uint32_t nt_gfx_stub_test_uniform_int_count(void) { return s_stub_uniform_int_count; }
 const char *nt_gfx_stub_test_uniform_int_name_at(uint32_t index) { return index < s_stub_uniform_int_count && index < NT_GFX_STUB_UNIFORM_NAMES ? s_stub_uniform_int_names[index] : NULL; }
 int nt_gfx_stub_test_uniform_int_value_at(uint32_t index) { return index < s_stub_uniform_int_count && index < NT_GFX_STUB_UNIFORM_NAMES ? s_stub_uniform_int_values[index] : -1; }
@@ -97,6 +99,7 @@ void nt_gfx_stub_test_reset(void) {
     s_stub_render_target_destroy_count = 0;
     s_stub_texture_create_count = 0;
     s_stub_program_create_count = 0;
+    s_stub_pipeline_create_count = 0;
     s_stub_uniform_int_count = 0;
     s_stub_update_texture_count = 0;
     s_stub_backend_restore_count = 0;
@@ -220,6 +223,7 @@ uint32_t nt_gfx_backend_create_pipeline(const nt_pipeline_desc_t *desc, uint32_t
         s_stub_fail_next_pipeline_create = false;
         return 0;
     }
+    s_stub_pipeline_create_count++;
     s_stub_last_pipeline_blend = desc->blend;
 #else
     (void)desc;

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -42,9 +42,16 @@ typedef struct {
     float oblique;          /* synthetic-oblique shear folded into the model in draw_n (faux-italic lean); 0 = upright */
 } nt_text_deco_t;
 
+typedef struct {
+    uint64_t key; /* material id folded with its version */
+    nt_pipeline_t pipeline;
+} nt_text_pipeline_entry_t;
+
 static struct {
     /* GPU resources */
-    nt_pipeline_t pipeline;
+    nt_pipeline_t pipeline; /* the entry selected for the bound material */
+    nt_text_pipeline_entry_t pipelines[NT_TEXT_RENDERER_MAX_PIPELINES];
+    uint8_t pipeline_count;
     nt_buffer_t vbo; /* dynamic vertex buffer */
     nt_buffer_t ibo; /* immutable index buffer (pre-generated quad pattern) */
 
@@ -61,9 +68,6 @@ static struct {
     float glyph_depth_bias;
     /* Per-run decoration axes (weight/outline/shadow/underline/strike/oblique); reset as one unit. */
     nt_text_deco_t deco;
-
-    /* Cached pipeline state */
-    uint32_t pipeline_material_version; /* version when pipeline was last created */
 
     bool initialized;
 
@@ -111,22 +115,29 @@ static void generate_quad_indices(void) {
 }
 // #endregion
 
-// #region Pipeline creation
-static void create_pipeline(void) {
-    if (s_text.pipeline.id != 0) {
-        nt_gfx_destroy_pipeline(s_text.pipeline);
-        s_text.pipeline = (nt_pipeline_t){0};
-    }
-
-    /* After the destroy, never before: a material whose program went away must
-     * not keep drawing through the pipeline built on it. */
+// #region Pipeline cache
+/* Resolve the bound material's pipeline, building it on a miss. The version is
+ * folded into the key, so a material that loses its program never selects the
+ * entry built on the old one. Returns an invalid handle while the material has
+ * no usable program -- flush discards the glyphs and retries next frame. */
+static nt_pipeline_t find_or_create_pipeline(void) {
     const nt_material_info_t *info = nt_material_get_info(s_text.material);
     if (!info || !info->ready) {
-        return;
+        return (nt_pipeline_t){0};
     }
     /* Nothing relinks an existing handle, so a ready material holding a program
      * without a GPU object never recovers -- clear the program instead. */
     NT_ASSERT(nt_gfx_program_ready(info->program) && "text material holds a program that will never link");
+
+    const uint64_t key = ((uint64_t)s_text.material.id << 32) | info->version;
+    for (uint8_t i = 0; i < s_text.pipeline_count; i++) {
+        if (s_text.pipelines[i].key == key) {
+            return s_text.pipelines[i].pipeline;
+        }
+    }
+
+    /* Cache full is a configuration bug, not a runtime recovery case. */
+    NT_ASSERT(s_text.pipeline_count < NT_TEXT_RENDERER_MAX_PIPELINES && "text pipeline cache exhausted; raise NT_TEXT_RENDERER_MAX_PIPELINES");
 
     /* Slug vertex layout: 6 attributes, stride = 72 bytes */
     nt_vertex_layout_t layout = {
@@ -144,7 +155,7 @@ static void create_pipeline(void) {
     };
 
     /* Read render state from material — same pattern as mesh_renderer */
-    s_text.pipeline = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
+    nt_pipeline_t pip = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
         .program = info->program,
         .layout = layout,
         .depth_test = info->depth_test,
@@ -154,14 +165,22 @@ static void create_pipeline(void) {
         .cull_mode = (uint8_t)info->cull_mode,
         .label = "text_renderer",
     });
+    /* Invalid means a lost context or a failed backend allocation. Caching it
+     * would pin the failure for the rest of the session; retry next frame. */
+    if (pip.id == 0) {
+        return pip;
+    }
 
-    s_text.pipeline_material_version = info->version;
+    s_text.pipelines[s_text.pipeline_count].key = key;
+    s_text.pipelines[s_text.pipeline_count].pipeline = pip;
+    s_text.pipeline_count++;
+    return pip;
 }
 // #endregion
 
 // #region Lifecycle
-/* GPU resources only — the pipeline is created lazily in flush, so this owns just the buffers + index
- * pattern. Must not touch s_text's logical fields; restore_gpu rebuilds these without wiping them. */
+/* GPU resources only — pipelines are built lazily on a cache miss, so this owns just the buffers +
+ * index pattern. Must not touch s_text's logical fields; restore_gpu rebuilds these without wiping them. */
 static void create_gpu_resources(void) {
     generate_quad_indices();
     s_text.vbo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
@@ -181,10 +200,12 @@ static void create_gpu_resources(void) {
 }
 
 static void destroy_gpu_resources(void) {
-    if (s_text.pipeline.id != 0) {
-        nt_gfx_destroy_pipeline(s_text.pipeline);
-        s_text.pipeline = (nt_pipeline_t){0};
+    for (uint8_t i = 0; i < s_text.pipeline_count; i++) {
+        nt_gfx_destroy_pipeline(s_text.pipelines[i].pipeline);
+        s_text.pipelines[i] = (nt_text_pipeline_entry_t){0};
     }
+    s_text.pipeline_count = 0;
+    s_text.pipeline = (nt_pipeline_t){0};
     nt_gfx_destroy_buffer(s_text.vbo);
     nt_gfx_destroy_buffer(s_text.ibo);
     s_text.vbo = (nt_buffer_t){0};
@@ -222,8 +243,7 @@ void nt_text_renderer_restore_gpu(void) {
     destroy_gpu_resources();
     create_gpu_resources();
     s_text.vertex_count = 0; /* in-flight staging is dropped across context loss */
-    s_text.glyph_count = 0;
-    s_text.pipeline_material_version = 0; /* pipeline destroyed above → flush rebuilds it lazily */
+    s_text.glyph_count = 0;  /* pipeline cache went with destroy_gpu_resources → flush rebuilds lazily */
 }
 // #endregion
 
@@ -248,8 +268,7 @@ void nt_text_renderer_set_material(nt_material_t mat) {
     }
 
     s_text.material = mat;
-    s_text.pipeline_material_version = 0;
-    create_pipeline();
+    s_text.pipeline = find_or_create_pipeline();
 }
 
 void nt_text_renderer_set_font(nt_font_t font) {
@@ -682,12 +701,10 @@ void nt_text_renderer_flush(void) {
     if (s_text.glyph_count == 0) {
         return;
     }
-    /* Rebuild on any material version bump -- a new program included. */
+    /* Re-resolve rather than trust the handle set_material picked: a version bump
+     * between the two (a new program) selects a different entry. Normally a hit. */
     if (s_text.material.id != 0) {
-        const nt_material_info_t *info = nt_material_get_info(s_text.material);
-        if (info && (s_text.pipeline.id == 0 || info->version != s_text.pipeline_material_version)) {
-            create_pipeline();
-        }
+        s_text.pipeline = find_or_create_pipeline();
     }
     if (s_text.pipeline.id == 0) {
         NT_LOG_WARN("nt_text_renderer_flush: no pipeline -- discarding %u glyphs", s_text.glyph_count);

--- a/engine/renderers/nt_text_renderer.h
+++ b/engine/renderers/nt_text_renderer.h
@@ -9,6 +9,10 @@
 
 #ifndef NT_TEXT_RENDERER_MAX_GLYPHS
 #define NT_TEXT_RENDERER_MAX_GLYPHS 4096
+/* One entry per (material, version) the frame draws through. UI text switches
+ * between a context default and per-style overrides, so a single slot would
+ * rebuild a VAO on every switch. */
+#define NT_TEXT_RENDERER_MAX_PIPELINES 4
 #endif
 
 #define NT_TEXT_RENDERER_MAX_VERTICES (NT_TEXT_RENDERER_MAX_GLYPHS * 4)

--- a/tests/unit/test_text_renderer.c
+++ b/tests/unit/test_text_renderer.c
@@ -333,6 +333,43 @@ void test_flush_stops_after_program_cleared(void) {
     nt_gfx_end_frame();
 }
 
+/* UI text alternates between a context default and per-style overrides, so a
+ * single pipeline slot rebuilt a VAO on every switch (#378). */
+void test_switching_back_to_a_material_reuses_its_pipeline(void) {
+    nt_material_t a = create_test_material_with_blend(nt_blend_alpha());
+    nt_material_t b = create_test_material_with_blend(nt_blend_opaque());
+
+    nt_gfx_stub_test_reset();
+    nt_text_renderer_set_material(a);
+    nt_text_renderer_set_material(b);
+    nt_text_renderer_set_material(a);
+
+    /* Three switches, two distinct materials: the third must be a cache hit. */
+    TEST_ASSERT_EQUAL_UINT32(2U, nt_gfx_stub_test_pipeline_create_count());
+}
+
+/* A new program means a new pipeline even though the material handle is the
+ * same -- the version is what makes the key differ. */
+void test_a_new_program_does_not_reuse_the_old_pipeline(void) {
+    nt_material_t mat = create_test_material_with_blend(nt_blend_alpha());
+    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "void main(){}"});
+    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "void main(){}"});
+
+    nt_gfx_stub_test_reset();
+    nt_text_renderer_set_material(mat);
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_gfx_stub_test_pipeline_create_count());
+
+    nt_material_set_program(mat, nt_gfx_make_program(vs, fs));
+    nt_text_renderer_draw("AB", s_identity, 32.0F, s_white, 0.0F, 0.0F);
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+    nt_text_renderer_flush();
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    TEST_ASSERT_EQUAL_UINT32(2U, nt_gfx_stub_test_pipeline_create_count());
+}
+
 /* A ready material pointing at a destroyed program is the mistake the spec says
  * must trap; discarding the glyphs instead would hide it behind a warning. */
 void test_flush_traps_on_a_destroyed_program(void) {
@@ -801,6 +838,8 @@ int main(void) {
     RUN_TEST(test_draw_newline_advances_to_next_line);
     RUN_TEST(test_flush_stops_after_program_cleared);
     RUN_TEST(test_flush_traps_on_a_destroyed_program);
+    RUN_TEST(test_switching_back_to_a_material_reuses_its_pipeline);
+    RUN_TEST(test_a_new_program_does_not_reuse_the_old_pipeline);
     RUN_TEST(test_draw_n_matches_draw);
     RUN_TEST(test_draw_n_letter_spacing_advances_pen);
     RUN_TEST(test_draw_n_line_leading_advances_pen_y);


### PR DESCRIPTION
Closes #378. Stacked on `353-gfx-program-object` — retarget to master once that merges.

## Problem

The text renderer held one pipeline plus a version stamp, so every material change destroyed the live pipeline and built a replacement: `glDeleteVertexArrays`, `glGenVertexArrays`, six `glEnableVertexAttribArray`, a VAO cache invalidation that forced a redundant re-bind on the next draw, and an `nt_gfx` pool free/alloc cycle.

Not rare: `nt_ui` resolves a text material per widget run, and `nt_ui_rich_text` picks between a style override and the context default inside a single frame.

Output was always correct — this is wasted driver work, not a rendering defect.

## Fix

A four-entry cache keyed on the material handle folded with its version, the shape `nt_sprite_renderer` and `nt_mesh_renderer` already use.

Folding the version into the key is what preserves the readiness contract from #353: a material that loses its program bumps its version, so it can never select the entry built on the old program. The dead `pipeline_material_version` field goes away with it — one resolution point now, `find_or_create_pipeline`, called from both `set_material` and `flush`.

Entries are dropped in `destroy_gpu_resources`, which `restore_gpu` calls, so a context restore still clears the whole cache — matching what the spec says about renderer-cached pipelines.

## Tests

Both verified against the mutation they exist to catch:

- `test_switching_back_to_a_material_reuses_its_pipeline` — A → B → A creates two pipelines, not three. Removing the cache lookup makes it read 3.
- `test_a_new_program_does_not_reuse_the_old_pipeline` — same material handle, new program, so the version differs and a second pipeline is built.

The stub backend gained `nt_gfx_stub_test_pipeline_create_count` alongside the existing program counter; without it the test could only infer a cache hit rather than observe one.

`bash scripts/check.sh --push` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Spzm9XcsFN53pcHxY4SXPc