### PR TITLE
mesh: skip a not-ready run instead of asserting on it

### DIFF
--- a/docs/spec/assets/resource.md
+++ b/docs/spec/assets/resource.md
@@ -159,11 +159,10 @@ Programs come back over several frames, not in the restore frame: the shader
 stages re-activate from `NT_ASSET_SHADER_CODE` through the resource step's
 activation budget. The game relinks once both stages resolve and assigns the new
 handle with `nt_material_set_program`. Until then materials are not `ready`.
-`nt_sprite_renderer_draw_list` skips a not-ready run silently;
-`nt_mesh_renderer_draw_list` asserts, so the game filters those entities out
-before it builds render items. The immediate-mode
-`nt_sprite_renderer_set_material` / `nt_text_renderer_set_material` entry points
-assert too, so a game must stop feeding them for the duration of the window.
+Both ECS `draw_list` paths skip a not-ready run silently -- it is normal runtime
+state, not a caller error. The immediate-mode `nt_sprite_renderer_set_material`
+/ `nt_text_renderer_set_material` entry points assert instead, so a game must
+stop feeding them for the duration of the window.
 A game whose materials sit on several programs gates on every one of them: the
 programs link on different frames, and one not-ready material is enough to trap.
 

--- a/engine/renderers/nt_mesh_renderer.c
+++ b/engine/renderers/nt_mesh_renderer.c
@@ -438,7 +438,10 @@ void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count) {
             const nt_material_info_t *mat_info = nt_material_get_info(run_mat);
             const nt_gfx_mesh_info_t *mesh_info = nt_gfx_get_mesh_info(run_mesh);
 
-            NT_ASSERT(mat_info && mat_info->ready && mesh_info); /* caller must filter not-ready items */
+            /* Not ready is legitimate runtime state, not a bug: async activation
+             * and the context-restore window both produce it. Skip like the
+             * sprite path does -- the material diagnostics report a material
+             * that never gets a program. */
             if (!mat_info || !mat_info->ready || !mesh_info) {
                 /* Still need to advance byte offset for skipped runs */
                 nt_color_mode_t cm = (mat_info != NULL) ? mat_info->color_mode : NT_COLOR_MODE_NONE;

--- a/tests/unit/test_mesh_renderer.c
+++ b/tests/unit/test_mesh_renderer.c
@@ -307,6 +307,33 @@ void test_draw_list_same_material_mesh_batching(void) {
     TEST_ASSERT_EQUAL_UINT32(3, nt_mesh_renderer_test_instance_total());
 }
 
+/* A material with no program yet is normal during async activation and the
+ * context-restore window, so the run is skipped, not asserted (#381). The ready
+ * run after it must still land at the right instance offset -- dropping the
+ * advance would draw it with the skipped run's instance data. */
+void test_draw_list_skips_a_not_ready_run_and_offsets_the_next(void) {
+    nt_mesh_t mesh = create_test_mesh();
+    nt_material_t not_ready = create_test_material();
+    nt_material_t ready = create_test_material();
+    nt_material_set_program(not_ready, NT_PROGRAM_INVALID);
+
+    nt_entity_t e0 = create_test_entity(mesh, not_ready);
+    nt_entity_t e1 = create_test_entity(mesh, ready);
+
+    nt_render_item_t items[2];
+    items[0].sort_key = 0;
+    items[0].entity = e0.id;
+    items[0].batch_key = nt_mesh_renderer_batch_key(not_ready, mesh);
+    items[1].sort_key = 1;
+    items[1].entity = e1.id;
+    items[1].batch_key = nt_mesh_renderer_batch_key(ready, mesh);
+
+    nt_mesh_renderer_draw_list(items, 2);
+
+    TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_draw_call_count());
+    TEST_ASSERT_EQUAL_UINT32(nt_gfx_stub_test_last_update_buffer_offset() + NT_INSTANCE_STRIDE_NONE, nt_gfx_stub_test_last_instance_offset());
+}
+
 /* ---- Test 5: 2 items with different materials -> 2 draw calls ---- */
 
 void test_draw_list_different_materials(void) {
@@ -753,6 +780,7 @@ int main(void) {
     RUN_TEST(test_draw_list_single_item);
     RUN_TEST(test_mesh_renderer_forwards_material_blend_state);
     RUN_TEST(test_draw_list_same_material_mesh_batching);
+    RUN_TEST(test_draw_list_skips_a_not_ready_run_and_offsets_the_next);
     RUN_TEST(test_draw_list_different_materials);
     RUN_TEST(test_draw_list_alternating_materials);
     RUN_TEST(test_pipeline_cache_reuse);


### PR DESCRIPTION
Closes #381. Stacked on `353-gfx-program-object` — retarget to master once that merges. Independent of #380.

## Problem

The two ECS `draw_list` paths did opposite things with the same state.

`nt_sprite_renderer_draw_list` skips the run: *"Material not yet ready — skip the run silently (legitimate runtime state, not a bug)."*
`nt_mesh_renderer_draw_list` asserted: `NT_ASSERT(mat_info && mat_info->ready && mesh_info); /* caller must filter not-ready items */`.

Found while reviewing #353 — the context-restore section of `docs/spec/assets/resource.md` claimed both paths skip, and the sentence had to be weakened to match the code.

## Why skipping is the right side

A material without a linked program is not an invariant violation. Async activation and the multi-frame context-restore window both produce it, and `resource.md` documents that window as expected behavior.

The assert also sat directly above a fallback skip. Under the release TRAP default the process dies before reaching that branch, so the branch only ran in `NT_ASSERT_MODE=OFF` — a configuration we do not ship. Removing the assert is what makes the code beneath it reachable.

What the assert actually guarded — a material that silently never receives a program — is now reported by the material diagnostics added on #353, which name the offending material instead of only saying a draw list was wrong.

The reverse fix (making the sprite path assert) would break context restore exactly where the spec promises graceful degradation.

## Test

`test_draw_list_skips_a_not_ready_run_and_offsets_the_next` puts the not-ready run **first**, so it pins two things at once: the following run still draws, and its instance-buffer offset advanced past the skipped run. Deleting the `draw_byte_offset` advance makes it read 0 instead of 48 — a single-run test would not have noticed, and the failure in a real frame is silent (right geometry, another run's transforms).

`bash scripts/check.sh --push` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Spzm9XcsFN53pcHxY4SXPc