### PR TITLE
gfx: owned vertex-input objects (VAO) — pipeline becomes program + render state (#355)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,10 +561,11 @@ jobs:
           npm ci
           npx playwright install --with-deps chromium
 
-      # serve.mjs serves the devapi_host wasm output (NT_SHOWCASE_DIR override); the spec drives
-      # window.__devapi deterministically and asserts the deferred capture is a decodable non-blank PNG.
+      # The devapi-chromium project's server defaults to build/examples/devapi_host/wasm-debug
+      # (NT_DEVAPI_DIR overrides); the spec drives window.__devapi deterministically and asserts
+      # the deferred capture is a decodable non-blank PNG.
       - name: Run devapi web smoke test
-        run: cd tests/browser && NT_SHOWCASE_DIR="$GITHUB_WORKSPACE/build/examples/devapi_host/wasm-debug" npx playwright test devapi.spec.ts
+        run: cd tests/browser && npx playwright test devapi.spec.ts
 
   lint:
     name: Format & Tidy

--- a/docs/spec/assets/resource.md
+++ b/docs/spec/assets/resource.md
@@ -167,16 +167,21 @@ module initialized but unable to draw; the game must retry
 `nt_sprite_renderer`, and `nt_text_renderer` borrow game material programs:
 restore drops queued commands and pipeline caches, then the game relinks.
 
-`nt_mesh_renderer_restore_gpu()` and `nt_sprite_renderer_restore_gpu()` return
-`nt_result_t`. They retain CPU allocations, configured capacities, and module
-initialization; only GPU buffers, cached pipelines/vertex inputs, and queued
-draw state are reset. An inactive module is a no-op returning `NT_OK`.
-Failed GPU creation returns `NT_ERR_INIT_FAILED` after releasing partial GPU
-resources. The module stays initialized, so the game can call restore again or
-shut it down. There is no automatic retry. After failure, the game must not
-submit draws or sprite materials until a restore succeeds; violating that
-precondition asserts. Examples may explicitly choose fail-fast handling, while
-a game that needs retries owns that policy.
+`nt_mesh_renderer_restore_gpu()`, `nt_sprite_renderer_restore_gpu()`, and
+`nt_text_renderer_restore_gpu()` return `nt_result_t`. They retain CPU
+allocations, configured capacities, and module initialization; only GPU
+buffers, cached pipelines/vertex inputs, and queued draw state are reset. An
+inactive module is a no-op returning `NT_OK` — this holds for every restore
+entry point, `nt_postfx_blur_restore_gpu` included. Failed GPU creation
+returns `NT_ERR_INIT_FAILED` after releasing partial GPU resources. The module
+stays initialized, so the game can call restore again or shut it down. There
+is no automatic retry, with one narrow exception: the text renderer's vertex
+input bakes over buffers it owns, so a recoverable backend failure there is
+retried lazily in flush and does not fail the restore. After a mesh or sprite
+failure, the game must not submit draws or sprite materials until a restore
+succeeds; violating that precondition asserts. The text renderer instead
+discards staged glyphs while its buffers are missing. Examples may explicitly
+choose fail-fast handling, while a game that needs retries owns that policy.
 
 Materials survive teardown and retain their old program handles. Destroying a
 program bumps its slot generation, so `nt_gfx_program_ready(info->program)`

--- a/docs/spec/assets/resource.md
+++ b/docs/spec/assets/resource.md
@@ -170,9 +170,10 @@ restore drops queued commands and pipeline caches, then the game relinks.
 `nt_mesh_renderer_restore_gpu()`, `nt_sprite_renderer_restore_gpu()`, and
 `nt_text_renderer_restore_gpu()` return `nt_result_t`. They retain CPU
 allocations, configured capacities, and module initialization; only GPU
-buffers, cached pipelines/vertex inputs, and queued draw state are reset. An
-inactive module is a no-op returning `NT_OK` — this holds for every restore
-entry point, `nt_postfx_blur_restore_gpu` included. Failed GPU creation
+buffers, cached pipelines/vertex inputs, and queued draw state are reset.
+Every restore entry point is an inactive no-op. The `nt_result_t`-returning
+mesh, sprite, text, and blur functions return `NT_OK` in that case;
+`nt_shape_renderer_restore_gpu` returns void. Failed GPU creation
 returns `NT_ERR_INIT_FAILED` after releasing partial GPU resources. The module
 stays initialized, so the game can call restore again or shut it down. There
 is no automatic retry, with one narrow exception: the text renderer's vertex

--- a/docs/spec/assets/resource.md
+++ b/docs/spec/assets/resource.md
@@ -167,6 +167,17 @@ module initialized but unable to draw; the game must retry
 `nt_sprite_renderer`, and `nt_text_renderer` borrow game material programs:
 restore drops queued commands and pipeline caches, then the game relinks.
 
+`nt_mesh_renderer_restore_gpu()` and `nt_sprite_renderer_restore_gpu()` return
+`nt_result_t`. They retain CPU allocations, configured capacities, and module
+initialization; only GPU buffers, cached pipelines/vertex inputs, and queued
+draw state are reset. An inactive module is a no-op returning `NT_OK`.
+Failed GPU creation returns `NT_ERR_INIT_FAILED` after releasing partial GPU
+resources. The module stays initialized, so the game can call restore again or
+shut it down. There is no automatic retry. After failure, the game must not
+submit draws or sprite materials until a restore succeeds; violating that
+precondition asserts. Examples may explicitly choose fail-fast handling, while
+a game that needs retries owns that policy.
+
 Materials survive teardown and retain their old program handles. Destroying a
 program bumps its slot generation, so `nt_gfx_program_ready(info->program)`
 reports false. Material handles remain unchanged; ECS components, the UI context,

--- a/docs/spec/core/api-contracts.md
+++ b/docs/spec/core/api-contracts.md
@@ -265,12 +265,16 @@ never reaches this descriptor. These cases, exhausted configured target
 capacity, stale handles, direct mutation of owned attachments, and
 render-target lifecycle calls inside an active pass are developer errors and
 assert. `nt_gfx_make_pipeline` follows the same split: a NULL descriptor, an
-unready program, an attribute count over `NT_GFX_MAX_VERTEX_ATTRS`, a stride
-over the WebGL2 cap of 255, and an exhausted pipeline pool all assert, so a
-returned invalid pipeline handle means a lost context or a failed backend
-allocation — the two recoverable outcomes, both retried on a later frame.
-Creating a pipeline preserves the currently bound pipeline and its vertex-input
-state; the caller does not need to rebind it after creating another pipeline.
+unready program, and an exhausted pipeline pool assert, so a returned invalid
+pipeline handle means a lost context or a failed backend allocation — the two
+recoverable outcomes, both retried on a later frame.
+`nt_gfx_make_vertex_input` applies the same contract to the layout checks: an
+attribute count over `NT_GFX_MAX_VERTEX_ATTRS` (instance layouts over
+`NT_GFX_MAX_INSTANCE_ATTRS`), a stride over the WebGL2 cap of 255, misaligned
+or duplicated attributes, mismatched buffers, and an exhausted pool all
+assert. Creating a pipeline or a vertex input preserves both current bindings
+(the bound pipeline and the bound vertex input); the caller does not need to
+rebind after creating another object.
 Backend allocation, framebuffer completeness, resize, and context-restore
 failures remain runtime failures reported through invalid handles, `false`, or
 readiness queries.

--- a/docs/spec/core/api-contracts.md
+++ b/docs/spec/core/api-contracts.md
@@ -272,12 +272,17 @@ recoverable outcomes, both retried on a later frame.
 attribute count over `NT_GFX_MAX_VERTEX_ATTRS` (instance layouts over
 `NT_GFX_MAX_INSTANCE_ATTRS`), a stride over the WebGL2 cap of 255, misaligned
 or duplicated attributes, mismatched buffers, and an exhausted pool all
-assert. Creating a pipeline or a vertex input preserves both current bindings
-(the bound pipeline and the bound vertex input); the caller does not need to
-rebind after creating another object.
-Backend allocation, framebuffer completeness, resize, and context-restore
-failures remain runtime failures reported through invalid handles, `false`, or
-readiness queries.
+assert. The returned vertex input is caller-owned and destroyed with
+`nt_gfx_destroy_vertex_input`; it borrows the referenced buffers, whose
+destruction may invalidate it through the documented cascade. The descriptor
+and label are borrowed only for the call. Creating a pipeline or a vertex input
+preserves both current bindings (the bound pipeline and the bound vertex
+input); the caller does not need to rebind after creating another object.
+Allocation failures from public GPU-resource operations, framebuffer
+completeness, resize, and context restore remain runtime failures reported
+through invalid handles, `false`, or readiness queries. Mandatory backend
+setup objects are internal invariants: failure to create the GL service EBO
+upload VAO with a live context asserts.
 
 `nt_gfx_begin_pass` asserts on invalid sequencing and on a non-ready target.
 Callers check readiness before beginning work that depends on restored GPU

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -100,10 +100,13 @@ index-buffer data ops run inside a service upload VAO in the backend,
 because the element-array binding is VAO state — it would otherwise be
 silently rewired into whichever vertex input is bound, and core-profile GL
 rejects the bind with VAO 0. Vertex inputs die with a lost context
-and are not auto-restored; renderer restore paths recreate them. Loss alone
-does not fail `nt_gfx_vertex_input_valid` — pool slots live until the restore
-path's buffer destroys cascade through them; a bind that reaches a
-context-orphaned vertex input first traps on its zeroed backend.
+and are not auto-restored: loss itself frees their pool slots, so a handle
+held across a loss goes stale and `nt_gfx_vertex_input_valid` reports false.
+Renderer restore paths recreate them; caches validate on lookup and
+self-heal. This is the rule for baked objects, which have no re-fill path.
+Primary resources (buffers, textures, shaders, programs) instead survive a
+loss as husks — pool slot alive, backend gone — because the restore recipe
+has their owners destroy the old handles explicitly.
 
 **Program / pipeline split.** A program is the linked (vertex, fragment) pair
 and owns everything that follows from linking: uniform locations, uniform
@@ -155,9 +158,11 @@ thrash as an invisible perf regression.
 
 The sprite renderer owns its vertex/index buffers and clears its entire
 vertex-input cache on shutdown or GPU restore before replacing those buffers.
-A cache hit asserts handle validity; a miss creates the vertex input and
-caches it only on success. Recoverable creation failures leave the cache
-unchanged so the next lookup retries.
+Cache entries are weak: a hit validates the handle, and an entry whose
+vertex input died (context loss) is recreated in place, so repeated losses
+cannot grow the cache. A miss creates the vertex input and caches it only on
+success; recoverable creation failures leave the cache unchanged so the next
+lookup retries.
 
 ### Render targets
 

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -97,7 +97,10 @@ keep the GL name, so baked attachments survive per-flush orphaning — and
 index-buffer data ops run with VAO 0 bound in the backend, because the
 element-array binding is VAO state and would otherwise be silently rewired
 into whichever vertex input is bound. Vertex inputs die with a lost context
-and are not auto-restored; renderer restore paths recreate them.
+and are not auto-restored; renderer restore paths recreate them. Loss alone
+does not fail `nt_gfx_vertex_input_valid` — pool slots live until the restore
+path's buffer destroys cascade through them; a bind that reaches a
+context-orphaned vertex input first traps on its zeroed backend.
 
 **Program / pipeline split.** A program is the linked (vertex, fragment) pair
 and owns everything that follows from linking: uniform locations, uniform

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -139,14 +139,16 @@ material module and every renderer).
 
 Vertex-input caches follow the same hash-as-identity standard for *derived*
 layouts. The mesh renderer keeps a per-mesh versions table
-(`[nt_gfx_max_meshes()][nt_mesh_renderer_desc_t.max_mesh_layouts]`): entry
-identity is the hash of the derived layout (mesh streams × material
-attr_map — attr_map entries matching no stream do not split; a material
+(`[nt_gfx_max_meshes()][nt_mesh_renderer_desc_t.max_mesh_layouts]`). Each row
+stores its mesh's full generation-checked handle. A different generation
+clears the entire row, including bufferless vertex inputs that have no
+destroy-cascade hook. Within the row, entry identity is the hash of the
+derived layout (mesh streams × material attr_map — attr_map entries
+matching no stream do not split; a material
 mapping none of the streams derives an empty layout and takes the
-attribute-less gl_VertexID path) plus color
-mode, plus the mesh's full generation-checked handle, which stays exact so
-pool-slot reuse cannot alias a stale entry. Exhausting a mesh's version row
-asserts, naming the knob — silent eviction would hide VAO re-creation
+attribute-less gl_VertexID path) plus color mode. Handles are revalidated on
+lookup because buffer destruction can invalidate cached versions.
+Exhausting a mesh's version row asserts, naming the knob — silent eviction would hide VAO re-creation
 thrash as an invisible perf regression.
 
 ### Render targets

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -90,9 +90,11 @@ keeps renderer-cached vertex inputs from outliving mesh buffers; mesh caches
 revalidate handles with `nt_gfx_vertex_input_valid` on lookup. Because the
 cascade makes stale handles routine, `nt_gfx_destroy_vertex_input` tolerates
 stale and INVALID handles as no-ops. The dynamically captured instance
-buffer is *not* cascade-tracked: destroying one while vertex inputs still
-hold pointers into it leaves zombie GL attachments until those vertex inputs
-die or re-point. Buffer *contents* may change freely — `update`/`orphan`
+buffer is *not* cascade-destroyed, but destroying one clears the dependents'
+pointed flag: their next instanced draw asserts until
+`nt_gfx_bind_instance_buffer` re-points them, and the GL attachment's
+storage lingers until that re-point or the vertex input's death.
+Buffer *contents* may change freely — `update`/`orphan`
 keep the GL name, so baked attachments survive per-flush orphaning — and
 index-buffer data ops run inside a service upload VAO in the backend,
 because the element-array binding is VAO state — it would otherwise be

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -103,10 +103,13 @@ rejects the bind with VAO 0. Vertex inputs die with a lost context
 and are not auto-restored: loss itself frees their pool slots, so a handle
 held across a loss goes stale and `nt_gfx_vertex_input_valid` reports false.
 Renderer restore paths recreate them; caches validate on lookup and
-self-heal. This is the rule for baked objects, which have no re-fill path.
-Primary resources (buffers, textures, shaders, programs) instead survive a
-loss as husks — pool slot alive, backend gone — because the restore recipe
-has their owners destroy the old handles explicitly.
+self-heal. This is the rule for baked objects — pipelines and vertex
+inputs, both assembled from other handles with no re-fill path: a context
+loss frees their pool slots outright. Primary resources (buffers, textures,
+shaders, programs) instead survive a loss as husks — pool slot alive,
+backend gone — because per-frame code keeps operating on them through the
+loss window and the restore recipe has their owners destroy the old handles
+explicitly.
 
 **Program / pipeline split.** A program is the linked (vertex, fragment) pair
 and owns everything that follows from linking: uniform locations, uniform
@@ -121,8 +124,9 @@ to sampler units and material params. Planned fixes are fixed sampler-unit
 assignments per program (#359) and per-material param UBOs bound at material
 transitions (#133). Until both land, two materials sharing one program must
 declare the same params and texture slots. Destroying a program destroys its
-pipelines; renderers remove dead cache
-records during insertion after a miss or when resetting their caches.
+pipelines, and a context loss frees every pipeline slot; renderers remove
+dead cache records during insertion after a miss or when resetting their
+caches.
 
 **Cache identity.** Renderers key their pipeline caches on a 64-bit
 hash of the pipeline signature — program handle and render

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -86,7 +86,7 @@ created once and cached by their owners, so the asserts are off the hot path.
 live vertex input referencing that buffer as its vertex or index buffer
 (precedent: destroying a program destroys its pipelines). Mesh deactivation
 destroys the mesh's buffers and reaches no renderer, so this cascade is what
-keeps renderer-cached vertex inputs from outliving mesh buffers; caches
+keeps renderer-cached vertex inputs from outliving mesh buffers; mesh caches
 revalidate handles with `nt_gfx_vertex_input_valid` on lookup. Because the
 cascade makes stale handles routine, `nt_gfx_destroy_vertex_input` tolerates
 stale and INVALID handles as no-ops. The dynamically captured instance
@@ -150,6 +150,12 @@ attribute-less gl_VertexID path) plus color mode. Handles are revalidated on
 lookup because buffer destruction can invalidate cached versions.
 Exhausting a mesh's version row asserts, naming the knob — silent eviction would hide VAO re-creation
 thrash as an invisible perf regression.
+
+The sprite renderer owns its vertex/index buffers and clears its entire
+vertex-input cache on shutdown or GPU restore before replacing those buffers.
+A cache hit asserts handle validity; a miss creates the vertex input and
+caches it only on success. Recoverable creation failures leave the cache
+unchanged so the next lookup retries.
 
 ### Render targets
 

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -50,29 +50,61 @@ renderer_draw_mesh(...);
 renderer_draw_sprite(...);
 ```
 
-### Vertex layouts
+### Vertex inputs
 
-A pipeline's vertex attribute is the raw GL triple `(type, count 1-4,
+Vertex-input state is an **owned public object**, `nt_vertex_input_t`: a
+vertex layout, an optional per-instance layout, and the vertex buffer
+[+ index buffer] baked together (GL: a VAO). One
+`nt_gfx_bind_vertex_input` selects the whole geometry for the following
+draws; per mesh switch that is a single `glBindVertexArray` instead of
+buffer re-binds plus per-attribute `glVertexAttribPointer` rewrites. The
+object's *static* half — vertex attributes and the index binding — is
+immutable after creation; its *instance* attribute pointers are re-specified
+into the bound object by each `nt_gfx_bind_instance_buffer` (WebGL2 has no
+baseInstance, so per-draw instance re-pointing stays). An empty layout with
+no buffers is the attribute-less `gl_VertexID` path; every draw asserts a
+bound vertex input.
+
+A vertex attribute is the raw GL triple `(type, count 1-4,
 normalized)` plus location and byte offset (`nt_vertex_attr_t`) — no enum of
 allowed combinations; the float/half/byte/short subset of the
 `vertexAttribPointer` space (no int32 or 2_10_10_2 packed types) is available
-to game-built pipelines and mesh-pack streams alike. The pack's on-disk stream
+to game-built layouts and mesh-pack streams alike. The pack's on-disk stream
 type enum stays separate from the gfx vertex type enum in the vertex-layout
 API (the mesh renderer maps between them totally; the mesh-activation side
 table `nt_gfx_mesh_info_t` still stores raw pack descs — a known, contained
-exception). Pipeline creation asserts the WebGL2 alignment rules (attribute
-offset and stride multiples of the attribute's type size, locations within
-the WebGL2-guaranteed 16): game-declared layouts never pass through the
-builder's validator, and desktop GL accepts what the browser rejects.
-Pack data never reaches those asserts: mesh activation hard-rejects invalid
-per-stream type/count/normalized, duplicate name hashes, and misaligned
-offsets/strides before any pipeline exists. Pipelines are cached, so the
-asserts are off the hot path.
+exception). Vertex-input creation asserts the WebGL2 alignment rules
+(attribute offset and stride multiples of the attribute's type size,
+locations within the WebGL2-guaranteed 16): game-declared layouts never pass
+through the builder's validator, and desktop GL accepts what the browser
+rejects. Pack data never reaches those asserts: mesh activation hard-rejects
+invalid per-stream type/count/normalized, duplicate name hashes, and
+misaligned offsets/strides before any vertex input exists. Vertex inputs are
+created once and cached by their owners, so the asserts are off the hot path.
+
+**Lifetime and the destroy cascade.** `nt_gfx_destroy_buffer` destroys every
+live vertex input referencing that buffer as its vertex or index buffer
+(precedent: destroying a program destroys its pipelines). Mesh deactivation
+destroys the mesh's buffers and reaches no renderer, so this cascade is what
+keeps renderer-cached vertex inputs from outliving mesh buffers; caches
+revalidate handles with `nt_gfx_vertex_input_valid` on lookup. Because the
+cascade makes stale handles routine, `nt_gfx_destroy_vertex_input` tolerates
+stale and INVALID handles as no-ops. The dynamically captured instance
+buffer is *not* cascade-tracked: destroying one while vertex inputs still
+hold pointers into it leaves zombie GL attachments until those vertex inputs
+die or re-point. Buffer *contents* may change freely — `update`/`orphan`
+keep the GL name, so baked attachments survive per-flush orphaning — and
+index-buffer data ops run with VAO 0 bound in the backend, because the
+element-array binding is VAO state and would otherwise be silently rewired
+into whichever vertex input is bound. Vertex inputs die with a lost context
+and are not auto-restored; renderer restore paths recreate them.
 
 **Program / pipeline split.** A program is the linked (vertex, fragment) pair
 and owns everything that follows from linking: uniform locations, uniform
-values, and global UBO block bindings. A pipeline is a VAO plus fixed-function
-state that *borrows* a program handle. Two pipelines on one program therefore
+values, and global UBO block bindings. A pipeline is fixed-function render
+state that *borrows* a program handle — it owns no vertex-input state, and
+pipeline and vertex-input binding are orthogonal: either may change without
+re-binding the other. Two pipelines on one program
 share every uniform value, and binding one does not reset what the other set —
 each consumer sets every uniform it needs on every draw. A uniform a material
 does not declare retains the value last written on that program; this applies
@@ -82,23 +114,34 @@ transitions (#133). Until both land, two materials sharing one program must
 declare the same params and texture slots. Destroying a program destroys its
 pipelines; renderers remove dead cache
 records during insertion after a miss or when resetting their caches.
-Moving vertex-input state out of the pipeline remains planned in #355.
 
-**Pipeline cache identity.** Renderers key their pipeline caches on a 64-bit
-hash of the full pipeline signature — vertex layout, program handle, render
+**Cache identity.** Renderers key their pipeline caches on a 64-bit
+hash of the pipeline signature — program handle and render
 state — and treat that hash as identity: descriptors are never compared on a
 hit. The cached pipelines borrow programs the game owns, so a cache entry never
 extends a program's lifetime.
-The hashed population is distinct layouts and material states, tens of values
+The hashed population is distinct material states, tens of values
 in a real game, so a 64-bit collision is not a practical risk, and a fixed
 array with a linear scan stays cheaper than a hash map at that scale. Every
 `nt_pipeline_desc_t` field a renderer varies must be folded into its key.
 
-A renderer whose descriptor is constant except for the program and the
-material's render state keys on those two alone — `nt_text_renderer` folds
-`program.id` with `nt_material_info_t.render_state_hash`. This key is complete
-while its vertex layout, depth function and label remain compile-time literals.
-Material identity would prevent sharing and fail to capture program replacement.
+Every renderer now keys pipelines on `program.id` folded with
+`nt_material_info_t.render_state_hash` (the `nt_text_renderer` pattern) —
+layouts moved to the vertex-input objects, so materials differing only in
+layout share one pipeline. `render_state_hash` folds `color_mode`, so mesh
+pipelines still split per color mode even though nothing in the slimmed
+pipeline depends on it — an accepted over-split (removing it would touch the
+material module and every renderer).
+
+Vertex-input caches follow the same hash-as-identity standard for *derived*
+layouts. The mesh renderer keeps a per-mesh versions table
+(`[nt_gfx_max_meshes()][nt_mesh_renderer_desc_t.max_mesh_layouts]`): entry
+identity is the hash of the derived layout (mesh streams × material
+attr_map — attr_map entries matching no stream do not split) plus color
+mode, plus the mesh's full generation-checked handle, which stays exact so
+pool-slot reuse cannot alias a stale entry. Exhausting a mesh's version row
+asserts, naming the knob — silent eviction would hide VAO re-creation
+thrash as an invisible perf regression.
 
 ### Render targets
 

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -52,9 +52,11 @@ renderer_draw_sprite(...);
 
 ### Vertex inputs
 
-Vertex-input state is an **owned public object**, `nt_vertex_input_t`: a
-vertex layout, an optional per-instance layout, and the vertex buffer
-[+ index buffer] baked together (GL: a VAO). One
+Vertex-input state is a public gfx object referenced by `nt_vertex_input_t`.
+The caller that creates it owns the handle and destroys it with
+`nt_gfx_destroy_vertex_input`; the object borrows its vertex and optional
+index buffer handles. It bakes those buffers together with a vertex layout
+and an optional per-instance layout (GL: a VAO). One
 `nt_gfx_bind_vertex_input` selects the whole geometry for the following
 draws; per mesh switch that is a single `glBindVertexArray` instead of
 buffer re-binds plus per-attribute `glVertexAttribPointer` rewrites. The
@@ -79,8 +81,9 @@ locations within the WebGL2-guaranteed 16): game-declared layouts never pass
 through the builder's validator, and desktop GL accepts what the browser
 rejects. Pack data never reaches those asserts: mesh activation hard-rejects
 invalid per-stream type/count/normalized, duplicate name hashes, and
-misaligned offsets/strides before any vertex input exists. Vertex inputs are
-created once and cached by their owners, so the asserts are off the hot path.
+misaligned offsets/strides before any vertex input exists. Renderer-owned
+vertex inputs are created on a cache miss and then reused, so validation is
+absent from the steady-state hot path.
 
 **Lifetime and the destroy cascade.** `nt_gfx_destroy_buffer` destroys every
 live vertex input referencing that buffer as its vertex or index buffer
@@ -91,9 +94,9 @@ revalidate handles with `nt_gfx_vertex_input_valid` on lookup. Because the
 cascade makes stale handles routine, `nt_gfx_destroy_vertex_input` tolerates
 stale and INVALID handles as no-ops. The dynamically captured instance
 buffer is *not* cascade-destroyed, but destroying one clears the dependents'
-pointed flag: their next instanced draw asserts until
-`nt_gfx_bind_instance_buffer` re-points them, and the GL attachment's
-storage lingers until that re-point or the vertex input's death.
+pointed flag: their next draw using that vertex input asserts until
+`nt_gfx_bind_instance_buffer` re-points it, and the GL attachment's storage
+lingers until that re-point or the vertex input's death.
 Buffer *contents* may change freely — `update`/`orphan`
 keep the GL name, so baked attachments survive per-flush orphaning — and
 index-buffer data ops run inside a service upload VAO in the backend,
@@ -138,13 +141,13 @@ in a real game, so a 64-bit collision is not a practical risk, and a fixed
 array with a linear scan stays cheaper than a hash map at that scale. Every
 `nt_pipeline_desc_t` field a renderer varies must be folded into its key.
 
-Every renderer now keys pipelines on `program.id` folded with
-`nt_material_info_t.render_state_hash` (the `nt_text_renderer` pattern) —
-layouts moved to the vertex-input objects, so materials differing only in
-layout share one pipeline. `render_state_hash` folds `color_mode`, so mesh
-pipelines still split per color mode even though nothing in the slimmed
-pipeline depends on it — an accepted over-split (removing it would touch the
-material module and every renderer).
+The material-driven mesh, sprite, and text renderer caches key pipelines on
+`program.id` folded with `nt_material_info_t.render_state_hash`. Layouts live
+on vertex-input objects, so materials differing only in layout share one
+pipeline. `render_state_hash` folds `color_mode`, so mesh pipelines still
+split per color mode even though nothing in the slimmed pipeline depends on
+it — an accepted over-split (removing it would touch the material module and
+all three caches).
 
 Vertex-input caches follow the same hash-as-identity standard for *derived*
 layouts. The mesh renderer keeps a per-mesh versions table

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -94,9 +94,10 @@ buffer is *not* cascade-tracked: destroying one while vertex inputs still
 hold pointers into it leaves zombie GL attachments until those vertex inputs
 die or re-point. Buffer *contents* may change freely — `update`/`orphan`
 keep the GL name, so baked attachments survive per-flush orphaning — and
-index-buffer data ops run with VAO 0 bound in the backend, because the
-element-array binding is VAO state and would otherwise be silently rewired
-into whichever vertex input is bound. Vertex inputs die with a lost context
+index-buffer data ops run inside a service upload VAO in the backend,
+because the element-array binding is VAO state — it would otherwise be
+silently rewired into whichever vertex input is bound, and core-profile GL
+rejects the bind with VAO 0. Vertex inputs die with a lost context
 and are not auto-restored; renderer restore paths recreate them. Loss alone
 does not fail `nt_gfx_vertex_input_valid` — pool slots live until the restore
 path's buffer destroys cascade through them; a bind that reaches a
@@ -140,7 +141,9 @@ Vertex-input caches follow the same hash-as-identity standard for *derived*
 layouts. The mesh renderer keeps a per-mesh versions table
 (`[nt_gfx_max_meshes()][nt_mesh_renderer_desc_t.max_mesh_layouts]`): entry
 identity is the hash of the derived layout (mesh streams × material
-attr_map — attr_map entries matching no stream do not split) plus color
+attr_map — attr_map entries matching no stream do not split; a material
+mapping none of the streams derives an empty layout and takes the
+attribute-less gl_VertexID path) plus color
 mode, plus the mesh's full generation-checked handle, which stays exact so
 pool-slot reuse cannot alias a stale entry. Exhausting a mesh's version row
 asserts, naming the knob — silent eviction would hide VAO re-creation

--- a/docs/spec/render/material.md
+++ b/docs/spec/render/material.md
@@ -96,7 +96,7 @@ Material-wide params (e.g. global alpha cutoff, roughness) can be mutated at run
 
 ## Render state and material
 
-Material stores render state (blend state, depth test/write, cull mode) because it is a property of the surface, not the pass. Pipeline (GPU state object) is derived from material render state + mesh vertex layout at render time.
+Material stores render state (blend state, depth test/write, cull mode) because it is a property of the surface, not the pass. Pipeline (GPU state object) is derived from material render state at render time; the mesh vertex layout is baked into a separately bound vertex-input object (see render/architecture.md).
 
 `nt_blend_state_t` is the public, backend-neutral fixed-function blend state. It
 contains separate source and destination factors and operations for RGB and

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -110,10 +110,13 @@ typedef struct {
 
 /* Owned vertex-input VAO. Static half (vertex attrs + element binding) is
  * baked at creation; instance pointers are re-specified into the bound VAO
- * by bind_instance_buffer, which needs the layout kept here. */
+ * by bind_instance_buffer, which needs the layout kept here. Compact copy:
+ * a full nt_vertex_layout_t per slot would cost ~200 B x max_vertex_inputs. */
 typedef struct {
     GLuint vao; /* 0 = free slot */
-    nt_vertex_layout_t instance_layout;
+    nt_vertex_attr_t instance_attrs[NT_GFX_MAX_INSTANCE_ATTRS];
+    uint8_t instance_attr_count;
+    uint16_t instance_stride;
 } nt_gfx_gl_vertex_input_t;
 
 /* ---- File-scope state ---- */
@@ -1243,7 +1246,11 @@ uint32_t nt_gfx_backend_create_vertex_input(const nt_vertex_input_desc_t *desc, 
     gl_bind_vao(s_gl_cache.vao);
 
     s_vertex_inputs[slot].vao = vao;
-    s_vertex_inputs[slot].instance_layout = desc->instance_layout;
+    for (uint8_t i = 0; i < desc->instance_layout.attr_count; i++) {
+        s_vertex_inputs[slot].instance_attrs[i] = desc->instance_layout.attrs[i];
+    }
+    s_vertex_inputs[slot].instance_attr_count = desc->instance_layout.attr_count;
+    s_vertex_inputs[slot].instance_stride = desc->instance_layout.stride;
     return slot;
 }
 
@@ -1393,14 +1400,11 @@ void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle, uint32_t byte_
     glBindBuffer(GL_ARRAY_BUFFER, buf);
 
     /* Re-specify the bound vertex input's instance pointers into its VAO. */
-    const nt_vertex_layout_t *layout = NULL;
     if (s_bound_vertex_input_slot != 0 && s_bound_vertex_input_slot <= s_init_desc.max_vertex_inputs) {
-        layout = &s_vertex_inputs[s_bound_vertex_input_slot].instance_layout;
-    }
-    if (layout != NULL) {
-        for (uint8_t i = 0; i < layout->attr_count; i++) {
-            const nt_vertex_attr_t *attr = &layout->attrs[i];
-            glVertexAttribPointer(attr->location, attr->count, map_vertex_type(attr->type), attr->normalized ? GL_TRUE : GL_FALSE, (GLsizei)layout->stride,
+        const nt_gfx_gl_vertex_input_t *vi = &s_vertex_inputs[s_bound_vertex_input_slot];
+        for (uint8_t i = 0; i < vi->instance_attr_count; i++) {
+            const nt_vertex_attr_t *attr = &vi->instance_attrs[i];
+            glVertexAttribPointer(attr->location, attr->count, map_vertex_type(attr->type), attr->normalized ? GL_TRUE : GL_FALSE, (GLsizei)vi->instance_stride,
                                   (void *)(uintptr_t)(attr->offset + byte_offset)); // NOLINT(performance-no-int-to-ptr)
 #ifdef NT_TEST_ACCESS
             s_test_instance_attrib_pointer_calls++;

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -446,6 +446,9 @@ static void nt_gfx_gl_init_context_features(void) {
     s_active_segment = -1;
     /* Fresh context (init or restore): the previous upload VAO died with it. */
     glGenVertexArrays(1, &s_ebo_upload_vao);
+    /* 0 with a live context would silently break every index-buffer upload on
+     * core GL; 0 on an already-lost context is retried by the next restore. */
+    NT_ASSERT(s_ebo_upload_vao != 0 || nt_gfx_gl_ctx_is_lost());
 }
 
 bool nt_gfx_backend_init(const nt_gfx_desc_t *desc) {
@@ -1339,6 +1342,10 @@ uint32_t nt_gfx_backend_create_buffer(const nt_buffer_desc_t *desc) {
     glBindBuffer(target, buf);
     glBufferData(target, (GLsizeiptr)desc->size, desc->data, usage);
     if (unhook_vao) {
+        /* Detach the EBO before leaving the upload VAO: GL keeps attached
+         * storage alive, so a dangling attachment would pin a deleted
+         * index buffer's memory until the next upload. */
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
         gl_bind_vao(s_gl_cache.vao);
     }
 
@@ -1386,6 +1393,10 @@ void nt_gfx_backend_update_buffer(uint32_t backend_handle, uint32_t offset, cons
     glBindBuffer(target, buf);
     glBufferSubData(target, (GLintptr)offset, (GLsizeiptr)size, data);
     if (unhook_vao) {
+        /* Detach the EBO before leaving the upload VAO: GL keeps attached
+         * storage alive, so a dangling attachment would pin a deleted
+         * index buffer's memory until the next upload. */
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
         gl_bind_vao(s_gl_cache.vao);
     }
 }
@@ -1409,6 +1420,10 @@ void nt_gfx_backend_orphan_buffer(uint32_t backend_handle, const void *data, uin
      * rewriting a buffer that's still in flight. */
     glBufferData(target, (GLsizeiptr)size, data, GL_DYNAMIC_DRAW);
     if (unhook_vao) {
+        /* Detach the EBO before leaving the upload VAO: GL keeps attached
+         * storage alive, so a dangling attachment would pin a deleted
+         * index buffer's memory until the next upload. */
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
         gl_bind_vao(s_gl_cache.vao);
     }
 }

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -75,7 +75,6 @@ typedef struct {
 } nt_cached_uniform_t;
 
 typedef struct {
-    GLuint vao;
     bool depth_test_enabled;
     bool depth_write_enabled;
     GLenum depth_func;
@@ -91,10 +90,7 @@ typedef struct {
     bool polygon_offset_enabled;
     float polygon_offset_factor;
     float polygon_offset_units;
-    /* Store layouts for re-applying vertex attrib pointers on buffer bind */
-    nt_vertex_layout_t layout;
-    nt_vertex_layout_t instance_layout;
-    uint32_t program_slot; /* index into s_programs; the pipeline borrows it */
+    uint32_t program_slot; /* index into s_programs; the pipeline borrows it. 0 = free slot */
 } nt_gfx_gl_pipeline_t;
 
 /* Uniform locations are per-program, so the cache lives here, not on the
@@ -792,22 +788,12 @@ bool nt_gfx_backend_read_pixels(int x, int y, int w, int h, void *out_rgba8) {
 
 /* ---- Pipeline bind ---- */
 
-/* Clear pipeline/VAO selection so later binds cannot mutate a stale VAO.
- * The program cache still describes the actual GL binding. */
-static void unbind_pipeline_state(void) {
-    s_bound_pipeline_slot = 0;
-    /* Transitional: the pipeline VAO replaced any bound vertex-input VAO. */
-    s_bound_vertex_input_slot = 0;
-    if (s_gl_cache.vao != 0) {
-        gl_bind_vao(0);
-        s_gl_cache.vao = 0;
-    }
-}
+/* Clear the pipeline selection so later uniform writes cannot target a stale
+ * program. Vertex-input state is orthogonal and stays bound. */
+static void unbind_pipeline_state(void) { s_bound_pipeline_slot = 0; }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_gfx_backend_bind_pipeline(uint32_t backend_handle) {
-    /* Clear both the slot mirror and VAO: later buffer binds must not rewrite
-     * the rejected pipeline's vertex attributes or element-buffer binding. */
     if (backend_handle == 0 || backend_handle > s_init_desc.max_pipelines) {
         unbind_pipeline_state();
         return;
@@ -820,12 +806,6 @@ void nt_gfx_backend_bind_pipeline(uint32_t backend_handle) {
         return;
     }
 
-    if (s_gl_cache.vao != pip->vao) {
-        gl_bind_vao(pip->vao);
-        s_gl_cache.vao = pip->vao;
-    }
-    /* Transitional: the pipeline VAO replaced any bound vertex-input VAO. */
-    s_bound_vertex_input_slot = 0;
     GLuint program = s_programs[pip->program_slot].program;
     if (s_gl_cache.program != program) {
         glUseProgram(program);
@@ -1176,7 +1156,7 @@ uint32_t nt_gfx_backend_create_pipeline(const nt_pipeline_desc_t *desc, uint32_t
     /* Find free pipeline slot */
     uint32_t slot = 0;
     for (uint32_t i = 1; i <= s_init_desc.max_pipelines; i++) {
-        if (s_pipelines[i].vao == 0) {
+        if (s_pipelines[i].program_slot == 0) {
             slot = i;
             break;
         }
@@ -1185,29 +1165,8 @@ uint32_t nt_gfx_backend_create_pipeline(const nt_pipeline_desc_t *desc, uint32_t
         return 0; /* no free slots */
     }
 
-    /* Create VAO with vertex layout.
-     * Only enable attributes here — actual glVertexAttribPointer calls happen
-     * in bind_vertex_buffer() once a buffer is bound.  WebGL requires a bound
-     * ARRAY_BUFFER for non-zero offsets, so calling it here would be an error. */
-    GLuint vao = 0;
-    glGenVertexArrays(1, &vao);
-    if (vao == 0) {
-        return 0;
-    }
-    gl_bind_vao(vao);
-    for (uint8_t i = 0; i < desc->layout.attr_count; i++) {
-        glEnableVertexAttribArray(desc->layout.attrs[i].location);
-    }
-    for (uint8_t i = 0; i < desc->instance_layout.attr_count; i++) {
-        GLuint loc = desc->instance_layout.attrs[i].location;
-        glEnableVertexAttribArray(loc);
-        glVertexAttribDivisor(loc, 1);
-    }
-    gl_bind_vao(s_gl_cache.vao);
-
-    /* Store pipeline data */
+    /* Store pipeline data (fixed-function state + borrowed program only) */
     nt_gfx_gl_pipeline_t *pip = &s_pipelines[slot];
-    pip->vao = vao;
     pip->program_slot = program_backend;
     pip->depth_test_enabled = desc->depth_test;
     pip->depth_write_enabled = desc->depth_write;
@@ -1224,8 +1183,6 @@ uint32_t nt_gfx_backend_create_pipeline(const nt_pipeline_desc_t *desc, uint32_t
     pip->polygon_offset_enabled = desc->polygon_offset;
     pip->polygon_offset_factor = desc->polygon_offset_factor;
     pip->polygon_offset_units = desc->polygon_offset_units;
-    pip->layout = desc->layout;
-    pip->instance_layout = desc->instance_layout;
 
     return slot;
 }
@@ -1234,19 +1191,12 @@ void nt_gfx_backend_destroy_pipeline(uint32_t backend_handle) {
     if (backend_handle == 0 || backend_handle > s_init_desc.max_pipelines) {
         return;
     }
-    nt_gfx_gl_pipeline_t *pip = &s_pipelines[backend_handle];
-    /* Invalidate cache if this pipeline's VAO is currently bound. The program
-     * is not ours to delete -- it outlives every pipeline built on it. */
-    if (pip->vao && s_gl_cache.vao == pip->vao) {
-        s_gl_cache.vao = 0;
-    }
-    if (pip->vao) {
-        glDeleteVertexArrays(1, &pip->vao);
-    }
+    /* The program is not ours to delete -- it outlives every pipeline built
+     * on it; the pipeline owns no GL objects of its own. */
     if (s_bound_pipeline_slot == backend_handle) {
         s_bound_pipeline_slot = 0;
     }
-    memset(pip, 0, sizeof(*pip));
+    memset(&s_pipelines[backend_handle], 0, sizeof(s_pipelines[backend_handle]));
 }
 
 uint32_t nt_gfx_backend_create_vertex_input(const nt_vertex_input_desc_t *desc, uint32_t vbo_backend, uint32_t ibo_backend) {
@@ -1435,37 +1385,6 @@ void nt_gfx_backend_orphan_buffer(uint32_t backend_handle, const void *data, uin
     }
 }
 
-void nt_gfx_backend_bind_vertex_buffer(uint32_t backend_handle) {
-    if (backend_handle == 0 || backend_handle > s_init_desc.max_buffers) {
-        return;
-    }
-    GLuint buf = s_buffer_gl[backend_handle];
-    glBindBuffer(GL_ARRAY_BUFFER, buf);
-
-    /* Re-apply vertex attribute pointers from the currently bound pipeline.
-     * VAOs record the buffer binding per attribute, so when a different
-     * buffer is bound we must re-set the pointers. */
-    if (s_bound_pipeline_slot != 0 && s_bound_pipeline_slot <= s_init_desc.max_pipelines) {
-        const nt_vertex_layout_t *layout = &s_pipelines[s_bound_pipeline_slot].layout;
-        for (uint8_t i = 0; i < layout->attr_count; i++) {
-            const nt_vertex_attr_t *attr = &layout->attrs[i];
-            glVertexAttribPointer(attr->location, attr->count, map_vertex_type(attr->type), attr->normalized ? GL_TRUE : GL_FALSE, (GLsizei)layout->stride,
-                                  (void *)(uintptr_t)attr->offset); // NOLINT(performance-no-int-to-ptr)
-#ifdef NT_TEST_ACCESS
-            s_test_static_attrib_pointer_calls++;
-#endif
-        }
-    }
-}
-
-void nt_gfx_backend_bind_index_buffer(uint32_t backend_handle) {
-    if (backend_handle == 0 || backend_handle > s_init_desc.max_buffers) {
-        return;
-    }
-    GLuint buf = s_buffer_gl[backend_handle];
-    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, buf);
-}
-
 void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle, uint32_t byte_offset) {
     if (backend_handle == 0 || backend_handle > s_init_desc.max_buffers) {
         return;
@@ -1473,13 +1392,10 @@ void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle, uint32_t byte_
     GLuint buf = s_buffer_gl[backend_handle];
     glBindBuffer(GL_ARRAY_BUFFER, buf);
 
-    /* The bound vertex input's instance layout wins; the bound pipeline's is
-     * the transitional fallback while pipelines still own layouts. */
+    /* Re-specify the bound vertex input's instance pointers into its VAO. */
     const nt_vertex_layout_t *layout = NULL;
     if (s_bound_vertex_input_slot != 0 && s_bound_vertex_input_slot <= s_init_desc.max_vertex_inputs) {
         layout = &s_vertex_inputs[s_bound_vertex_input_slot].instance_layout;
-    } else if (s_bound_pipeline_slot != 0 && s_bound_pipeline_slot <= s_init_desc.max_pipelines) {
-        layout = &s_pipelines[s_bound_pipeline_slot].instance_layout;
     }
     if (layout != NULL) {
         for (uint8_t i = 0; i < layout->attr_count; i++) {

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -252,6 +252,18 @@ static void gl_bind_vao(GLuint vao) {
     glBindVertexArray(vao);
 }
 
+/* GL_ELEMENT_ARRAY_BUFFER binding is VAO state: with a vertex-input VAO bound
+ * a data op would silently rewire its index binding, and core profile rejects
+ * the bind with VAO 0 -- so index-buffer data ops run inside the service
+ * upload VAO. The EBO detaches on exit because GL keeps attached storage
+ * alive: a dangling attachment would pin a deleted index buffer's memory. */
+static void ebo_upload_begin(void) { gl_bind_vao(s_ebo_upload_vao); }
+
+static void ebo_upload_end(void) {
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
+    gl_bind_vao(s_gl_cache.vao);
+}
+
 static void nt_gfx_gl_cache_reset(void) {
     gl_bind_vao(0);
     glUseProgram(0);
@@ -1165,22 +1177,12 @@ void nt_gfx_backend_destroy_program(uint32_t backend_handle) {
     memset(&s_programs[backend_handle], 0, sizeof(s_programs[backend_handle]));
 }
 
-uint32_t nt_gfx_backend_create_pipeline(const nt_pipeline_desc_t *desc, uint32_t program_backend) {
+uint32_t nt_gfx_backend_create_pipeline(const nt_pipeline_desc_t *desc, uint32_t program_backend, uint32_t slot) {
     if (program_backend == 0 || program_backend > s_init_desc.max_programs) {
         return 0;
     }
-
-    /* Find free pipeline slot */
-    uint32_t slot = 0;
-    for (uint32_t i = 1; i <= s_init_desc.max_pipelines; i++) {
-        if (s_pipelines[i].program_slot == 0) {
-            slot = i;
-            break;
-        }
-    }
-    if (slot == 0) {
-        return 0; /* no free slots */
-    }
+    /* The frontend pool owns slot allocation; the backend table mirrors it. */
+    NT_ASSERT(slot > 0 && slot <= s_init_desc.max_pipelines && s_pipelines[slot].program_slot == 0);
 
     /* Store pipeline data (fixed-function state + borrowed program only) */
     nt_gfx_gl_pipeline_t *pip = &s_pipelines[slot];
@@ -1216,18 +1218,11 @@ void nt_gfx_backend_destroy_pipeline(uint32_t backend_handle) {
     memset(&s_pipelines[backend_handle], 0, sizeof(s_pipelines[backend_handle]));
 }
 
-uint32_t nt_gfx_backend_create_vertex_input(const nt_vertex_input_desc_t *desc, uint32_t vbo_backend, uint32_t ibo_backend) {
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) -- NT_ASSERT expansion inflates the metric
+uint32_t nt_gfx_backend_create_vertex_input(const nt_vertex_input_desc_t *desc, uint32_t vbo_backend, uint32_t ibo_backend, uint32_t slot) {
     NT_ASSERT(desc != NULL);
-    uint32_t slot = 0;
-    for (uint32_t i = 1; i <= s_init_desc.max_vertex_inputs; i++) {
-        if (s_vertex_inputs[i].vao == 0) {
-            slot = i;
-            break;
-        }
-    }
-    if (slot == 0) {
-        return 0; /* no free slots */
-    }
+    /* The frontend pool owns slot allocation; the backend table mirrors it. */
+    NT_ASSERT(slot > 0 && slot <= s_init_desc.max_vertex_inputs && s_vertex_inputs[slot].vao == 0);
 
     GLuint vao = 0;
     glGenVertexArrays(1, &vao);
@@ -1331,22 +1326,14 @@ uint32_t nt_gfx_backend_create_buffer(const nt_buffer_desc_t *desc) {
         break;
     }
     GLenum usage = map_buffer_usage(desc->usage);
-    /* GL_ELEMENT_ARRAY_BUFFER binding is VAO state: with a vertex-input VAO
-     * bound this data op would silently rewire its index binding, and core
-     * profile rejects the bind with VAO 0. All index-buffer data ops run
-     * inside the service upload VAO (few extra binds, off hot path). */
     bool unhook_vao = target == GL_ELEMENT_ARRAY_BUFFER;
     if (unhook_vao) {
-        gl_bind_vao(s_ebo_upload_vao);
+        ebo_upload_begin();
     }
     glBindBuffer(target, buf);
     glBufferData(target, (GLsizeiptr)desc->size, desc->data, usage);
     if (unhook_vao) {
-        /* Detach the EBO before leaving the upload VAO: GL keeps attached
-         * storage alive, so a dangling attachment would pin a deleted
-         * index buffer's memory until the next upload. */
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
-        gl_bind_vao(s_gl_cache.vao);
+        ebo_upload_end();
     }
 
     /* Find free buffer slot */
@@ -1385,19 +1372,14 @@ void nt_gfx_backend_update_buffer(uint32_t backend_handle, uint32_t offset, cons
     }
     GLuint buf = s_buffer_gl[backend_handle];
     GLenum target = s_buffer_targets[backend_handle];
-    /* Index-buffer data ops run inside the upload VAO -- see create_buffer. */
     bool unhook_vao = target == GL_ELEMENT_ARRAY_BUFFER;
     if (unhook_vao) {
-        gl_bind_vao(s_ebo_upload_vao);
+        ebo_upload_begin();
     }
     glBindBuffer(target, buf);
     glBufferSubData(target, (GLintptr)offset, (GLsizeiptr)size, data);
     if (unhook_vao) {
-        /* Detach the EBO before leaving the upload VAO: GL keeps attached
-         * storage alive, so a dangling attachment would pin a deleted
-         * index buffer's memory until the next upload. */
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
-        gl_bind_vao(s_gl_cache.vao);
+        ebo_upload_end();
     }
 }
 
@@ -1407,10 +1389,9 @@ void nt_gfx_backend_orphan_buffer(uint32_t backend_handle, const void *data, uin
     }
     GLuint buf = s_buffer_gl[backend_handle];
     GLenum target = s_buffer_targets[backend_handle];
-    /* Index-buffer data ops run inside the upload VAO -- see create_buffer. */
     bool unhook_vao = target == GL_ELEMENT_ARRAY_BUFFER;
     if (unhook_vao) {
-        gl_bind_vao(s_ebo_upload_vao);
+        ebo_upload_begin();
     }
     glBindBuffer(target, buf);
     /* glBufferData with non-NULL data both orphans the existing storage and
@@ -1420,11 +1401,7 @@ void nt_gfx_backend_orphan_buffer(uint32_t backend_handle, const void *data, uin
      * rewriting a buffer that's still in flight. */
     glBufferData(target, (GLsizeiptr)size, data, GL_DYNAMIC_DRAW);
     if (unhook_vao) {
-        /* Detach the EBO before leaving the upload VAO: GL keeps attached
-         * storage alive, so a dangling attachment would pin a deleted
-         * index buffer's memory until the next upload. */
-        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
-        gl_bind_vao(s_gl_cache.vao);
+        ebo_upload_end();
     }
 }
 

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -123,6 +123,9 @@ typedef struct {
 
 static uint32_t s_bound_pipeline_slot;     /* currently bound pipeline index */
 static uint32_t s_bound_vertex_input_slot; /* currently bound vertex-input index */
+/* Service VAO for index-buffer data ops: the ELEMENT_ARRAY_BUFFER bind is VAO
+ * state, and core profile rejects it with VAO 0 bound (INVALID_OPERATION). */
+static GLuint s_ebo_upload_vao;
 
 static nt_gfx_gl_program_t *s_programs;           /* linked programs, indexed by slot */
 static nt_gfx_gl_pipeline_t *s_pipelines;         /* pipeline data, indexed by slot */
@@ -441,6 +444,8 @@ static void nt_gfx_gl_init_context_features(void) {
     nt_gfx_gl_ctx_enable_debug_callback();
     s_segment_count = 0;
     s_active_segment = -1;
+    /* Fresh context (init or restore): the previous upload VAO died with it. */
+    glGenVertexArrays(1, &s_ebo_upload_vao);
 }
 
 bool nt_gfx_backend_init(const nt_gfx_desc_t *desc) {
@@ -500,6 +505,10 @@ void nt_gfx_backend_shutdown(void) {
     s_bound_pipeline_slot = 0;
     s_bound_vertex_input_slot = 0;
     s_bound_framebuffer = 0;
+    if (s_ebo_upload_vao != 0) {
+        glDeleteVertexArrays(1, &s_ebo_upload_vao);
+        s_ebo_upload_vao = 0;
+    }
 
     nt_gfx_gl_ctx_destroy();
 }
@@ -1309,11 +1318,12 @@ uint32_t nt_gfx_backend_create_buffer(const nt_buffer_desc_t *desc) {
     }
     GLenum usage = map_buffer_usage(desc->usage);
     /* GL_ELEMENT_ARRAY_BUFFER binding is VAO state: with a vertex-input VAO
-     * bound this data op would silently rewire its index binding, so run
-     * index-buffer data ops with VAO 0 bound (few extra binds, off hot path). */
-    bool unhook_vao = target == GL_ELEMENT_ARRAY_BUFFER && s_gl_cache.vao != 0;
+     * bound this data op would silently rewire its index binding, and core
+     * profile rejects the bind with VAO 0. All index-buffer data ops run
+     * inside the service upload VAO (few extra binds, off hot path). */
+    bool unhook_vao = target == GL_ELEMENT_ARRAY_BUFFER;
     if (unhook_vao) {
-        gl_bind_vao(0);
+        gl_bind_vao(s_ebo_upload_vao);
     }
     glBindBuffer(target, buf);
     glBufferData(target, (GLsizeiptr)desc->size, desc->data, usage);
@@ -1357,10 +1367,10 @@ void nt_gfx_backend_update_buffer(uint32_t backend_handle, uint32_t offset, cons
     }
     GLuint buf = s_buffer_gl[backend_handle];
     GLenum target = s_buffer_targets[backend_handle];
-    /* Index-buffer data ops run with VAO 0 -- see create_buffer. */
-    bool unhook_vao = target == GL_ELEMENT_ARRAY_BUFFER && s_gl_cache.vao != 0;
+    /* Index-buffer data ops run inside the upload VAO -- see create_buffer. */
+    bool unhook_vao = target == GL_ELEMENT_ARRAY_BUFFER;
     if (unhook_vao) {
-        gl_bind_vao(0);
+        gl_bind_vao(s_ebo_upload_vao);
     }
     glBindBuffer(target, buf);
     glBufferSubData(target, (GLintptr)offset, (GLsizeiptr)size, data);
@@ -1375,10 +1385,10 @@ void nt_gfx_backend_orphan_buffer(uint32_t backend_handle, const void *data, uin
     }
     GLuint buf = s_buffer_gl[backend_handle];
     GLenum target = s_buffer_targets[backend_handle];
-    /* Index-buffer data ops run with VAO 0 -- see create_buffer. */
-    bool unhook_vao = target == GL_ELEMENT_ARRAY_BUFFER && s_gl_cache.vao != 0;
+    /* Index-buffer data ops run inside the upload VAO -- see create_buffer. */
+    bool unhook_vao = target == GL_ELEMENT_ARRAY_BUFFER;
     if (unhook_vao) {
-        gl_bind_vao(0);
+        gl_bind_vao(s_ebo_upload_vao);
     }
     glBindBuffer(target, buf);
     /* glBufferData with non-NULL data both orphans the existing storage and

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -112,15 +112,25 @@ typedef struct {
     uint16_t height;
 } nt_gfx_gl_render_target_t;
 
+/* Owned vertex-input VAO. Static half (vertex attrs + element binding) is
+ * baked at creation; instance pointers are re-specified into the bound VAO
+ * by bind_instance_buffer, which needs the layout kept here. */
+typedef struct {
+    GLuint vao; /* 0 = free slot */
+    nt_vertex_layout_t instance_layout;
+} nt_gfx_gl_vertex_input_t;
+
 /* ---- File-scope state ---- */
 
-static uint32_t s_bound_pipeline_slot; /* currently bound pipeline index */
+static uint32_t s_bound_pipeline_slot;     /* currently bound pipeline index */
+static uint32_t s_bound_vertex_input_slot; /* currently bound vertex-input index */
 
-static nt_gfx_gl_program_t *s_programs;   /* linked programs, indexed by slot */
-static nt_gfx_gl_pipeline_t *s_pipelines; /* pipeline data, indexed by slot */
-static GLuint *s_buffer_gl;               /* GL buffer names, indexed by slot */
-static GLenum *s_buffer_targets;          /* GL_ARRAY_BUFFER or GL_ELEMENT_ARRAY_BUFFER */
-static GLuint *s_texture_gl;              /* GL texture names, indexed by slot */
+static nt_gfx_gl_program_t *s_programs;           /* linked programs, indexed by slot */
+static nt_gfx_gl_pipeline_t *s_pipelines;         /* pipeline data, indexed by slot */
+static nt_gfx_gl_vertex_input_t *s_vertex_inputs; /* vertex-input VAOs, indexed by slot */
+static GLuint *s_buffer_gl;                       /* GL buffer names, indexed by slot */
+static GLenum *s_buffer_targets;                  /* GL_ARRAY_BUFFER or GL_ELEMENT_ARRAY_BUFFER */
+static GLuint *s_texture_gl;                      /* GL texture names, indexed by slot */
 static nt_gfx_gl_render_target_t *s_render_targets;
 static GLuint s_bound_framebuffer;
 
@@ -213,8 +223,35 @@ static GLint pipeline_get_uniform(const char *name) {
     return -1;
 }
 
+// #region test counters
+#ifdef NT_TEST_ACCESS
+static uint32_t s_test_static_attrib_pointer_calls;   /* divisor-0 glVertexAttribPointer */
+static uint32_t s_test_instance_attrib_pointer_calls; /* divisor-1 glVertexAttribPointer */
+static uint32_t s_test_vao_binds;
+
+void nt_gfx_gl_test_reset_counters(void) {
+    s_test_static_attrib_pointer_calls = 0;
+    s_test_instance_attrib_pointer_calls = 0;
+    s_test_vao_binds = 0;
+}
+
+uint32_t nt_gfx_gl_test_static_attrib_pointer_calls(void) { return s_test_static_attrib_pointer_calls; }
+uint32_t nt_gfx_gl_test_instance_attrib_pointer_calls(void) { return s_test_instance_attrib_pointer_calls; }
+uint32_t nt_gfx_gl_test_vao_binds(void) { return s_test_vao_binds; }
+#endif
+// #endregion
+
+/* Every VAO bind goes through here so the test counter sees them all;
+ * s_gl_cache.vao bookkeeping stays at the call sites. */
+static void gl_bind_vao(GLuint vao) {
+#ifdef NT_TEST_ACCESS
+    s_test_vao_binds++;
+#endif
+    glBindVertexArray(vao);
+}
+
 static void nt_gfx_gl_cache_reset(void) {
-    glBindVertexArray(0);
+    gl_bind_vao(0);
     glUseProgram(0);
     glDisable(GL_DEPTH_TEST);
     glDepthMask(GL_TRUE);
@@ -418,12 +455,14 @@ bool nt_gfx_backend_init(const nt_gfx_desc_t *desc) {
     /* Allocate backend resource arrays (+1 because slots are 1-based) */
     s_programs = (nt_gfx_gl_program_t *)calloc(s_init_desc.max_programs + 1, sizeof(nt_gfx_gl_program_t));
     s_pipelines = (nt_gfx_gl_pipeline_t *)calloc(s_init_desc.max_pipelines + 1, sizeof(nt_gfx_gl_pipeline_t));
+    s_vertex_inputs = (nt_gfx_gl_vertex_input_t *)calloc(s_init_desc.max_vertex_inputs + 1, sizeof(nt_gfx_gl_vertex_input_t));
     s_buffer_gl = (GLuint *)calloc(s_init_desc.max_buffers + 1, sizeof(GLuint));
     s_buffer_targets = (GLenum *)calloc(s_init_desc.max_buffers + 1, sizeof(GLenum));
     s_texture_gl = (GLuint *)calloc(s_init_desc.max_textures + 1, sizeof(GLuint));
     s_render_targets = (nt_gfx_gl_render_target_t *)calloc(s_init_desc.max_render_targets + 1, sizeof(nt_gfx_gl_render_target_t));
 
     s_bound_pipeline_slot = 0;
+    s_bound_vertex_input_slot = 0;
     s_bound_framebuffer = 0;
     nt_gfx_gl_cache_reset();
 
@@ -442,6 +481,7 @@ void nt_gfx_backend_shutdown(void) {
 
     free(s_programs);
     free(s_pipelines);
+    free(s_vertex_inputs);
     free(s_buffer_gl);
     free(s_buffer_targets);
     free(s_texture_gl);
@@ -450,6 +490,7 @@ void nt_gfx_backend_shutdown(void) {
 
     s_programs = NULL;
     s_pipelines = NULL;
+    s_vertex_inputs = NULL;
     s_buffer_gl = NULL;
     s_buffer_targets = NULL;
     s_texture_gl = NULL;
@@ -458,6 +499,7 @@ void nt_gfx_backend_shutdown(void) {
     s_transcode_buf_size = 0;
 
     s_bound_pipeline_slot = 0;
+    s_bound_vertex_input_slot = 0;
     s_bound_framebuffer = 0;
 
     nt_gfx_gl_ctx_destroy();
@@ -565,6 +607,7 @@ void nt_gfx_backend_begin_frame(void) {
      * the cache stale. */
     nt_gfx_gl_cache_reset();
     s_bound_pipeline_slot = 0;
+    s_bound_vertex_input_slot = 0;
 
     /* GL_GPU_DISJOINT_EXT exists only in EXT_disjoint_timer_query_webgl2 (and
      * GLES variants). Native ARB_timer_query has no disjoint concept — GPU
@@ -753,8 +796,10 @@ bool nt_gfx_backend_read_pixels(int x, int y, int w, int h, void *out_rgba8) {
  * The program cache still describes the actual GL binding. */
 static void unbind_pipeline_state(void) {
     s_bound_pipeline_slot = 0;
+    /* Transitional: the pipeline VAO replaced any bound vertex-input VAO. */
+    s_bound_vertex_input_slot = 0;
     if (s_gl_cache.vao != 0) {
-        glBindVertexArray(0);
+        gl_bind_vao(0);
         s_gl_cache.vao = 0;
     }
 }
@@ -776,9 +821,11 @@ void nt_gfx_backend_bind_pipeline(uint32_t backend_handle) {
     }
 
     if (s_gl_cache.vao != pip->vao) {
-        glBindVertexArray(pip->vao);
+        gl_bind_vao(pip->vao);
         s_gl_cache.vao = pip->vao;
     }
+    /* Transitional: the pipeline VAO replaced any bound vertex-input VAO. */
+    s_bound_vertex_input_slot = 0;
     GLuint program = s_programs[pip->program_slot].program;
     if (s_gl_cache.program != program) {
         glUseProgram(program);
@@ -1147,7 +1194,7 @@ uint32_t nt_gfx_backend_create_pipeline(const nt_pipeline_desc_t *desc, uint32_t
     if (vao == 0) {
         return 0;
     }
-    glBindVertexArray(vao);
+    gl_bind_vao(vao);
     for (uint8_t i = 0; i < desc->layout.attr_count; i++) {
         glEnableVertexAttribArray(desc->layout.attrs[i].location);
     }
@@ -1156,7 +1203,7 @@ uint32_t nt_gfx_backend_create_pipeline(const nt_pipeline_desc_t *desc, uint32_t
         glEnableVertexAttribArray(loc);
         glVertexAttribDivisor(loc, 1);
     }
-    glBindVertexArray(s_gl_cache.vao);
+    gl_bind_vao(s_gl_cache.vao);
 
     /* Store pipeline data */
     nt_gfx_gl_pipeline_t *pip = &s_pipelines[slot];
@@ -1202,6 +1249,89 @@ void nt_gfx_backend_destroy_pipeline(uint32_t backend_handle) {
     memset(pip, 0, sizeof(*pip));
 }
 
+uint32_t nt_gfx_backend_create_vertex_input(const nt_vertex_input_desc_t *desc, uint32_t vbo_backend, uint32_t ibo_backend) {
+    NT_ASSERT(desc != NULL);
+    uint32_t slot = 0;
+    for (uint32_t i = 1; i <= s_init_desc.max_vertex_inputs; i++) {
+        if (s_vertex_inputs[i].vao == 0) {
+            slot = i;
+            break;
+        }
+    }
+    if (slot == 0) {
+        return 0; /* no free slots */
+    }
+
+    GLuint vao = 0;
+    glGenVertexArrays(1, &vao);
+    if (vao == 0) {
+        return 0;
+    }
+    gl_bind_vao(vao);
+    if (vbo_backend != 0 && vbo_backend <= s_init_desc.max_buffers) {
+        /* Buffer bound before the pointer calls -- satisfies the WebGL "no
+         * pointer without a bound ARRAY_BUFFER" rule at creation time. */
+        glBindBuffer(GL_ARRAY_BUFFER, s_buffer_gl[vbo_backend]);
+        for (uint8_t i = 0; i < desc->layout.attr_count; i++) {
+            const nt_vertex_attr_t *attr = &desc->layout.attrs[i];
+            glEnableVertexAttribArray(attr->location);
+            glVertexAttribPointer(attr->location, attr->count, map_vertex_type(attr->type), attr->normalized ? GL_TRUE : GL_FALSE, (GLsizei)desc->layout.stride,
+                                  (void *)(uintptr_t)attr->offset); // NOLINT(performance-no-int-to-ptr)
+#ifdef NT_TEST_ACCESS
+            s_test_static_attrib_pointer_calls++;
+#endif
+        }
+    }
+    if (ibo_backend != 0 && ibo_backend <= s_init_desc.max_buffers) {
+        glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, s_buffer_gl[ibo_backend]); /* captured by the VAO */
+    }
+    for (uint8_t i = 0; i < desc->instance_layout.attr_count; i++) {
+        GLuint loc = desc->instance_layout.attrs[i].location;
+        glEnableVertexAttribArray(loc);
+        glVertexAttribDivisor(loc, 1); /* pointers deferred to bind_instance_buffer */
+    }
+    gl_bind_vao(s_gl_cache.vao);
+
+    s_vertex_inputs[slot].vao = vao;
+    s_vertex_inputs[slot].instance_layout = desc->instance_layout;
+    return slot;
+}
+
+void nt_gfx_backend_destroy_vertex_input(uint32_t backend_handle) {
+    if (backend_handle == 0 || backend_handle > s_init_desc.max_vertex_inputs) {
+        return;
+    }
+    nt_gfx_gl_vertex_input_t *vi = &s_vertex_inputs[backend_handle];
+    /* Deleting the bound VAO reverts the GL binding to 0 -- mirror it. */
+    if (vi->vao && s_gl_cache.vao == vi->vao) {
+        s_gl_cache.vao = 0;
+    }
+    if (vi->vao) {
+        glDeleteVertexArrays(1, &vi->vao);
+    }
+    if (s_bound_vertex_input_slot == backend_handle) {
+        s_bound_vertex_input_slot = 0;
+    }
+    memset(vi, 0, sizeof(*vi));
+}
+
+void nt_gfx_backend_bind_vertex_input(uint32_t backend_handle) {
+    if (backend_handle == 0 || backend_handle > s_init_desc.max_vertex_inputs || s_vertex_inputs[backend_handle].vao == 0) {
+        s_bound_vertex_input_slot = 0;
+        if (s_gl_cache.vao != 0) {
+            gl_bind_vao(0);
+            s_gl_cache.vao = 0;
+        }
+        return;
+    }
+    GLuint vao = s_vertex_inputs[backend_handle].vao;
+    if (s_gl_cache.vao != vao) {
+        gl_bind_vao(vao);
+        s_gl_cache.vao = vao;
+    }
+    s_bound_vertex_input_slot = backend_handle;
+}
+
 uint32_t nt_gfx_backend_create_buffer(const nt_buffer_desc_t *desc) {
     GLuint buf;
     glGenBuffers(1, &buf);
@@ -1221,8 +1351,18 @@ uint32_t nt_gfx_backend_create_buffer(const nt_buffer_desc_t *desc) {
         break;
     }
     GLenum usage = map_buffer_usage(desc->usage);
+    /* GL_ELEMENT_ARRAY_BUFFER binding is VAO state: with a vertex-input VAO
+     * bound this data op would silently rewire its index binding, so run
+     * index-buffer data ops with VAO 0 bound (few extra binds, off hot path). */
+    bool unhook_vao = target == GL_ELEMENT_ARRAY_BUFFER && s_gl_cache.vao != 0;
+    if (unhook_vao) {
+        gl_bind_vao(0);
+    }
     glBindBuffer(target, buf);
     glBufferData(target, (GLsizeiptr)desc->size, desc->data, usage);
+    if (unhook_vao) {
+        gl_bind_vao(s_gl_cache.vao);
+    }
 
     /* Find free buffer slot */
     uint32_t slot = 0;
@@ -1260,8 +1400,16 @@ void nt_gfx_backend_update_buffer(uint32_t backend_handle, uint32_t offset, cons
     }
     GLuint buf = s_buffer_gl[backend_handle];
     GLenum target = s_buffer_targets[backend_handle];
+    /* Index-buffer data ops run with VAO 0 -- see create_buffer. */
+    bool unhook_vao = target == GL_ELEMENT_ARRAY_BUFFER && s_gl_cache.vao != 0;
+    if (unhook_vao) {
+        gl_bind_vao(0);
+    }
     glBindBuffer(target, buf);
     glBufferSubData(target, (GLintptr)offset, (GLsizeiptr)size, data);
+    if (unhook_vao) {
+        gl_bind_vao(s_gl_cache.vao);
+    }
 }
 
 void nt_gfx_backend_orphan_buffer(uint32_t backend_handle, const void *data, uint32_t size) {
@@ -1270,6 +1418,11 @@ void nt_gfx_backend_orphan_buffer(uint32_t backend_handle, const void *data, uin
     }
     GLuint buf = s_buffer_gl[backend_handle];
     GLenum target = s_buffer_targets[backend_handle];
+    /* Index-buffer data ops run with VAO 0 -- see create_buffer. */
+    bool unhook_vao = target == GL_ELEMENT_ARRAY_BUFFER && s_gl_cache.vao != 0;
+    if (unhook_vao) {
+        gl_bind_vao(0);
+    }
     glBindBuffer(target, buf);
     /* glBufferData with non-NULL data both orphans the existing storage and
      * uploads in one call. The driver may allocate fresh memory for the new
@@ -1277,6 +1430,9 @@ void nt_gfx_backend_orphan_buffer(uint32_t backend_handle, const void *data, uin
      * avoiding the pipeline stall that glBufferSubData can introduce when
      * rewriting a buffer that's still in flight. */
     glBufferData(target, (GLsizeiptr)size, data, GL_DYNAMIC_DRAW);
+    if (unhook_vao) {
+        gl_bind_vao(s_gl_cache.vao);
+    }
 }
 
 void nt_gfx_backend_bind_vertex_buffer(uint32_t backend_handle) {
@@ -1295,6 +1451,9 @@ void nt_gfx_backend_bind_vertex_buffer(uint32_t backend_handle) {
             const nt_vertex_attr_t *attr = &layout->attrs[i];
             glVertexAttribPointer(attr->location, attr->count, map_vertex_type(attr->type), attr->normalized ? GL_TRUE : GL_FALSE, (GLsizei)layout->stride,
                                   (void *)(uintptr_t)attr->offset); // NOLINT(performance-no-int-to-ptr)
+#ifdef NT_TEST_ACCESS
+            s_test_static_attrib_pointer_calls++;
+#endif
         }
     }
 }
@@ -1314,13 +1473,22 @@ void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle, uint32_t byte_
     GLuint buf = s_buffer_gl[backend_handle];
     glBindBuffer(GL_ARRAY_BUFFER, buf);
 
-    /* Re-apply instance attribute pointers from the currently bound pipeline. */
-    if (s_bound_pipeline_slot != 0 && s_bound_pipeline_slot <= s_init_desc.max_pipelines) {
-        const nt_vertex_layout_t *layout = &s_pipelines[s_bound_pipeline_slot].instance_layout;
+    /* The bound vertex input's instance layout wins; the bound pipeline's is
+     * the transitional fallback while pipelines still own layouts. */
+    const nt_vertex_layout_t *layout = NULL;
+    if (s_bound_vertex_input_slot != 0 && s_bound_vertex_input_slot <= s_init_desc.max_vertex_inputs) {
+        layout = &s_vertex_inputs[s_bound_vertex_input_slot].instance_layout;
+    } else if (s_bound_pipeline_slot != 0 && s_bound_pipeline_slot <= s_init_desc.max_pipelines) {
+        layout = &s_pipelines[s_bound_pipeline_slot].instance_layout;
+    }
+    if (layout != NULL) {
         for (uint8_t i = 0; i < layout->attr_count; i++) {
             const nt_vertex_attr_t *attr = &layout->attrs[i];
             glVertexAttribPointer(attr->location, attr->count, map_vertex_type(attr->type), attr->normalized ? GL_TRUE : GL_FALSE, (GLsizei)layout->stride,
                                   (void *)(uintptr_t)(attr->offset + byte_offset)); // NOLINT(performance-no-int-to-ptr)
+#ifdef NT_TEST_ACCESS
+            s_test_instance_attrib_pointer_calls++;
+#endif
         }
     }
 }
@@ -1970,6 +2138,9 @@ bool nt_gfx_backend_recreate_all_resources(void) {
     if (s_pipelines) {
         memset(s_pipelines, 0, (s_init_desc.max_pipelines + 1) * sizeof(nt_gfx_gl_pipeline_t));
     }
+    if (s_vertex_inputs) {
+        memset(s_vertex_inputs, 0, (s_init_desc.max_vertex_inputs + 1) * sizeof(nt_gfx_gl_vertex_input_t));
+    }
     if (s_buffer_gl) {
         memset(s_buffer_gl, 0, (s_init_desc.max_buffers + 1) * sizeof(GLuint));
     }
@@ -1983,6 +2154,7 @@ bool nt_gfx_backend_recreate_all_resources(void) {
         memset(s_render_targets, 0, (s_init_desc.max_render_targets + 1) * sizeof(nt_gfx_gl_render_target_t));
     }
     s_bound_pipeline_slot = 0;
+    s_bound_vertex_input_slot = 0;
     s_bound_framebuffer = 0;
     nt_gfx_gl_cache_reset();
     nt_gfx_gl_init_context_features();

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -108,10 +108,8 @@ typedef struct {
     uint16_t height;
 } nt_gfx_gl_render_target_t;
 
-/* Owned vertex-input VAO. Static half (vertex attrs + element binding) is
- * baked at creation; instance pointers are re-specified into the bound VAO
- * by bind_instance_buffer, which needs the layout kept here. Compact copy:
- * a full nt_vertex_layout_t per slot would cost ~200 B x max_vertex_inputs. */
+/* Static attrs and EBO are baked; instance pointers are re-pointed per draw.
+ * Keeping only the instance layout avoids ~200 B per vertex-input slot. */
 typedef struct {
     GLuint vao; /* 0 = free slot */
     nt_vertex_attr_t instance_attrs[NT_GFX_MAX_INSTANCE_ATTRS];
@@ -252,11 +250,8 @@ static void gl_bind_vao(GLuint vao) {
     glBindVertexArray(vao);
 }
 
-/* GL_ELEMENT_ARRAY_BUFFER binding is VAO state: with a vertex-input VAO bound
- * a data op would silently rewire its index binding, and core profile rejects
- * the bind with VAO 0 -- so index-buffer data ops run inside the service
- * upload VAO. The EBO detaches on exit because GL keeps attached storage
- * alive: a dangling attachment would pin a deleted index buffer's memory. */
+/* The service VAO prevents EBO data operations from rewriting a draw VAO.
+ * Detaching on exit lets deletion release the uploaded buffer's storage. */
 static void ebo_upload_begin(void) { gl_bind_vao(s_ebo_upload_vao); }
 
 static void ebo_upload_end(void) {
@@ -1255,8 +1250,6 @@ uint32_t nt_gfx_backend_create_vertex_input(const nt_vertex_input_desc_t *desc, 
     gl_bind_vao(s_gl_cache.vao);
 
     s_vertex_inputs[slot].vao = vao;
-    /* Clamped copy: the frontend asserts the cap, but OFF must not write past
-     * the compact array (the full-size source could not overflow, this can). */
     uint8_t inst_count = desc->instance_layout.attr_count;
     if (inst_count > NT_GFX_MAX_INSTANCE_ATTRS) {
         inst_count = NT_GFX_MAX_INSTANCE_ATTRS;

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -505,10 +505,12 @@ void nt_gfx_backend_shutdown(void) {
     s_bound_pipeline_slot = 0;
     s_bound_vertex_input_slot = 0;
     s_bound_framebuffer = 0;
-    if (s_ebo_upload_vao != 0) {
+    /* A dead context already reclaimed the name; a GL call here would run
+     * without a current context on web. */
+    if (s_ebo_upload_vao != 0 && !nt_gfx_gl_ctx_is_lost()) {
         glDeleteVertexArrays(1, &s_ebo_upload_vao);
-        s_ebo_upload_vao = 0;
     }
+    s_ebo_upload_vao = 0;
 
     nt_gfx_gl_ctx_destroy();
 }
@@ -1255,10 +1257,16 @@ uint32_t nt_gfx_backend_create_vertex_input(const nt_vertex_input_desc_t *desc, 
     gl_bind_vao(s_gl_cache.vao);
 
     s_vertex_inputs[slot].vao = vao;
-    for (uint8_t i = 0; i < desc->instance_layout.attr_count; i++) {
+    /* Clamped copy: the frontend asserts the cap, but OFF must not write past
+     * the compact array (the full-size source could not overflow, this can). */
+    uint8_t inst_count = desc->instance_layout.attr_count;
+    if (inst_count > NT_GFX_MAX_INSTANCE_ATTRS) {
+        inst_count = NT_GFX_MAX_INSTANCE_ATTRS;
+    }
+    for (uint8_t i = 0; i < inst_count; i++) {
         s_vertex_inputs[slot].instance_attrs[i] = desc->instance_layout.attrs[i];
     }
-    s_vertex_inputs[slot].instance_attr_count = desc->instance_layout.attr_count;
+    s_vertex_inputs[slot].instance_attr_count = inst_count;
     s_vertex_inputs[slot].instance_stride = desc->instance_layout.stride;
     return slot;
 }
@@ -1301,6 +1309,9 @@ void nt_gfx_backend_bind_vertex_input(uint32_t backend_handle) {
 uint32_t nt_gfx_backend_create_buffer(const nt_buffer_desc_t *desc) {
     GLuint buf;
     glGenBuffers(1, &buf);
+    if (buf == 0) {
+        return 0; /* lost context: storing name 0 would alias the free-slot sentinel */
+    }
     GLenum target;
     switch (desc->type) {
     case NT_BUFFER_VERTEX:

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -570,10 +570,16 @@ void nt_gfx_begin_frame(void) {
         for (uint32_t i = 1; i <= s_gfx.pipeline_pool.capacity; i++) {
             s_gfx.pipeline_backends[i] = 0;
         }
-        /* Vertex inputs die with the context and are not auto-restored --
-         * the zeroed backend makes a stale bind after recovery trap. */
+        /* Vertex inputs are baked objects with no re-fill path: loss frees
+         * their slots outright, so handles held across a loss go stale and
+         * renderer caches self-heal on their validity checks. Primary
+         * resources below stay as husks -- their owners destroy the handles. */
         for (uint32_t i = 1; i <= s_gfx.vertex_input_pool.capacity; i++) {
+            if (nt_pool_slot_alive(&s_gfx.vertex_input_pool, i)) {
+                nt_pool_free(&s_gfx.vertex_input_pool, s_gfx.vertex_input_pool.slots[i].id);
+            }
             s_gfx.vertex_input_backends[i] = 0;
+            memset(&s_gfx.vertex_input_metas[i], 0, sizeof(nt_gfx_vertex_input_meta_t));
         }
         for (uint32_t i = 1; i <= s_gfx.buffer_pool.capacity; i++) {
             s_gfx.buffer_backends[i] = 0;
@@ -1495,7 +1501,8 @@ void nt_gfx_bind_vertex_input(nt_vertex_input_t vi) {
         return;
     }
     uint32_t slot = nt_pool_slot_index(vi.id);
-    NT_ASSERT(s_gfx.vertex_input_backends[slot] != 0 && "bind_vertex_input: this vertex input outlived a context loss -- recreate it from the restored frame's resources");
+    /* Loss frees vertex-input slots, so a live slot always has a backend. */
+    NT_ASSERT(s_gfx.vertex_input_backends[slot] != 0 && "bind_vertex_input: live slot without backend");
     s_gfx.bound_vertex_input = vi.id;
     /* NT_INDEX_NONE for a non-indexed vertex input: cleared, not stale. */
     s_gfx.bound_index_type = s_gfx.vertex_input_metas[slot].index_type;

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -149,7 +149,7 @@ static struct {
     uint32_t bound_pipeline;     /* currently bound pipeline backend handle */
     uint32_t bound_vertex_input; /* full handle of the bound vertex input, 0 = none */
     uint32_t bound_texture_ids[NT_GFX_MAX_TEXTURE_SLOTS];
-    uint8_t bound_index_type; /* index type of currently bound IBO (1=uint16, 2=uint32) */
+    uint8_t bound_index_type; /* from the bound vertex input; NT_INDEX_NONE = non-indexed or none bound */
     bool scissor_enabled;     /* mirrors GL_SCISSOR_TEST */
 
     /* Mirrors of last set_scissor / set_viewport — only NT_TEST_ACCESS
@@ -322,8 +322,8 @@ void nt_gfx_shutdown(void) {
 
     /* The native context survives backend teardown, so release remaining GL objects.
      * Backend destroys clear entries; owned attachments and mesh buffers are safe
-     * to revisit. Pipelines
-     * own their VAOs, not their programs. */
+     * to revisit. Vertex inputs own the VAOs; pipelines own no GL objects and
+     * never their programs. */
     for (uint32_t i = 1; i <= s_gfx.vertex_input_pool.capacity; i++) {
         nt_gfx_backend_destroy_vertex_input(s_gfx.vertex_input_backends[i]);
     }
@@ -952,7 +952,7 @@ nt_vertex_input_t nt_gfx_make_vertex_input(const nt_vertex_input_desc_t *desc) {
         return result;
     }
     NT_ASSERT(desc->layout.attr_count <= NT_GFX_MAX_VERTEX_ATTRS && "too many vertex attrs");
-    NT_ASSERT(desc->instance_layout.attr_count <= NT_GFX_MAX_VERTEX_ATTRS && "too many instance attrs");
+    NT_ASSERT(desc->instance_layout.attr_count <= NT_GFX_MAX_INSTANCE_ATTRS && "too many instance attrs (NT_GFX_MAX_INSTANCE_ATTRS)");
     /* WebGL2 caps vertexAttribPointer stride at 255 bytes (INVALID_VALUE beyond).
      * Reachable only from game-declared layouts -- mesh-pack strides max out at 128. */
     NT_ASSERT(desc->layout.stride <= 255 && desc->instance_layout.stride <= 255 && "WebGL2 caps vertex stride at 255 bytes");
@@ -969,6 +969,9 @@ nt_vertex_input_t nt_gfx_make_vertex_input(const nt_vertex_input_desc_t *desc) {
         uint32_t vbo_slot = nt_pool_slot_index(desc->vertex_buffer.id);
         NT_ASSERT(s_gfx.buffer_metas[vbo_slot].type == NT_BUFFER_VERTEX && "make_vertex_input: vertex_buffer is not vertex type");
         vbo_backend = s_gfx.buffer_backends[vbo_slot];
+        /* A pool-valid buffer with no backend outlived a context loss; baking
+         * it would produce a VAO that silently draws nothing. */
+        NT_ASSERT(vbo_backend != 0 && "make_vertex_input: vertex_buffer has no live backend -- recreate it after context restore");
     }
     uint32_t ibo_backend = 0;
     uint8_t index_type = NT_INDEX_NONE;
@@ -980,6 +983,7 @@ nt_vertex_input_t nt_gfx_make_vertex_input(const nt_vertex_input_desc_t *desc) {
         /* Without the declared type the backend would silently draw UINT16. */
         NT_ASSERT(index_type != NT_INDEX_NONE && "make_vertex_input: index_buffer was created without an index_type");
         ibo_backend = s_gfx.buffer_backends[ibo_slot];
+        NT_ASSERT(ibo_backend != 0 && "make_vertex_input: index_buffer has no live backend -- recreate it after context restore");
     }
 
     uint32_t id = nt_pool_alloc(&s_gfx.vertex_input_pool);
@@ -1794,6 +1798,7 @@ void nt_gfx_draw(uint32_t first_vertex, uint32_t num_vertices) {
         return;
     }
     assert_vertex_input_bound();
+    assert_instance_attribs_pointed();
 
     g_nt_gfx.frame_stats.draw_calls++;
     g_nt_gfx.frame_stats.vertices += num_vertices;
@@ -1850,6 +1855,7 @@ void nt_gfx_draw_indexed(uint32_t first_index, uint32_t num_indices, uint32_t nu
     }
     assert_vertex_input_bound();
     assert_indexed_draw_has_index_type();
+    assert_instance_attribs_pointed();
 
     g_nt_gfx.frame_stats.draw_calls++;
     g_nt_gfx.frame_stats.vertices += num_vertices;
@@ -2484,9 +2490,6 @@ uint32_t nt_gfx_activate_mesh(const uint8_t *data, uint32_t size) {
         stride += (uint16_t)(nt_stream_type_size(src_streams[i].type) * src_streams[i].count);
     }
     s_gfx.mesh_table[slot].stride = stride;
-
-    /* Compute layout_hash from stream descriptors for pipeline cache keying */
-    s_gfx.mesh_table[slot].layout_hash = nt_hash64(src_streams, (uint32_t)hdr->stream_count * (uint32_t)sizeof(NtStreamDesc)).value;
 
     return mesh_id;
 }

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -937,15 +937,15 @@ nt_pipeline_t nt_gfx_make_pipeline(const nt_pipeline_desc_t *desc) {
     uint32_t id = nt_pool_alloc(&s_gfx.pipeline_pool);
     NT_ASSERT(id != 0 && "pipeline pool full -- raise nt_gfx_desc_t.max_pipelines");
 
+    uint32_t slot = nt_pool_slot_index(id);
     uint32_t program_backend = s_gfx.program_backends[nt_pool_slot_index(desc->program.id)];
-    uint32_t backend = nt_gfx_backend_create_pipeline(desc, program_backend);
+    uint32_t backend = nt_gfx_backend_create_pipeline(desc, program_backend, slot);
     if (backend == 0) {
         NT_LOG_ERROR("backend pipeline creation failed");
         nt_pool_free(&s_gfx.pipeline_pool, id);
         return result;
     }
 
-    uint32_t slot = nt_pool_slot_index(id);
     s_gfx.pipeline_backends[slot] = backend;
     s_gfx.pipeline_programs[slot] = desc->program.id;
 
@@ -1000,14 +1000,14 @@ nt_vertex_input_t nt_gfx_make_vertex_input(const nt_vertex_input_desc_t *desc) {
     uint32_t id = nt_pool_alloc(&s_gfx.vertex_input_pool);
     NT_ASSERT(id != 0 && "vertex input pool full -- raise nt_gfx_desc_t.max_vertex_inputs");
 
-    uint32_t backend = nt_gfx_backend_create_vertex_input(desc, vbo_backend, ibo_backend);
+    uint32_t slot = nt_pool_slot_index(id);
+    uint32_t backend = nt_gfx_backend_create_vertex_input(desc, vbo_backend, ibo_backend, slot);
     if (backend == 0) {
         NT_LOG_ERROR("backend vertex input creation failed");
         nt_pool_free(&s_gfx.vertex_input_pool, id);
         return result;
     }
 
-    uint32_t slot = nt_pool_slot_index(id);
     s_gfx.vertex_input_backends[slot] = backend;
     s_gfx.vertex_input_metas[slot] = (nt_gfx_vertex_input_meta_t){
         .vbo_id = desc->vertex_buffer.id,

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -64,10 +64,11 @@ typedef struct {
 typedef struct {
     uint32_t vbo_id; /* full buffer handles: destroy_buffer cascades on exact match */
     uint32_t ibo_id;
-    uint8_t index_type; /* captured from the IBO; NT_INDEX_NONE for non-indexed */
+    uint32_t inst_buf_id; /* last buffer pointed by bind_instance_buffer; its destruction unpoints */
+    uint8_t index_type;   /* captured from the IBO; NT_INDEX_NONE for non-indexed */
     uint8_t instance_attr_count;
     /* Enabled-but-unpointed instance attribs are invalid GL that fails
-     * silently -- draws assert this went through bind_instance_buffer once. */
+     * silently -- draws assert the attribs currently point at a live buffer. */
     bool instance_pointed;
 } nt_gfx_vertex_input_meta_t;
 
@@ -1321,6 +1322,12 @@ void nt_gfx_destroy_buffer(nt_buffer_t buf) {
     for (uint32_t i = 1; i <= s_gfx.vertex_input_pool.capacity; i++) {
         if (s_gfx.vertex_input_metas[i].vbo_id == buf.id || s_gfx.vertex_input_metas[i].ibo_id == buf.id) {
             nt_gfx_destroy_vertex_input((nt_vertex_input_t){s_gfx.vertex_input_pool.slots[i].id});
+        } else if (s_gfx.vertex_input_metas[i].inst_buf_id == buf.id) {
+            /* Instance attachments are not destroy-tracked, but the pointed
+             * flag must not lie: the next instanced draw without a re-point
+             * traps instead of silently reading the dead buffer. */
+            s_gfx.vertex_input_metas[i].instance_pointed = false;
+            s_gfx.vertex_input_metas[i].inst_buf_id = 0;
         }
     }
     uint32_t slot = nt_pool_slot_index(buf.id);
@@ -1919,6 +1926,9 @@ void nt_gfx_bind_instance_buffer(nt_buffer_t buf, uint32_t byte_offset) {
         NT_LOG_ERROR("bind_instance_buffer: buffer is not vertex type");
         return;
     }
+    /* Pool slots survive context loss; pointing into a zeroed backend would
+     * silently draw garbage on the restored context. */
+    NT_ASSERT(s_gfx.buffer_backends[slot] != 0 && "bind_instance_buffer: buffer has no live backend -- recreate it after context restore");
     NT_ASSERT(byte_offset <= s_gfx.buffer_metas[slot].size && "bind_instance_buffer: offset exceeds buffer capacity");
     NT_ASSERT((byte_offset & 3U) == 0 && "bind_instance_buffer: offset must be 4-byte aligned (WebGL2 attrib rule)");
     NT_ASSERT(s_gfx.bound_vertex_input != 0 && "bind_instance_buffer: requires a bound vertex input");
@@ -1929,6 +1939,7 @@ void nt_gfx_bind_instance_buffer(nt_buffer_t buf, uint32_t byte_offset) {
     uint32_t vi_slot = nt_pool_slot_index(s_gfx.bound_vertex_input);
     NT_ASSERT(s_gfx.vertex_input_metas[vi_slot].instance_attr_count > 0 && "bind_instance_buffer: bound vertex input declares no instance layout");
     s_gfx.vertex_input_metas[vi_slot].instance_pointed = true;
+    s_gfx.vertex_input_metas[vi_slot].inst_buf_id = buf.id;
     nt_gfx_backend_bind_instance_buffer(s_gfx.buffer_backends[slot], byte_offset);
 }
 

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -567,13 +567,17 @@ void nt_gfx_begin_frame(void) {
         for (uint32_t i = 1; i <= s_gfx.program_pool.capacity; i++) {
             s_gfx.program_backends[i] = 0;
         }
+        /* Pipelines and vertex inputs are baked objects with no re-fill path:
+         * loss frees their slots outright, so handles held across a loss go
+         * stale and the weak renderer caches self-heal on their validity
+         * checks. Primary resources stay as husks -- owners destroy them. */
         for (uint32_t i = 1; i <= s_gfx.pipeline_pool.capacity; i++) {
+            if (nt_pool_slot_alive(&s_gfx.pipeline_pool, i)) {
+                nt_pool_free(&s_gfx.pipeline_pool, s_gfx.pipeline_pool.slots[i].id);
+            }
             s_gfx.pipeline_backends[i] = 0;
+            s_gfx.pipeline_programs[i] = 0;
         }
-        /* Vertex inputs are baked objects with no re-fill path: loss frees
-         * their slots outright, so handles held across a loss go stale and
-         * renderer caches self-heal on their validity checks. Primary
-         * resources below stay as husks -- their owners destroy the handles. */
         for (uint32_t i = 1; i <= s_gfx.vertex_input_pool.capacity; i++) {
             if (nt_pool_slot_alive(&s_gfx.vertex_input_pool, i)) {
                 nt_pool_free(&s_gfx.vertex_input_pool, s_gfx.vertex_input_pool.slots[i].id);
@@ -1478,8 +1482,8 @@ void nt_gfx_bind_pipeline(nt_pipeline_t pip) {
         return;
     }
     uint32_t slot = nt_pool_slot_index(pip.id);
-    NT_ASSERT(s_gfx.pipeline_backends[slot] != 0 &&
-              "bind_pipeline: this pipeline outlived a context loss -- call the owning renderer's restore entry point (nt_*_renderer_restore_gpu) in the restored frame");
+    /* Loss frees pipeline slots, so a live slot always has a backend. */
+    NT_ASSERT(s_gfx.pipeline_backends[slot] != 0 && "bind_pipeline: live slot without backend");
     s_gfx.bound_pipeline = s_gfx.pipeline_backends[slot];
 #ifdef NT_TEST_ACCESS
     s_test_bound_pipeline = pip;

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -921,15 +921,6 @@ nt_pipeline_t nt_gfx_make_pipeline(const nt_pipeline_desc_t *desc) {
         return result;
     }
     NT_ASSERT(nt_gfx_program_ready(desc->program) && "make_pipeline: program is not linked");
-    NT_ASSERT(desc->layout.attr_count <= NT_GFX_MAX_VERTEX_ATTRS && "too many vertex attrs");
-    NT_ASSERT(desc->instance_layout.attr_count <= NT_GFX_MAX_VERTEX_ATTRS && "too many instance attrs");
-    /* WebGL2 caps vertexAttribPointer stride at 255 bytes (INVALID_VALUE beyond).
-     * Reachable only from game-declared layouts -- mesh-pack strides max out at 128. */
-    NT_ASSERT(desc->layout.stride <= 255 && desc->instance_layout.stride <= 255 && "WebGL2 caps vertex stride at 255 bytes");
-    /* After the attr_count asserts -- the loops read attr_count entries. */
-    assert_layout_webgl2_rules(&desc->layout);
-    assert_layout_webgl2_rules(&desc->instance_layout);
-    NT_ASSERT(layout_locations_unique(&desc->layout, &desc->instance_layout) && "attribute location used twice across vertex/instance layouts");
     NT_ASSERT(blend_state_valid(&desc->blend));
 
     uint32_t id = nt_pool_alloc(&s_gfx.pipeline_pool);
@@ -962,6 +953,8 @@ nt_vertex_input_t nt_gfx_make_vertex_input(const nt_vertex_input_desc_t *desc) {
     }
     NT_ASSERT(desc->layout.attr_count <= NT_GFX_MAX_VERTEX_ATTRS && "too many vertex attrs");
     NT_ASSERT(desc->instance_layout.attr_count <= NT_GFX_MAX_VERTEX_ATTRS && "too many instance attrs");
+    /* WebGL2 caps vertexAttribPointer stride at 255 bytes (INVALID_VALUE beyond).
+     * Reachable only from game-declared layouts -- mesh-pack strides max out at 128. */
     NT_ASSERT(desc->layout.stride <= 255 && desc->instance_layout.stride <= 255 && "WebGL2 caps vertex stride at 255 bytes");
     /* After the attr_count asserts -- the loops read attr_count entries. */
     assert_layout_webgl2_rules(&desc->layout);
@@ -1454,13 +1447,9 @@ void nt_gfx_bind_pipeline(nt_pipeline_t pip) {
     if (g_nt_gfx.context_lost) {
         return;
     }
-    /* Transitional while pipelines still own VAOs: binding one clobbers the
-     * bound vertex input, so the mirror must not survive (bind_instance_buffer
-     * would otherwise write foreign pointers into the pipeline's VAO). */
-    s_gfx.bound_vertex_input = 0;
     if (!nt_pool_valid(&s_gfx.pipeline_pool, pip.id)) {
-        /* Clear both bind mirrors so later draws or buffer binds cannot reuse
-         * the previous pipeline's program and VAO. */
+        /* Clear the mirror so later draws cannot reuse the previous
+         * pipeline's program. The bound vertex input is orthogonal state. */
         s_gfx.bound_pipeline = 0;
         nt_gfx_backend_bind_pipeline(0);
         NT_LOG_ERROR("bind_pipeline: invalid handle");
@@ -1495,41 +1484,6 @@ void nt_gfx_bind_vertex_input(nt_vertex_input_t vi) {
     /* NT_INDEX_NONE for a non-indexed vertex input: cleared, not stale. */
     s_gfx.bound_index_type = s_gfx.vertex_input_metas[slot].index_type;
     nt_gfx_backend_bind_vertex_input(s_gfx.vertex_input_backends[slot]);
-}
-
-void nt_gfx_bind_vertex_buffer(nt_buffer_t buf) {
-    if (g_nt_gfx.context_lost) {
-        return;
-    }
-    if (!nt_pool_valid(&s_gfx.buffer_pool, buf.id)) {
-        NT_LOG_ERROR("bind_vertex_buffer: invalid handle");
-        return;
-    }
-    uint32_t slot = nt_pool_slot_index(buf.id);
-    NT_ASSERT(s_gfx.buffer_metas[slot].type == NT_BUFFER_VERTEX);
-    if (s_gfx.buffer_metas[slot].type != NT_BUFFER_VERTEX) {
-        NT_LOG_ERROR("bind_vertex_buffer: buffer is not vertex type");
-        return;
-    }
-    nt_gfx_backend_bind_vertex_buffer(s_gfx.buffer_backends[slot]);
-}
-
-void nt_gfx_bind_index_buffer(nt_buffer_t buf) {
-    if (g_nt_gfx.context_lost) {
-        return;
-    }
-    if (!nt_pool_valid(&s_gfx.buffer_pool, buf.id)) {
-        NT_LOG_ERROR("bind_index_buffer: invalid handle");
-        return;
-    }
-    uint32_t slot = nt_pool_slot_index(buf.id);
-    NT_ASSERT(s_gfx.buffer_metas[slot].type == NT_BUFFER_INDEX);
-    if (s_gfx.buffer_metas[slot].type != NT_BUFFER_INDEX) {
-        NT_LOG_ERROR("bind_index_buffer: buffer is not index type");
-        return;
-    }
-    s_gfx.bound_index_type = s_gfx.buffer_metas[slot].index_type;
-    nt_gfx_backend_bind_index_buffer(s_gfx.buffer_backends[slot]);
 }
 
 void nt_gfx_bind_texture(nt_texture_t tex, uint32_t slot) {
@@ -1806,21 +1760,22 @@ void nt_gfx_set_uniform_int(const char *name, int val) {
  * restored frame and submit on the next. Pass clears remain legal. */
 static void assert_draws_allowed_this_frame(void) { NT_ASSERT(!g_nt_gfx.context_restored && "no draws on the restored frame; see docs/spec/assets/resource.md"); }
 
-/* Enabled-but-unpointed instance attribs are invalid GL that fails silently.
- * Transitional: enforced only when a vertex input is bound -- the legacy
- * pipeline-VAO path keeps its old checks until it is removed. */
+/* Every draw reads vertex-input state; attribute-less draws bind an empty one. */
+static void assert_vertex_input_bound(void) { NT_ASSERT(s_gfx.bound_vertex_input != 0 && "draw: no vertex input bound -- bind one with nt_gfx_bind_vertex_input"); }
+
+/* Enabled-but-unpointed instance attribs are invalid GL that fails silently. */
 static void assert_instance_attribs_pointed(void) {
     if (s_gfx.bound_vertex_input == 0) {
-        return;
+        return; /* the missing bind itself already trapped */
     }
     NT_ASSERT(
         (s_gfx.vertex_input_metas[nt_pool_slot_index(s_gfx.bound_vertex_input)].instance_attr_count == 0 || s_gfx.vertex_input_metas[nt_pool_slot_index(s_gfx.bound_vertex_input)].instance_pointed) &&
         "instanced draw: bind_instance_buffer has not pointed the bound vertex input's instance attribs");
 }
 
-/* Transitional like above: a bound vertex input carries its own index type;
- * NT_INDEX_NONE here means the caller draws indexed on a non-indexed input. */
-static void assert_indexed_draw_has_index_type(void) { NT_ASSERT((s_gfx.bound_vertex_input == 0 || s_gfx.bound_index_type != NT_INDEX_NONE) && "draw_indexed: bound vertex input is non-indexed"); }
+/* The bound vertex input carries its own index type; NT_INDEX_NONE here means
+ * the caller draws indexed on a non-indexed input. */
+static void assert_indexed_draw_has_index_type(void) { NT_ASSERT(s_gfx.bound_index_type != NT_INDEX_NONE && "draw_indexed: bound vertex input is non-indexed"); }
 
 void nt_gfx_draw(uint32_t first_vertex, uint32_t num_vertices) {
     if (g_nt_gfx.context_lost) {
@@ -1838,6 +1793,7 @@ void nt_gfx_draw(uint32_t first_vertex, uint32_t num_vertices) {
         NT_LOG_ERROR("draw called without bound pipeline");
         return;
     }
+    assert_vertex_input_bound();
 
     g_nt_gfx.frame_stats.draw_calls++;
     g_nt_gfx.frame_stats.vertices += num_vertices;
@@ -1863,6 +1819,7 @@ void nt_gfx_draw_instanced(uint32_t first_vertex, uint32_t num_vertices, uint32_
         NT_LOG_ERROR("draw_instanced called without bound pipeline");
         return;
     }
+    assert_vertex_input_bound();
     assert_instance_attribs_pointed();
 
     g_nt_gfx.frame_stats.draw_calls++;
@@ -1891,6 +1848,7 @@ void nt_gfx_draw_indexed(uint32_t first_index, uint32_t num_indices, uint32_t nu
         NT_LOG_ERROR("draw_indexed called without bound pipeline");
         return;
     }
+    assert_vertex_input_bound();
     assert_indexed_draw_has_index_type();
 
     g_nt_gfx.frame_stats.draw_calls++;
@@ -1918,6 +1876,7 @@ void nt_gfx_draw_indexed_instanced(uint32_t first_index, uint32_t num_indices, u
         NT_LOG_ERROR("draw_indexed_instanced called without bound pipeline");
         return;
     }
+    assert_vertex_input_bound();
     assert_indexed_draw_has_index_type();
     assert_instance_attribs_pointed();
 
@@ -1951,18 +1910,14 @@ void nt_gfx_bind_instance_buffer(nt_buffer_t buf, uint32_t byte_offset) {
     }
     NT_ASSERT(byte_offset <= s_gfx.buffer_metas[slot].size && "bind_instance_buffer: offset exceeds buffer capacity");
     NT_ASSERT((byte_offset & 3U) == 0 && "bind_instance_buffer: offset must be 4-byte aligned (WebGL2 attrib rule)");
-    if (s_gfx.bound_vertex_input != 0) {
-        uint32_t vi_slot = nt_pool_slot_index(s_gfx.bound_vertex_input);
-        NT_ASSERT(s_gfx.vertex_input_metas[vi_slot].instance_attr_count > 0 && "bind_instance_buffer: bound vertex input declares no instance layout");
-        s_gfx.vertex_input_metas[vi_slot].instance_pointed = true;
-    } else {
-        /* Transitional fallback while pipelines still own instance layouts. */
-        NT_ASSERT(s_gfx.bound_pipeline != 0 && "bind_instance_buffer: requires a bound vertex input or pipeline");
-        if (s_gfx.bound_pipeline == 0) {
-            NT_LOG_ERROR("bind_instance_buffer: no pipeline bound");
-            return;
-        }
+    NT_ASSERT(s_gfx.bound_vertex_input != 0 && "bind_instance_buffer: requires a bound vertex input");
+    if (s_gfx.bound_vertex_input == 0) {
+        NT_LOG_ERROR("bind_instance_buffer: no vertex input bound");
+        return;
     }
+    uint32_t vi_slot = nt_pool_slot_index(s_gfx.bound_vertex_input);
+    NT_ASSERT(s_gfx.vertex_input_metas[vi_slot].instance_attr_count > 0 && "bind_instance_buffer: bound vertex input declares no instance layout");
+    s_gfx.vertex_input_metas[vi_slot].instance_pointed = true;
     nt_gfx_backend_bind_instance_buffer(s_gfx.buffer_backends[slot], byte_offset);
 }
 

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -59,6 +59,18 @@ typedef struct {
     uint32_t size;
 } nt_gfx_buffer_meta_t;
 
+/* ---- Vertex input metadata (destroy cascade + draw-invariant checks) ---- */
+
+typedef struct {
+    uint32_t vbo_id; /* full buffer handles: destroy_buffer cascades on exact match */
+    uint32_t ibo_id;
+    uint8_t index_type; /* captured from the IBO; NT_INDEX_NONE for non-indexed */
+    uint8_t instance_attr_count;
+    /* Enabled-but-unpointed instance attribs are invalid GL that fails
+     * silently -- draws assert this went through bind_instance_buffer once. */
+    bool instance_pointed;
+} nt_gfx_vertex_input_meta_t;
+
 /* ---- Texture metadata (format + dimensions for update_texture validation) ---- */
 
 typedef struct {
@@ -105,6 +117,7 @@ static struct {
     nt_pool_t shader_pool;
     nt_pool_t program_pool;
     nt_pool_t pipeline_pool;
+    nt_pool_t vertex_input_pool;
     nt_pool_t buffer_pool;
     nt_pool_t texture_pool;
     nt_pool_t render_target_pool;
@@ -113,12 +126,14 @@ static struct {
     uint32_t *program_backends;
     uint32_t *pipeline_backends;
     uint32_t *pipeline_programs; /* full program handle each pipeline borrows */
+    uint32_t *vertex_input_backends;
     uint32_t *buffer_backends;
     uint32_t *texture_backends;
     uint32_t *render_target_backends;
 
     nt_gfx_buffer_meta_t *buffer_metas;   /* minimal buffer metadata for runtime validation */
     nt_gfx_texture_meta_t *texture_metas; /* format + dimensions for update_texture validation */
+    nt_gfx_vertex_input_meta_t *vertex_input_metas;
     nt_gfx_render_target_meta_t *render_target_metas;
 
     /* Sampler cache (dedup by descriptor; samplers are immutable after create
@@ -131,7 +146,8 @@ static struct {
 
     nt_gfx_render_state_t render_state;
     bool context_restore_retry;
-    uint32_t bound_pipeline; /* currently bound pipeline backend handle */
+    uint32_t bound_pipeline;     /* currently bound pipeline backend handle */
+    uint32_t bound_vertex_input; /* full handle of the bound vertex input, 0 = none */
     uint32_t bound_texture_ids[NT_GFX_MAX_TEXTURE_SLOTS];
     uint8_t bound_index_type; /* index type of currently bound IBO (1=uint16, 2=uint32) */
     bool scissor_enabled;     /* mirrors GL_SCISSOR_TEST */
@@ -223,6 +239,7 @@ void nt_gfx_init(const nt_gfx_desc_t *desc) {
     NT_ASSERT(desc->max_buffers > 0 && "nt_gfx_desc_t.max_buffers is 0 -- use nt_gfx_desc_defaults() or set explicitly");
     NT_ASSERT(desc->max_textures > 0 && "nt_gfx_desc_t.max_textures is 0 -- use nt_gfx_desc_defaults() or set explicitly");
     NT_ASSERT(desc->max_meshes > 0 && "nt_gfx_desc_t.max_meshes is 0 -- use nt_gfx_desc_defaults() or set explicitly");
+    NT_ASSERT(desc->max_vertex_inputs > 0 && "nt_gfx_desc_t.max_vertex_inputs is 0 -- use nt_gfx_desc_defaults() or set explicitly");
     NT_ASSERT(desc->max_render_targets > 0 && "nt_gfx_desc_t.max_render_targets is 0 -- use nt_gfx_desc_defaults() or set explicitly");
     uint16_t max_render_targets = desc->max_render_targets;
     memset(&s_gfx, 0, sizeof(s_gfx));
@@ -231,6 +248,7 @@ void nt_gfx_init(const nt_gfx_desc_t *desc) {
     nt_pool_init(&s_gfx.shader_pool, desc->max_shaders);
     nt_pool_init(&s_gfx.program_pool, desc->max_programs);
     nt_pool_init(&s_gfx.pipeline_pool, desc->max_pipelines);
+    nt_pool_init(&s_gfx.vertex_input_pool, desc->max_vertex_inputs);
     nt_pool_init(&s_gfx.buffer_pool, desc->max_buffers);
     nt_pool_init(&s_gfx.texture_pool, desc->max_textures);
     nt_pool_init(&s_gfx.render_target_pool, max_render_targets);
@@ -239,11 +257,13 @@ void nt_gfx_init(const nt_gfx_desc_t *desc) {
     s_gfx.program_backends = (uint32_t *)calloc(desc->max_programs + 1, sizeof(uint32_t));
     s_gfx.pipeline_backends = (uint32_t *)calloc(desc->max_pipelines + 1, sizeof(uint32_t));
     s_gfx.pipeline_programs = (uint32_t *)calloc(desc->max_pipelines + 1, sizeof(uint32_t));
+    s_gfx.vertex_input_backends = (uint32_t *)calloc(desc->max_vertex_inputs + 1, sizeof(uint32_t));
     s_gfx.buffer_backends = (uint32_t *)calloc(desc->max_buffers + 1, sizeof(uint32_t));
     s_gfx.texture_backends = (uint32_t *)calloc(desc->max_textures + 1, sizeof(uint32_t));
     s_gfx.render_target_backends = (uint32_t *)calloc(max_render_targets + 1, sizeof(uint32_t));
 
     s_gfx.buffer_metas = (nt_gfx_buffer_meta_t *)calloc(desc->max_buffers + 1, sizeof(nt_gfx_buffer_meta_t));
+    s_gfx.vertex_input_metas = (nt_gfx_vertex_input_meta_t *)calloc(desc->max_vertex_inputs + 1, sizeof(nt_gfx_vertex_input_meta_t));
     s_gfx.texture_metas = (nt_gfx_texture_meta_t *)calloc(desc->max_textures + 1, sizeof(nt_gfx_texture_meta_t));
     s_gfx.render_target_metas = (nt_gfx_render_target_meta_t *)calloc(max_render_targets + 1, sizeof(nt_gfx_render_target_meta_t));
 
@@ -304,6 +324,9 @@ void nt_gfx_shutdown(void) {
      * Backend destroys clear entries; owned attachments and mesh buffers are safe
      * to revisit. Pipelines
      * own their VAOs, not their programs. */
+    for (uint32_t i = 1; i <= s_gfx.vertex_input_pool.capacity; i++) {
+        nt_gfx_backend_destroy_vertex_input(s_gfx.vertex_input_backends[i]);
+    }
     for (uint32_t i = 1; i <= s_gfx.pipeline_pool.capacity; i++) {
         nt_gfx_backend_destroy_pipeline(s_gfx.pipeline_backends[i]);
     }
@@ -325,6 +348,7 @@ void nt_gfx_shutdown(void) {
     nt_pool_shutdown(&s_gfx.shader_pool);
     nt_pool_shutdown(&s_gfx.program_pool);
     nt_pool_shutdown(&s_gfx.pipeline_pool);
+    nt_pool_shutdown(&s_gfx.vertex_input_pool);
     nt_pool_shutdown(&s_gfx.buffer_pool);
     nt_pool_shutdown(&s_gfx.texture_pool);
     nt_pool_shutdown(&s_gfx.render_target_pool);
@@ -334,10 +358,12 @@ void nt_gfx_shutdown(void) {
     free(s_gfx.program_backends);
     free(s_gfx.pipeline_backends);
     free(s_gfx.pipeline_programs);
+    free(s_gfx.vertex_input_backends);
     free(s_gfx.buffer_backends);
     free(s_gfx.texture_backends);
     free(s_gfx.render_target_backends);
     free(s_gfx.buffer_metas);
+    free(s_gfx.vertex_input_metas);
     free(s_gfx.texture_metas);
     free(s_gfx.render_target_metas);
     free(s_gfx.mesh_table);
@@ -543,6 +569,11 @@ void nt_gfx_begin_frame(void) {
         for (uint32_t i = 1; i <= s_gfx.pipeline_pool.capacity; i++) {
             s_gfx.pipeline_backends[i] = 0;
         }
+        /* Vertex inputs die with the context and are not auto-restored --
+         * the zeroed backend makes a stale bind after recovery trap. */
+        for (uint32_t i = 1; i <= s_gfx.vertex_input_pool.capacity; i++) {
+            s_gfx.vertex_input_backends[i] = 0;
+        }
         for (uint32_t i = 1; i <= s_gfx.buffer_pool.capacity; i++) {
             s_gfx.buffer_backends[i] = 0;
         }
@@ -557,6 +588,8 @@ void nt_gfx_begin_frame(void) {
          * call deactivate_mesh() which returns slots to mesh pool.
          * destroy_buffer on zeroed backend handles is safe (glDeleteBuffers(0) = no-op). */
         s_gfx.bound_pipeline = 0;
+        s_gfx.bound_vertex_input = 0;
+        s_gfx.bound_index_type = NT_INDEX_NONE;
         memset(s_gfx.bound_texture_ids, 0, sizeof(s_gfx.bound_texture_ids));
         /* Sampler cache: zero only the GL backend ids — keys, descs
          * and sampler_count stay so material-stored sampler.id values
@@ -618,6 +651,8 @@ void nt_gfx_begin_frame(void) {
     /* Backend resets its pipeline cache per frame; mirror it so the
      * bound-pipeline asserts stay truthful across frame boundaries. */
     s_gfx.bound_pipeline = 0;
+    s_gfx.bound_vertex_input = 0;
+    s_gfx.bound_index_type = NT_INDEX_NONE;
     nt_gfx_backend_begin_frame();
 }
 
@@ -916,6 +951,68 @@ nt_pipeline_t nt_gfx_make_pipeline(const nt_pipeline_desc_t *desc) {
     return result;
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) -- NT_ASSERT expansion inflates the metric
+nt_vertex_input_t nt_gfx_make_vertex_input(const nt_vertex_input_desc_t *desc) {
+    /* Same contract as make_pipeline: caller errors trap, only a lost context
+     * or a failed backend allocation returns an invalid handle. */
+    nt_vertex_input_t result = {0};
+    NT_ASSERT(desc != NULL);
+    if (g_nt_gfx.context_lost || nt_gfx_backend_is_context_lost()) {
+        return result;
+    }
+    NT_ASSERT(desc->layout.attr_count <= NT_GFX_MAX_VERTEX_ATTRS && "too many vertex attrs");
+    NT_ASSERT(desc->instance_layout.attr_count <= NT_GFX_MAX_VERTEX_ATTRS && "too many instance attrs");
+    NT_ASSERT(desc->layout.stride <= 255 && desc->instance_layout.stride <= 255 && "WebGL2 caps vertex stride at 255 bytes");
+    /* After the attr_count asserts -- the loops read attr_count entries. */
+    assert_layout_webgl2_rules(&desc->layout);
+    assert_layout_webgl2_rules(&desc->instance_layout);
+    NT_ASSERT(layout_locations_unique(&desc->layout, &desc->instance_layout) && "attribute location used twice across vertex/instance layouts");
+    /* attr_count 0 with no buffers is the attribute-less gl_VertexID path. */
+    NT_ASSERT((desc->layout.attr_count > 0) == (desc->vertex_buffer.id != 0) && "make_vertex_input: vertex_buffer is required iff layout has attrs");
+
+    uint32_t vbo_backend = 0;
+    if (desc->vertex_buffer.id != 0) {
+        NT_ASSERT(nt_pool_valid(&s_gfx.buffer_pool, desc->vertex_buffer.id) && "make_vertex_input: invalid vertex_buffer handle");
+        uint32_t vbo_slot = nt_pool_slot_index(desc->vertex_buffer.id);
+        NT_ASSERT(s_gfx.buffer_metas[vbo_slot].type == NT_BUFFER_VERTEX && "make_vertex_input: vertex_buffer is not vertex type");
+        vbo_backend = s_gfx.buffer_backends[vbo_slot];
+    }
+    uint32_t ibo_backend = 0;
+    uint8_t index_type = NT_INDEX_NONE;
+    if (desc->index_buffer.id != 0) {
+        NT_ASSERT(nt_pool_valid(&s_gfx.buffer_pool, desc->index_buffer.id) && "make_vertex_input: invalid index_buffer handle");
+        uint32_t ibo_slot = nt_pool_slot_index(desc->index_buffer.id);
+        NT_ASSERT(s_gfx.buffer_metas[ibo_slot].type == NT_BUFFER_INDEX && "make_vertex_input: index_buffer is not index type");
+        index_type = s_gfx.buffer_metas[ibo_slot].index_type;
+        /* Without the declared type the backend would silently draw UINT16. */
+        NT_ASSERT(index_type != NT_INDEX_NONE && "make_vertex_input: index_buffer was created without an index_type");
+        ibo_backend = s_gfx.buffer_backends[ibo_slot];
+    }
+
+    uint32_t id = nt_pool_alloc(&s_gfx.vertex_input_pool);
+    NT_ASSERT(id != 0 && "vertex input pool full -- raise nt_gfx_desc_t.max_vertex_inputs");
+
+    uint32_t backend = nt_gfx_backend_create_vertex_input(desc, vbo_backend, ibo_backend);
+    if (backend == 0) {
+        NT_LOG_ERROR("backend vertex input creation failed");
+        nt_pool_free(&s_gfx.vertex_input_pool, id);
+        return result;
+    }
+
+    uint32_t slot = nt_pool_slot_index(id);
+    s_gfx.vertex_input_backends[slot] = backend;
+    s_gfx.vertex_input_metas[slot] = (nt_gfx_vertex_input_meta_t){
+        .vbo_id = desc->vertex_buffer.id,
+        .ibo_id = desc->index_buffer.id,
+        .index_type = index_type,
+        .instance_attr_count = desc->instance_layout.attr_count,
+        .instance_pointed = false,
+    };
+
+    result.id = id;
+    return result;
+}
+
 nt_buffer_t nt_gfx_make_buffer(const nt_buffer_desc_t *desc) {
     nt_buffer_t result = {0};
     if (!desc) {
@@ -1191,6 +1288,23 @@ void nt_gfx_destroy_pipeline(nt_pipeline_t pip) {
     nt_pool_free(&s_gfx.pipeline_pool, pip.id);
 }
 
+void nt_gfx_destroy_vertex_input(nt_vertex_input_t vi) {
+    /* The destroy_buffer cascade makes stale handles routine here, so both
+     * INVALID and stale are tolerated no-ops (same contract as pipelines). */
+    if (!nt_pool_valid(&s_gfx.vertex_input_pool, vi.id)) {
+        return;
+    }
+    uint32_t slot = nt_pool_slot_index(vi.id);
+    if (s_gfx.bound_vertex_input == vi.id) {
+        s_gfx.bound_vertex_input = 0;
+        s_gfx.bound_index_type = NT_INDEX_NONE;
+    }
+    nt_gfx_backend_destroy_vertex_input(s_gfx.vertex_input_backends[slot]);
+    s_gfx.vertex_input_backends[slot] = 0;
+    memset(&s_gfx.vertex_input_metas[slot], 0, sizeof(nt_gfx_vertex_input_meta_t));
+    nt_pool_free(&s_gfx.vertex_input_pool, vi.id);
+}
+
 void nt_gfx_destroy_buffer(nt_buffer_t buf) {
     if (buf.id == 0) {
         return; /* invalid-zero is a first-class value, as for programs */
@@ -1198,6 +1312,14 @@ void nt_gfx_destroy_buffer(nt_buffer_t buf) {
     if (!nt_pool_valid(&s_gfx.buffer_pool, buf.id)) {
         NT_LOG_ERROR("destroy_buffer: invalid handle");
         return;
+    }
+    /* Dependent vertex inputs baked this buffer into their VAO state and can
+     * never draw correctly again -- reclaim them now. Mesh deactivation
+     * reaches no renderer, so renderer caches rely on this cascade. */
+    for (uint32_t i = 1; i <= s_gfx.vertex_input_pool.capacity; i++) {
+        if (s_gfx.vertex_input_metas[i].vbo_id == buf.id || s_gfx.vertex_input_metas[i].ibo_id == buf.id) {
+            nt_gfx_destroy_vertex_input((nt_vertex_input_t){s_gfx.vertex_input_pool.slots[i].id});
+        }
     }
     uint32_t slot = nt_pool_slot_index(buf.id);
     nt_gfx_backend_destroy_buffer(s_gfx.buffer_backends[slot]);
@@ -1288,6 +1410,8 @@ bool nt_gfx_program_valid(nt_program_t prog) { return nt_pool_valid(&s_gfx.progr
 
 bool nt_gfx_pipeline_valid(nt_pipeline_t pip) { return nt_pool_valid(&s_gfx.pipeline_pool, pip.id); }
 
+bool nt_gfx_vertex_input_valid(nt_vertex_input_t vi) { return nt_pool_valid(&s_gfx.vertex_input_pool, vi.id); }
+
 bool nt_gfx_program_ready(nt_program_t prog) {
     if (!nt_pool_valid(&s_gfx.program_pool, prog.id)) {
         return false;
@@ -1330,6 +1454,10 @@ void nt_gfx_bind_pipeline(nt_pipeline_t pip) {
     if (g_nt_gfx.context_lost) {
         return;
     }
+    /* Transitional while pipelines still own VAOs: binding one clobbers the
+     * bound vertex input, so the mirror must not survive (bind_instance_buffer
+     * would otherwise write foreign pointers into the pipeline's VAO). */
+    s_gfx.bound_vertex_input = 0;
     if (!nt_pool_valid(&s_gfx.pipeline_pool, pip.id)) {
         /* Clear both bind mirrors so later draws or buffer binds cannot reuse
          * the previous pipeline's program and VAO. */
@@ -1346,6 +1474,27 @@ void nt_gfx_bind_pipeline(nt_pipeline_t pip) {
     s_test_bound_pipeline = pip;
 #endif
     nt_gfx_backend_bind_pipeline(s_gfx.bound_pipeline);
+}
+
+void nt_gfx_bind_vertex_input(nt_vertex_input_t vi) {
+    if (g_nt_gfx.context_lost) {
+        return;
+    }
+    if (!nt_pool_valid(&s_gfx.vertex_input_pool, vi.id)) {
+        /* Parallel to bind_pipeline's invalid path: clear the mirrors and
+         * bind VAO 0 so later draws cannot use stale vertex-input state. */
+        s_gfx.bound_vertex_input = 0;
+        s_gfx.bound_index_type = NT_INDEX_NONE;
+        nt_gfx_backend_bind_vertex_input(0);
+        NT_LOG_ERROR("bind_vertex_input: invalid handle");
+        return;
+    }
+    uint32_t slot = nt_pool_slot_index(vi.id);
+    NT_ASSERT(s_gfx.vertex_input_backends[slot] != 0 && "bind_vertex_input: this vertex input outlived a context loss -- recreate it from the restored frame's resources");
+    s_gfx.bound_vertex_input = vi.id;
+    /* NT_INDEX_NONE for a non-indexed vertex input: cleared, not stale. */
+    s_gfx.bound_index_type = s_gfx.vertex_input_metas[slot].index_type;
+    nt_gfx_backend_bind_vertex_input(s_gfx.vertex_input_backends[slot]);
 }
 
 void nt_gfx_bind_vertex_buffer(nt_buffer_t buf) {
@@ -1657,6 +1806,22 @@ void nt_gfx_set_uniform_int(const char *name, int val) {
  * restored frame and submit on the next. Pass clears remain legal. */
 static void assert_draws_allowed_this_frame(void) { NT_ASSERT(!g_nt_gfx.context_restored && "no draws on the restored frame; see docs/spec/assets/resource.md"); }
 
+/* Enabled-but-unpointed instance attribs are invalid GL that fails silently.
+ * Transitional: enforced only when a vertex input is bound -- the legacy
+ * pipeline-VAO path keeps its old checks until it is removed. */
+static void assert_instance_attribs_pointed(void) {
+    if (s_gfx.bound_vertex_input == 0) {
+        return;
+    }
+    NT_ASSERT(
+        (s_gfx.vertex_input_metas[nt_pool_slot_index(s_gfx.bound_vertex_input)].instance_attr_count == 0 || s_gfx.vertex_input_metas[nt_pool_slot_index(s_gfx.bound_vertex_input)].instance_pointed) &&
+        "instanced draw: bind_instance_buffer has not pointed the bound vertex input's instance attribs");
+}
+
+/* Transitional like above: a bound vertex input carries its own index type;
+ * NT_INDEX_NONE here means the caller draws indexed on a non-indexed input. */
+static void assert_indexed_draw_has_index_type(void) { NT_ASSERT((s_gfx.bound_vertex_input == 0 || s_gfx.bound_index_type != NT_INDEX_NONE) && "draw_indexed: bound vertex input is non-indexed"); }
+
 void nt_gfx_draw(uint32_t first_vertex, uint32_t num_vertices) {
     if (g_nt_gfx.context_lost) {
         return;
@@ -1698,6 +1863,7 @@ void nt_gfx_draw_instanced(uint32_t first_vertex, uint32_t num_vertices, uint32_
         NT_LOG_ERROR("draw_instanced called without bound pipeline");
         return;
     }
+    assert_instance_attribs_pointed();
 
     g_nt_gfx.frame_stats.draw_calls++;
     g_nt_gfx.frame_stats.draw_calls_instanced++;
@@ -1725,6 +1891,7 @@ void nt_gfx_draw_indexed(uint32_t first_index, uint32_t num_indices, uint32_t nu
         NT_LOG_ERROR("draw_indexed called without bound pipeline");
         return;
     }
+    assert_indexed_draw_has_index_type();
 
     g_nt_gfx.frame_stats.draw_calls++;
     g_nt_gfx.frame_stats.vertices += num_vertices;
@@ -1751,6 +1918,8 @@ void nt_gfx_draw_indexed_instanced(uint32_t first_index, uint32_t num_indices, u
         NT_LOG_ERROR("draw_indexed_instanced called without bound pipeline");
         return;
     }
+    assert_indexed_draw_has_index_type();
+    assert_instance_attribs_pointed();
 
     g_nt_gfx.frame_stats.draw_calls++;
     g_nt_gfx.frame_stats.draw_calls_instanced++;
@@ -1782,10 +1951,17 @@ void nt_gfx_bind_instance_buffer(nt_buffer_t buf, uint32_t byte_offset) {
     }
     NT_ASSERT(byte_offset <= s_gfx.buffer_metas[slot].size && "bind_instance_buffer: offset exceeds buffer capacity");
     NT_ASSERT((byte_offset & 3U) == 0 && "bind_instance_buffer: offset must be 4-byte aligned (WebGL2 attrib rule)");
-    NT_ASSERT(s_gfx.bound_pipeline != 0 && "bind_instance_buffer: requires a bound pipeline");
-    if (s_gfx.bound_pipeline == 0) {
-        NT_LOG_ERROR("bind_instance_buffer: no pipeline bound");
-        return;
+    if (s_gfx.bound_vertex_input != 0) {
+        uint32_t vi_slot = nt_pool_slot_index(s_gfx.bound_vertex_input);
+        NT_ASSERT(s_gfx.vertex_input_metas[vi_slot].instance_attr_count > 0 && "bind_instance_buffer: bound vertex input declares no instance layout");
+        s_gfx.vertex_input_metas[vi_slot].instance_pointed = true;
+    } else {
+        /* Transitional fallback while pipelines still own instance layouts. */
+        NT_ASSERT(s_gfx.bound_pipeline != 0 && "bind_instance_buffer: requires a bound vertex input or pipeline");
+        if (s_gfx.bound_pipeline == 0) {
+            NT_LOG_ERROR("bind_instance_buffer: no pipeline bound");
+            return;
+        }
     }
     nt_gfx_backend_bind_instance_buffer(s_gfx.buffer_backends[slot], byte_offset);
 }

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -1015,6 +1015,11 @@ nt_buffer_t nt_gfx_make_buffer(const nt_buffer_desc_t *desc) {
     if (!desc) {
         return result;
     }
+    /* Same recoverable contract as the other make_* creators -- without this
+     * a lost-frame creation yields a pool-valid buffer with a dead GL name. */
+    if (g_nt_gfx.context_lost || nt_gfx_backend_is_context_lost()) {
+        return result;
+    }
 
     /* Pool exhaustion is a configuration error, not a backend allocation failure. */
     uint32_t id = nt_pool_alloc(&s_gfx.buffer_pool);
@@ -1774,7 +1779,7 @@ static void assert_instance_attribs_pointed(void) {
     }
     NT_ASSERT(
         (s_gfx.vertex_input_metas[nt_pool_slot_index(s_gfx.bound_vertex_input)].instance_attr_count == 0 || s_gfx.vertex_input_metas[nt_pool_slot_index(s_gfx.bound_vertex_input)].instance_pointed) &&
-        "instanced draw: bind_instance_buffer has not pointed the bound vertex input's instance attribs");
+        "draw: bound vertex input has instance attribs that bind_instance_buffer has not pointed");
 }
 
 /* The bound vertex input carries its own index type; NT_INDEX_NONE here means

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -67,8 +67,7 @@ typedef struct {
     uint32_t inst_buf_id; /* last buffer pointed by bind_instance_buffer; its destruction unpoints */
     uint8_t index_type;   /* captured from the IBO; NT_INDEX_NONE for non-indexed */
     uint8_t instance_attr_count;
-    /* Enabled-but-unpointed instance attribs are invalid GL that fails
-     * silently -- draws assert the attribs currently point at a live buffer. */
+    /* Every draw requires declared instance attrs to point at a live buffer. */
     bool instance_pointed;
 } nt_gfx_vertex_input_meta_t;
 
@@ -1333,9 +1332,8 @@ void nt_gfx_destroy_buffer(nt_buffer_t buf) {
         if (s_gfx.vertex_input_metas[i].vbo_id == buf.id || s_gfx.vertex_input_metas[i].ibo_id == buf.id) {
             nt_gfx_destroy_vertex_input((nt_vertex_input_t){s_gfx.vertex_input_pool.slots[i].id});
         } else if (s_gfx.vertex_input_metas[i].inst_buf_id == buf.id) {
-            /* Instance attachments are not destroy-tracked, but the pointed
-             * flag must not lie: the next instanced draw without a re-point
-             * traps instead of silently reading the dead buffer. */
+            /* Instance storage stays attached, but no draw may reuse it after
+             * destruction without an explicit re-point. */
             s_gfx.vertex_input_metas[i].instance_pointed = false;
             s_gfx.vertex_input_metas[i].inst_buf_id = 0;
         }

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -2602,6 +2602,8 @@ void nt_gfx_deactivate_shader(uint32_t handle) {
 
 /* ---- Mesh info query ---- */
 
+uint16_t nt_gfx_max_meshes(void) { return s_gfx.mesh_pool.capacity; }
+
 const nt_gfx_mesh_info_t *nt_gfx_get_mesh_info(nt_mesh_t mesh) {
     if (!nt_pool_valid(&s_gfx.mesh_pool, mesh.id)) {
         return NULL;

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -519,7 +519,8 @@ void nt_gfx_destroy_shader(nt_shader_t shd);
  * Clear
  * the caller's handle to NT_PROGRAM_INVALID after destruction. */
 void nt_gfx_destroy_program(nt_program_t prog);
-/* Invalid and stale handles are no-ops because program destruction also destroys pipelines. */
+/* Invalid and stale handles are no-ops: program destruction also destroys
+ * pipelines, and a context loss frees every pipeline slot. */
 void nt_gfx_destroy_pipeline(nt_pipeline_t pip);
 /* Invalid and stale handles are no-ops because buffer destruction also
  * destroys dependent vertex inputs (see nt_gfx_destroy_buffer). */
@@ -551,7 +552,9 @@ bool nt_gfx_texture_ready(nt_texture_t tex);
 bool nt_gfx_shader_ready(nt_shader_t shd);
 /* Reports a live pool slot, independent of GPU readiness. */
 bool nt_gfx_program_valid(nt_program_t prog);
-/* Reports a live pipeline slot; false after pipeline or program destruction. */
+/* Reports a live pipeline slot; false after pipeline or program destruction,
+ * or a context loss (loss frees every pipeline slot -- pipelines are baked
+ * objects, like vertex inputs). Renderer caches check this on lookup. */
 bool nt_gfx_pipeline_valid(nt_pipeline_t pip);
 /* Reports a live vertex-input slot; false after direct destruction, the
  * destroy_buffer cascade, or a context loss (loss frees every vertex-input

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -553,8 +553,10 @@ bool nt_gfx_shader_ready(nt_shader_t shd);
 bool nt_gfx_program_valid(nt_program_t prog);
 /* Reports a live pipeline slot; false after pipeline or program destruction. */
 bool nt_gfx_pipeline_valid(nt_pipeline_t pip);
-/* Reports a live vertex-input slot; false after direct destruction or the
- * destroy_buffer cascade. Renderer caches check this on lookup. */
+/* Reports a live vertex-input slot; false after direct destruction, the
+ * destroy_buffer cascade, or a context loss (loss frees every vertex-input
+ * slot -- they are baked objects with no re-fill path). Renderer caches
+ * check this on lookup and self-heal. */
 bool nt_gfx_vertex_input_valid(nt_vertex_input_t vi);
 /* Reports a live program backend, required by nt_gfx_make_pipeline.
  * Readiness lost to context loss never returns for that handle. */

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -670,6 +670,9 @@ void nt_gfx_deactivate_shader(uint32_t handle);
 /* ---- Mesh info query ---- */
 
 const nt_gfx_mesh_info_t *nt_gfx_get_mesh_info(nt_mesh_t mesh);
+/* Mesh pool capacity from nt_gfx_desc_t (valid after nt_gfx_init) -- sizes
+ * renderer-side per-mesh tables; mesh pool slots index [1..max]. */
+uint16_t nt_gfx_max_meshes(void);
 
 // #region test_access
 #ifdef NT_TEST_ACCESS

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -353,7 +353,7 @@ typedef struct {
     nt_vertex_layout_t instance_layout; /* optional per-instance attrs, divisor 1; pointers set per draw by nt_gfx_bind_instance_buffer */
     nt_buffer_t vertex_buffer;          /* NT_BUFFER_VERTEX; required iff layout.attr_count > 0 */
     nt_buffer_t index_buffer;           /* optional ({0} = non-indexed); NT_BUFFER_INDEX with index_type != NT_INDEX_NONE */
-    const char *label;                  /* debug name; static storage */
+    const char *label;                  /* optional debug name; borrowed for the call */
 } nt_vertex_input_desc_t;
 
 typedef struct {
@@ -496,12 +496,9 @@ nt_shader_t nt_gfx_make_shader(const nt_shader_desc_t *desc);
 nt_program_t nt_gfx_make_program(nt_shader_t vs, nt_shader_t fs);
 /* Creation preserves the currently bound pipeline. */
 nt_pipeline_t nt_gfx_make_pipeline(const nt_pipeline_desc_t *desc);
-/* Bakes the vertex layout, buffers and index binding into an owned object.
- * Caller errors (bad handles, invalid layouts) assert; INVALID is returned
- * only on a lost context or backend allocation failure. Buffer CONTENTS may
- * still change (update/orphan keep the GL name); replacing a buffer OBJECT
- * means destroy + recreate the vertex input. Creation preserves the
- * currently bound vertex input. */
+/* Caller owns the result; destroy it with nt_gfx_destroy_vertex_input. The VI
+ * borrows its buffers; creation borrows desc/label and preserves the bound VI.
+ * INVALID means context loss or backend allocation failure; caller errors assert. */
 nt_vertex_input_t nt_gfx_make_vertex_input(const nt_vertex_input_desc_t *desc);
 nt_buffer_t nt_gfx_make_buffer(const nt_buffer_desc_t *desc);
 nt_texture_t nt_gfx_make_texture(const nt_texture_desc_t *desc);
@@ -525,13 +522,9 @@ void nt_gfx_destroy_pipeline(nt_pipeline_t pip);
 /* Invalid and stale handles are no-ops because buffer destruction also
  * destroys dependent vertex inputs (see nt_gfx_destroy_buffer). */
 void nt_gfx_destroy_vertex_input(nt_vertex_input_t vi);
-/* Also destroys every vertex input referencing this buffer as its vertex or
- * index buffer -- mesh deactivation reaches no renderer, so the cascade is
- * what keeps cached vertex inputs from outliving mesh buffers. Instance
- * buffers captured by nt_gfx_bind_instance_buffer are not cascade-destroyed,
- * but destroying one UNPOINTS dependent vertex inputs: their next instanced
- * draw asserts until bind_instance_buffer re-points them. The GL attachment's
- * storage lingers until that re-point or the vertex input's death. */
+/* Destroys VIs that borrow this vertex/index buffer. Destroying a captured
+ * instance buffer instead makes every draw assert until it is re-pointed;
+ * GL retains the old storage until that re-point or the VI's destruction. */
 void nt_gfx_destroy_buffer(nt_buffer_t buf);
 void nt_gfx_destroy_texture(nt_texture_t tex);
 void nt_gfx_destroy_render_target(nt_render_target_t rt);

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -95,7 +95,6 @@ typedef struct {
     uint8_t index_type;                        /* 0=none, 1=uint16, 2=uint32 */
     NtStreamDesc streams[NT_MESH_MAX_STREAMS]; /* copied from pack data at activation */
     uint16_t stride;                           /* total vertex size in bytes */
-    uint64_t layout_hash;                      /* stream-descriptor hash; serves as pipeline-cache identity, hence 64-bit */
 } nt_gfx_mesh_info_t;
 
 /* ---- Enums ---- */
@@ -286,6 +285,9 @@ typedef enum {
 /* ---- Vertex layout ---- */
 
 #define NT_GFX_MAX_VERTEX_ATTRS 16
+/* Instance layouts are capped tighter: the backend keeps a per-vertex-input
+ * copy for per-draw re-pointing, and max_vertex_inputs slots exist. */
+#define NT_GFX_MAX_INSTANCE_ATTRS 8
 #define NT_GFX_MAX_TEXTURE_SLOTS 8
 
 typedef struct {
@@ -311,8 +313,9 @@ typedef struct {
     uint16_t max_buffers;   /* default: 128 */
     uint16_t max_textures;  /* default: 64 */
     uint16_t max_meshes;    /* default: 128 */
-    /* default: 528 = max_meshes(128) x mesh renderer max_mesh_layouts(4)
-     * worst case + 16 for fixed renderer-owned vertex inputs. */
+    /* default: 560 = max_meshes(128) x mesh renderer max_mesh_layouts(4)
+     * worst case + 48 for renderer-owned vertex inputs (shape ~13, text,
+     * blur, sprite custom layouts). */
     uint16_t max_vertex_inputs;
     uint16_t max_render_targets; /* default: 16 */
     bool depth;                  /* request depth buffer (default: true) */
@@ -453,7 +456,7 @@ static inline nt_gfx_desc_t nt_gfx_desc_defaults(void) {
         .max_buffers = 128,
         .max_textures = 64,
         .max_meshes = 128,
-        .max_vertex_inputs = 528,
+        .max_vertex_inputs = 560,
         .max_render_targets = 16,
         .depth = true,
         .premultiplied_alpha = true,

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -328,19 +328,19 @@ typedef struct {
     const char *label;
 } nt_shader_desc_t;
 
+/* Program + fixed render state only; vertex input is a separate owned object
+ * (nt_vertex_input_desc_t) bound independently of the pipeline. */
 typedef struct {
     /* Borrowed; destroying the program also destroys this pipeline. */
     nt_program_t program;
-    nt_vertex_layout_t layout;
     bool depth_test;
     bool depth_write;
     nt_depth_func_t depth_func;
     uint8_t cull_mode; /* 0=none, 1=back, 2=front (matches nt_cull_mode_t) */
     nt_blend_state_t blend;
-    bool polygon_offset;                /* enable GL_POLYGON_OFFSET_FILL */
-    float polygon_offset_factor;        /* glPolygonOffset factor (typically 1.0) */
-    float polygon_offset_units;         /* glPolygonOffset units (typically 1.0) */
-    nt_vertex_layout_t instance_layout; /* per-instance vertex attributes (optional, divisor=1) */
+    bool polygon_offset;         /* enable GL_POLYGON_OFFSET_FILL */
+    float polygon_offset_factor; /* glPolygonOffset factor (typically 1.0) */
+    float polygon_offset_units;  /* glPolygonOffset units (typically 1.0) */
     const char *label;
 } nt_pipeline_desc_t;
 
@@ -563,12 +563,10 @@ nt_texture_format_t nt_gfx_texture_format(nt_texture_t tex);
 
 void nt_gfx_bind_pipeline(nt_pipeline_t pip);
 /* One backend bind selects the whole vertex-input state (layout + buffers +
- * index binding) for the following draws. Transitional while pipelines still
- * own vertex layouts: bind the pipeline FIRST, then the vertex input --
- * nt_gfx_bind_pipeline clears the bound vertex input. */
+ * index binding) for the following draws. Orthogonal to pipeline binding --
+ * either may change without re-binding the other. Every draw requires a bound
+ * vertex input (asserted); attribute-less draws bind an empty one. */
 void nt_gfx_bind_vertex_input(nt_vertex_input_t vi);
-void nt_gfx_bind_vertex_buffer(nt_buffer_t buf);
-void nt_gfx_bind_index_buffer(nt_buffer_t buf);
 void nt_gfx_bind_texture(nt_texture_t tex, uint32_t slot);
 /* Bind sampler to texture unit `slot`, after nt_gfx_bind_texture for that slot —
  * bind_texture installs the texture's own default sampler and discards this one.
@@ -619,11 +617,9 @@ bool nt_gfx_read_pixels(int x, int y, int w, int h, uint8_t *out, uint32_t out_c
 /* ---- Instance buffer ---- */
 
 /* Re-specifies instance attrib pointers at byte_offset into the bound vertex
- * input (which must declare a nonempty instance_layout; asserted). With no
- * vertex input bound it falls back to the bound pipeline's instance layout
- * (transitional while pipelines still own layouts). The offset must be
- * 4-byte aligned (WebGL2 rejects unaligned attrib offsets); asserted.
- * Re-bind per draw to re-point. */
+ * input, which must declare a nonempty instance_layout; both asserted. The
+ * offset must be 4-byte aligned (WebGL2 rejects unaligned attrib offsets);
+ * asserted. Re-bind per draw to re-point. */
 void nt_gfx_bind_instance_buffer(nt_buffer_t buf, uint32_t byte_offset);
 void nt_gfx_set_vertex_attrib_default(uint8_t location, float x, float y, float z, float w);
 

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -46,9 +46,18 @@ typedef struct {
     uint32_t id;
 } nt_mesh_t;
 
+/* Owned vertex-input object (GL: a VAO): vertex layout + optional instance
+ * layout baked against a VBO [+ IBO]. The static half (vertex attrs + index
+ * buffer) is immutable after creation; the instance attribute pointers are
+ * re-specified into the bound object by each nt_gfx_bind_instance_buffer. */
+typedef struct {
+    uint32_t id;
+} nt_vertex_input_t;
+
 #define NT_RENDER_TARGET_INVALID ((nt_render_target_t){0})
 #define NT_MESH_INVALID ((nt_mesh_t){0})
 #define NT_PROGRAM_INVALID ((nt_program_t){0})
+#define NT_VERTEX_INPUT_INVALID ((nt_vertex_input_t){0})
 
 /* Sampler object — texture-side filter/wrap state decoupled from the texture
  * itself. One texture can be sampled with different filters in different
@@ -296,12 +305,15 @@ typedef struct {
 /* ---- Descriptor structs ---- */
 
 typedef struct {
-    uint16_t max_shaders;        /* default: 32 */
-    uint16_t max_programs;       /* default: 16 */
-    uint16_t max_pipelines;      /* default: 16 */
-    uint16_t max_buffers;        /* default: 128 */
-    uint16_t max_textures;       /* default: 64 */
-    uint16_t max_meshes;         /* default: 128 */
+    uint16_t max_shaders;   /* default: 32 */
+    uint16_t max_programs;  /* default: 16 */
+    uint16_t max_pipelines; /* default: 16 */
+    uint16_t max_buffers;   /* default: 128 */
+    uint16_t max_textures;  /* default: 64 */
+    uint16_t max_meshes;    /* default: 128 */
+    /* default: 528 = max_meshes(128) x mesh renderer max_mesh_layouts(4)
+     * worst case + 16 for fixed renderer-owned vertex inputs. */
+    uint16_t max_vertex_inputs;
     uint16_t max_render_targets; /* default: 16 */
     bool depth;                  /* request depth buffer (default: true) */
     bool stencil;                /* request stencil buffer (default: false) */
@@ -331,6 +343,14 @@ typedef struct {
     nt_vertex_layout_t instance_layout; /* per-instance vertex attributes (optional, divisor=1) */
     const char *label;
 } nt_pipeline_desc_t;
+
+typedef struct {
+    nt_vertex_layout_t layout;          /* per-vertex attrs, divisor 0; attr_count 0 = attribute-less (gl_VertexID) */
+    nt_vertex_layout_t instance_layout; /* optional per-instance attrs, divisor 1; pointers set per draw by nt_gfx_bind_instance_buffer */
+    nt_buffer_t vertex_buffer;          /* NT_BUFFER_VERTEX; required iff layout.attr_count > 0 */
+    nt_buffer_t index_buffer;           /* optional ({0} = non-indexed); NT_BUFFER_INDEX with index_type != NT_INDEX_NONE */
+    const char *label;                  /* debug name; static storage */
+} nt_vertex_input_desc_t;
 
 typedef struct {
     nt_buffer_type_t type;
@@ -433,6 +453,7 @@ static inline nt_gfx_desc_t nt_gfx_desc_defaults(void) {
         .max_buffers = 128,
         .max_textures = 64,
         .max_meshes = 128,
+        .max_vertex_inputs = 528,
         .max_render_targets = 16,
         .depth = true,
         .premultiplied_alpha = true,
@@ -471,6 +492,13 @@ nt_shader_t nt_gfx_make_shader(const nt_shader_desc_t *desc);
 nt_program_t nt_gfx_make_program(nt_shader_t vs, nt_shader_t fs);
 /* Creation preserves the currently bound pipeline. */
 nt_pipeline_t nt_gfx_make_pipeline(const nt_pipeline_desc_t *desc);
+/* Bakes the vertex layout, buffers and index binding into an owned object.
+ * Caller errors (bad handles, invalid layouts) assert; INVALID is returned
+ * only on a lost context or backend allocation failure. Buffer CONTENTS may
+ * still change (update/orphan keep the GL name); replacing a buffer OBJECT
+ * means destroy + recreate the vertex input. Creation preserves the
+ * currently bound vertex input. */
+nt_vertex_input_t nt_gfx_make_vertex_input(const nt_vertex_input_desc_t *desc);
 nt_buffer_t nt_gfx_make_buffer(const nt_buffer_desc_t *desc);
 nt_texture_t nt_gfx_make_texture(const nt_texture_desc_t *desc);
 nt_sampler_t nt_gfx_make_sampler(const nt_sampler_desc_t *desc);
@@ -489,6 +517,15 @@ void nt_gfx_destroy_shader(nt_shader_t shd);
 void nt_gfx_destroy_program(nt_program_t prog);
 /* Invalid and stale handles are no-ops because program destruction also destroys pipelines. */
 void nt_gfx_destroy_pipeline(nt_pipeline_t pip);
+/* Invalid and stale handles are no-ops because buffer destruction also
+ * destroys dependent vertex inputs (see nt_gfx_destroy_buffer). */
+void nt_gfx_destroy_vertex_input(nt_vertex_input_t vi);
+/* Also destroys every vertex input referencing this buffer as its vertex or
+ * index buffer -- mesh deactivation reaches no renderer, so the cascade is
+ * what keeps cached vertex inputs from outliving mesh buffers. Instance
+ * buffers captured by nt_gfx_bind_instance_buffer are NOT cascade-tracked:
+ * destroying one while vertex inputs still point into it leaves zombie GL
+ * attachments until those vertex inputs die or re-point. */
 void nt_gfx_destroy_buffer(nt_buffer_t buf);
 void nt_gfx_destroy_texture(nt_texture_t tex);
 void nt_gfx_destroy_render_target(nt_render_target_t rt);
@@ -511,6 +548,9 @@ bool nt_gfx_shader_ready(nt_shader_t shd);
 bool nt_gfx_program_valid(nt_program_t prog);
 /* Reports a live pipeline slot; false after pipeline or program destruction. */
 bool nt_gfx_pipeline_valid(nt_pipeline_t pip);
+/* Reports a live vertex-input slot; false after direct destruction or the
+ * destroy_buffer cascade. Renderer caches check this on lookup. */
+bool nt_gfx_vertex_input_valid(nt_vertex_input_t vi);
 /* Reports a live program backend, required by nt_gfx_make_pipeline.
  * Readiness lost to context loss never returns for that handle. */
 bool nt_gfx_program_ready(nt_program_t prog);
@@ -522,6 +562,11 @@ nt_texture_format_t nt_gfx_texture_format(nt_texture_t tex);
 /* ---- Draw state ---- */
 
 void nt_gfx_bind_pipeline(nt_pipeline_t pip);
+/* One backend bind selects the whole vertex-input state (layout + buffers +
+ * index binding) for the following draws. Transitional while pipelines still
+ * own vertex layouts: bind the pipeline FIRST, then the vertex input --
+ * nt_gfx_bind_pipeline clears the bound vertex input. */
+void nt_gfx_bind_vertex_input(nt_vertex_input_t vi);
 void nt_gfx_bind_vertex_buffer(nt_buffer_t buf);
 void nt_gfx_bind_index_buffer(nt_buffer_t buf);
 void nt_gfx_bind_texture(nt_texture_t tex, uint32_t slot);
@@ -573,9 +618,12 @@ bool nt_gfx_read_pixels(int x, int y, int w, int h, uint8_t *out, uint32_t out_c
 
 /* ---- Instance buffer ---- */
 
-/* Applies the bound pipeline's instance attrib pointers at byte_offset — a
- * pipeline must be bound first and the offset 4-byte aligned (WebGL2 rejects
- * unaligned attrib offsets); both asserted. Re-bind per draw to re-point. */
+/* Re-specifies instance attrib pointers at byte_offset into the bound vertex
+ * input (which must declare a nonempty instance_layout; asserted). With no
+ * vertex input bound it falls back to the bound pipeline's instance layout
+ * (transitional while pipelines still own layouts). The offset must be
+ * 4-byte aligned (WebGL2 rejects unaligned attrib offsets); asserted.
+ * Re-bind per draw to re-point. */
 void nt_gfx_bind_instance_buffer(nt_buffer_t buf, uint32_t byte_offset);
 void nt_gfx_set_vertex_attrib_default(uint8_t location, float x, float y, float z, float w);
 

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -314,8 +314,9 @@ typedef struct {
     uint16_t max_textures;  /* default: 64 */
     uint16_t max_meshes;    /* default: 128 */
     /* default: 560 = max_meshes(128) x mesh renderer max_mesh_layouts(4)
-     * worst case + 48 for renderer-owned vertex inputs (shape ~13, text,
-     * blur, sprite custom layouts). */
+     * worst case + 48 for renderer-owned vertex inputs (shape ~14, text,
+     * blur, ~32 sprite custom layouts). Scale it together with max_meshes;
+     * raise it near the sprite custom-layout hardcap (64). */
     uint16_t max_vertex_inputs;
     uint16_t max_render_targets; /* default: 16 */
     bool depth;                  /* request depth buffer (default: true) */

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -526,9 +526,10 @@ void nt_gfx_destroy_vertex_input(nt_vertex_input_t vi);
 /* Also destroys every vertex input referencing this buffer as its vertex or
  * index buffer -- mesh deactivation reaches no renderer, so the cascade is
  * what keeps cached vertex inputs from outliving mesh buffers. Instance
- * buffers captured by nt_gfx_bind_instance_buffer are NOT cascade-tracked:
- * destroying one while vertex inputs still point into it leaves zombie GL
- * attachments until those vertex inputs die or re-point. */
+ * buffers captured by nt_gfx_bind_instance_buffer are not cascade-destroyed,
+ * but destroying one UNPOINTS dependent vertex inputs: their next instanced
+ * draw asserts until bind_instance_buffer re-points them. The GL attachment's
+ * storage lingers until that re-point or the vertex input's death. */
 void nt_gfx_destroy_buffer(nt_buffer_t buf);
 void nt_gfx_destroy_texture(nt_texture_t tex);
 void nt_gfx_destroy_render_target(nt_render_target_t rt);

--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -149,6 +149,7 @@ uint32_t nt_gfx_stub_test_update_buffer_count(void);
 uint32_t nt_gfx_stub_test_backend_restore_count(void);
 uint32_t nt_gfx_stub_test_gpu_caps_probe_count(void);
 void nt_gfx_stub_test_fail_texture_creates(uint8_t mask);
+void nt_gfx_stub_test_fail_buffer_creates(uint8_t mask);
 void nt_gfx_stub_test_fail_next_backend_restore(void);
 void nt_gfx_stub_test_fail_next_render_target_create(void);
 void nt_gfx_stub_test_fail_next_render_target_resize(void);

--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -34,6 +34,13 @@ void nt_gfx_backend_destroy_program(uint32_t backend_handle);
 uint32_t nt_gfx_backend_create_pipeline(const nt_pipeline_desc_t *desc, uint32_t program_backend);
 void nt_gfx_backend_destroy_pipeline(uint32_t backend_handle);
 
+/* Bakes the desc's layouts and the given buffer backends into an owned VAO.
+ * Restores the previously bound VAO before returning. Returns 0 on failure. */
+uint32_t nt_gfx_backend_create_vertex_input(const nt_vertex_input_desc_t *desc, uint32_t vbo_backend, uint32_t ibo_backend);
+void nt_gfx_backend_destroy_vertex_input(uint32_t backend_handle);
+/* 0 unbinds (VAO 0) and clears the backend's bound-vertex-input record. */
+void nt_gfx_backend_bind_vertex_input(uint32_t backend_handle);
+
 uint32_t nt_gfx_backend_create_buffer(const nt_buffer_desc_t *desc);
 void nt_gfx_backend_destroy_buffer(uint32_t backend_handle);
 void nt_gfx_backend_update_buffer(uint32_t backend_handle, uint32_t offset, const void *data, uint32_t size);
@@ -150,7 +157,22 @@ void nt_gfx_stub_test_set_context_lost(bool lost);
 uint32_t nt_gfx_stub_test_last_update_buffer_offset(void);
 uint32_t nt_gfx_stub_test_last_instance_offset(void);
 nt_blend_state_t nt_gfx_stub_test_last_pipeline_blend(void);
+uint32_t nt_gfx_stub_test_vertex_input_create_count(void);
+uint32_t nt_gfx_stub_test_bind_vertex_input_count(void);
+uint32_t nt_gfx_stub_test_bound_vertex_input(void);
+void nt_gfx_stub_test_fail_next_vertex_input_create(void);
 void nt_gfx_stub_test_reset(void);
+#endif
+
+#ifdef NT_TEST_ACCESS
+/* GL-backend-only counters (defined in gl/nt_gfx_gl.c; link only from tests
+ * using the real GL backend). Static = divisor-0 glVertexAttribPointer calls
+ * (create-time and legacy per-bind re-pointing); instance = divisor-1 calls,
+ * legitimately per-draw. Steady-state frames must show static == 0. */
+void nt_gfx_gl_test_reset_counters(void);
+uint32_t nt_gfx_gl_test_static_attrib_pointer_calls(void);
+uint32_t nt_gfx_gl_test_instance_attrib_pointer_calls(void);
+uint32_t nt_gfx_gl_test_vao_binds(void);
 #endif
 
 #ifdef NT_TEST_ACCESS

--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -165,8 +165,8 @@ void nt_gfx_stub_test_reset(void);
 
 #ifdef NT_TEST_ACCESS
 /* GL-backend-only counters (defined in gl/nt_gfx_gl.c; link only from tests
- * using the real GL backend). Static = divisor-0 glVertexAttribPointer calls
- * (create-time and legacy per-bind re-pointing); instance = divisor-1 calls,
+ * using the real GL backend). Static = divisor-0 glVertexAttribPointer calls,
+ * issued only at vertex-input creation; instance = divisor-1 calls,
  * legitimately per-draw. Steady-state frames must show static == 0. */
 void nt_gfx_gl_test_reset_counters(void);
 uint32_t nt_gfx_gl_test_static_attrib_pointer_calls(void);

--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -31,12 +31,14 @@ void nt_gfx_backend_destroy_shader(uint32_t backend_handle);
 uint32_t nt_gfx_backend_create_program(uint32_t vs_backend, uint32_t fs_backend);
 void nt_gfx_backend_destroy_program(uint32_t backend_handle);
 
-uint32_t nt_gfx_backend_create_pipeline(const nt_pipeline_desc_t *desc, uint32_t program_backend);
+/* `slot` is the frontend pool slot: the pool owns allocation, the backend
+ * table mirrors it 1:1 (create_* returns the slot, or 0 on failure). */
+uint32_t nt_gfx_backend_create_pipeline(const nt_pipeline_desc_t *desc, uint32_t program_backend, uint32_t slot);
 void nt_gfx_backend_destroy_pipeline(uint32_t backend_handle);
 
 /* Bakes the desc's layouts and the given buffer backends into an owned VAO.
  * Restores the previously bound VAO before returning. Returns 0 on failure. */
-uint32_t nt_gfx_backend_create_vertex_input(const nt_vertex_input_desc_t *desc, uint32_t vbo_backend, uint32_t ibo_backend);
+uint32_t nt_gfx_backend_create_vertex_input(const nt_vertex_input_desc_t *desc, uint32_t vbo_backend, uint32_t ibo_backend, uint32_t slot);
 void nt_gfx_backend_destroy_vertex_input(uint32_t backend_handle);
 /* 0 unbinds (VAO 0) and clears the backend's bound-vertex-input record. */
 void nt_gfx_backend_bind_vertex_input(uint32_t backend_handle);

--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -62,8 +62,7 @@ void nt_gfx_backend_destroy_sampler(uint32_t backend_handle);
 void nt_gfx_backend_bind_sampler(uint32_t backend_handle, uint32_t slot);
 
 void nt_gfx_backend_bind_pipeline(uint32_t backend_handle);
-void nt_gfx_backend_bind_vertex_buffer(uint32_t backend_handle);
-void nt_gfx_backend_bind_index_buffer(uint32_t backend_handle);
+/* Re-points the bound vertex input's instance attribs at byte_offset. */
 void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle, uint32_t byte_offset);
 void nt_gfx_backend_set_vertex_attrib_default(uint8_t location, float x, float y, float z, float w);
 

--- a/engine/graphics/stub/nt_gfx_stub.c
+++ b/engine/graphics/stub/nt_gfx_stub.c
@@ -37,6 +37,7 @@ static uint32_t s_stub_next_texture_backend;
 static bool s_stub_context_lost;
 static bool s_stub_backend_missing;
 static uint8_t s_stub_fail_texture_creates;
+static uint8_t s_stub_fail_buffer_creates;
 static bool s_stub_fail_next_program_create;
 static bool s_stub_lose_context_on_program_create;
 static bool s_stub_fail_next_pipeline_create;
@@ -89,6 +90,10 @@ void nt_gfx_stub_test_fail_texture_creates(uint8_t mask) {
     NT_ASSERT(mask <= 3);
     s_stub_fail_texture_creates = mask;
 }
+void nt_gfx_stub_test_fail_buffer_creates(uint8_t mask) {
+    NT_ASSERT(mask <= 3);
+    s_stub_fail_buffer_creates = mask;
+}
 void nt_gfx_stub_test_fail_next_program_create(void) { s_stub_fail_next_program_create = true; }
 void nt_gfx_stub_test_lose_context_on_program_create(void) { s_stub_lose_context_on_program_create = true; }
 void nt_gfx_stub_test_fail_next_pipeline_create(void) { s_stub_fail_next_pipeline_create = true; }
@@ -138,6 +143,7 @@ void nt_gfx_stub_test_reset(void) {
     s_stub_context_lost = false;
     s_stub_backend_missing = false;
     s_stub_fail_texture_creates = 0;
+    s_stub_fail_buffer_creates = 0;
     s_stub_fail_next_program_create = false;
     s_stub_lose_context_on_program_create = false;
     s_stub_fail_next_pipeline_create = false;
@@ -300,6 +306,13 @@ void nt_gfx_backend_bind_vertex_input(uint32_t backend_handle) {
 
 uint32_t nt_gfx_backend_create_buffer(const nt_buffer_desc_t *desc) {
     (void)desc;
+#ifdef NT_TEST_ACCESS
+    bool fail = (s_stub_fail_buffer_creates & 1U) != 0;
+    s_stub_fail_buffer_creates >>= 1U;
+    if (fail) {
+        return 0;
+    }
+#endif
     return 1;
 }
 

--- a/engine/graphics/stub/nt_gfx_stub.c
+++ b/engine/graphics/stub/nt_gfx_stub.c
@@ -50,7 +50,6 @@ static nt_blend_state_t s_stub_last_pipeline_blend;
 static uint32_t s_stub_vertex_input_create_count;
 static uint32_t s_stub_bind_vertex_input_count;
 static uint32_t s_stub_bound_vertex_input; /* mirrors the GL backend's bound slot */
-static uint32_t s_stub_next_vertex_input_backend;
 static bool s_stub_fail_next_vertex_input_create;
 
 uint32_t nt_gfx_stub_test_last_sampler(uint32_t slot) {
@@ -138,7 +137,6 @@ void nt_gfx_stub_test_reset(void) {
     s_stub_vertex_input_create_count = 0;
     s_stub_bind_vertex_input_count = 0;
     s_stub_bound_vertex_input = 0;
-    s_stub_next_vertex_input_backend = 0;
     s_stub_fail_next_vertex_input_create = false;
     s_stub_context_lost = false;
     s_stub_backend_missing = false;
@@ -251,7 +249,7 @@ uint32_t nt_gfx_backend_create_program(uint32_t vs_backend, uint32_t fs_backend)
 
 void nt_gfx_backend_destroy_program(uint32_t backend_handle) { (void)backend_handle; }
 
-uint32_t nt_gfx_backend_create_pipeline(const nt_pipeline_desc_t *desc, uint32_t program_backend) {
+uint32_t nt_gfx_backend_create_pipeline(const nt_pipeline_desc_t *desc, uint32_t program_backend, uint32_t slot) {
 #ifdef NT_TEST_ACCESS
     if (s_stub_fail_next_pipeline_create) {
         s_stub_fail_next_pipeline_create = false;
@@ -263,12 +261,12 @@ uint32_t nt_gfx_backend_create_pipeline(const nt_pipeline_desc_t *desc, uint32_t
     (void)desc;
 #endif
     (void)program_backend;
-    return 1;
+    return slot;
 }
 
 void nt_gfx_backend_destroy_pipeline(uint32_t backend_handle) { (void)backend_handle; }
 
-uint32_t nt_gfx_backend_create_vertex_input(const nt_vertex_input_desc_t *desc, uint32_t vbo_backend, uint32_t ibo_backend) {
+uint32_t nt_gfx_backend_create_vertex_input(const nt_vertex_input_desc_t *desc, uint32_t vbo_backend, uint32_t ibo_backend, uint32_t slot) {
     (void)desc;
     (void)vbo_backend;
     (void)ibo_backend;
@@ -278,10 +276,8 @@ uint32_t nt_gfx_backend_create_vertex_input(const nt_vertex_input_desc_t *desc, 
         s_stub_fail_next_vertex_input_create = false;
         return 0;
     }
-    return ++s_stub_next_vertex_input_backend;
-#else
-    return 1;
 #endif
+    return slot;
 }
 
 void nt_gfx_backend_destroy_vertex_input(uint32_t backend_handle) {

--- a/engine/graphics/stub/nt_gfx_stub.c
+++ b/engine/graphics/stub/nt_gfx_stub.c
@@ -46,6 +46,11 @@ static bool s_stub_fail_next_render_target_resize;
 static uint32_t s_stub_last_update_buffer_offset;
 static uint32_t s_stub_last_instance_offset;
 static nt_blend_state_t s_stub_last_pipeline_blend;
+static uint32_t s_stub_vertex_input_create_count;
+static uint32_t s_stub_bind_vertex_input_count;
+static uint32_t s_stub_bound_vertex_input; /* mirrors the GL backend's bound slot */
+static uint32_t s_stub_next_vertex_input_backend;
+static bool s_stub_fail_next_vertex_input_create;
 
 uint32_t nt_gfx_stub_test_last_sampler(uint32_t slot) {
     if (slot >= NT_GFX_STUB_MAX_SLOTS) {
@@ -92,6 +97,10 @@ void nt_gfx_stub_test_set_context_lost(bool lost) { s_stub_context_lost = lost; 
 uint32_t nt_gfx_stub_test_last_update_buffer_offset(void) { return s_stub_last_update_buffer_offset; }
 uint32_t nt_gfx_stub_test_last_instance_offset(void) { return s_stub_last_instance_offset; }
 nt_blend_state_t nt_gfx_stub_test_last_pipeline_blend(void) { return s_stub_last_pipeline_blend; }
+uint32_t nt_gfx_stub_test_vertex_input_create_count(void) { return s_stub_vertex_input_create_count; }
+uint32_t nt_gfx_stub_test_bind_vertex_input_count(void) { return s_stub_bind_vertex_input_count; }
+uint32_t nt_gfx_stub_test_bound_vertex_input(void) { return s_stub_bound_vertex_input; }
+void nt_gfx_stub_test_fail_next_vertex_input_create(void) { s_stub_fail_next_vertex_input_create = true; }
 
 void nt_gfx_stub_test_reset(void) {
     for (uint32_t i = 0; i < NT_GFX_STUB_MAX_SLOTS; i++) {
@@ -121,6 +130,11 @@ void nt_gfx_stub_test_reset(void) {
     s_stub_last_update_buffer_offset = 0;
     s_stub_last_instance_offset = 0;
     s_stub_last_pipeline_blend = (nt_blend_state_t){0};
+    s_stub_vertex_input_create_count = 0;
+    s_stub_bind_vertex_input_count = 0;
+    s_stub_bound_vertex_input = 0;
+    s_stub_next_vertex_input_backend = 0;
+    s_stub_fail_next_vertex_input_create = false;
     s_stub_context_lost = false;
     s_stub_backend_missing = false;
     s_stub_fail_texture_creates = 0;
@@ -247,6 +261,42 @@ uint32_t nt_gfx_backend_create_pipeline(const nt_pipeline_desc_t *desc, uint32_t
 }
 
 void nt_gfx_backend_destroy_pipeline(uint32_t backend_handle) { (void)backend_handle; }
+
+uint32_t nt_gfx_backend_create_vertex_input(const nt_vertex_input_desc_t *desc, uint32_t vbo_backend, uint32_t ibo_backend) {
+    (void)desc;
+    (void)vbo_backend;
+    (void)ibo_backend;
+#ifdef NT_TEST_ACCESS
+    s_stub_vertex_input_create_count++;
+    if (s_stub_fail_next_vertex_input_create) {
+        s_stub_fail_next_vertex_input_create = false;
+        return 0;
+    }
+    return ++s_stub_next_vertex_input_backend;
+#else
+    return 1;
+#endif
+}
+
+void nt_gfx_backend_destroy_vertex_input(uint32_t backend_handle) {
+#ifdef NT_TEST_ACCESS
+    /* Mirror the GL backend: destroying the bound vertex input unbinds it. */
+    if (backend_handle != 0 && s_stub_bound_vertex_input == backend_handle) {
+        s_stub_bound_vertex_input = 0;
+    }
+#else
+    (void)backend_handle;
+#endif
+}
+
+void nt_gfx_backend_bind_vertex_input(uint32_t backend_handle) {
+#ifdef NT_TEST_ACCESS
+    s_stub_bind_vertex_input_count++;
+    s_stub_bound_vertex_input = backend_handle;
+#else
+    (void)backend_handle;
+#endif
+}
 
 uint32_t nt_gfx_backend_create_buffer(const nt_buffer_desc_t *desc) {
     (void)desc;
@@ -426,7 +476,14 @@ void nt_gfx_backend_update_texture(uint32_t backend_handle, uint16_t x, uint16_t
     (void)data;
 }
 
-void nt_gfx_backend_bind_pipeline(uint32_t backend_handle) { (void)backend_handle; }
+void nt_gfx_backend_bind_pipeline(uint32_t backend_handle) {
+    (void)backend_handle;
+#ifdef NT_TEST_ACCESS
+    /* Mirror the GL backend's transitional rule: a pipeline bind clobbers
+     * the bound vertex input (pipelines still own VAOs). */
+    s_stub_bound_vertex_input = 0;
+#endif
+}
 
 void nt_gfx_backend_bind_vertex_buffer(uint32_t backend_handle) { (void)backend_handle; }
 

--- a/engine/graphics/stub/nt_gfx_stub.c
+++ b/engine/graphics/stub/nt_gfx_stub.c
@@ -476,18 +476,7 @@ void nt_gfx_backend_update_texture(uint32_t backend_handle, uint16_t x, uint16_t
     (void)data;
 }
 
-void nt_gfx_backend_bind_pipeline(uint32_t backend_handle) {
-    (void)backend_handle;
-#ifdef NT_TEST_ACCESS
-    /* Mirror the GL backend's transitional rule: a pipeline bind clobbers
-     * the bound vertex input (pipelines still own VAOs). */
-    s_stub_bound_vertex_input = 0;
-#endif
-}
-
-void nt_gfx_backend_bind_vertex_buffer(uint32_t backend_handle) { (void)backend_handle; }
-
-void nt_gfx_backend_bind_index_buffer(uint32_t backend_handle) { (void)backend_handle; }
+void nt_gfx_backend_bind_pipeline(uint32_t backend_handle) { (void)backend_handle; }
 
 void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle, uint32_t byte_offset) {
     (void)backend_handle;

--- a/engine/postfx/nt_postfx_blur.c
+++ b/engine/postfx/nt_postfx_blur.c
@@ -233,7 +233,7 @@ void nt_postfx_blur_shutdown(void) {
 nt_result_t nt_postfx_blur_restore_gpu(void) {
     /* Games may include inactive modules in their recovery sequence. */
     if (!s_blur.initialized) {
-        return NT_ERR_INIT_FAILED;
+        return NT_OK;
     }
     s_blur.gpu_ready = false;
     destroy_gpu_resources();

--- a/engine/postfx/nt_postfx_blur.c
+++ b/engine/postfx/nt_postfx_blur.c
@@ -64,6 +64,7 @@ static struct {
     nt_program_t program;
     nt_pipeline_t pipeline;
     nt_buffer_t triangle_vbo;
+    nt_vertex_input_t vertex_input;
     /* Logical life and GPU life are separate: a restore that fails leaves the
      * module active so the next one retries, with the pass skipped meanwhile. */
     bool initialized;
@@ -137,6 +138,7 @@ static void pack_kernel_pairs(const float weights[NT_POSTFX_BLUR_MAX_KERNEL], ui
 }
 
 static void destroy_gpu_resources(void) {
+    nt_gfx_destroy_vertex_input(s_blur.vertex_input);
     if (s_blur.triangle_vbo.id != 0) {
         nt_gfx_destroy_buffer(s_blur.triangle_vbo);
     }
@@ -149,6 +151,7 @@ static void destroy_gpu_resources(void) {
     if (s_blur.vs.id != 0) {
         nt_gfx_destroy_shader(s_blur.vs);
     }
+    s_blur.vertex_input = NT_VERTEX_INPUT_INVALID;
     s_blur.triangle_vbo = (nt_buffer_t){0};
     s_blur.pipeline = (nt_pipeline_t){0};
     s_blur.program = NT_PROGRAM_INVALID;
@@ -173,16 +176,6 @@ static bool make_gpu_resources(void) {
     }
     s_blur.pipeline = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
         .program = s_blur.program,
-        .layout =
-            {
-                .stride = sizeof(nt_postfx_blur_vertex_t),
-                .attr_count = 2,
-                .attrs =
-                    {
-                        {.location = NT_ATTR_POSITION, .type = NT_VERTEX_FLOAT, .count = 2, .offset = 0},
-                        {.location = NT_ATTR_TEXCOORD0, .type = NT_VERTEX_FLOAT, .count = 2, .offset = 8},
-                    },
-            },
         .depth_test = false,
         .depth_write = false,
         .depth_func = NT_DEPTH_ALWAYS,
@@ -196,7 +189,24 @@ static bool make_gpu_resources(void) {
         .size = sizeof(verts),
         .label = "postfx_blur_triangle",
     });
-    return s_blur.pipeline.id != 0 && s_blur.triangle_vbo.id != 0;
+    if (s_blur.triangle_vbo.id == 0) {
+        return false;
+    }
+    s_blur.vertex_input = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){
+        .layout =
+            {
+                .stride = sizeof(nt_postfx_blur_vertex_t),
+                .attr_count = 2,
+                .attrs =
+                    {
+                        {.location = NT_ATTR_POSITION, .type = NT_VERTEX_FLOAT, .count = 2, .offset = 0},
+                        {.location = NT_ATTR_TEXCOORD0, .type = NT_VERTEX_FLOAT, .count = 2, .offset = 8},
+                    },
+            },
+        .vertex_buffer = s_blur.triangle_vbo,
+        .label = "postfx_blur_vi",
+    });
+    return s_blur.pipeline.id != 0 && s_blur.vertex_input.id != 0;
 }
 
 nt_result_t nt_postfx_blur_init(void) {
@@ -376,7 +386,7 @@ static void upload_kernel(uint32_t radius, const float packed[20]) {
 static void draw_blur_pass(nt_texture_t source, nt_render_target_t target, const float direction[4], uint32_t radius, const float packed[20]) {
     nt_gfx_begin_pass(&(nt_pass_desc_t){.target = target, .clear_color = {0.0F, 0.0F, 0.0F, 0.0F}, .clear_depth = 1.0F});
     nt_gfx_bind_pipeline(s_blur.pipeline);
-    nt_gfx_bind_vertex_buffer(s_blur.triangle_vbo);
+    nt_gfx_bind_vertex_input(s_blur.vertex_input);
     nt_gfx_bind_texture(source, 0);
     nt_gfx_set_uniform_int("u_source", 0);
     nt_gfx_set_uniform_vec4("u_direction", direction);

--- a/engine/renderers/nt_mesh_renderer.c
+++ b/engine/renderers/nt_mesh_renderer.c
@@ -19,9 +19,7 @@
 typedef struct {
     uint64_t key;
     nt_vertex_input_t vi;
-    uint32_t last_mat; /* memo: last material resolved to this entry; attr_map
-                        * and color_mode are immutable per material handle, so a
-                        * repeat (mesh, material) pair skips the layout rebuild. */
+    uint32_t last_mat; /* most recently resolved material for this VI version */
 } nt_mesh_vi_version_t;
 
 static struct {
@@ -274,8 +272,7 @@ static nt_vertex_input_t find_or_create_vertex_input(nt_material_t mat, nt_mesh_
             reusable = e;
         }
     }
-    /* Crash-early over silent eviction: 5+ layouts cycling on one mesh would
-     * re-create VAOs every frame as an invisible perf regression. */
+    /* Crash early instead of hiding VAO churn behind version eviction. */
     NT_ASSERT(reusable != NULL && "mesh vertex-input versions exhausted -- raise nt_mesh_renderer_desc_t.max_mesh_layouts");
     if (reusable == NULL) {
         return NT_VERTEX_INPUT_INVALID;

--- a/engine/renderers/nt_mesh_renderer.c
+++ b/engine/renderers/nt_mesh_renderer.c
@@ -19,6 +19,9 @@
 typedef struct {
     uint64_t key;
     nt_vertex_input_t vi;
+    uint32_t last_mat; /* memo: last material resolved to this entry; attr_map
+                        * and color_mode are immutable per material handle, so a
+                        * repeat (mesh, material) pair skips the layout rebuild. */
 } nt_mesh_vi_version_t;
 
 static struct {
@@ -231,14 +234,7 @@ static nt_vertex_layout_t build_mesh_vertex_layout(const nt_material_info_t *mat
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity) -- NT_ASSERT expansion inflates the metric
-static nt_vertex_input_t find_or_create_vertex_input(nt_mesh_t mesh, const nt_material_info_t *mat_info, const nt_gfx_mesh_info_t *mesh_info) {
-    const nt_vertex_layout_t layout = build_mesh_vertex_layout(mat_info, mesh_info);
-    /* Hash only the used attrs (memset'd, so padding is deterministic; the
-     * unused tail would be pure noise). color_mode selects the instance
-     * layout, which the baked divisor state depends on. */
-    uint64_t key = nt_hash64(layout.attrs, (uint32_t)layout.attr_count * (uint32_t)sizeof(nt_vertex_attr_t)).value;
-    key = key * 0x9E3779B97F4A7C15ULL + ((uint64_t)layout.attr_count << 24 | (uint64_t)layout.stride << 8 | (uint64_t)mat_info->color_mode);
-
+static nt_vertex_input_t find_or_create_vertex_input(nt_material_t mat, nt_mesh_t mesh, const nt_material_info_t *mat_info, const nt_gfx_mesh_info_t *mesh_info) {
     const uint32_t slot = nt_pool_slot_index(mesh.id);
     NT_ASSERT(slot != 0 && slot <= s_mesh_renderer.vi_mesh_capacity);
     nt_mesh_vi_version_t *row = &s_mesh_renderer.vi_versions[(size_t)(slot - 1) * s_mesh_renderer.max_mesh_layouts];
@@ -250,12 +246,28 @@ static nt_vertex_input_t find_or_create_vertex_input(nt_mesh_t mesh, const nt_ma
         }
         s_mesh_renderer.vi_meshes[slot - 1] = mesh;
     }
+    /* Memo fast path: the generational mat.id pins attr_map + color_mode, so a
+     * hit needs no layout rebuild or hash. Misses (first sight, entry stolen by
+     * a same-key sharing material, cascade-killed vi) fall through. */
+    for (uint16_t i = 0; i < s_mesh_renderer.max_mesh_layouts; i++) {
+        if (row[i].last_mat == mat.id && nt_gfx_vertex_input_valid(row[i].vi)) {
+            return row[i].vi;
+        }
+    }
+
+    const nt_vertex_layout_t layout = build_mesh_vertex_layout(mat_info, mesh_info);
+    /* Hash only the used attrs (memset'd, so padding is deterministic; the
+     * unused tail would be pure noise). color_mode selects the instance
+     * layout, which the baked divisor state depends on. */
+    uint64_t key = nt_hash64(layout.attrs, (uint32_t)layout.attr_count * (uint32_t)sizeof(nt_vertex_attr_t)).value;
+    key = key * 0x9E3779B97F4A7C15ULL + ((uint64_t)layout.attr_count << 24 | (uint64_t)layout.stride << 8 | (uint64_t)mat_info->color_mode);
 
     nt_mesh_vi_version_t *reusable = NULL;
     for (uint16_t i = 0; i < s_mesh_renderer.max_mesh_layouts; i++) {
         nt_mesh_vi_version_t *e = &row[i];
         const bool live = nt_gfx_vertex_input_valid(e->vi);
         if (e->key == key && live) {
+            e->last_mat = mat.id;
             return e->vi;
         }
         if (reusable == NULL && !live) {
@@ -283,6 +295,7 @@ static nt_vertex_input_t find_or_create_vertex_input(nt_mesh_t mesh, const nt_ma
     }
     reusable->key = key;
     reusable->vi = vi;
+    reusable->last_mat = mat.id;
     return vi;
 }
 
@@ -530,7 +543,7 @@ void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count) {
             /* Bind pipeline + vertex input (if material or mesh changed) */
             if (run_mat.id != prev_mat.id || run_mesh.id != prev_mesh.id) {
                 nt_pipeline_t pip = find_or_create_pipeline(mat_info);
-                nt_vertex_input_t vi = (pip.id != 0) ? find_or_create_vertex_input(run_mesh, mat_info, mesh_info) : NT_VERTEX_INPUT_INVALID;
+                nt_vertex_input_t vi = (pip.id != 0) ? find_or_create_vertex_input(run_mat, run_mesh, mat_info, mesh_info) : NT_VERTEX_INPUT_INVALID;
                 if (pip.id == 0 || vi.id == 0) {
                     draw_byte_offset += instance_count * s_instance_layouts[mat_info->color_mode].stride;
                     run_start = run_end;

--- a/engine/renderers/nt_mesh_renderer.c
+++ b/engine/renderers/nt_mesh_renderer.c
@@ -254,6 +254,14 @@ static nt_vertex_input_t find_or_create_vertex_input(nt_mesh_t mesh, const nt_ma
         if (e->mesh_id == mesh.id && e->key == key && nt_gfx_vertex_input_valid(e->vi)) {
             return e->vi;
         }
+        /* Row i serves pool slot i, so a different mesh_id is a dead
+         * generation. Destroy its vi here -- a bufferless vi (empty layout,
+         * non-indexed mesh) has no cascade hook and would otherwise pin the
+         * entry until shutdown. */
+        if (e->mesh_id != 0 && e->mesh_id != mesh.id) {
+            nt_gfx_destroy_vertex_input(e->vi);
+            *e = (nt_mesh_vi_version_t){0};
+        }
         if (reusable == NULL && (e->vi.id == 0 || !nt_gfx_vertex_input_valid(e->vi))) {
             reusable = e;
         }

--- a/engine/renderers/nt_mesh_renderer.c
+++ b/engine/renderers/nt_mesh_renderer.c
@@ -16,14 +16,9 @@
 
 /* ---- Module state ---- */
 
-/* One vertex-input version per (derived layout x color mode) drawing a mesh.
- * mesh_id is the full generation-checked handle -- slot reuse must not alias
- * a stale entry; key is the derived-layout hash (hash-as-identity, per the
- * pipeline-cache standard). */
 typedef struct {
     uint64_t key;
     nt_vertex_input_t vi;
-    uint32_t mesh_id;
 } nt_mesh_vi_version_t;
 
 static struct {
@@ -32,6 +27,8 @@ static struct {
     uint16_t count;
 
     nt_mesh_vi_version_t *vi_versions; /* [nt_gfx_max_meshes()][max_mesh_layouts] */
+    /* Row ownership includes the mesh generation. */
+    nt_mesh_t *vi_meshes;
     uint16_t max_mesh_layouts;
     uint16_t vi_mesh_capacity; /* nt_gfx_max_meshes() at init time */
 
@@ -245,24 +242,23 @@ static nt_vertex_input_t find_or_create_vertex_input(nt_mesh_t mesh, const nt_ma
     const uint32_t slot = nt_pool_slot_index(mesh.id);
     NT_ASSERT(slot != 0 && slot <= s_mesh_renderer.vi_mesh_capacity);
     nt_mesh_vi_version_t *row = &s_mesh_renderer.vi_versions[(size_t)(slot - 1) * s_mesh_renderer.max_mesh_layouts];
+    if (s_mesh_renderer.vi_meshes[slot - 1].id != mesh.id) {
+        /* Bufferless vertex inputs have no buffer-destroy cascade hook. */
+        for (uint16_t i = 0; i < s_mesh_renderer.max_mesh_layouts; i++) {
+            nt_gfx_destroy_vertex_input(row[i].vi);
+            row[i] = (nt_mesh_vi_version_t){0};
+        }
+        s_mesh_renderer.vi_meshes[slot - 1] = mesh;
+    }
 
     nt_mesh_vi_version_t *reusable = NULL;
     for (uint16_t i = 0; i < s_mesh_renderer.max_mesh_layouts; i++) {
         nt_mesh_vi_version_t *e = &row[i];
-        /* Exact mesh identity (generation-checked) + live handle: slot reuse
-         * and the destroy-buffer cascade both kill entries without notice. */
-        if (e->mesh_id == mesh.id && e->key == key && nt_gfx_vertex_input_valid(e->vi)) {
+        const bool live = nt_gfx_vertex_input_valid(e->vi);
+        if (e->key == key && live) {
             return e->vi;
         }
-        /* Row i serves pool slot i, so a different mesh_id is a dead
-         * generation. Destroy its vi here -- a bufferless vi (empty layout,
-         * non-indexed mesh) has no cascade hook and would otherwise pin the
-         * entry until shutdown. */
-        if (e->mesh_id != 0 && e->mesh_id != mesh.id) {
-            nt_gfx_destroy_vertex_input(e->vi);
-            *e = (nt_mesh_vi_version_t){0};
-        }
-        if (reusable == NULL && (e->vi.id == 0 || !nt_gfx_vertex_input_valid(e->vi))) {
+        if (reusable == NULL && !live) {
             reusable = e;
         }
     }
@@ -287,7 +283,6 @@ static nt_vertex_input_t find_or_create_vertex_input(nt_mesh_t mesh, const nt_ma
     }
     reusable->key = key;
     reusable->vi = vi;
-    reusable->mesh_id = mesh.id;
     return vi;
 }
 
@@ -320,7 +315,12 @@ nt_result_t nt_mesh_renderer_init(const nt_mesh_renderer_desc_t *desc) {
 
     /* Vertex-input versions table: one row per mesh pool slot */
     s_mesh_renderer.vi_versions = (nt_mesh_vi_version_t *)calloc((size_t)s_mesh_renderer.vi_mesh_capacity * desc->max_mesh_layouts, sizeof(nt_mesh_vi_version_t));
-    if (!s_mesh_renderer.vi_versions) {
+    s_mesh_renderer.vi_meshes = (nt_mesh_t *)calloc(s_mesh_renderer.vi_mesh_capacity, sizeof(nt_mesh_t));
+    if (!s_mesh_renderer.vi_versions || !s_mesh_renderer.vi_meshes) {
+        free(s_mesh_renderer.vi_meshes);
+        s_mesh_renderer.vi_meshes = NULL;
+        free(s_mesh_renderer.vi_versions);
+        s_mesh_renderer.vi_versions = NULL;
         free(s_mesh_renderer.entries);
         s_mesh_renderer.entries = NULL;
         NT_LOG_ERROR("failed to allocate vertex-input versions");
@@ -330,6 +330,8 @@ nt_result_t nt_mesh_renderer_init(const nt_mesh_renderer_desc_t *desc) {
     /* Allocate CPU staging byte buffer (worst-case stride) */
     s_mesh_renderer.instance_data = (uint8_t *)calloc(desc->max_instances, NT_INSTANCE_STRIDE_MAX);
     if (!s_mesh_renderer.instance_data) {
+        free(s_mesh_renderer.vi_meshes);
+        s_mesh_renderer.vi_meshes = NULL;
         free(s_mesh_renderer.vi_versions);
         s_mesh_renderer.vi_versions = NULL;
         free(s_mesh_renderer.entries);
@@ -350,6 +352,8 @@ nt_result_t nt_mesh_renderer_init(const nt_mesh_renderer_desc_t *desc) {
     if (s_mesh_renderer.instance_buf.id == 0) {
         free(s_mesh_renderer.instance_data);
         s_mesh_renderer.instance_data = NULL;
+        free(s_mesh_renderer.vi_meshes);
+        s_mesh_renderer.vi_meshes = NULL;
         free(s_mesh_renderer.vi_versions);
         s_mesh_renderer.vi_versions = NULL;
         free(s_mesh_renderer.entries);
@@ -386,6 +390,7 @@ void nt_mesh_renderer_shutdown(void) {
         nt_gfx_destroy_vertex_input(s_mesh_renderer.vi_versions[i].vi);
     }
     free(s_mesh_renderer.vi_versions);
+    free(s_mesh_renderer.vi_meshes);
 
     /* Free pipeline cache */
     free(s_mesh_renderer.entries);

--- a/engine/renderers/nt_mesh_renderer.c
+++ b/engine/renderers/nt_mesh_renderer.c
@@ -268,7 +268,9 @@ static nt_vertex_input_t find_or_create_vertex_input(nt_mesh_t mesh, const nt_ma
     const nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){
         .layout = layout,
         .instance_layout = s_instance_layouts[mat_info->color_mode],
-        .vertex_buffer = mesh_info->vbo,
+        /* A material mapping none of this mesh's streams derives an empty
+         * layout -- the attribute-less gl_VertexID path takes no buffer. */
+        .vertex_buffer = (layout.attr_count > 0) ? mesh_info->vbo : (nt_buffer_t){0},
         .index_buffer = mesh_info->ibo,
         .label = "mesh_vi",
     });

--- a/engine/renderers/nt_mesh_renderer.c
+++ b/engine/renderers/nt_mesh_renderer.c
@@ -236,10 +236,11 @@ static nt_vertex_layout_t build_mesh_vertex_layout(const nt_material_info_t *mat
 // NOLINTNEXTLINE(readability-function-cognitive-complexity) -- NT_ASSERT expansion inflates the metric
 static nt_vertex_input_t find_or_create_vertex_input(nt_mesh_t mesh, const nt_material_info_t *mat_info, const nt_gfx_mesh_info_t *mesh_info) {
     const nt_vertex_layout_t layout = build_mesh_vertex_layout(mat_info, mesh_info);
-    /* memset'd struct, so padding hashes deterministically; color_mode selects
-     * the instance layout, which the baked divisor state depends on. */
-    uint64_t key = nt_hash64(&layout, (uint32_t)sizeof(layout)).value;
-    key = key * 0x9E3779B97F4A7C15ULL + (uint64_t)mat_info->color_mode;
+    /* Hash only the used attrs (memset'd, so padding is deterministic; the
+     * unused tail would be pure noise). color_mode selects the instance
+     * layout, which the baked divisor state depends on. */
+    uint64_t key = nt_hash64(layout.attrs, (uint32_t)layout.attr_count * (uint32_t)sizeof(nt_vertex_attr_t)).value;
+    key = key * 0x9E3779B97F4A7C15ULL + ((uint64_t)layout.attr_count << 24 | (uint64_t)layout.stride << 8 | (uint64_t)mat_info->color_mode);
 
     const uint32_t slot = nt_pool_slot_index(mesh.id);
     NT_ASSERT(slot != 0 && slot <= s_mesh_renderer.vi_mesh_capacity);
@@ -521,8 +522,6 @@ void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count) {
                     continue;
                 }
                 nt_gfx_bind_pipeline(pip);
-                /* Pipeline first: binding it clears the bound vertex input
-                 * while pipelines still own VAOs (transitional rule). */
                 nt_gfx_bind_vertex_input(vi);
 
                 /* Sampler units are program state shared with every other

--- a/engine/renderers/nt_mesh_renderer.c
+++ b/engine/renderers/nt_mesh_renderer.c
@@ -3,6 +3,7 @@
 #include "core/nt_assert.h"
 #include "drawable_comp/nt_drawable_comp.h"
 #include "graphics/nt_gfx.h"
+#include "hash/nt_hash.h"
 #include "log/nt_log.h"
 #include "material/nt_material.h"
 #include "material_comp/nt_material_comp.h"
@@ -15,10 +16,24 @@
 
 /* ---- Module state ---- */
 
+/* One vertex-input version per (derived layout x color mode) drawing a mesh.
+ * mesh_id is the full generation-checked handle -- slot reuse must not alias
+ * a stale entry; key is the derived-layout hash (hash-as-identity, per the
+ * pipeline-cache standard). */
+typedef struct {
+    uint64_t key;
+    nt_vertex_input_t vi;
+    uint32_t mesh_id;
+} nt_mesh_vi_version_t;
+
 static struct {
     nt_renderer_pipeline_entry_t *entries; /* [max_pipelines] */
     uint16_t max_pipelines;
     uint16_t count;
+
+    nt_mesh_vi_version_t *vi_versions; /* [nt_gfx_max_meshes()][max_mesh_layouts] */
+    uint16_t max_mesh_layouts;
+    uint16_t vi_mesh_capacity; /* nt_gfx_max_meshes() at init time */
 
     nt_buffer_t instance_buf; /* dynamic vertex buffer for instance data */
 
@@ -149,30 +164,41 @@ static uint16_t stream_byte_size(const NtStreamDesc *s) { return (uint16_t)(nt_s
 
 /* ---- Pipeline cache lookup/create ---- */
 
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
-static nt_pipeline_t find_or_create_pipeline(const nt_material_info_t *mat_info, const nt_gfx_mesh_info_t *mesh_info) {
+static nt_pipeline_t find_or_create_pipeline(const nt_material_info_t *mat_info) {
     /* Sprite and text gate on readiness here; this renderer gates in draw_list, so
      * state the requirement where the pipeline is actually built. */
     NT_ASSERT(nt_gfx_program_ready(mat_info->program) && "find_or_create_pipeline: caller must gate on nt_gfx_program_ready");
 
-    /* Full pipeline signature: layout + program + render state. The 64-bit hash
-     * IS the cache identity -- descriptors are never compared on a hit, so every
-     * nt_pipeline_desc_t field this renderer varies must be folded in here. */
-    uint64_t key = mesh_info->layout_hash;
-    key = key * 0x9E3779B97F4A7C15ULL + mat_info->program.id;
-    key = key * 0x9E3779B97F4A7C15ULL + mat_info->render_state_hash;
-    key = key * 0x9E3779B97F4A7C15ULL + mat_info->attr_map_count;
-    for (uint8_t i = 0; i < mat_info->attr_map_count; i++) {
-        key = key * 0x9E3779B97F4A7C15ULL + mat_info->attr_map_hashes[i];
-        key = key * 0x9E3779B97F4A7C15ULL + mat_info->attr_map_locations[i];
-    }
+    /* Layouts live on the vertex-input versions; the pipeline signature is
+     * program x render state (the text-renderer pattern). render_state_hash
+     * folds color_mode, so pipelines still split per color mode -- an accepted
+     * over-split: nothing in the slimmed pipeline depends on it. */
+    const uint64_t key = ((uint64_t)mat_info->program.id * 0x9E3779B97F4A7C15ULL) + mat_info->render_state_hash;
 
     const nt_pipeline_t cached = nt_renderer_pipeline_cache_find(s_mesh_renderer.entries, s_mesh_renderer.count, key);
     if (cached.id != 0) {
         return cached;
     }
 
-    /* Build vertex layout from mesh streams + material attr_map */
+    nt_pipeline_desc_t desc;
+    memset(&desc, 0, sizeof(desc));
+    desc.program = mat_info->program;
+    desc.depth_test = mat_info->depth_test;
+    desc.depth_write = mat_info->depth_write;
+    desc.depth_func = NT_DEPTH_LESS;
+    desc.blend = mat_info->blend;
+    desc.cull_mode = (uint8_t)mat_info->cull_mode;
+    desc.label = (mat_info->label != NULL) ? mat_info->label : "mesh_pipeline";
+
+    return nt_renderer_pipeline_cache_insert(s_mesh_renderer.entries, &s_mesh_renderer.count, s_mesh_renderer.max_pipelines, key, &desc, &s_mesh_renderer.warned_program_not_ready);
+}
+
+/* ---- Vertex-input versions (Godot-style, one row per mesh pool slot) ---- */
+
+/* Derived layout = mesh streams x material attr_map: only mapped streams
+ * become attributes, so materials whose extra attr_map entries match none of
+ * this mesh's streams share a vertex input. */
+static nt_vertex_layout_t build_mesh_vertex_layout(const nt_material_info_t *mat_info, const nt_gfx_mesh_info_t *mesh_info) {
     nt_vertex_layout_t layout;
     memset(&layout, 0, sizeof(layout));
     layout.stride = mesh_info->stride;
@@ -204,21 +230,54 @@ static nt_pipeline_t find_or_create_pipeline(const nt_material_info_t *mat_info,
 
         offset += stream_byte_size(stream);
     }
+    return layout;
+}
 
-    /* Create pipeline descriptor */
-    nt_pipeline_desc_t desc;
-    memset(&desc, 0, sizeof(desc));
-    desc.program = mat_info->program;
-    desc.layout = layout;
-    desc.instance_layout = s_instance_layouts[mat_info->color_mode];
-    desc.depth_test = mat_info->depth_test;
-    desc.depth_write = mat_info->depth_write;
-    desc.depth_func = NT_DEPTH_LESS;
-    desc.blend = mat_info->blend;
-    desc.cull_mode = (uint8_t)mat_info->cull_mode;
-    desc.label = (mat_info->label != NULL) ? mat_info->label : "mesh_pipeline";
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) -- NT_ASSERT expansion inflates the metric
+static nt_vertex_input_t find_or_create_vertex_input(nt_mesh_t mesh, const nt_material_info_t *mat_info, const nt_gfx_mesh_info_t *mesh_info) {
+    const nt_vertex_layout_t layout = build_mesh_vertex_layout(mat_info, mesh_info);
+    /* memset'd struct, so padding hashes deterministically; color_mode selects
+     * the instance layout, which the baked divisor state depends on. */
+    uint64_t key = nt_hash64(&layout, (uint32_t)sizeof(layout)).value;
+    key = key * 0x9E3779B97F4A7C15ULL + (uint64_t)mat_info->color_mode;
 
-    return nt_renderer_pipeline_cache_insert(s_mesh_renderer.entries, &s_mesh_renderer.count, s_mesh_renderer.max_pipelines, key, &desc, &s_mesh_renderer.warned_program_not_ready);
+    const uint32_t slot = nt_pool_slot_index(mesh.id);
+    NT_ASSERT(slot != 0 && slot <= s_mesh_renderer.vi_mesh_capacity);
+    nt_mesh_vi_version_t *row = &s_mesh_renderer.vi_versions[(size_t)(slot - 1) * s_mesh_renderer.max_mesh_layouts];
+
+    nt_mesh_vi_version_t *reusable = NULL;
+    for (uint16_t i = 0; i < s_mesh_renderer.max_mesh_layouts; i++) {
+        nt_mesh_vi_version_t *e = &row[i];
+        /* Exact mesh identity (generation-checked) + live handle: slot reuse
+         * and the destroy-buffer cascade both kill entries without notice. */
+        if (e->mesh_id == mesh.id && e->key == key && nt_gfx_vertex_input_valid(e->vi)) {
+            return e->vi;
+        }
+        if (reusable == NULL && (e->vi.id == 0 || !nt_gfx_vertex_input_valid(e->vi))) {
+            reusable = e;
+        }
+    }
+    /* Crash-early over silent eviction: 5+ layouts cycling on one mesh would
+     * re-create VAOs every frame as an invisible perf regression. */
+    NT_ASSERT(reusable != NULL && "mesh vertex-input versions exhausted -- raise nt_mesh_renderer_desc_t.max_mesh_layouts");
+    if (reusable == NULL) {
+        return NT_VERTEX_INPUT_INVALID;
+    }
+
+    const nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){
+        .layout = layout,
+        .instance_layout = s_instance_layouts[mat_info->color_mode],
+        .vertex_buffer = mesh_info->vbo,
+        .index_buffer = mesh_info->ibo,
+        .label = "mesh_vi",
+    });
+    if (vi.id == 0) {
+        return vi; /* lost context / backend failure: caller skips the run */
+    }
+    reusable->key = key;
+    reusable->vi = vi;
+    reusable->mesh_id = mesh.id;
+    return vi;
 }
 
 /* ---- Lifecycle ---- */
@@ -229,11 +288,17 @@ nt_result_t nt_mesh_renderer_init(const nt_mesh_renderer_desc_t *desc) {
     NT_ASSERT(desc);
     NT_ASSERT(desc->max_instances > 0);
     NT_ASSERT(desc->max_pipelines > 0);
+    NT_ASSERT(desc->max_mesh_layouts > 0);
 
     memset(&s_mesh_renderer, 0, sizeof(s_mesh_renderer));
 
     s_mesh_renderer.max_instances = desc->max_instances;
     s_mesh_renderer.max_pipelines = desc->max_pipelines;
+    s_mesh_renderer.max_mesh_layouts = desc->max_mesh_layouts;
+    /* The capacity lives only in nt_gfx_desc_t; hardcoding it here would write
+     * out of bounds on bigger gfx configs. */
+    s_mesh_renderer.vi_mesh_capacity = nt_gfx_max_meshes();
+    NT_ASSERT(s_mesh_renderer.vi_mesh_capacity > 0 && "nt_mesh_renderer_init: nt_gfx_init must run first");
 
     /* Allocate pipeline cache */
     s_mesh_renderer.entries = (nt_renderer_pipeline_entry_t *)calloc(desc->max_pipelines, sizeof(nt_renderer_pipeline_entry_t));
@@ -242,9 +307,20 @@ nt_result_t nt_mesh_renderer_init(const nt_mesh_renderer_desc_t *desc) {
         return NT_ERR_INIT_FAILED;
     }
 
+    /* Vertex-input versions table: one row per mesh pool slot */
+    s_mesh_renderer.vi_versions = (nt_mesh_vi_version_t *)calloc((size_t)s_mesh_renderer.vi_mesh_capacity * desc->max_mesh_layouts, sizeof(nt_mesh_vi_version_t));
+    if (!s_mesh_renderer.vi_versions) {
+        free(s_mesh_renderer.entries);
+        s_mesh_renderer.entries = NULL;
+        NT_LOG_ERROR("failed to allocate vertex-input versions");
+        return NT_ERR_INIT_FAILED;
+    }
+
     /* Allocate CPU staging byte buffer (worst-case stride) */
     s_mesh_renderer.instance_data = (uint8_t *)calloc(desc->max_instances, NT_INSTANCE_STRIDE_MAX);
     if (!s_mesh_renderer.instance_data) {
+        free(s_mesh_renderer.vi_versions);
+        s_mesh_renderer.vi_versions = NULL;
         free(s_mesh_renderer.entries);
         s_mesh_renderer.entries = NULL;
         NT_LOG_ERROR("failed to allocate instance data");
@@ -263,6 +339,8 @@ nt_result_t nt_mesh_renderer_init(const nt_mesh_renderer_desc_t *desc) {
     if (s_mesh_renderer.instance_buf.id == 0) {
         free(s_mesh_renderer.instance_data);
         s_mesh_renderer.instance_data = NULL;
+        free(s_mesh_renderer.vi_versions);
+        s_mesh_renderer.vi_versions = NULL;
         free(s_mesh_renderer.entries);
         s_mesh_renderer.entries = NULL;
         NT_LOG_ERROR("failed to create instance buffer");
@@ -291,6 +369,13 @@ void nt_mesh_renderer_shutdown(void) {
         nt_gfx_destroy_pipeline(s_mesh_renderer.entries[i].pipeline);
     }
 
+    /* Destroy cached vertex inputs. Tolerant stale-destroy makes any
+     * deactivate-then-shutdown order safe (the cascade may have run first). */
+    for (size_t i = 0; i < (size_t)s_mesh_renderer.vi_mesh_capacity * s_mesh_renderer.max_mesh_layouts; i++) {
+        nt_gfx_destroy_vertex_input(s_mesh_renderer.vi_versions[i].vi);
+    }
+    free(s_mesh_renderer.vi_versions);
+
     /* Free pipeline cache */
     free(s_mesh_renderer.entries);
 
@@ -308,8 +393,9 @@ void nt_mesh_renderer_restore_gpu(void) {
     }
     uint16_t saved_max = s_mesh_renderer.max_instances;
     uint16_t saved_pip = s_mesh_renderer.max_pipelines;
+    uint16_t saved_layouts = s_mesh_renderer.max_mesh_layouts;
     nt_mesh_renderer_shutdown();
-    nt_mesh_renderer_desc_t desc = {.max_instances = saved_max, .max_pipelines = saved_pip};
+    nt_mesh_renderer_desc_t desc = {.max_instances = saved_max, .max_pipelines = saved_pip, .max_mesh_layouts = saved_layouts};
     nt_result_t res = nt_mesh_renderer_init(&desc);
     NT_ASSERT(res == NT_OK); /* context alive but GPU alloc failed = fatal */
     (void)res;
@@ -425,15 +511,19 @@ void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count) {
                 continue;
             }
 
-            /* Bind pipeline (if material or mesh changed) */
+            /* Bind pipeline + vertex input (if material or mesh changed) */
             if (run_mat.id != prev_mat.id || run_mesh.id != prev_mesh.id) {
-                nt_pipeline_t pip = find_or_create_pipeline(mat_info, mesh_info);
-                if (pip.id == 0) {
+                nt_pipeline_t pip = find_or_create_pipeline(mat_info);
+                nt_vertex_input_t vi = (pip.id != 0) ? find_or_create_vertex_input(run_mesh, mat_info, mesh_info) : NT_VERTEX_INPUT_INVALID;
+                if (pip.id == 0 || vi.id == 0) {
                     draw_byte_offset += instance_count * s_instance_layouts[mat_info->color_mode].stride;
                     run_start = run_end;
                     continue;
                 }
                 nt_gfx_bind_pipeline(pip);
+                /* Pipeline first: binding it clears the bound vertex input
+                 * while pipelines still own VAOs (transitional rule). */
+                nt_gfx_bind_vertex_input(vi);
 
                 /* Sampler units are program state shared with every other
                  * material on this program, so each declared slot is written
@@ -455,11 +545,6 @@ void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count) {
                     if (mat_info->param_names[p] != NULL) {
                         nt_gfx_set_uniform_vec4(mat_info->param_names[p], mat_info->params[p]);
                     }
-                }
-
-                nt_gfx_bind_vertex_buffer(mesh_info->vbo);
-                if (mesh_info->index_count > 0) {
-                    nt_gfx_bind_index_buffer(mesh_info->ibo);
                 }
 
                 prev_mat = run_mat;
@@ -488,6 +573,16 @@ void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count) {
 /* ---- Test accessors (always compiled; header guard controls visibility) ---- */
 
 uint32_t nt_mesh_renderer_test_pipeline_cache_count(void) { return s_mesh_renderer.count; }
+
+uint32_t nt_mesh_renderer_test_vertex_input_count(void) {
+    uint32_t live = 0;
+    for (size_t i = 0; i < (size_t)s_mesh_renderer.vi_mesh_capacity * s_mesh_renderer.max_mesh_layouts; i++) {
+        if (nt_gfx_vertex_input_valid(s_mesh_renderer.vi_versions[i].vi)) {
+            live++;
+        }
+    }
+    return live;
+}
 
 uint32_t nt_mesh_renderer_test_draw_call_count(void) { return s_mesh_renderer.frame_draw_calls; }
 

--- a/engine/renderers/nt_mesh_renderer.c
+++ b/engine/renderers/nt_mesh_renderer.c
@@ -288,6 +288,39 @@ static nt_vertex_input_t find_or_create_vertex_input(nt_mesh_t mesh, const nt_ma
 
 /* ---- Lifecycle ---- */
 
+static nt_result_t create_gpu_resources(void) {
+    s_mesh_renderer.instance_buf = nt_gfx_make_buffer(&(nt_buffer_desc_t){
+        .type = NT_BUFFER_VERTEX,
+        .usage = NT_USAGE_STREAM,
+        .size = (uint32_t)s_mesh_renderer.max_instances * (uint32_t)NT_INSTANCE_STRIDE_MAX,
+        .label = "mesh_renderer_instance",
+    });
+    if (s_mesh_renderer.instance_buf.id == 0) {
+        return NT_ERR_INIT_FAILED;
+    }
+    /* NONE color mode reads the generic attribute instead of a buffer. */
+    nt_gfx_set_vertex_attrib_default(7, 1.0F, 1.0F, 1.0F, 1.0F);
+    return NT_OK;
+}
+
+static void destroy_gpu_resources(void) {
+    nt_gfx_destroy_buffer(s_mesh_renderer.instance_buf);
+    s_mesh_renderer.instance_buf = (nt_buffer_t){0};
+    for (uint16_t i = 0; i < s_mesh_renderer.count; i++) {
+        nt_gfx_destroy_pipeline(s_mesh_renderer.entries[i].pipeline);
+    }
+    s_mesh_renderer.count = 0;
+    for (size_t i = 0; i < (size_t)s_mesh_renderer.vi_mesh_capacity * s_mesh_renderer.max_mesh_layouts; i++) {
+        nt_gfx_destroy_vertex_input(s_mesh_renderer.vi_versions[i].vi);
+        s_mesh_renderer.vi_versions[i] = (nt_mesh_vi_version_t){0};
+    }
+    memset(s_mesh_renderer.vi_meshes, 0, (size_t)s_mesh_renderer.vi_mesh_capacity * sizeof(nt_mesh_t));
+    s_mesh_renderer.ring_cursor = 0;
+    s_mesh_renderer.frame_draw_calls = 0;
+    s_mesh_renderer.frame_instance_total = 0;
+    s_mesh_renderer.warned_program_not_ready = false;
+}
+
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 nt_result_t nt_mesh_renderer_init(const nt_mesh_renderer_desc_t *desc) {
     NT_ASSERT(!s_mesh_renderer.initialized);
@@ -340,16 +373,7 @@ nt_result_t nt_mesh_renderer_init(const nt_mesh_renderer_desc_t *desc) {
         return NT_ERR_INIT_FAILED;
     }
 
-    /* Create instance buffer (STREAM: ring-suballocated, refilled every frame) */
-    s_mesh_renderer.instance_buf = nt_gfx_make_buffer(&(nt_buffer_desc_t){
-        .type = NT_BUFFER_VERTEX,
-        .usage = NT_USAGE_STREAM,
-        .size = (uint32_t)desc->max_instances * (uint32_t)NT_INSTANCE_STRIDE_MAX,
-        .data = NULL,
-        .label = "mesh_renderer_instance",
-    });
-
-    if (s_mesh_renderer.instance_buf.id == 0) {
+    if (create_gpu_resources() != NT_OK) {
         free(s_mesh_renderer.instance_data);
         s_mesh_renderer.instance_data = NULL;
         free(s_mesh_renderer.vi_meshes);
@@ -362,11 +386,6 @@ nt_result_t nt_mesh_renderer_init(const nt_mesh_renderer_desc_t *desc) {
         return NT_ERR_INIT_FAILED;
     }
 
-    /* Set generic attribute 7 to white -- when color attribute is disabled
-     * (NONE mode), shaders read (1,1,1,1) as identity for multiplication.
-     * Must be called after GL context exists. */
-    nt_gfx_set_vertex_attrib_default(7, 1.0F, 1.0F, 1.0F, 1.0F);
-
     s_mesh_renderer.initialized = true;
     return NT_OK;
 }
@@ -376,19 +395,7 @@ void nt_mesh_renderer_shutdown(void) {
         return;
     }
 
-    /* Destroy instance buffer */
-    nt_gfx_destroy_buffer(s_mesh_renderer.instance_buf);
-
-    /* Destroy all cached pipelines */
-    for (uint16_t i = 0; i < s_mesh_renderer.count; i++) {
-        nt_gfx_destroy_pipeline(s_mesh_renderer.entries[i].pipeline);
-    }
-
-    /* Destroy cached vertex inputs. Tolerant stale-destroy makes any
-     * deactivate-then-shutdown order safe (the cascade may have run first). */
-    for (size_t i = 0; i < (size_t)s_mesh_renderer.vi_mesh_capacity * s_mesh_renderer.max_mesh_layouts; i++) {
-        nt_gfx_destroy_vertex_input(s_mesh_renderer.vi_versions[i].vi);
-    }
+    destroy_gpu_resources();
     free(s_mesh_renderer.vi_versions);
     free(s_mesh_renderer.vi_meshes);
 
@@ -401,20 +408,12 @@ void nt_mesh_renderer_shutdown(void) {
     memset(&s_mesh_renderer, 0, sizeof(s_mesh_renderer));
 }
 
-void nt_mesh_renderer_restore_gpu(void) {
-    /* The contract is "every ACTIVE renderer", and a game that restores all four
-     * unconditionally would otherwise re-init this one from a zeroed desc. */
+nt_result_t nt_mesh_renderer_restore_gpu(void) {
     if (!s_mesh_renderer.initialized) {
-        return;
+        return NT_OK;
     }
-    uint16_t saved_max = s_mesh_renderer.max_instances;
-    uint16_t saved_pip = s_mesh_renderer.max_pipelines;
-    uint16_t saved_layouts = s_mesh_renderer.max_mesh_layouts;
-    nt_mesh_renderer_shutdown();
-    nt_mesh_renderer_desc_t desc = {.max_instances = saved_max, .max_pipelines = saved_pip, .max_mesh_layouts = saved_layouts};
-    nt_result_t res = nt_mesh_renderer_init(&desc);
-    NT_ASSERT(res == NT_OK); /* context alive but GPU alloc failed = fatal */
-    (void)res;
+    destroy_gpu_resources();
+    return create_gpu_resources();
 }
 
 /* ---- Draw list ---- */
@@ -427,6 +426,7 @@ void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count) {
         return;
     }
     NT_ASSERT(items != NULL);
+    NT_ASSERT(s_mesh_renderer.instance_buf.id != 0 && "retry failed GPU restore before drawing");
 
     /* Reset per-frame tracking */
     s_mesh_renderer.frame_draw_calls = 0;

--- a/engine/renderers/nt_mesh_renderer.h
+++ b/engine/renderers/nt_mesh_renderer.h
@@ -24,9 +24,14 @@ static inline uint32_t nt_mesh_renderer_batch_key(nt_material_t material, nt_mes
 typedef struct {
     uint16_t max_instances; /* max per single instanced draw call, default: 4096 */
     uint16_t max_pipelines; /* pipeline cache capacity, default: 64 */
+    /* Vertex-input versions kept per mesh (one per distinct derived layout x
+     * color mode drawing that mesh). Exceeding it ASSERTS -- silent eviction
+     * would hide re-creation thrash as an invisible perf regression; raise the
+     * knob instead. Default: 4 (3-4 versions is the expected population). */
+    uint16_t max_mesh_layouts;
 } nt_mesh_renderer_desc_t;
 
-static inline nt_mesh_renderer_desc_t nt_mesh_renderer_desc_defaults(void) { return (nt_mesh_renderer_desc_t){.max_instances = 4096, .max_pipelines = 64}; }
+static inline nt_mesh_renderer_desc_t nt_mesh_renderer_desc_defaults(void) { return (nt_mesh_renderer_desc_t){.max_instances = 4096, .max_pipelines = 64, .max_mesh_layouts = 4}; }
 
 nt_result_t nt_mesh_renderer_init(const nt_mesh_renderer_desc_t *desc);
 void nt_mesh_renderer_shutdown(void);
@@ -46,6 +51,8 @@ void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count);
 // #region test_access
 #ifdef NT_TEST_ACCESS
 uint32_t nt_mesh_renderer_test_pipeline_cache_count(void);
+/* Live entries across the whole vertex-input versions table. */
+uint32_t nt_mesh_renderer_test_vertex_input_count(void);
 uint32_t nt_mesh_renderer_test_draw_call_count(void);
 uint32_t nt_mesh_renderer_test_instance_total(void);
 uint32_t nt_mesh_renderer_test_ring_cursor(void);

--- a/engine/renderers/nt_mesh_renderer.h
+++ b/engine/renderers/nt_mesh_renderer.h
@@ -35,8 +35,10 @@ static inline nt_mesh_renderer_desc_t nt_mesh_renderer_desc_defaults(void) { ret
 
 nt_result_t nt_mesh_renderer_init(const nt_mesh_renderer_desc_t *desc);
 void nt_mesh_renderer_shutdown(void);
-/* Reinitializes buffers and pipeline cache with the existing capacities. */
-void nt_mesh_renderer_restore_gpu(void);
+/* Retains CPU storage and initialization; drops GPU caches and recreates buffers.
+ * Failure returns NT_ERR_INIT_FAILED: retry before drawing, or shut down.
+ * Inactive modules are unchanged and return NT_OK. */
+nt_result_t nt_mesh_renderer_restore_gpu(void);
 
 /* Contract: caller must pre-filter `items` by visibility — the renderer draws
  * every entry unconditionally and does not consult drawable_comp's visible

--- a/engine/renderers/nt_shape_renderer.c
+++ b/engine/renderers/nt_shape_renderer.c
@@ -722,7 +722,11 @@ void nt_shape_renderer_init(void) {
 
     /* Verify all buffers/pipelines were created successfully (the vertex
      * inputs below trap on invalid buffer handles instead of skipping). */
-    if (!s_shape.batch_pip_depth.id || !s_shape.batch_pip_overlay.id || !s_shape.inst_pip_depth.id || !s_shape.inst_pip_overlay.id || !s_shape.cap_inst_pip_depth.id ||
+    bool template_bufs_ok = true;
+    for (int t = 0; t < NT_SHAPE_TYPE_COUNT; t++) {
+        template_bufs_ok = template_bufs_ok && s_shape.templates[t].vbo.id != 0 && s_shape.templates[t].ibo.id != 0;
+    }
+    if (!template_bufs_ok || !s_shape.batch_pip_depth.id || !s_shape.batch_pip_overlay.id || !s_shape.inst_pip_depth.id || !s_shape.inst_pip_overlay.id || !s_shape.cap_inst_pip_depth.id ||
         !s_shape.cap_inst_pip_overlay.id || !s_shape.line_pip_depth.id || !s_shape.line_pip_overlay.id || !s_shape.batch_vbo.id || !s_shape.batch_ibo.id || !s_shape.inst_buf.id ||
         !s_shape.line_template_vbo.id || !s_shape.line_template_ibo.id || !s_shape.line_instance_buf.id) {
         NT_LOG_ERROR("init failed -- resource creation error");

--- a/engine/renderers/nt_shape_renderer.c
+++ b/engine/renderers/nt_shape_renderer.c
@@ -177,6 +177,7 @@ static struct {
     nt_pipeline_t batch_pip_active;
     nt_buffer_t batch_vbo;
     nt_buffer_t batch_ibo;
+    nt_vertex_input_t batch_vi;
     nt_shape_renderer_vertex_t vertices[NT_SHAPE_RENDERER_MAX_VERTICES];
     nt_shape_index_t indices[NT_SHAPE_RENDERER_MAX_INDICES];
     uint32_t vertex_count;
@@ -191,6 +192,9 @@ static struct {
     nt_buffer_t inst_buf;      /* shared GPU instance buffer, reused per type */
     uint32_t inst_ring_cursor; /* next free byte; disjoint writes avoid driver copies of in-flight data */
     nt_shape_template_t templates[NT_SHAPE_TYPE_COUNT];
+    /* One vertex input per template (depth/overlay pipeline pairs share it);
+     * instance pointers are re-specified into it by each flush. */
+    nt_vertex_input_t template_vi[NT_SHAPE_TYPE_COUNT];
     nt_shape_instance_t inst_data[NT_SHAPE_TYPE_COUNT][NT_SHAPE_RENDERER_MAX_INSTANCES];
     uint32_t inst_counts[NT_SHAPE_TYPE_COUNT];
 
@@ -210,6 +214,7 @@ static struct {
     nt_buffer_t line_template_vbo;
     nt_buffer_t line_template_ibo;
     nt_buffer_t line_instance_buf;
+    nt_vertex_input_t line_vi;
     uint32_t line_ring_cursor;
     nt_shape_line_instance_t lines[NT_SHAPE_RENDERER_MAX_LINES];
     uint32_t line_count;
@@ -240,19 +245,74 @@ static nt_pipeline_t get_active_cap_inst_pipeline(void) { return s_shape.depth_e
 
 static nt_pipeline_t get_active_line_pipeline(void) { return s_shape.depth_enabled ? s_shape.line_pip_depth : s_shape.line_pip_overlay; }
 
+/* Vertex/instance layouts now live on the vertex-input objects; the depth and
+ * overlay pipeline pair for each program shares one vertex input. */
+static nt_vertex_layout_t batch_vertex_layout(void) {
+    return (nt_vertex_layout_t){
+        .attr_count = 2,
+        .stride = (uint16_t)sizeof(nt_shape_renderer_vertex_t),
+        .attrs =
+            {
+                {.location = NT_ATTR_POSITION, .type = NT_VERTEX_FLOAT, .count = 3, .offset = 0},
+                {.location = NT_ATTR_COLOR, .type = NT_VERTEX_UINT8, .count = 4, .normalized = true, .offset = 12},
+            },
+    };
+}
+
+static nt_vertex_layout_t inst_template_layout(void) {
+    return (nt_vertex_layout_t){
+        .attr_count = 1,
+        .stride = (uint16_t)(3 * sizeof(float)),
+        .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 3, .offset = 0}},
+    };
+}
+
+static nt_vertex_layout_t cap_template_layout(void) {
+    return (nt_vertex_layout_t){
+        .attr_count = 1,
+        .stride = (uint16_t)(4 * sizeof(float)), /* vec4 template */
+        .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 4, .offset = 0}},
+    };
+}
+
+static nt_vertex_layout_t shape_instance_layout(void) {
+    return (nt_vertex_layout_t){
+        .attr_count = 4,
+        .stride = (uint16_t)sizeof(nt_shape_instance_t),
+        .attrs =
+            {
+                {.location = 1, .type = NT_VERTEX_FLOAT, .count = 3, .offset = 0},
+                {.location = 2, .type = NT_VERTEX_FLOAT, .count = 3, .offset = 12},
+                {.location = 3, .type = NT_VERTEX_FLOAT, .count = 4, .offset = 24},
+                {.location = 4, .type = NT_VERTEX_UINT8, .count = 4, .normalized = true, .offset = 40},
+            },
+    };
+}
+
+static nt_vertex_layout_t line_template_layout(void) {
+    return (nt_vertex_layout_t){
+        .attr_count = 1,
+        .stride = (uint16_t)(2 * sizeof(float)),
+        .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 2, .offset = 0}},
+    };
+}
+
+static nt_vertex_layout_t line_instance_layout(void) {
+    return (nt_vertex_layout_t){
+        .attr_count = 3,
+        .stride = (uint16_t)sizeof(nt_shape_line_instance_t),
+        .attrs =
+            {
+                {.location = 1, .type = NT_VERTEX_FLOAT, .count = 3, .offset = 0},
+                {.location = 2, .type = NT_VERTEX_FLOAT, .count = 3, .offset = 12},
+                {.location = 3, .type = NT_VERTEX_UINT8, .count = 4, .normalized = true, .offset = 24},
+            },
+    };
+}
+
 static nt_pipeline_t make_batch_pipeline(bool depth, bool poly_offset) {
     nt_pipeline_desc_t desc = {
         .program = s_shape.batch_prog,
-        .layout =
-            {
-                .attr_count = 2,
-                .stride = (uint16_t)sizeof(nt_shape_renderer_vertex_t),
-                .attrs =
-                    {
-                        {.location = NT_ATTR_POSITION, .type = NT_VERTEX_FLOAT, .count = 3, .offset = 0},
-                        {.location = NT_ATTR_COLOR, .type = NT_VERTEX_UINT8, .count = 4, .normalized = true, .offset = 12},
-                    },
-            },
         .depth_test = depth,
         .depth_write = depth,
         .depth_func = NT_DEPTH_LEQUAL,
@@ -268,26 +328,6 @@ static nt_pipeline_t make_batch_pipeline(bool depth, bool poly_offset) {
 static nt_pipeline_t make_line_pipeline(bool depth) {
     nt_pipeline_desc_t desc = {
         .program = s_shape.line_prog,
-        .layout =
-            {
-                .attr_count = 1,
-                .stride = (uint16_t)(2 * sizeof(float)),
-                .attrs =
-                    {
-                        {.location = 0, .type = NT_VERTEX_FLOAT, .count = 2, .offset = 0},
-                    },
-            },
-        .instance_layout =
-            {
-                .attr_count = 3,
-                .stride = (uint16_t)sizeof(nt_shape_line_instance_t),
-                .attrs =
-                    {
-                        {.location = 1, .type = NT_VERTEX_FLOAT, .count = 3, .offset = 0},
-                        {.location = 2, .type = NT_VERTEX_FLOAT, .count = 3, .offset = 12},
-                        {.location = 3, .type = NT_VERTEX_UINT8, .count = 4, .normalized = true, .offset = 24},
-                    },
-            },
         .depth_test = depth,
         .depth_write = depth,
         .depth_func = NT_DEPTH_LEQUAL,
@@ -300,27 +340,6 @@ static nt_pipeline_t make_line_pipeline(bool depth) {
 static nt_pipeline_t make_inst_pipeline(bool depth) {
     nt_pipeline_desc_t desc = {
         .program = s_shape.inst_prog,
-        .layout =
-            {
-                .attr_count = 1,
-                .stride = (uint16_t)(3 * sizeof(float)),
-                .attrs =
-                    {
-                        {.location = 0, .type = NT_VERTEX_FLOAT, .count = 3, .offset = 0},
-                    },
-            },
-        .instance_layout =
-            {
-                .attr_count = 4,
-                .stride = (uint16_t)sizeof(nt_shape_instance_t),
-                .attrs =
-                    {
-                        {.location = 1, .type = NT_VERTEX_FLOAT, .count = 3, .offset = 0},
-                        {.location = 2, .type = NT_VERTEX_FLOAT, .count = 3, .offset = 12},
-                        {.location = 3, .type = NT_VERTEX_FLOAT, .count = 4, .offset = 24},
-                        {.location = 4, .type = NT_VERTEX_UINT8, .count = 4, .normalized = true, .offset = 40},
-                    },
-            },
         .depth_test = depth,
         .depth_write = depth,
         .depth_func = NT_DEPTH_LEQUAL,
@@ -336,27 +355,6 @@ static nt_pipeline_t make_inst_pipeline(bool depth) {
 static nt_pipeline_t make_cap_inst_pipeline(bool depth) {
     nt_pipeline_desc_t desc = {
         .program = s_shape.cap_inst_prog,
-        .layout =
-            {
-                .attr_count = 1,
-                .stride = (uint16_t)(4 * sizeof(float)), /* vec4 template */
-                .attrs =
-                    {
-                        {.location = 0, .type = NT_VERTEX_FLOAT, .count = 4, .offset = 0},
-                    },
-            },
-        .instance_layout =
-            {
-                .attr_count = 4,
-                .stride = (uint16_t)sizeof(nt_shape_instance_t),
-                .attrs =
-                    {
-                        {.location = 1, .type = NT_VERTEX_FLOAT, .count = 3, .offset = 0},
-                        {.location = 2, .type = NT_VERTEX_FLOAT, .count = 3, .offset = 12},
-                        {.location = 3, .type = NT_VERTEX_FLOAT, .count = 4, .offset = 24},
-                        {.location = 4, .type = NT_VERTEX_UINT8, .count = 4, .normalized = true, .offset = 40},
-                    },
-            },
         .depth_test = depth,
         .depth_write = depth,
         .depth_func = NT_DEPTH_LEQUAL,
@@ -432,7 +430,8 @@ static nt_shape_template_t make_template_ex(const float *verts, uint32_t nv, uin
     t.num_vertices = nv;
     t.num_indices = ni;
     t.vbo = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_IMMUTABLE, .data = verts, .size = nv * components * (uint32_t)sizeof(float), .label = label});
-    t.ibo = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_INDEX, .usage = NT_USAGE_IMMUTABLE, .data = idx, .size = ni * (uint32_t)sizeof(uint16_t), .label = label});
+    t.ibo = nt_gfx_make_buffer(
+        &(nt_buffer_desc_t){.type = NT_BUFFER_INDEX, .usage = NT_USAGE_IMMUTABLE, .data = idx, .size = ni * (uint32_t)sizeof(uint16_t), .index_type = NT_INDEX_UINT16, .label = label});
     return t;
 }
 
@@ -716,16 +715,47 @@ void nt_shape_renderer_init(void) {
     s_shape.line_template_vbo =
         nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_IMMUTABLE, .data = line_template_verts, .size = sizeof(line_template_verts), .label = "shape_line_quad"});
     static const uint16_t line_template_indices[] = {0, 1, 2, 0, 2, 3};
-    s_shape.line_template_ibo =
-        nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_INDEX, .usage = NT_USAGE_IMMUTABLE, .data = line_template_indices, .size = sizeof(line_template_indices), .label = "shape_line_idx"});
+    s_shape.line_template_ibo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
+        .type = NT_BUFFER_INDEX, .usage = NT_USAGE_IMMUTABLE, .data = line_template_indices, .size = sizeof(line_template_indices), .index_type = NT_INDEX_UINT16, .label = "shape_line_idx"});
     s_shape.line_instance_buf = nt_gfx_make_buffer(
         &(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = NT_SHAPE_RENDERER_MAX_LINES * (uint32_t)sizeof(nt_shape_line_instance_t), .label = "shape_line_inst"});
 
-    /* Verify all resources were created successfully */
+    /* Verify all buffers/pipelines were created successfully (the vertex
+     * inputs below trap on invalid buffer handles instead of skipping). */
     if (!s_shape.batch_pip_depth.id || !s_shape.batch_pip_overlay.id || !s_shape.inst_pip_depth.id || !s_shape.inst_pip_overlay.id || !s_shape.cap_inst_pip_depth.id ||
         !s_shape.cap_inst_pip_overlay.id || !s_shape.line_pip_depth.id || !s_shape.line_pip_overlay.id || !s_shape.batch_vbo.id || !s_shape.batch_ibo.id || !s_shape.inst_buf.id ||
         !s_shape.line_template_vbo.id || !s_shape.line_template_ibo.id || !s_shape.line_instance_buf.id) {
         NT_LOG_ERROR("init failed -- resource creation error");
+        nt_shape_renderer_shutdown();
+        return;
+    }
+
+    /* Vertex inputs: one per template + batch + line; each depth/overlay
+     * pipeline pair shares one. */
+    s_shape.batch_vi =
+        nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = batch_vertex_layout(), .vertex_buffer = s_shape.batch_vbo, .index_buffer = s_shape.batch_ibo, .label = "shape_batch_vi"});
+    for (int t = 0; t < NT_SHAPE_TYPE_COUNT; t++) {
+        s_shape.template_vi[t] = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){
+            .layout = (t == NT_SHAPE_CAPSULE) ? cap_template_layout() : inst_template_layout(),
+            .instance_layout = shape_instance_layout(),
+            .vertex_buffer = s_shape.templates[t].vbo,
+            .index_buffer = s_shape.templates[t].ibo,
+            .label = "shape_template_vi",
+        });
+    }
+    s_shape.line_vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){
+        .layout = line_template_layout(),
+        .instance_layout = line_instance_layout(),
+        .vertex_buffer = s_shape.line_template_vbo,
+        .index_buffer = s_shape.line_template_ibo,
+        .label = "shape_line_vi",
+    });
+    bool template_vis_ok = true;
+    for (int t = 0; t < NT_SHAPE_TYPE_COUNT; t++) {
+        template_vis_ok = template_vis_ok && s_shape.template_vi[t].id != 0;
+    }
+    if (!s_shape.batch_vi.id || !template_vis_ok || !s_shape.line_vi.id) {
+        NT_LOG_ERROR("init failed -- vertex input creation error");
         nt_shape_renderer_shutdown();
         return;
     }
@@ -746,6 +776,11 @@ void nt_shape_renderer_shutdown(void) {
     if (!s_shape.initialized) {
         return;
     }
+    nt_gfx_destroy_vertex_input(s_shape.line_vi);
+    for (int t = NT_SHAPE_TYPE_COUNT - 1; t >= 0; t--) {
+        nt_gfx_destroy_vertex_input(s_shape.template_vi[t]);
+    }
+    nt_gfx_destroy_vertex_input(s_shape.batch_vi);
     nt_gfx_destroy_buffer(s_shape.line_instance_buf);
     nt_gfx_destroy_buffer(s_shape.line_template_ibo);
     nt_gfx_destroy_buffer(s_shape.line_template_vbo);
@@ -831,8 +866,7 @@ void nt_shape_renderer_flush(void) {
         s_shape.inst_ring_cursor = inst_base + inst_bytes;
         nt_gfx_update_buffer(s_shape.inst_buf, inst_base, s_shape.inst_data[t], inst_bytes);
         nt_gfx_bind_pipeline(t == NT_SHAPE_CAPSULE ? s_shape.cap_inst_pip_active : s_shape.inst_pip_active);
-        nt_gfx_bind_vertex_buffer(s_shape.templates[t].vbo);
-        nt_gfx_bind_index_buffer(s_shape.templates[t].ibo);
+        nt_gfx_bind_vertex_input(s_shape.template_vi[t]);
         nt_gfx_bind_instance_buffer(s_shape.inst_buf, inst_base);
         nt_gfx_set_uniform_mat4("u_vp", s_shape.vp);
 
@@ -848,8 +882,7 @@ void nt_shape_renderer_flush(void) {
         nt_gfx_update_buffer(s_shape.batch_ibo, 0, s_shape.indices, s_shape.index_count * (uint32_t)sizeof(nt_shape_index_t));
 
         nt_gfx_bind_pipeline(s_shape.batch_pip_active);
-        nt_gfx_bind_vertex_buffer(s_shape.batch_vbo);
-        nt_gfx_bind_index_buffer(s_shape.batch_ibo);
+        nt_gfx_bind_vertex_input(s_shape.batch_vi);
         nt_gfx_set_uniform_mat4("u_vp", s_shape.vp);
 
         nt_gfx_draw_indexed(0, s_shape.index_count, s_shape.vertex_count);
@@ -870,8 +903,7 @@ void nt_shape_renderer_flush(void) {
         nt_gfx_update_buffer(s_shape.line_instance_buf, line_base, s_shape.lines, line_bytes);
 
         nt_gfx_bind_pipeline(s_shape.line_pip_active);
-        nt_gfx_bind_vertex_buffer(s_shape.line_template_vbo);
-        nt_gfx_bind_index_buffer(s_shape.line_template_ibo);
+        nt_gfx_bind_vertex_input(s_shape.line_vi);
         nt_gfx_bind_instance_buffer(s_shape.line_instance_buf, line_base);
         nt_gfx_set_uniform_mat4("u_vp", s_shape.vp);
         float cp4[4] = {s_shape.cam_pos[0], s_shape.cam_pos[1], s_shape.cam_pos[2], 0.0F};

--- a/engine/renderers/nt_shape_renderer.c
+++ b/engine/renderers/nt_shape_renderer.c
@@ -245,8 +245,7 @@ static nt_pipeline_t get_active_cap_inst_pipeline(void) { return s_shape.depth_e
 
 static nt_pipeline_t get_active_line_pipeline(void) { return s_shape.depth_enabled ? s_shape.line_pip_depth : s_shape.line_pip_overlay; }
 
-/* Vertex/instance layouts now live on the vertex-input objects; the depth and
- * overlay pipeline pair for each program shares one vertex input. */
+/* Matching depth/overlay layouts share one vertex input per program. */
 static nt_vertex_layout_t batch_vertex_layout(void) {
     return (nt_vertex_layout_t){
         .attr_count = 2,

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -29,6 +29,10 @@
 // #region module state
 typedef struct {
     nt_pipeline_t pipeline;
+    /* Snapshotted with the pipeline: two custom layouts can share one pipeline
+     * (pipelines no longer own layouts), so replay delta-binds the vertex
+     * input independently of pipeline changes. */
+    nt_vertex_input_t vertex_input;
     nt_material_t material; /* handle for material-param lookup at flush; param values
                                are NOT snapshotted — material info is stable within a
                                frame (nt_material_step ran before render) so we
@@ -47,6 +51,15 @@ static struct {
     uint16_t max_pipelines;
     nt_renderer_pipeline_entry_t entries[NT_SPRITE_RENDERER_MAX_PIPELINES_HARDCAP];
     uint16_t count;
+
+    /* Vertex-input cache keyed by the layout hash (0 = base 20 B layout).
+     * All layouts bake over the one (vbo, ibo) pair; layout populations are a
+     * subset of pipeline populations, so the same hardcap bounds it. */
+    struct {
+        uint64_t key;
+        nt_vertex_input_t vi;
+    } vi_entries[NT_SPRITE_RENDERER_MAX_PIPELINES_HARDCAP];
+    uint16_t vi_count;
 
     nt_buffer_t vbo; /* dynamic, sized for the worst single flush (staging_size) */
     nt_buffer_t ibo; /* dynamic, sized for max_indices * 2 (uint16 indices) */
@@ -194,6 +207,10 @@ void nt_sprite_renderer_shutdown(void) {
         s_sprite.entries[i] = (nt_renderer_pipeline_entry_t){0};
     }
     s_sprite.count = 0;
+    for (uint16_t i = 0; i < s_sprite.vi_count; i++) {
+        nt_gfx_destroy_vertex_input(s_sprite.vi_entries[i].vi);
+    }
+    s_sprite.vi_count = 0;
     nt_gfx_destroy_buffer(s_sprite.vbo);
     nt_gfx_destroy_buffer(s_sprite.ibo);
     memset(&s_sprite, 0, sizeof(s_sprite));
@@ -295,10 +312,9 @@ static nt_pipeline_t find_or_create_pipeline(const nt_material_info_t *mat_info)
         nt_renderer_warn_program_not_ready(&s_sprite.warned_program_not_ready, mat_info);
         return (nt_pipeline_t){0};
     }
-    /* Include the layout discriminator even for the base layout (zero), so
-     * custom attributes cannot alias the base pipeline. */
-    uint64_t key = nt_sprite_layout_hash(mat_info);
-    key = key * 0x9E3779B97F4A7C15ULL + mat_info->program.id;
+    /* Layouts live on the vertex-input cache now, so two custom layouts can
+     * share one pipeline: the key is program x render state only. */
+    uint64_t key = (uint64_t)mat_info->program.id * 0x9E3779B97F4A7C15ULL;
     key = key * 0x9E3779B97F4A7C15ULL + mat_info->render_state_hash;
 
     const nt_pipeline_t cached = nt_renderer_pipeline_cache_find(s_sprite.entries, s_sprite.count, key);
@@ -309,7 +325,6 @@ static nt_pipeline_t find_or_create_pipeline(const nt_material_info_t *mat_info)
     nt_pipeline_desc_t desc;
     memset(&desc, 0, sizeof(desc));
     desc.program = mat_info->program;
-    desc.layout = build_sprite_layout(mat_info);
     desc.depth_test = mat_info->depth_test;
     desc.depth_write = mat_info->depth_write;
     desc.depth_func = NT_DEPTH_LESS;
@@ -318,6 +333,40 @@ static nt_pipeline_t find_or_create_pipeline(const nt_material_info_t *mat_info)
     desc.label = (mat_info->label != NULL) ? mat_info->label : "sprite_pipeline";
 
     return nt_renderer_pipeline_cache_insert(s_sprite.entries, &s_sprite.count, s_sprite.max_pipelines, key, &desc, &s_sprite.warned_program_not_ready);
+}
+
+/* One vertex input per distinct layout, all baked over the shared (vbo, ibo)
+ * pair. Cached handles are revalidated on lookup: context loss (or a buffer
+ * cascade) kills them without notifying the renderer. */
+static nt_vertex_input_t find_or_create_vertex_input(const nt_material_info_t *mat_info) {
+    const uint64_t key = nt_sprite_layout_hash(mat_info);
+    for (uint16_t i = 0; i < s_sprite.vi_count; i++) {
+        if (s_sprite.vi_entries[i].key != key) {
+            continue;
+        }
+        if (!nt_gfx_vertex_input_valid(s_sprite.vi_entries[i].vi)) {
+            s_sprite.vi_entries[i].vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){
+                .layout = build_sprite_layout(mat_info),
+                .vertex_buffer = s_sprite.vbo,
+                .index_buffer = s_sprite.ibo,
+                .label = "sprite_vi",
+            });
+        }
+        return s_sprite.vi_entries[i].vi;
+    }
+    NT_ASSERT(s_sprite.vi_count < NT_SPRITE_RENDERER_MAX_PIPELINES_HARDCAP && "sprite vertex-input cache full; raise NT_SPRITE_RENDERER_MAX_PIPELINES_HARDCAP");
+    nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){
+        .layout = build_sprite_layout(mat_info),
+        .vertex_buffer = s_sprite.vbo,
+        .index_buffer = s_sprite.ibo,
+        .label = "sprite_vi",
+    });
+    if (vi.id != 0) {
+        s_sprite.vi_entries[s_sprite.vi_count].key = key;
+        s_sprite.vi_entries[s_sprite.vi_count].vi = vi;
+        s_sprite.vi_count++;
+    }
+    return vi;
 }
 // #endregion
 
@@ -347,6 +396,7 @@ static void open_cmd(nt_pipeline_t pip, const nt_material_info_t *mi, nt_materia
     nt_sprite_draw_cmd_t *c = &s_sprite.cmds[s_sprite.cmd_count++];
     memset(c, 0, sizeof(*c)); /* slots reuse across frames; clear stale fields */
     c->pipeline = pip;
+    c->vertex_input = find_or_create_vertex_input(mi);
     c->material = mat;
     s_sprite.current_mat = mat;
     s_sprite.current_program = mi->program;
@@ -1318,7 +1368,7 @@ void nt_sprite_renderer_flush(void) {
     }
 
     uint32_t bound_pipeline_id = 0;
-    uint32_t bound_ibo_id = 0;
+    uint32_t bound_vi_id = 0;
     uint32_t bound_tex_ids[NT_MATERIAL_MAX_TEXTURES] = {0};
     /* Tracked separately so override→no-override cmd transitions reset to default. */
     uint32_t bound_sampler_ids[NT_MATERIAL_MAX_TEXTURES] = {0};
@@ -1327,30 +1377,30 @@ void nt_sprite_renderer_flush(void) {
     for (uint32_t ci = 0; ci < s_sprite.cmd_count; ci++) {
         const nt_sprite_draw_cmd_t *c = &s_sprite.cmds[ci];
 
-        /* Context loss or program destruction can invalidate a queued pipeline. */
-        if (!nt_gfx_pipeline_valid(c->pipeline)) {
+        /* Context loss or program destruction can invalidate a queued pipeline;
+         * the vertex input dies with the context or a buffer cascade. */
+        if (!nt_gfx_pipeline_valid(c->pipeline) || !nt_gfx_vertex_input_valid(c->vertex_input)) {
             continue;
         }
 
         bool pipeline_changed = false;
         if (c->pipeline.id != bound_pipeline_id) {
-            /* GL ordering: each pipeline owns a VAO, and GL_ELEMENT_ARRAY_BUFFER
-             * is part of VAO state. So pipeline → VBO (re-applies attribs into
-             * the new VAO) → IBO (binds the EBO into the new VAO). Reordering
-             * any of these breaks the next draw silently. */
             nt_gfx_bind_pipeline(c->pipeline);
-            nt_gfx_bind_vertex_buffer(s_sprite.vbo);
             bound_pipeline_id = c->pipeline.id;
-            bound_ibo_id = 0;
+            /* bind_pipeline clears the bound vertex input (transitional rule),
+             * so re-bind it below even if the cmd's handle didn't change. */
+            bound_vi_id = 0;
             /* Params and sampler uniforms belong to programs and need replay.
              * Texture-unit bindings belong to the context and survive the switch. */
             bound_mat_id = 0;
             pipeline_changed = true;
         }
 
-        if (s_sprite.ibo.id != bound_ibo_id) {
-            nt_gfx_bind_index_buffer(s_sprite.ibo);
-            bound_ibo_id = s_sprite.ibo.id;
+        /* Geometry is one bind, independent of pipeline changes: two custom
+         * layouts can share a pipeline and still switch vertex inputs here. */
+        if (c->vertex_input.id != bound_vi_id) {
+            nt_gfx_bind_vertex_input(c->vertex_input);
+            bound_vi_id = c->vertex_input.id;
         }
 
         /* Destroyed materials contribute no params; queued commands retain
@@ -1443,6 +1493,7 @@ void nt_sprite_renderer_test_last_emit_radial(uint32_t v_idx, float *out, uint8_
 }
 
 uint32_t nt_sprite_renderer_test_pipeline_cache_count(void) { return s_sprite.count; }
+uint32_t nt_sprite_renderer_test_vertex_input_cache_count(void) { return s_sprite.vi_count; }
 
 uint32_t nt_sprite_renderer_test_cmd_count(void) { return s_sprite.cmd_count; }
 uint32_t nt_sprite_renderer_test_draw_call_count(void) { return s_sprite.last_draw_list_calls; }

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -121,6 +121,58 @@ static struct {
 // #endregion
 
 // #region lifecycle
+static nt_result_t create_gpu_resources(void) {
+    s_sprite.vbo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
+        .type = NT_BUFFER_VERTEX,
+        .usage = NT_USAGE_DYNAMIC,
+        .size = s_sprite.staging_size,
+        .label = "sprite_vbo",
+    });
+    if (s_sprite.vbo.id == 0) {
+        return NT_ERR_INIT_FAILED;
+    }
+    s_sprite.ibo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
+        .type = NT_BUFFER_INDEX,
+        .usage = NT_USAGE_DYNAMIC,
+        .size = s_sprite.max_indices * (uint32_t)sizeof(uint16_t),
+        .index_type = NT_INDEX_UINT16,
+        .label = "sprite_ibo",
+    });
+    if (s_sprite.ibo.id == 0) {
+        nt_gfx_destroy_buffer(s_sprite.vbo);
+        s_sprite.vbo = (nt_buffer_t){0};
+        return NT_ERR_INIT_FAILED;
+    }
+    return NT_OK;
+}
+
+static void destroy_gpu_resources(void) {
+    for (uint16_t i = 0; i < s_sprite.count; i++) {
+        nt_gfx_destroy_pipeline(s_sprite.entries[i].pipeline);
+    }
+    s_sprite.count = 0;
+    for (uint16_t i = 0; i < s_sprite.vi_count; i++) {
+        nt_gfx_destroy_vertex_input(s_sprite.vi_entries[i].vi);
+    }
+    s_sprite.vi_count = 0;
+    nt_gfx_destroy_buffer(s_sprite.vbo);
+    nt_gfx_destroy_buffer(s_sprite.ibo);
+    s_sprite.vbo = (nt_buffer_t){0};
+    s_sprite.ibo = (nt_buffer_t){0};
+
+    /* Queued commands reference the discarded GPU objects; never flush them. */
+    s_sprite.cmd_count = 0;
+    s_sprite.vertex_count = 0;
+    s_sprite.index_count = 0;
+    s_sprite.cur_stride = 0;
+    s_sprite.cur_custom_bytes = 0;
+    s_sprite.cur_material_custom_bytes = 0;
+    s_sprite.current_mat = (nt_material_t){0};
+    s_sprite.current_program = NT_PROGRAM_INVALID;
+    s_sprite.last_draw_list_calls = 0;
+    s_sprite.warned_program_not_ready = false;
+}
+
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 nt_result_t nt_sprite_renderer_init(const nt_sprite_renderer_desc_t *desc) {
     NT_ASSERT(!s_sprite.initialized);
@@ -156,37 +208,16 @@ nt_result_t nt_sprite_renderer_init(const nt_sprite_renderer_desc_t *desc) {
     const uint32_t custom_bytes = d.custom_max_vertices * (NT_SPRITE_BASE_STRIDE + NT_SPRITE_CUSTOM_STRIDE_MAX);
     s_sprite.staging_size = (plain_bytes > custom_bytes) ? plain_bytes : custom_bytes;
 
-    /* Dynamic VBO and IBO. Pattern: nt_text_renderer.c init code. Sized to
-     * staging_size so any single flush's direct upload fits. */
-    s_sprite.vbo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
-        .type = NT_BUFFER_VERTEX,
-        .usage = NT_USAGE_DYNAMIC,
-        .size = s_sprite.staging_size,
-        .label = "sprite_vbo",
-    });
-    NT_ASSERT(s_sprite.vbo.id != 0);
-
-    s_sprite.ibo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
-        .type = NT_BUFFER_INDEX,
-        .usage = NT_USAGE_DYNAMIC,
-        .size = d.max_indices * (uint32_t)sizeof(uint16_t),
-        .index_type = NT_INDEX_UINT16,
-        .label = "sprite_ibo",
-    });
-    NT_ASSERT(s_sprite.ibo.id != 0);
-
     /* Heap-backed CPU staging (mirrors nt_mesh_renderer): one variable-stride
      * byte buffer holds base + interleaved custom block by construction, so flush
      * uploads it directly with no interleave pass. */
     s_sprite.staging = (uint8_t *)calloc(1, s_sprite.staging_size);
     s_sprite.indices = (uint16_t *)calloc(d.max_indices, sizeof(uint16_t));
-    if (s_sprite.staging == NULL || s_sprite.indices == NULL) {
+    if (s_sprite.staging == NULL || s_sprite.indices == NULL || create_gpu_resources() != NT_OK) {
         free(s_sprite.staging);
         free(s_sprite.indices);
-        nt_gfx_destroy_buffer(s_sprite.vbo);
-        nt_gfx_destroy_buffer(s_sprite.ibo);
         memset(&s_sprite, 0, sizeof(s_sprite));
-        NT_LOG_ERROR("failed to allocate sprite CPU staging");
+        NT_LOG_ERROR("failed to initialize sprite renderer");
         return NT_ERR_INIT_FAILED;
     }
 
@@ -198,41 +229,18 @@ void nt_sprite_renderer_shutdown(void) {
     if (!s_sprite.initialized) {
         return;
     }
-    /* Free CPU staging first (final memset also zeros, but free before reset). */
+    destroy_gpu_resources();
     free(s_sprite.staging);
     free(s_sprite.indices);
-    s_sprite.staging = NULL;
-    s_sprite.indices = NULL;
-    /* Destroy pipelines in cache */
-    for (uint16_t i = 0; i < s_sprite.count; i++) {
-        nt_gfx_destroy_pipeline(s_sprite.entries[i].pipeline);
-        s_sprite.entries[i] = (nt_renderer_pipeline_entry_t){0};
-    }
-    s_sprite.count = 0;
-    for (uint16_t i = 0; i < s_sprite.vi_count; i++) {
-        nt_gfx_destroy_vertex_input(s_sprite.vi_entries[i].vi);
-    }
-    s_sprite.vi_count = 0;
-    nt_gfx_destroy_buffer(s_sprite.vbo);
-    nt_gfx_destroy_buffer(s_sprite.ibo);
     memset(&s_sprite, 0, sizeof(s_sprite));
 }
 
-void nt_sprite_renderer_restore_gpu(void) {
+nt_result_t nt_sprite_renderer_restore_gpu(void) {
     if (!s_sprite.initialized) {
-        return;
+        return NT_OK;
     }
-    uint16_t saved_pip = s_sprite.max_pipelines;
-    uint32_t saved_max_v = s_sprite.max_vertices;
-    uint32_t saved_max_i = s_sprite.max_indices;
-    uint32_t saved_custom_v = s_sprite.custom_max_vertices;
-    nt_sprite_renderer_shutdown();
-    nt_sprite_renderer_desc_t desc = {.max_pipelines = saved_pip, .max_vertices = saved_max_v, .max_indices = saved_max_i, .custom_max_vertices = saved_custom_v};
-    /* Outside the assert: NT_ASSERT does not evaluate its expression under OFF,
-     * which would leave the renderer shut down after every context restore. */
-    const nt_result_t res = nt_sprite_renderer_init(&desc);
-    NT_ASSERT(res == NT_OK);
-    (void)res;
+    destroy_gpu_resources();
+    return create_gpu_resources();
 }
 // #endregion
 
@@ -495,8 +503,10 @@ void nt_sprite_renderer_set_custom_attrs(const float *attrs, uint8_t bytes) {
 // #endregion
 
 // #region set_material
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_sprite_renderer_set_material(nt_material_t mat) {
     NT_ASSERT(s_sprite.initialized);
+    NT_ASSERT(s_sprite.vbo.id != 0 && s_sprite.ibo.id != 0 && "retry failed GPU restore before submitting materials");
     NT_ASSERT(mat.id != 0 && "nt_sprite_renderer_set_material: invalid material handle");
 
     /* Validate BEFORE same-handle early return: stale handle (destroyed material,
@@ -1290,12 +1300,14 @@ void nt_sprite_renderer_emit_slice9(nt_resource_t atlas, uint32_t region_index, 
 
 // #region draw_list
 /* Emit pass: stream verts into staging per batch_key; flush() does the upload. */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_sprite_renderer_draw_list(const nt_render_item_t *items, uint32_t count) {
     NT_ASSERT(s_sprite.initialized);
     if (count == 0) {
         return;
     }
     NT_ASSERT(items != NULL);
+    NT_ASSERT(s_sprite.vbo.id != 0 && s_sprite.ibo.id != 0 && "retry failed GPU restore before drawing");
 
     s_sprite.last_draw_list_calls = 0;
     s_sprite.cur_custom_bytes = 0; /* ECS sprite path emits no custom attrs */

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -29,9 +29,7 @@
 // #region module state
 typedef struct {
     nt_pipeline_t pipeline;
-    /* Snapshotted with the pipeline: two custom layouts can share one pipeline
-     * (pipelines no longer own layouts), so replay delta-binds the vertex
-     * input independently of pipeline changes. */
+    /* Captured independently because custom layouts may share a pipeline. */
     nt_vertex_input_t vertex_input;
     nt_material_t material; /* handle for material-param lookup at flush; param values
                                are NOT snapshotted — material info is stable within a
@@ -52,11 +50,8 @@ static struct {
     nt_renderer_pipeline_entry_t entries[NT_SPRITE_RENDERER_MAX_PIPELINES_HARDCAP];
     uint16_t count;
 
-    /* Vertex-input cache keyed by the layout hash (0 = base 20 B layout).
-     * All layouts bake over the one (vbo, ibo) pair. Bounded by distinct
-     * custom attr_map layouts -- one pipeline (program x render state) can
-     * host many of them, so this population is independent of the pipeline
-     * count; the hardcap is shared only as a sizing choice. */
+    /* Layout-hash cache over the shared VBO/IBO; custom layouts may share a
+     * pipeline. The pipeline hardcap is reused only as a capacity choice. */
     struct {
         uint64_t key;
         nt_vertex_input_t vi;
@@ -322,8 +317,7 @@ static nt_pipeline_t find_or_create_pipeline(const nt_material_info_t *mat_info)
         nt_renderer_warn_program_not_ready(&s_sprite.warned_program_not_ready, mat_info);
         return (nt_pipeline_t){0};
     }
-    /* Layouts live on the vertex-input cache now, so two custom layouts can
-     * share one pipeline: the key is program x render state only. */
+    /* Vertex-inputs own layouts, so the pipeline key is program x state. */
     uint64_t key = (uint64_t)mat_info->program.id * 0x9E3779B97F4A7C15ULL;
     key = key * 0x9E3779B97F4A7C15ULL + mat_info->render_state_hash;
 

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -337,23 +337,14 @@ static nt_pipeline_t find_or_create_pipeline(const nt_material_info_t *mat_info)
     return nt_renderer_pipeline_cache_insert(s_sprite.entries, &s_sprite.count, s_sprite.max_pipelines, key, &desc, &s_sprite.warned_program_not_ready);
 }
 
-/* One vertex input per distinct layout, all baked over the shared (vbo, ibo)
- * pair. Cached handles are revalidated on lookup: the destroy-buffer cascade
- * (restore_gpu recreates vbo/ibo) kills them without notifying the renderer. */
+/* The renderer owns both buffers and clears the cache before replacing them. */
 static nt_vertex_input_t find_or_create_vertex_input(const nt_material_info_t *mat_info) {
     const uint64_t key = nt_sprite_layout_hash(mat_info);
     for (uint16_t i = 0; i < s_sprite.vi_count; i++) {
         if (s_sprite.vi_entries[i].key != key) {
             continue;
         }
-        if (!nt_gfx_vertex_input_valid(s_sprite.vi_entries[i].vi)) {
-            s_sprite.vi_entries[i].vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){
-                .layout = build_sprite_layout(mat_info),
-                .vertex_buffer = s_sprite.vbo,
-                .index_buffer = s_sprite.ibo,
-                .label = "sprite_vi",
-            });
-        }
+        NT_ASSERT(nt_gfx_vertex_input_valid(s_sprite.vi_entries[i].vi));
         return s_sprite.vi_entries[i].vi;
     }
     NT_ASSERT(s_sprite.vi_count < NT_SPRITE_RENDERER_MAX_PIPELINES_HARDCAP && "sprite vertex-input cache full; raise NT_SPRITE_RENDERER_MAX_PIPELINES_HARDCAP");

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -345,19 +345,27 @@ static nt_pipeline_t find_or_create_pipeline(const nt_material_info_t *mat_info)
     return nt_renderer_pipeline_cache_insert(s_sprite.entries, &s_sprite.count, s_sprite.max_pipelines, key, &desc, &s_sprite.warned_program_not_ready);
 }
 
-/* The renderer owns both buffers and clears the cache before replacing them. */
+/* Entries are weak: a context loss frees vertex-input slots, so a hit
+ * validates and a dead entry recreates in place (the mesh-row pattern) --
+ * repeated losses must not grow the cache toward the hardcap. */
 static nt_vertex_input_t find_or_create_vertex_input(const nt_material_info_t *mat_info) {
     const uint64_t key = nt_sprite_layout_hash(mat_info);
+    uint16_t idx = s_sprite.vi_count;
     for (uint16_t i = 0; i < s_sprite.vi_count; i++) {
         if (s_sprite.vi_entries[i].key != key) {
             continue;
         }
-        NT_ASSERT(nt_gfx_vertex_input_valid(s_sprite.vi_entries[i].vi));
-        return s_sprite.vi_entries[i].vi;
+        if (nt_gfx_vertex_input_valid(s_sprite.vi_entries[i].vi)) {
+            return s_sprite.vi_entries[i].vi;
+        }
+        idx = i; /* dead entry: recreate in place */
+        break;
     }
-    NT_ASSERT(s_sprite.vi_count < NT_SPRITE_RENDERER_MAX_PIPELINES_HARDCAP && "sprite vertex-input cache full; raise NT_SPRITE_RENDERER_MAX_PIPELINES_HARDCAP");
-    if (s_sprite.vi_count >= NT_SPRITE_RENDERER_MAX_PIPELINES_HARDCAP) {
-        return NT_VERTEX_INPUT_INVALID; /* OFF-mode guard, same as the mesh versions table */
+    if (idx == s_sprite.vi_count) {
+        NT_ASSERT(s_sprite.vi_count < NT_SPRITE_RENDERER_MAX_PIPELINES_HARDCAP && "sprite vertex-input cache full; raise NT_SPRITE_RENDERER_MAX_PIPELINES_HARDCAP");
+        if (s_sprite.vi_count >= NT_SPRITE_RENDERER_MAX_PIPELINES_HARDCAP) {
+            return NT_VERTEX_INPUT_INVALID; /* OFF-mode guard, same as the mesh versions table */
+        }
     }
     nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){
         .layout = build_sprite_layout(mat_info),
@@ -366,9 +374,11 @@ static nt_vertex_input_t find_or_create_vertex_input(const nt_material_info_t *m
         .label = "sprite_vi",
     });
     if (vi.id != 0) {
-        s_sprite.vi_entries[s_sprite.vi_count].key = key;
-        s_sprite.vi_entries[s_sprite.vi_count].vi = vi;
-        s_sprite.vi_count++;
+        s_sprite.vi_entries[idx].key = key;
+        s_sprite.vi_entries[idx].vi = vi;
+        if (idx == s_sprite.vi_count) {
+            s_sprite.vi_count++;
+        }
     }
     return vi;
 }

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -53,8 +53,10 @@ static struct {
     uint16_t count;
 
     /* Vertex-input cache keyed by the layout hash (0 = base 20 B layout).
-     * All layouts bake over the one (vbo, ibo) pair; layout populations are a
-     * subset of pipeline populations, so the same hardcap bounds it. */
+     * All layouts bake over the one (vbo, ibo) pair. Bounded by distinct
+     * custom attr_map layouts -- one pipeline (program x render state) can
+     * host many of them, so this population is independent of the pipeline
+     * count; the hardcap is shared only as a sizing choice. */
     struct {
         uint64_t key;
         nt_vertex_input_t vi;
@@ -336,8 +338,8 @@ static nt_pipeline_t find_or_create_pipeline(const nt_material_info_t *mat_info)
 }
 
 /* One vertex input per distinct layout, all baked over the shared (vbo, ibo)
- * pair. Cached handles are revalidated on lookup: context loss (or a buffer
- * cascade) kills them without notifying the renderer. */
+ * pair. Cached handles are revalidated on lookup: the destroy-buffer cascade
+ * (restore_gpu recreates vbo/ibo) kills them without notifying the renderer. */
 static nt_vertex_input_t find_or_create_vertex_input(const nt_material_info_t *mat_info) {
     const uint64_t key = nt_sprite_layout_hash(mat_info);
     for (uint16_t i = 0; i < s_sprite.vi_count; i++) {
@@ -355,6 +357,9 @@ static nt_vertex_input_t find_or_create_vertex_input(const nt_material_info_t *m
         return s_sprite.vi_entries[i].vi;
     }
     NT_ASSERT(s_sprite.vi_count < NT_SPRITE_RENDERER_MAX_PIPELINES_HARDCAP && "sprite vertex-input cache full; raise NT_SPRITE_RENDERER_MAX_PIPELINES_HARDCAP");
+    if (s_sprite.vi_count >= NT_SPRITE_RENDERER_MAX_PIPELINES_HARDCAP) {
+        return NT_VERTEX_INPUT_INVALID; /* OFF-mode guard, same as the mesh versions table */
+    }
     nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){
         .layout = build_sprite_layout(mat_info),
         .vertex_buffer = s_sprite.vbo,
@@ -1387,9 +1392,6 @@ void nt_sprite_renderer_flush(void) {
         if (c->pipeline.id != bound_pipeline_id) {
             nt_gfx_bind_pipeline(c->pipeline);
             bound_pipeline_id = c->pipeline.id;
-            /* bind_pipeline clears the bound vertex input (transitional rule),
-             * so re-bind it below even if the cmd's handle didn't change. */
-            bound_vi_id = 0;
             /* Params and sampler uniforms belong to programs and need replay.
              * Texture-unit bindings belong to the context and survive the switch. */
             bound_mat_id = 0;

--- a/engine/renderers/nt_sprite_renderer.h
+++ b/engine/renderers/nt_sprite_renderer.h
@@ -192,6 +192,7 @@ void nt_sprite_renderer_test_layout(nt_material_t mat, nt_sprite_layout_info_t *
  * emit, from the byte-staging path. float_count floats written. */
 void nt_sprite_renderer_test_last_emit_radial(uint32_t v_idx, float *out, uint8_t float_count);
 uint32_t nt_sprite_renderer_test_pipeline_cache_count(void);
+uint32_t nt_sprite_renderer_test_vertex_input_cache_count(void);
 /* Draw commands staged but not yet flushed. */
 uint32_t nt_sprite_renderer_test_cmd_count(void);
 /* Per-renderer test counter (separate from nt_gfx_get_frame_draw_calls). */

--- a/engine/renderers/nt_sprite_renderer.h
+++ b/engine/renderers/nt_sprite_renderer.h
@@ -85,9 +85,10 @@ static inline uint32_t nt_sprite_renderer_batch_key(nt_material_t material, nt_r
 
 nt_result_t nt_sprite_renderer_init(const nt_sprite_renderer_desc_t *desc);
 void nt_sprite_renderer_shutdown(void);
-/* Full reset: drops every queued draw command and every cached pipeline, then
- * rebuilds the GPU-side buffers. */
-void nt_sprite_renderer_restore_gpu(void);
+/* Retains CPU storage and initialization; drops queued draws and GPU caches.
+ * Failure returns NT_ERR_INIT_FAILED: retry before drawing/setting materials, or shut down.
+ * Inactive modules are unchanged and return NT_OK. */
+nt_result_t nt_sprite_renderer_restore_gpu(void);
 
 /* Contracts:
  *   1. Atlas page texture binds to slot 0; material may override sampler.

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -152,9 +152,8 @@ static nt_pipeline_t find_or_create_pipeline(void) {
 // #endregion
 
 // #region Lifecycle
-/* Buffer creation can fail only on a lost context; skip the vertex input
- * then (make_vertex_input traps on invalid buffer handles). Flush retries
- * this after a recoverable backend failure, like the lazy pipeline cache. */
+/* Missing buffers make VI creation invalid; restore reports their failure.
+ * A VI-only backend failure remains lazy and flush retries it. */
 static void create_vertex_input(void) {
     if (s_text.vbo.id == 0 || s_text.ibo.id == 0) {
         return;

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -249,8 +249,13 @@ nt_result_t nt_text_renderer_restore_gpu(void) {
     create_gpu_resources();
     s_text.vertex_count = 0; /* in-flight staging is dropped across context loss */
     s_text.glyph_count = 0;  /* The first quad of the next batch resolves a new pipeline. */
+    if (s_text.vbo.id == 0 || s_text.ibo.id == 0) {
+        /* Restore contract: failure releases partial GPU resources. */
+        destroy_gpu_resources();
+        return NT_ERR_INIT_FAILED;
+    }
     /* The vertex input is not part of the verdict: flush retries it lazily. */
-    return (s_text.vbo.id != 0 && s_text.ibo.id != 0) ? NT_OK : NT_ERR_INIT_FAILED;
+    return NT_OK;
 }
 // #endregion
 

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -152,6 +152,35 @@ static nt_pipeline_t find_or_create_pipeline(void) {
 // #endregion
 
 // #region Lifecycle
+/* Buffer creation can fail only on a lost context; skip the vertex input
+ * then (make_vertex_input traps on invalid buffer handles). Flush retries
+ * this after a recoverable backend failure, like the lazy pipeline cache. */
+static void create_vertex_input(void) {
+    if (s_text.vbo.id == 0 || s_text.ibo.id == 0) {
+        return;
+    }
+    /* Slug vertex layout: 6 attributes, stride = 72 bytes */
+    s_text.vertex_input = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){
+        .layout =
+            {
+                .attr_count = 6,
+                .stride = 72,
+                .attrs =
+                    {
+                        {.location = 0, .type = NT_VERTEX_FLOAT, .count = 3, .offset = 0},  /* a_position */
+                        {.location = 1, .type = NT_VERTEX_FLOAT, .count = 2, .offset = 12}, /* a_texcoord */
+                        {.location = 2, .type = NT_VERTEX_FLOAT, .count = 4, .offset = 20}, /* a_glyph_data */
+                        {.location = 3, .type = NT_VERTEX_FLOAT, .count = 4, .offset = 36}, /* a_glyph_bounds */
+                        {.location = 4, .type = NT_VERTEX_FLOAT, .count = 4, .offset = 52}, /* a_color */
+                        {.location = 5, .type = NT_VERTEX_FLOAT, .count = 1, .offset = 68}, /* a_depth_bias */
+                    },
+            },
+        .vertex_buffer = s_text.vbo,
+        .index_buffer = s_text.ibo,
+        .label = "text_vi",
+    });
+}
+
 /* GPU resources only — pipelines are built lazily on a cache miss, so this owns just the buffers +
  * index pattern. Must not touch s_text's logical fields; restore_gpu rebuilds these without wiping them. */
 static void create_gpu_resources(void) {
@@ -170,30 +199,7 @@ static void create_gpu_resources(void) {
         .index_type = NT_INDEX_UINT16,
         .label = "text_ibo",
     });
-    /* Buffer creation can fail only on a lost context; skip the vertex input
-     * then (make_vertex_input traps on invalid buffer handles). */
-    if (s_text.vbo.id != 0 && s_text.ibo.id != 0) {
-        /* Slug vertex layout: 6 attributes, stride = 72 bytes */
-        s_text.vertex_input = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){
-            .layout =
-                {
-                    .attr_count = 6,
-                    .stride = 72,
-                    .attrs =
-                        {
-                            {.location = 0, .type = NT_VERTEX_FLOAT, .count = 3, .offset = 0},  /* a_position */
-                            {.location = 1, .type = NT_VERTEX_FLOAT, .count = 2, .offset = 12}, /* a_texcoord */
-                            {.location = 2, .type = NT_VERTEX_FLOAT, .count = 4, .offset = 20}, /* a_glyph_data */
-                            {.location = 3, .type = NT_VERTEX_FLOAT, .count = 4, .offset = 36}, /* a_glyph_bounds */
-                            {.location = 4, .type = NT_VERTEX_FLOAT, .count = 4, .offset = 52}, /* a_color */
-                            {.location = 5, .type = NT_VERTEX_FLOAT, .count = 1, .offset = 68}, /* a_depth_bias */
-                        },
-                },
-            .vertex_buffer = s_text.vbo,
-            .index_buffer = s_text.ibo,
-            .label = "text_vi",
-        });
-    }
+    create_vertex_input();
 }
 
 static void destroy_gpu_resources(void) {
@@ -709,10 +715,15 @@ void nt_text_renderer_flush(void) {
     if (s_text.glyph_count == 0) {
         return;
     }
+    /* A recoverable creation failure (backend VAO alloc) must not disable
+     * text until the next restore -- retry lazily, like the pipeline cache. */
+    if (!nt_gfx_vertex_input_valid(s_text.vertex_input)) {
+        create_vertex_input();
+    }
     /* Resolved when the batch opened. Re-checked rather than trusted: destroying
      * a program destroys the pipelines built on it, and that can happen between
-     * the first glyph and here. The vertex input can be missing after a failed
-     * backend allocation in create_gpu_resources. */
+     * the first glyph and here. The vertex input stays invalid when the retry
+     * above failed (context still lost / backend failure). */
     const nt_pipeline_t pipeline = s_text.batch_pipeline;
     if (!nt_gfx_pipeline_valid(pipeline) || !nt_gfx_vertex_input_valid(s_text.vertex_input)) {
         /* Unready programs were reported at batch open; destruction of a captured

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -47,8 +47,9 @@ static struct {
     /* GPU resources */
     nt_renderer_pipeline_entry_t pipelines[NT_TEXT_RENDERER_MAX_PIPELINES];
     uint16_t pipeline_count;
-    nt_buffer_t vbo; /* dynamic vertex buffer */
-    nt_buffer_t ibo; /* immutable index buffer (pre-generated quad pattern) */
+    nt_buffer_t vbo;                /* dynamic vertex buffer */
+    nt_buffer_t ibo;                /* immutable index buffer (pre-generated quad pattern) */
+    nt_vertex_input_t vertex_input; /* slug layout baked over vbo+ibo */
 
     /* CPU staging buffer (compile-time arrays) */
     nt_text_vertex_t vertices[NT_TEXT_RENDERER_MAX_VERTICES];
@@ -118,7 +119,8 @@ static void generate_quad_indices(void) {
 // #endregion
 
 // #region Pipeline cache
-/* The key omits layout, depth_func and label because they are constant here. */
+/* The key omits depth_func and label because they are constant here; vertex
+ * input is a separate owned object, not pipeline state. */
 static nt_pipeline_t find_or_create_pipeline(void) {
     const nt_material_info_t *info = nt_material_get_info(s_text.material);
     const nt_program_t program = (info != NULL) ? info->program : NT_PROGRAM_INVALID;
@@ -135,25 +137,9 @@ static nt_pipeline_t find_or_create_pipeline(void) {
         return cached;
     }
 
-    /* Slug vertex layout: 6 attributes, stride = 72 bytes */
-    nt_vertex_layout_t layout = {
-        .attr_count = 6,
-        .stride = 72,
-        .attrs =
-            {
-                {.location = 0, .type = NT_VERTEX_FLOAT, .count = 3, .offset = 0},  /* a_position */
-                {.location = 1, .type = NT_VERTEX_FLOAT, .count = 2, .offset = 12}, /* a_texcoord */
-                {.location = 2, .type = NT_VERTEX_FLOAT, .count = 4, .offset = 20}, /* a_glyph_data */
-                {.location = 3, .type = NT_VERTEX_FLOAT, .count = 4, .offset = 36}, /* a_glyph_bounds */
-                {.location = 4, .type = NT_VERTEX_FLOAT, .count = 4, .offset = 52}, /* a_color */
-                {.location = 5, .type = NT_VERTEX_FLOAT, .count = 1, .offset = 68}, /* a_depth_bias */
-            },
-    };
-
     /* Read render state from material — same pattern as mesh_renderer */
     const nt_pipeline_desc_t desc = {
         .program = program,
-        .layout = layout,
         .depth_test = info->depth_test,
         .depth_write = info->depth_write,
         .depth_func = NT_DEPTH_LEQUAL,
@@ -184,6 +170,30 @@ static void create_gpu_resources(void) {
         .index_type = NT_INDEX_UINT16,
         .label = "text_ibo",
     });
+    /* Buffer creation can fail only on a lost context; skip the vertex input
+     * then (make_vertex_input traps on invalid buffer handles). */
+    if (s_text.vbo.id != 0 && s_text.ibo.id != 0) {
+        /* Slug vertex layout: 6 attributes, stride = 72 bytes */
+        s_text.vertex_input = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){
+            .layout =
+                {
+                    .attr_count = 6,
+                    .stride = 72,
+                    .attrs =
+                        {
+                            {.location = 0, .type = NT_VERTEX_FLOAT, .count = 3, .offset = 0},  /* a_position */
+                            {.location = 1, .type = NT_VERTEX_FLOAT, .count = 2, .offset = 12}, /* a_texcoord */
+                            {.location = 2, .type = NT_VERTEX_FLOAT, .count = 4, .offset = 20}, /* a_glyph_data */
+                            {.location = 3, .type = NT_VERTEX_FLOAT, .count = 4, .offset = 36}, /* a_glyph_bounds */
+                            {.location = 4, .type = NT_VERTEX_FLOAT, .count = 4, .offset = 52}, /* a_color */
+                            {.location = 5, .type = NT_VERTEX_FLOAT, .count = 1, .offset = 68}, /* a_depth_bias */
+                        },
+                },
+            .vertex_buffer = s_text.vbo,
+            .index_buffer = s_text.ibo,
+            .label = "text_vi",
+        });
+    }
 }
 
 static void destroy_gpu_resources(void) {
@@ -193,8 +203,10 @@ static void destroy_gpu_resources(void) {
     }
     s_text.pipeline_count = 0;
     s_text.batch_pipeline = (nt_pipeline_t){0}; /* the cache it pointed into is gone */
+    nt_gfx_destroy_vertex_input(s_text.vertex_input);
     nt_gfx_destroy_buffer(s_text.vbo);
     nt_gfx_destroy_buffer(s_text.ibo);
+    s_text.vertex_input = NT_VERTEX_INPUT_INVALID;
     s_text.vbo = (nt_buffer_t){0};
     s_text.ibo = (nt_buffer_t){0};
 }
@@ -720,8 +732,7 @@ void nt_text_renderer_flush(void) {
     nt_gfx_orphan_buffer(s_text.vbo, s_text.vertices, s_text.vertex_count * (uint32_t)sizeof(nt_text_vertex_t));
 
     nt_gfx_bind_pipeline(pipeline);
-    nt_gfx_bind_vertex_buffer(s_text.vbo);
-    nt_gfx_bind_index_buffer(s_text.ibo);
+    nt_gfx_bind_vertex_input(s_text.vertex_input);
 
     /* Bind font textures */
     if (s_text.font.id != 0) {

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -711,13 +711,14 @@ void nt_text_renderer_flush(void) {
     }
     /* Resolved when the batch opened. Re-checked rather than trusted: destroying
      * a program destroys the pipelines built on it, and that can happen between
-     * the first glyph and here. */
+     * the first glyph and here. The vertex input can be missing after a failed
+     * backend allocation in create_gpu_resources. */
     const nt_pipeline_t pipeline = s_text.batch_pipeline;
-    if (!nt_gfx_pipeline_valid(pipeline)) {
+    if (!nt_gfx_pipeline_valid(pipeline) || !nt_gfx_vertex_input_valid(s_text.vertex_input)) {
         /* Unready programs were reported at batch open; destruction of a captured
          * pipeline or backend allocation failure still needs a warning. */
         if (!s_text.warned_no_pipeline) {
-            NT_LOG_WARN("nt_text_renderer_flush: no usable pipeline -- discarding %u glyphs", s_text.glyph_count);
+            NT_LOG_WARN("nt_text_renderer_flush: no usable pipeline or vertex input -- discarding %u glyphs", s_text.glyph_count);
             s_text.warned_no_pipeline = true;
         }
         s_text.vertex_count = 0;

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -780,6 +780,8 @@ void nt_text_renderer_flush(void) {
     s_text.vertex_count = 0;
     s_text.glyph_count = 0;
     s_text.batch_pipeline = (nt_pipeline_t){0};
+    /* Recovered: a later distinct failure warns again instead of going silent. */
+    s_text.warned_no_pipeline = false;
 }
 // #endregion
 

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -238,9 +238,9 @@ void nt_text_renderer_shutdown(void) {
     memset(&s_text, 0, sizeof(s_text));
 }
 
-void nt_text_renderer_restore_gpu(void) {
+nt_result_t nt_text_renderer_restore_gpu(void) {
     if (!s_text.initialized) {
-        return;
+        return NT_OK;
     }
     /* Context-loss recovery: rebuild ONLY GPU resources. Logical state (material, font,
      * glyph_depth_bias, oblique, sticky decoration) is left untouched, so it survives by default — no
@@ -249,6 +249,8 @@ void nt_text_renderer_restore_gpu(void) {
     create_gpu_resources();
     s_text.vertex_count = 0; /* in-flight staging is dropped across context loss */
     s_text.glyph_count = 0;  /* The first quad of the next batch resolves a new pipeline. */
+    /* The vertex input is not part of the verdict: flush retries it lazily. */
+    return (s_text.vbo.id != 0 && s_text.ibo.id != 0) ? NT_OK : NT_ERR_INIT_FAILED;
 }
 // #endregion
 

--- a/engine/renderers/nt_text_renderer.h
+++ b/engine/renderers/nt_text_renderer.h
@@ -33,9 +33,12 @@ _Static_assert(NT_TEXT_RENDERER_MAX_GLYPHS <= 16383, "NT_TEXT_RENDERER_MAX_GLYPH
 
 void nt_text_renderer_init(void);
 void nt_text_renderer_shutdown(void);
-/* Drops staged quads and cached pipelines, then rebuilds GPU buffers.
- * Material, font and decoration state are preserved. */
-void nt_text_renderer_restore_gpu(void);
+/* Drops staged quads and cached pipelines, then rebuilds GPU buffers; material,
+ * font and decoration state are preserved. Failure returns NT_ERR_INIT_FAILED:
+ * retry, or shut down (flush discards glyphs meanwhile instead of asserting; a
+ * failed vertex-input bake alone is retried lazily in flush and reports NT_OK).
+ * Inactive modules are unchanged and return NT_OK. */
+nt_result_t nt_text_renderer_restore_gpu(void);
 
 /* Requires an assigned slug_text program, premultiplied-compatible blend and cull NONE; setters flush on handle changes.
  * Declare u_alpha_cutoff on every material sharing the program or none: omitted uniforms retain prior values.

--- a/examples/atlas/main.c
+++ b/examples/atlas/main.c
@@ -190,7 +190,9 @@ static void frame(void) {
         });
         /* Materials retain their handles; rendering waits for relinking on a later frame.
          * Renderer reset and program destruction may run in either order without draws. */
-        nt_mesh_renderer_restore_gpu();
+        const nt_result_t restore_result = nt_mesh_renderer_restore_gpu();
+        NT_ASSERT(restore_result == NT_OK && "GPU restore failed");
+        (void)restore_result;
         nt_program_ref_drop(&s_program);
         nt_resource_invalidate(NT_ASSET_SHADER_CODE);
     }

--- a/examples/bench_shapes/main.c
+++ b/examples/bench_shapes/main.c
@@ -612,7 +612,8 @@ int main(void) {
     g_nt_window.height = 600;
     nt_window_init();
     nt_input_init();
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_programs = 16, .max_pipelines = 16, .max_buffers = 128, .max_textures = 16, .max_meshes = 64, .max_render_targets = 16, .depth = true});
+    nt_gfx_init(&(nt_gfx_desc_t){
+        .max_shaders = 32, .max_programs = 16, .max_pipelines = 16, .max_buffers = 128, .max_textures = 16, .max_meshes = 64, .max_vertex_inputs = 64, .max_render_targets = 16, .depth = true});
     nt_shape_renderer_init();
 
 #ifdef NT_PLATFORM_WEB

--- a/examples/bunnymark/main.c
+++ b/examples/bunnymark/main.c
@@ -420,7 +420,9 @@ static void frame(void) {
         });
         /* Materials retain their handles; rendering waits for relinking on a later frame.
          * Renderer reset and program destruction may run in either order without draws. */
-        nt_sprite_renderer_restore_gpu();
+        const nt_result_t restore_result = nt_sprite_renderer_restore_gpu();
+        NT_ASSERT(restore_result == NT_OK && "GPU restore failed");
+        (void)restore_result;
         nt_text_renderer_restore_gpu();
         nt_program_ref_drop(&s_sprite_program);
         nt_program_ref_drop(&s_text_program);

--- a/examples/bunnymark/main.c
+++ b/examples/bunnymark/main.c
@@ -420,10 +420,11 @@ static void frame(void) {
         });
         /* Materials retain their handles; rendering waits for relinking on a later frame.
          * Renderer reset and program destruction may run in either order without draws. */
-        const nt_result_t restore_result = nt_sprite_renderer_restore_gpu();
+        nt_result_t restore_result = nt_sprite_renderer_restore_gpu();
+        NT_ASSERT(restore_result == NT_OK && "GPU restore failed");
+        restore_result = nt_text_renderer_restore_gpu();
         NT_ASSERT(restore_result == NT_OK && "GPU restore failed");
         (void)restore_result;
-        nt_text_renderer_restore_gpu();
         nt_program_ref_drop(&s_sprite_program);
         nt_program_ref_drop(&s_text_program);
         nt_resource_invalidate(NT_ASSET_SHADER_CODE);

--- a/examples/capture_host/main.c
+++ b/examples/capture_host/main.c
@@ -94,7 +94,8 @@ int main(void) {
     nt_window_init();
     nt_window_set_vsync(NT_VSYNC_OFF);
     nt_input_init();
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_programs = 16, .max_pipelines = 16, .max_buffers = 128, .max_textures = 16, .max_meshes = 64, .max_render_targets = 16, .depth = true});
+    nt_gfx_init(&(nt_gfx_desc_t){
+        .max_shaders = 32, .max_programs = 16, .max_pipelines = 16, .max_buffers = 128, .max_textures = 16, .max_meshes = 64, .max_vertex_inputs = 64, .max_render_targets = 16, .depth = true});
     /* No nt_fpng_init here: the capture group inits its own encoder dependency in nt_devapi_register_capture. */
 
     /* devapi wiring: init builds the framework, then this capture-focused host registers ONLY the groups

--- a/examples/devapi_host/main.c
+++ b/examples/devapi_host/main.c
@@ -298,7 +298,8 @@ int main(void) {
 #ifdef NT_DEVAPI_HOST_WEB_CAPTURE
     /* Web capture build: a real GL context so the pre-swap capture seam reads a non-blank frame.
        The capture group inits its own fpng encoder in nt_devapi_register_capture (no nt_fpng_init here). */
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_programs = 16, .max_pipelines = 16, .max_buffers = 128, .max_textures = 16, .max_meshes = 64, .max_render_targets = 16, .depth = true});
+    nt_gfx_init(&(nt_gfx_desc_t){
+        .max_shaders = 32, .max_programs = 16, .max_pipelines = 16, .max_buffers = 128, .max_textures = 16, .max_meshes = 64, .max_vertex_inputs = 64, .max_render_targets = 16, .depth = true});
 #endif
 
     /* Obs wiring: host pushes frames into nt_metrics; the log ring captures nt_log_write for log.tail.

--- a/examples/rtt_showcase/main.c
+++ b/examples/rtt_showcase/main.c
@@ -131,6 +131,7 @@ static struct {
     nt_program_t quad_program;
     nt_pipeline_t quad_pipeline;
     nt_buffer_t quad_vbo;
+    nt_vertex_input_t quad_vi;
     uint16_t rt_width;
     uint16_t rt_height;
     bool large_target;
@@ -147,6 +148,7 @@ typedef enum {
 } rtt_resize_result_t;
 
 static void destroy_quad_resources(void) {
+    nt_gfx_destroy_vertex_input(s_demo.quad_vi);
     if (s_demo.quad_vbo.id != 0) {
         nt_gfx_destroy_buffer(s_demo.quad_vbo);
     }
@@ -162,6 +164,7 @@ static void destroy_quad_resources(void) {
     if (s_demo.white.id != 0) {
         nt_gfx_destroy_texture(s_demo.white);
     }
+    s_demo.quad_vi = NT_VERTEX_INPUT_INVALID;
     s_demo.quad_vbo = (nt_buffer_t){0};
     s_demo.quad_pipeline = (nt_pipeline_t){0};
     s_demo.quad_program = NT_PROGRAM_INVALID;
@@ -183,16 +186,6 @@ static bool make_quad_resources(void) {
 
     s_demo.quad_pipeline = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
         .program = s_demo.quad_program,
-        .layout =
-            {
-                .stride = sizeof(rtt_quad_vertex_t),
-                .attr_count = 2,
-                .attrs =
-                    {
-                        {.location = NT_ATTR_POSITION, .type = NT_VERTEX_FLOAT, .count = 2, .offset = 0},
-                        {.location = NT_ATTR_TEXCOORD0, .type = NT_VERTEX_FLOAT, .count = 2, .offset = 8},
-                    },
-            },
         .depth_test = false,
         .depth_write = false,
         .depth_func = NT_DEPTH_ALWAYS,
@@ -205,6 +198,24 @@ static bool make_quad_resources(void) {
         .size = 6U * (uint32_t)sizeof(rtt_quad_vertex_t),
         .label = "rtt_quad_vbo",
     });
+    if (s_demo.quad_vbo.id != 0) {
+        /* Layout lives on the owned vertex input; update_buffer keeps the GL
+         * name, so the per-frame vertex rewrite leaves the binding intact. */
+        s_demo.quad_vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){
+            .layout =
+                {
+                    .stride = sizeof(rtt_quad_vertex_t),
+                    .attr_count = 2,
+                    .attrs =
+                        {
+                            {.location = NT_ATTR_POSITION, .type = NT_VERTEX_FLOAT, .count = 2, .offset = 0},
+                            {.location = NT_ATTR_TEXCOORD0, .type = NT_VERTEX_FLOAT, .count = 2, .offset = 8},
+                        },
+                },
+            .vertex_buffer = s_demo.quad_vbo,
+            .label = "rtt_quad_vi",
+        });
+    }
     s_demo.white = nt_gfx_make_texture(&(nt_texture_desc_t){
         .width = 1,
         .height = 1,
@@ -216,7 +227,7 @@ static bool make_quad_resources(void) {
         .wrap_v = NT_WRAP_CLAMP_TO_EDGE,
         .label = "rtt_white",
     });
-    return s_demo.quad_pipeline.id != 0 && s_demo.quad_vbo.id != 0 && s_demo.white.id != 0;
+    return s_demo.quad_pipeline.id != 0 && s_demo.quad_vbo.id != 0 && s_demo.quad_vi.id != 0 && s_demo.white.id != 0;
 }
 
 static nt_render_target_t make_target(const char *label, uint16_t width, uint16_t height, nt_render_target_depth_t depth) {
@@ -476,7 +487,7 @@ static void draw_textured_quad(nt_texture_t texture, float x0, float y0, float x
     };
     nt_gfx_update_buffer(s_demo.quad_vbo, 0, verts, sizeof(verts));
     nt_gfx_bind_pipeline(s_demo.quad_pipeline);
-    nt_gfx_bind_vertex_buffer(s_demo.quad_vbo);
+    nt_gfx_bind_vertex_input(s_demo.quad_vi);
     nt_gfx_bind_texture(texture, 0);
     nt_gfx_set_uniform_int("u_texture", 0);
     nt_gfx_set_uniform_int("u_mode", mode);

--- a/examples/rtt_showcase/main.c
+++ b/examples/rtt_showcase/main.c
@@ -524,7 +524,8 @@ static void frame(void) {
     if (nt_input_key_is_pressed(NT_KEY_R)) {
         bool make_large = !s_demo.large_target;
         rtt_resize_result_t resize_result = make_large ? resize_targets(768, 432) : resize_targets(512, 288);
-        s_demo.render_resources_ready = resize_result != RTT_RESIZE_UNUSABLE;
+        /* Resizing targets cannot repair a failed renderer restore. */
+        s_demo.render_resources_ready = s_demo.render_resources_ready && resize_result != RTT_RESIZE_UNUSABLE;
         if (resize_result == RTT_RESIZE_COMMITTED) {
             s_demo.large_target = make_large;
         }
@@ -556,7 +557,7 @@ static void frame(void) {
             .label = "rtt_frame_uniforms",
         });
         restored = s_frame_ubo.id != 0 && restored;
-        nt_sprite_renderer_restore_gpu();
+        restored = (nt_sprite_renderer_restore_gpu() == NT_OK) && restored;
         nt_text_renderer_restore_gpu();
         nt_program_ref_drop(&s_sprite_program);
         nt_program_ref_drop(&s_text_program);

--- a/examples/rtt_showcase/main.c
+++ b/examples/rtt_showcase/main.c
@@ -558,7 +558,7 @@ static void frame(void) {
         });
         restored = s_frame_ubo.id != 0 && restored;
         restored = (nt_sprite_renderer_restore_gpu() == NT_OK) && restored;
-        nt_text_renderer_restore_gpu();
+        restored = (nt_text_renderer_restore_gpu() == NT_OK) && restored;
         nt_program_ref_drop(&s_sprite_program);
         nt_program_ref_drop(&s_text_program);
         nt_resource_invalidate(NT_ASSET_SHADER_CODE);

--- a/examples/slice9_demo/main.c
+++ b/examples/slice9_demo/main.c
@@ -413,7 +413,9 @@ static void frame(void) {
         });
         /* Materials retain their handles; rendering waits for relinking on a later frame.
          * Renderer reset and program destruction may run in either order without draws. */
-        nt_sprite_renderer_restore_gpu();
+        const nt_result_t restore_result = nt_sprite_renderer_restore_gpu();
+        NT_ASSERT(restore_result == NT_OK && "GPU restore failed");
+        (void)restore_result;
         nt_text_renderer_restore_gpu();
         nt_program_ref_drop(&s_sprite_program);
         nt_program_ref_drop(&s_text_program);

--- a/examples/slice9_demo/main.c
+++ b/examples/slice9_demo/main.c
@@ -413,10 +413,11 @@ static void frame(void) {
         });
         /* Materials retain their handles; rendering waits for relinking on a later frame.
          * Renderer reset and program destruction may run in either order without draws. */
-        const nt_result_t restore_result = nt_sprite_renderer_restore_gpu();
+        nt_result_t restore_result = nt_sprite_renderer_restore_gpu();
+        NT_ASSERT(restore_result == NT_OK && "GPU restore failed");
+        restore_result = nt_text_renderer_restore_gpu();
         NT_ASSERT(restore_result == NT_OK && "GPU restore failed");
         (void)restore_result;
-        nt_text_renderer_restore_gpu();
         nt_program_ref_drop(&s_sprite_program);
         nt_program_ref_drop(&s_text_program);
         nt_resource_invalidate(NT_ASSET_SHADER_CODE);

--- a/examples/spinning_cube/main.c
+++ b/examples/spinning_cube/main.c
@@ -383,7 +383,8 @@ int main(void) {
     g_nt_window.height = 600;
     nt_window_init();
     nt_input_init();
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_programs = 16, .max_pipelines = 16, .max_buffers = 128, .max_textures = 16, .max_meshes = 64, .max_render_targets = 16, .depth = true});
+    nt_gfx_init(&(nt_gfx_desc_t){
+        .max_shaders = 32, .max_programs = 16, .max_pipelines = 16, .max_buffers = 128, .max_textures = 16, .max_meshes = 64, .max_vertex_inputs = 64, .max_render_targets = 16, .depth = true});
     nt_shape_renderer_init();
 
     /* ---- Entity system init ---- */

--- a/examples/sponza/main.c
+++ b/examples/sponza/main.c
@@ -647,6 +647,8 @@ int main(void) {
     gfx_desc.max_textures = 256;
     gfx_desc.max_buffers = 512;
     gfx_desc.max_meshes = 256;
+    /* The vertex-input default is derived from max_meshes(128); scale it too. */
+    gfx_desc.max_vertex_inputs = 256 * 4 + 48;
     nt_gfx_init(&gfx_desc);
 
     /* Register global UBO blocks */

--- a/examples/sponza/main.c
+++ b/examples/sponza/main.c
@@ -566,7 +566,9 @@ static void frame(void) {
         });
         /* Materials retain their handles; rendering waits for relinking on a later frame.
          * Renderer reset and program destruction may run in either order without draws. */
-        nt_mesh_renderer_restore_gpu();
+        const nt_result_t restore_result = nt_mesh_renderer_restore_gpu();
+        NT_ASSERT(restore_result == NT_OK && "GPU restore failed");
+        (void)restore_result;
         drop_programs(); /* GL objects are gone; this frees the pool slots too */
         nt_resource_invalidate(NT_ASSET_SHADER_CODE);
     }

--- a/examples/text/main.c
+++ b/examples/text/main.c
@@ -314,7 +314,9 @@ static void frame(void) {
         });
         /* Materials retain their handles; rendering waits for relinking on a later frame.
          * Renderer reset and program destruction may run in either order without draws. */
-        nt_text_renderer_restore_gpu();
+        const nt_result_t restore_result = nt_text_renderer_restore_gpu();
+        NT_ASSERT(restore_result == NT_OK && "GPU restore failed");
+        (void)restore_result;
         nt_program_ref_drop(&s_text_program);
         nt_resource_invalidate(NT_ASSET_SHADER_CODE);
     }

--- a/examples/textured_quad/main.c
+++ b/examples/textured_quad/main.c
@@ -327,7 +327,9 @@ static void frame(void) {
         });
         /* Materials retain their handles; rendering waits for relinking on a later frame.
          * Renderer reset and program destruction may run in either order without draws. */
-        nt_mesh_renderer_restore_gpu();
+        const nt_result_t restore_result = nt_mesh_renderer_restore_gpu();
+        NT_ASSERT(restore_result == NT_OK && "GPU restore failed");
+        (void)restore_result;
         nt_program_ref_drop(&s_cube_program);
         nt_resource_invalidate(NT_ASSET_SHADER_CODE);
     }

--- a/examples/ui_3d_demo/main.c
+++ b/examples/ui_3d_demo/main.c
@@ -875,10 +875,11 @@ static void frame(void) {
         /* Materials retain their handles; rendering waits for relinking on a later frame.
          * Renderer reset and program destruction may run in either order without draws. */
         nt_shape_renderer_restore_gpu();
-        const nt_result_t restore_result = nt_sprite_renderer_restore_gpu();
+        nt_result_t restore_result = nt_sprite_renderer_restore_gpu();
+        NT_ASSERT(restore_result == NT_OK && "GPU restore failed");
+        restore_result = nt_text_renderer_restore_gpu();
         NT_ASSERT(restore_result == NT_OK && "GPU restore failed");
         (void)restore_result;
-        nt_text_renderer_restore_gpu();
         nt_program_ref_drop(&s_sprite_cutoff_program);
         nt_program_ref_drop(&s_sprite_program);
         nt_program_ref_drop(&s_text_program);

--- a/examples/ui_3d_demo/main.c
+++ b/examples/ui_3d_demo/main.c
@@ -875,7 +875,9 @@ static void frame(void) {
         /* Materials retain their handles; rendering waits for relinking on a later frame.
          * Renderer reset and program destruction may run in either order without draws. */
         nt_shape_renderer_restore_gpu();
-        nt_sprite_renderer_restore_gpu();
+        const nt_result_t restore_result = nt_sprite_renderer_restore_gpu();
+        NT_ASSERT(restore_result == NT_OK && "GPU restore failed");
+        (void)restore_result;
         nt_text_renderer_restore_gpu();
         nt_program_ref_drop(&s_sprite_cutoff_program);
         nt_program_ref_drop(&s_sprite_program);

--- a/examples/ui_showcase/main.c
+++ b/examples/ui_showcase/main.c
@@ -3737,10 +3737,11 @@ static void frame(void) {
         });
         /* Materials retain their handles; rendering waits for relinking on a later frame.
          * Renderer reset and program destruction may run in either order without draws. */
-        const nt_result_t restore_result = nt_sprite_renderer_restore_gpu();
+        nt_result_t restore_result = nt_sprite_renderer_restore_gpu();
+        NT_ASSERT(restore_result == NT_OK && "GPU restore failed");
+        restore_result = nt_text_renderer_restore_gpu();
         NT_ASSERT(restore_result == NT_OK && "GPU restore failed");
         (void)restore_result;
-        nt_text_renderer_restore_gpu();
         nt_shape_renderer_restore_gpu();
         nt_program_ref_drop(&s_sprite_program);
         nt_program_ref_drop(&s_text_program);

--- a/examples/ui_showcase/main.c
+++ b/examples/ui_showcase/main.c
@@ -3737,7 +3737,9 @@ static void frame(void) {
         });
         /* Materials retain their handles; rendering waits for relinking on a later frame.
          * Renderer reset and program destruction may run in either order without draws. */
-        nt_sprite_renderer_restore_gpu();
+        const nt_result_t restore_result = nt_sprite_renderer_restore_gpu();
+        NT_ASSERT(restore_result == NT_OK && "GPU restore failed");
+        (void)restore_result;
         nt_text_renderer_restore_gpu();
         nt_shape_renderer_restore_gpu();
         nt_program_ref_drop(&s_sprite_program);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -254,6 +254,16 @@ if(NOT EMSCRIPTEN)
     )
     add_test(NAME test_gfx COMMAND test_gfx)
 
+    # --- Vertex-input object tests (lifecycle, cascade, bind mirrors) ---
+    add_executable(test_gfx_vertex_input unit/test_gfx_vertex_input.c)
+    target_link_libraries(test_gfx_vertex_input PRIVATE nt_gfx_stub nt_basisu_transcoder_stub nt_log_stub unity nt_meshwire)
+    nt_set_warning_flags(test_gfx_vertex_input)
+    nt_set_sanitizer_flags(test_gfx_vertex_input)
+    set_target_properties(test_gfx_vertex_input PROPERTIES
+        RUNTIME_OUTPUT_DIRECTORY "${CMAKE_SOURCE_DIR}/build/tests/${NT_PRESET_NAME}"
+    )
+    add_test(NAME test_gfx_vertex_input COMMAND test_gfx_vertex_input)
+
     # --- Graphics readback tests (nt_gfx_read_pixels) ---
     # nt_gfx_stub bundles the shared nt_gfx.c (nt_gfx_read_pixels orchestration)
     # with the synthetic readback backend, so it alone proves the readback contract headless.

--- a/tests/browser/app/main.c
+++ b/tests/browser/app/main.c
@@ -127,7 +127,9 @@ static const char *s_mesh_fs_src = "precision mediump float;\n"
                                    "out vec4 frag_color;\n"
                                    "void main() { frag_color = vec4(0.0, 1.0, 0.0, 1.0); }\n";
 
-static void mesh_probe_create(void) {
+/* False when the context is (still) lost mid-restore: the caller retries on a
+ * later frame; partial handles are {0}-safe for mesh_probe_destroy. */
+static bool mesh_probe_create(void) {
     /* Unit quad, one float3 position stream, uint16 indices. */
     static const float verts[12] = {0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 1.0F, 1.0F, 0.0F, 0.0F, 1.0F, 0.0F};
     static const uint16_t indices[6] = {0, 1, 2, 0, 2, 3};
@@ -150,7 +152,9 @@ static void mesh_probe_create(void) {
     memcpy(blob + sizeof(NtMeshAssetHeader) + sizeof(NtStreamDesc) + sizeof(verts), indices, sizeof(indices));
 
     s_mesh_handle = nt_gfx_activate_mesh(blob, (uint32_t)sizeof(blob));
-    NT_ASSERT(s_mesh_handle != 0);
+    if (s_mesh_handle == 0) {
+        return false; /* lost context during activation */
+    }
     const nt_gfx_mesh_info_t *info = nt_gfx_get_mesh_info((nt_mesh_t){s_mesh_handle});
     s_mesh_index_count = info->index_count;
     s_mesh_vertex_count = info->vertex_count;
@@ -167,6 +171,7 @@ static void mesh_probe_create(void) {
         .label = "mesh_probe_vi",
     });
     s_mesh_instance_buf = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64, .label = "mesh_probe_inst"});
+    return s_mesh_pipeline.id != 0 && s_mesh_vi.id != 0 && s_mesh_instance_buf.id != 0;
 }
 
 static void mesh_probe_destroy(void) {
@@ -349,6 +354,29 @@ static void render_rich(nt_ui_context_t *ctx) {
 // #endregion
 
 // #region frame
+/* Retryable half of context recovery. A second loss during the restored frame
+ * can fail any create here; the app then skips rendering and retries next
+ * frame instead of trapping (double-loss thrash is a real mobile scenario the
+ * smoke test must survive). Destroys are stale-/{0}-safe to re-run. */
+static bool s_gpu_restore_pending;
+
+static bool gpu_restore_step(void) {
+    nt_gfx_destroy_buffer(s_frame_ubo);
+    s_frame_ubo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
+        .type = NT_BUFFER_UNIFORM,
+        .usage = NT_USAGE_DYNAMIC,
+        .size = sizeof(nt_frame_uniforms_t),
+        .label = "frame_uniforms",
+    });
+    bool ok = s_frame_ubo.id != 0;
+    ok = (nt_sprite_renderer_restore_gpu() == NT_OK) && ok;
+    ok = (nt_text_renderer_restore_gpu() == NT_OK) && ok;
+    /* The probe's mesh and vertex input died with the context. */
+    mesh_probe_destroy();
+    ok = mesh_probe_create() && ok;
+    return ok;
+}
+
 static void frame(void) {
     nt_window_poll();
     nt_input_poll();
@@ -389,30 +417,21 @@ static void frame(void) {
 
     nt_gfx_begin_frame();
     if (g_nt_gfx.context_restored) {
+        /* One-shot per restored event; the GPU recreation below may retry. */
         nt_resource_invalidate(NT_ASSET_TEXTURE);
         nt_resource_invalidate(NT_ASSET_FONT);
-        nt_gfx_destroy_buffer(s_frame_ubo);
-        s_frame_ubo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
-            .type = NT_BUFFER_UNIFORM,
-            .usage = NT_USAGE_DYNAMIC,
-            .size = sizeof(nt_frame_uniforms_t),
-            .label = "frame_uniforms",
-        });
         /* Materials retain their handles; rendering waits for relinking on a later frame.
          * Renderer reset and program destruction may run in either order without draws. */
-        const nt_result_t restore_result = nt_sprite_renderer_restore_gpu();
-        NT_ASSERT(restore_result == NT_OK && "GPU restore failed");
-        (void)restore_result;
-        nt_text_renderer_restore_gpu();
-        /* The probe's mesh and vertex input died with the context. */
-        mesh_probe_destroy();
-        mesh_probe_create();
         nt_program_ref_drop(&s_sprite_program);
         nt_program_ref_drop(&s_text_program);
         nt_resource_invalidate(NT_ASSET_SHADER_CODE);
         s_atlas_bound = false;
         /* Font sources survive restore; adding them again asserts on duplicates.
          * nt_font_step rebuilds textures after the font assets reactivate. */
+        s_gpu_restore_pending = true;
+    }
+    if (s_gpu_restore_pending) {
+        s_gpu_restore_pending = !gpu_restore_step();
     }
 
     nt_gfx_begin_pass(&(nt_pass_desc_t){
@@ -424,7 +443,10 @@ static void frame(void) {
 
     const nt_material_info_t *sprite_info = nt_material_get_info(s_sprite_material);
     const nt_material_info_t *text_info = nt_material_get_info(s_text_material);
-    const bool can_render = s_atlas_bound && s_font_bound && s_rich_font_bound && sprite_info && nt_gfx_program_ready(sprite_info->program) && text_info && nt_gfx_program_ready(text_info->program);
+    /* A pending restore means renderer buffers may be missing; submitting
+     * sprites then asserts by contract, so rendering waits it out. */
+    const bool can_render = !s_gpu_restore_pending && s_atlas_bound && s_font_bound && s_rich_font_bound && sprite_info && nt_gfx_program_ready(sprite_info->program) && text_info &&
+                            nt_gfx_program_ready(text_info->program);
 
     if (can_render) {
         nt_gfx_update_buffer(s_frame_ubo, 0, &uniforms, sizeof(uniforms));
@@ -554,7 +576,9 @@ int main(int argc, char *argv[]) {
     nt_sprite_renderer_desc_t sr_desc = nt_sprite_renderer_desc_defaults();
     nt_sprite_renderer_init(&sr_desc);
     nt_text_renderer_init();
-    mesh_probe_create();
+    const bool probe_ok = mesh_probe_create();
+    NT_ASSERT(probe_ok && "mesh probe creation failed at startup"); /* cold start: the context is alive */
+    (void)probe_ok;
 
     nt_ui_module_init();
     nt_ui_create_desc_t ui_desc = nt_ui_create_desc_defaults();

--- a/tests/browser/app/main.c
+++ b/tests/browser/app/main.c
@@ -107,10 +107,8 @@ static nt_ui_input_style_t s_input_style; /* filled at init (defaults + visible 
 // #endregion
 
 // #region mesh probe (instanced VAO path)
-/* Two green quads in the bottom-right corner drawn through an owned vertex
- * input (baked VBO+IBO, per-draw instance re-pointing at a nonzero byte
- * offset) -- the WebGL2 VAO path the mesh renderer uses, exercised in the
- * browser where its validation actually lives. */
+/* Browser probe: two quads use a baked VBO/IBO and instance re-pointing at a
+ * nonzero offset, matching the mesh renderer's WebGL2 VAO path. */
 static nt_shader_t s_mesh_vs, s_mesh_fs;
 static nt_program_t s_mesh_program;
 static nt_pipeline_t s_mesh_pipeline;
@@ -354,10 +352,8 @@ static void render_rich(nt_ui_context_t *ctx) {
 // #endregion
 
 // #region frame
-/* Retryable half of context recovery. A second loss during the restored frame
- * can fail any create here; the app then skips rendering and retries next
- * frame instead of trapping (double-loss thrash is a real mobile scenario the
- * smoke test must survive). Destroys are stale-/{0}-safe to re-run. */
+/* A second loss during recovery skips rendering and retries next frame.
+ * Destroy calls are stale-/{0}-safe, so the step may repeat. */
 static bool s_gpu_restore_pending;
 
 static bool gpu_restore_step(void) {

--- a/tests/browser/app/main.c
+++ b/tests/browser/app/main.c
@@ -400,7 +400,9 @@ static void frame(void) {
         });
         /* Materials retain their handles; rendering waits for relinking on a later frame.
          * Renderer reset and program destruction may run in either order without draws. */
-        nt_sprite_renderer_restore_gpu();
+        const nt_result_t restore_result = nt_sprite_renderer_restore_gpu();
+        NT_ASSERT(restore_result == NT_OK && "GPU restore failed");
+        (void)restore_result;
         nt_text_renderer_restore_gpu();
         /* The probe's mesh and vertex input died with the context. */
         mesh_probe_destroy();

--- a/tests/browser/app/main.c
+++ b/tests/browser/app/main.c
@@ -18,6 +18,7 @@
 #include "material/nt_program_ref.h"
 #include "math/nt_math.h"
 #include "memory/nt_mem_scratch.h"
+#include "nt_mesh_format.h" /* in-code mesh blob for the instanced VAO probe */
 #include "nt_pack_format.h" /* NT_ASSET_* resource-type enum */
 #include "render/nt_render_defs.h"
 #include "renderers/nt_sprite_renderer.h"
@@ -103,6 +104,103 @@ static uint32_t s_id_input_cyrillic; /* nt_ui_id, resolved once */
 static const nt_ui_label_style_t s_caption = {.font_id = 0, .font_size = 16, .color = {165.0F, 170.0F, 182.0F, 255.0F}};
 static const nt_ui_label_style_t s_body = {.font_id = 0, .font_size = 22, .color = {225.0F, 228.0F, 235.0F, 255.0F}};
 static nt_ui_input_style_t s_input_style; /* filled at init (defaults + visible bg/border) */
+// #endregion
+
+// #region mesh probe (instanced VAO path)
+/* Two green quads in the bottom-right corner drawn through an owned vertex
+ * input (baked VBO+IBO, per-draw instance re-pointing at a nonzero byte
+ * offset) -- the WebGL2 VAO path the mesh renderer uses, exercised in the
+ * browser where its validation actually lives. */
+static nt_shader_t s_mesh_vs, s_mesh_fs;
+static nt_program_t s_mesh_program;
+static nt_pipeline_t s_mesh_pipeline;
+static nt_vertex_input_t s_mesh_vi;
+static nt_buffer_t s_mesh_instance_buf;
+static uint32_t s_mesh_handle;
+static uint32_t s_mesh_index_count, s_mesh_vertex_count;
+
+static const char *s_mesh_vs_src = "precision mediump float;\n"
+                                   "layout(location = 0) in vec3 a_position;\n"
+                                   "layout(location = 4) in vec2 i_offset;\n"
+                                   "void main() { gl_Position = vec4(a_position.xy * 0.1 + i_offset, 0.0, 1.0); }\n";
+static const char *s_mesh_fs_src = "precision mediump float;\n"
+                                   "out vec4 frag_color;\n"
+                                   "void main() { frag_color = vec4(0.0, 1.0, 0.0, 1.0); }\n";
+
+static void mesh_probe_create(void) {
+    /* Unit quad, one float3 position stream, uint16 indices. */
+    static const float verts[12] = {0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 1.0F, 1.0F, 0.0F, 0.0F, 1.0F, 0.0F};
+    static const uint16_t indices[6] = {0, 1, 2, 0, 2, 3};
+    uint8_t blob[sizeof(NtMeshAssetHeader) + sizeof(NtStreamDesc) + sizeof(verts) + sizeof(indices)];
+    memset(blob, 0, sizeof(blob));
+    NtMeshAssetHeader *hdr = (NtMeshAssetHeader *)blob;
+    hdr->magic = NT_MESH_MAGIC;
+    hdr->version = NT_MESH_VERSION;
+    hdr->stream_count = 1;
+    hdr->index_type = NT_INDEX_UINT16;
+    hdr->vertex_count = 4;
+    hdr->index_count = 6;
+    hdr->vertex_data_size = sizeof(verts);
+    hdr->index_data_size = sizeof(indices);
+    NtStreamDesc *sd = (NtStreamDesc *)(blob + sizeof(NtMeshAssetHeader));
+    sd->name_hash = nt_hash32_str("position").value;
+    sd->type = NT_STREAM_FLOAT32;
+    sd->count = 3;
+    memcpy(blob + sizeof(NtMeshAssetHeader) + sizeof(NtStreamDesc), verts, sizeof(verts));
+    memcpy(blob + sizeof(NtMeshAssetHeader) + sizeof(NtStreamDesc) + sizeof(verts), indices, sizeof(indices));
+
+    s_mesh_handle = nt_gfx_activate_mesh(blob, (uint32_t)sizeof(blob));
+    NT_ASSERT(s_mesh_handle != 0);
+    const nt_gfx_mesh_info_t *info = nt_gfx_get_mesh_info((nt_mesh_t){s_mesh_handle});
+    s_mesh_index_count = info->index_count;
+    s_mesh_vertex_count = info->vertex_count;
+
+    s_mesh_vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = s_mesh_vs_src, .label = "mesh_probe_vs"});
+    s_mesh_fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = s_mesh_fs_src, .label = "mesh_probe_fs"});
+    s_mesh_program = nt_gfx_make_program(s_mesh_vs, s_mesh_fs);
+    s_mesh_pipeline = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = s_mesh_program, .label = "mesh_probe_pipeline"});
+    s_mesh_vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){
+        .layout = {.attr_count = 1, .stride = 12, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 3}}},
+        .instance_layout = {.attr_count = 1, .stride = 8, .attrs = {{.location = 4, .type = NT_VERTEX_FLOAT, .count = 2}}},
+        .vertex_buffer = info->vbo,
+        .index_buffer = info->ibo,
+        .label = "mesh_probe_vi",
+    });
+    s_mesh_instance_buf = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64, .label = "mesh_probe_inst"});
+}
+
+static void mesh_probe_destroy(void) {
+    nt_gfx_destroy_vertex_input(s_mesh_vi); /* also stale-safe after a context loss */
+    s_mesh_vi = NT_VERTEX_INPUT_INVALID;
+    if (s_mesh_handle != 0) {
+        nt_gfx_deactivate_mesh(s_mesh_handle);
+        s_mesh_handle = 0;
+    }
+    nt_gfx_destroy_buffer(s_mesh_instance_buf);
+    s_mesh_instance_buf = (nt_buffer_t){0};
+    nt_gfx_destroy_pipeline(s_mesh_pipeline);
+    s_mesh_pipeline = (nt_pipeline_t){0};
+    nt_gfx_destroy_program(s_mesh_program);
+    s_mesh_program = NT_PROGRAM_INVALID;
+    nt_gfx_destroy_shader(s_mesh_fs);
+    nt_gfx_destroy_shader(s_mesh_vs);
+    s_mesh_fs = (nt_shader_t){0};
+    s_mesh_vs = (nt_shader_t){0};
+}
+
+static void mesh_probe_draw(void) {
+    if (s_mesh_vi.id == 0 || !nt_gfx_program_ready(s_mesh_program)) {
+        return;
+    }
+    /* Instance data at byte offset 8: proves the nonzero-offset re-pointing
+     * the mesh renderer's ring allocator relies on. Two stacked quads. */
+    float inst[6] = {0.0F, 0.0F, 0.85F, -0.95F, 0.85F, -0.82F};
+    nt_gfx_update_buffer(s_mesh_instance_buf, 0, inst, sizeof(inst));
+    nt_gfx_bind_pipeline(s_mesh_pipeline);
+    nt_gfx_bind_vertex_input(s_mesh_vi);
+    nt_gfx_bind_instance_buffer(s_mesh_instance_buf, 8);
+    nt_gfx_draw_indexed_instanced(0, s_mesh_index_count, s_mesh_vertex_count, 2);
+}
 // #endregion
 
 // #region resource binding
@@ -304,6 +402,9 @@ static void frame(void) {
          * Renderer reset and program destruction may run in either order without draws. */
         nt_sprite_renderer_restore_gpu();
         nt_text_renderer_restore_gpu();
+        /* The probe's mesh and vertex input died with the context. */
+        mesh_probe_destroy();
+        mesh_probe_create();
         nt_program_ref_drop(&s_sprite_program);
         nt_program_ref_drop(&s_text_program);
         nt_resource_invalidate(NT_ASSET_SHADER_CODE);
@@ -396,6 +497,7 @@ static void frame(void) {
 #endif /* __EMSCRIPTEN__ */
 
         nt_text_renderer_flush();
+        mesh_probe_draw(); /* on top of the UI so the spec can pixel-probe it */
 #ifdef __EMSCRIPTEN__
         /* Count frames that actually submitted geometry: reaching the draw path
          * proves nothing if every renderer skipped. */
@@ -450,6 +552,7 @@ int main(int argc, char *argv[]) {
     nt_sprite_renderer_desc_t sr_desc = nt_sprite_renderer_desc_defaults();
     nt_sprite_renderer_init(&sr_desc);
     nt_text_renderer_init();
+    mesh_probe_create();
 
     nt_ui_module_init();
     nt_ui_create_desc_t ui_desc = nt_ui_create_desc_defaults();
@@ -585,6 +688,7 @@ int main(int argc, char *argv[]) {
     nt_fs_shutdown();
     nt_http_shutdown();
     nt_hash_shutdown();
+    mesh_probe_destroy();
     nt_gfx_destroy_buffer(s_frame_ubo);
     nt_gfx_shutdown();
     nt_input_shutdown();

--- a/tests/browser/context_loss.spec.ts
+++ b/tests/browser/context_loss.spec.ts
@@ -39,6 +39,14 @@ function pixelsMatch(actual: number[], expected: number[]): boolean {
   return actual.length === expected.length && actual.every((value, i) => Math.abs(value - expected[i]) <= 1);
 }
 
+function expectMeshProbe(pixels: number[]): void {
+  let green = 0;
+  for (let i = 0; i < pixels.length; i += 4) {
+    if (pixels[i] < 80 && pixels[i + 1] > 200 && pixels[i + 2] < 80) green++;
+  }
+  expect(green, 'mesh probe must be solid green (instanced draw through an owned vertex input)').toBeGreaterThan((pixels.length / 4) * 0.9);
+}
+
 function expectVisibleProbes(sprite: number[], text: number[]): void {
   let skinPixels = 0;
   for (let i = 0; i < sprite.length; i += 4) {
@@ -79,9 +87,13 @@ test('context loss: both renderers restore their pixels after two loss cycles', 
   // Right-side skin excludes the input text/caret; the caption is above the field.
   const spriteRect = { x: Math.round(canvas!.x + field.x + field.w / 2 - 32), y: Math.round(canvas!.y + field.y - 5), width: 20, height: 10 };
   const textRect = { x: Math.round(canvas!.x + 24), y: Math.round(canvas!.y + 24), width: 230, height: 24 };
+  // The wasm app's mesh probe: two instanced green quads in the bottom-right
+  // corner drawn through an owned vertex input (the WebGL2 VAO path).
+  const meshRect = { x: Math.round(canvas!.x + 1194), y: Math.round(canvas!.y + 748), width: 40, height: 24 };
   const spriteBaseline = await capturePixels(page, spriteRect);
   const textBaseline = await capturePixels(page, textRect);
   expectVisibleProbes(spriteBaseline, textBaseline);
+  expectMeshProbe(await capturePixels(page, meshRect));
 
   // These controls prove pixel-matcher sensitivity, not a simulated recovery failure.
   for (const mode of [1, 2]) {
@@ -120,6 +132,7 @@ test('context loss: both renderers restore their pixels after two loss cycles', 
       const sprite = await capturePixels(page, spriteRect);
       const text = await capturePixels(page, textRect);
       expectVisibleProbes(sprite, text);
+      expectMeshProbe(await capturePixels(page, meshRect));
       expect(pixelsMatch(sprite, spriteBaseline), 'sprite pixels after restore').toBe(true);
       expect(pixelsMatch(text, textBaseline), 'text pixels after restore').toBe(true);
       expect(errors, 'unexpected browser/gfx errors').toEqual([]);

--- a/tests/browser/context_loss.spec.ts
+++ b/tests/browser/context_loss.spec.ts
@@ -88,12 +88,15 @@ test('context loss: both renderers restore their pixels after two loss cycles', 
   const spriteRect = { x: Math.round(canvas!.x + field.x + field.w / 2 - 32), y: Math.round(canvas!.y + field.y - 5), width: 20, height: 10 };
   const textRect = { x: Math.round(canvas!.x + 24), y: Math.round(canvas!.y + 24), width: 230, height: 24 };
   // The wasm app's mesh probe: two instanced green quads in the bottom-right
-  // corner drawn through an owned vertex input (the WebGL2 VAO path).
+  // corner drawn through an owned vertex input (the WebGL2 VAO path). One rect
+  // per quad -- the second (y 688..728) fails if only instance 0 is drawn.
   const meshRect = { x: Math.round(canvas!.x + 1194), y: Math.round(canvas!.y + 748), width: 40, height: 24 };
+  const meshRect2 = { x: Math.round(canvas!.x + 1194), y: Math.round(canvas!.y + 696), width: 40, height: 24 };
   const spriteBaseline = await capturePixels(page, spriteRect);
   const textBaseline = await capturePixels(page, textRect);
   expectVisibleProbes(spriteBaseline, textBaseline);
   expectMeshProbe(await capturePixels(page, meshRect));
+  expectMeshProbe(await capturePixels(page, meshRect2));
 
   // These controls prove pixel-matcher sensitivity, not a simulated recovery failure.
   for (const mode of [1, 2]) {
@@ -133,6 +136,7 @@ test('context loss: both renderers restore their pixels after two loss cycles', 
       const text = await capturePixels(page, textRect);
       expectVisibleProbes(sprite, text);
       expectMeshProbe(await capturePixels(page, meshRect));
+      expectMeshProbe(await capturePixels(page, meshRect2));
       expect(pixelsMatch(sprite, spriteBaseline), 'sprite pixels after restore').toBe(true);
       expect(pixelsMatch(text, textBaseline), 'text pixels after restore').toBe(true);
       expect(errors, 'unexpected browser/gfx errors').toEqual([]);

--- a/tests/browser/playwright.config.ts
+++ b/tests/browser/playwright.config.ts
@@ -1,7 +1,21 @@
 import { defineConfig, devices } from '@playwright/test';
+import { join } from 'node:path';
 
-// The static server serves the ui_showcase wasm-debug build (NT_SHOWCASE_DIR overrides the dir in CI).
+// Two static servers, one per wasm target: the browser_smoke app (input/rich/context_loss specs)
+// and the devapi_host capture build (devapi.spec.ts). Each spec file runs in the project whose
+// server serves the app it drives — a plain `npx playwright test` covers both, provided both
+// targets are built (browser_smoke via the wasm-debug preset; devapi_host via
+// `cmake --build build/_cmake/wasm-debug --target devapi_host`).
 const PORT = Number(process.env.NT_SHOWCASE_PORT || 8123);
+const DEVAPI_PORT = Number(process.env.NT_DEVAPI_PORT || 8124);
+const DEVAPI_DIR = process.env.NT_DEVAPI_DIR || join(__dirname, '..', '..', 'build', 'examples', 'devapi_host', 'wasm-debug');
+
+// SwiftShader GL: WebGL2 must work in headless CI (and on GPUs whose headless context is
+// unreliable). The engine needs a real GL2 context for texture upload; without this the context
+// is lost and the wasm app traps on first glTexImage2D.
+const chromiumGl = {
+  args: ['--use-gl=angle', '--use-angle=swiftshader', '--enable-unsafe-swiftshader', '--ignore-gpu-blocklist'],
+};
 
 export default defineConfig({
   testDir: '.',
@@ -14,28 +28,39 @@ export default defineConfig({
     permissions: ['clipboard-read', 'clipboard-write'],
     trace: 'on-first-retry',
   },
-  webServer: {
-    command: 'node serve.mjs',
-    url: `http://localhost:${PORT}/index.html`,
-    reuseExistingServer: !process.env.CI,
-    timeout: 60_000,
-  },
+  // Port checks only (not url): each CI job builds just the wasm target its specs drive, and the
+  // OTHER project's server must still come up over an empty build dir without a startup timeout.
+  webServer: [
+    {
+      command: 'node serve.mjs',
+      port: PORT,
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+    },
+    {
+      command: 'node serve.mjs',
+      port: DEVAPI_PORT,
+      env: { NT_SHOWCASE_DIR: DEVAPI_DIR, NT_SHOWCASE_PORT: String(DEVAPI_PORT) },
+      reuseExistingServer: !process.env.CI,
+      timeout: 60_000,
+    },
+  ],
   projects: [
     {
       name: 'chromium',
+      testIgnore: '**/devapi.spec.ts',
       use: {
         ...devices['Desktop Chrome'],
-        // Force the SwiftShader GL backend so WebGL2 works in headless CI (and on GPUs whose
-        // headless context is unreliable). The engine needs a real GL2 context for texture upload;
-        // without this the context is lost and the wasm app traps on first glTexImage2D.
-        launchOptions: {
-          args: [
-            '--use-gl=angle',
-            '--use-angle=swiftshader',
-            '--enable-unsafe-swiftshader',
-            '--ignore-gpu-blocklist',
-          ],
-        },
+        launchOptions: chromiumGl,
+      },
+    },
+    {
+      name: 'devapi-chromium',
+      testMatch: '**/devapi.spec.ts',
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: `http://localhost:${DEVAPI_PORT}`,
+        launchOptions: chromiumGl,
       },
     },
   ],

--- a/tests/unit/test_debug_overlay.c
+++ b/tests/unit/test_debug_overlay.c
@@ -44,7 +44,7 @@ static void test_assert_handler(const char *expr, const char *file, int line) {
 /* clang-format on */
 
 void setUp(void) {
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 16, .max_textures = 8, .max_meshes = 8, .max_render_targets = 16});
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 16, .max_textures = 8, .max_meshes = 8, .max_vertex_inputs = 16, .max_render_targets = 16});
     nt_text_renderer_init();
     nt_text_renderer_test_reset_call_counters();
     nt_metrics_init();

--- a/tests/unit/test_font.c
+++ b/tests/unit/test_font.c
@@ -243,7 +243,7 @@ static void test_assert_handler(const char *expr, const char *file, int line) {
 void setUp(void) {
     nt_assert_handler = test_assert_handler;
     nt_gfx_stub_test_reset();
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 8, .max_textures = 32, .max_meshes = 8, .max_render_targets = 16});
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 8, .max_textures = 32, .max_meshes = 8, .max_vertex_inputs = 16, .max_render_targets = 16});
     nt_hash_init(&(nt_hash_desc_t){0});
     nt_resource_init(&(nt_resource_desc_t){0});
     nt_font_init(&(nt_font_desc_t){.max_fonts = 4});

--- a/tests/unit/test_gfx.c
+++ b/tests/unit/test_gfx.c
@@ -1842,6 +1842,9 @@ void test_gfx_restored_frame_rejects_draws(void) {
         .program = nt_gfx_make_program(make_test_vs(), make_test_fs()),
     });
     nt_gfx_bind_pipeline(rebuilt);
+    /* Full draw state bound: the ONLY reason these trap is the restored-frame
+     * rule, not a missing vertex input. */
+    bind_test_vertex_input();
     EXPECT_ASSERT(nt_gfx_draw(0, 0));
     EXPECT_ASSERT(nt_gfx_draw_indexed(0, 0, 0));
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_get_frame_draw_calls());

--- a/tests/unit/test_gfx.c
+++ b/tests/unit/test_gfx.c
@@ -208,7 +208,6 @@ void test_gfx_make_destroy_pipeline(void) {
 
     nt_pipeline_t pip = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
         .program = prog,
-        .layout = {.attr_count = 1, .stride = 12, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 3}}},
     });
     TEST_ASSERT_NOT_EQUAL_UINT32(0, pip.id);
     nt_gfx_destroy_pipeline(pip);
@@ -222,7 +221,6 @@ void test_gfx_pipeline_survives_shader_destroy(void) {
     nt_program_t prog = nt_gfx_make_program(vs, fs);
     nt_pipeline_t pip = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
         .program = prog,
-        .layout = {.attr_count = 1, .stride = 12, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 3}}},
     });
     TEST_ASSERT_NOT_EQUAL_UINT32(0, pip.id);
 
@@ -275,6 +273,20 @@ void test_gfx_pipeline_asserts_unready_program(void) { EXPECT_ASSERT(nt_gfx_make
 static nt_shader_t make_test_vs(void) { return nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "v"}); }
 
 static nt_shader_t make_test_fs(void) { return nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "f"}); }
+
+/* Draws require a bound vertex input; an indexed one satisfies every draw
+ * variant (draw_indexed asserts a captured index type). */
+static void bind_test_vertex_input(void) {
+    static const float verts[9] = {0};
+    static const uint16_t indices[3] = {0, 1, 2};
+    nt_buffer_t vbo = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_IMMUTABLE, .data = verts, .size = sizeof(verts)});
+    nt_buffer_t ibo = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_INDEX, .usage = NT_USAGE_IMMUTABLE, .data = indices, .size = sizeof(indices), .index_type = NT_INDEX_UINT16});
+    nt_gfx_bind_vertex_input(nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){
+        .layout = {.attr_count = 1, .stride = 12, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 3}}},
+        .vertex_buffer = vbo,
+        .index_buffer = ibo,
+    }));
+}
 
 /* ---- Program: no dedup — same pair links twice ---- */
 
@@ -593,6 +605,7 @@ void test_gfx_destroy_program_destroys_its_pipelines(void) {
     nt_gfx_begin_frame();
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
     nt_gfx_bind_pipeline(untouched);
+    bind_test_vertex_input();
     nt_gfx_draw(0, 0);
     TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_get_frame_draw_calls());
 
@@ -645,92 +658,6 @@ static void expect_pipeline_blend_accept(nt_blend_state_t blend) {
     nt_gfx_destroy_shader(vs);
 }
 
-void test_gfx_pipeline_asserts_duplicate_location(void) {
-    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "v"});
-    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "f"});
-    nt_program_t prog = nt_gfx_make_program(vs, fs);
-
-    /* Same location in vertex and instance layouts: glVertexAttribPointer twice on one slot */
-    EXPECT_ASSERT(nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
-        .program = prog,
-        .layout = {.attr_count = 1, .stride = 12, .attrs = {{.location = 3, .type = NT_VERTEX_FLOAT, .count = 3}}},
-        .instance_layout = {.attr_count = 1, .stride = 16, .attrs = {{.location = 3, .type = NT_VERTEX_FLOAT, .count = 4}}},
-    }));
-
-    nt_gfx_destroy_shader(vs);
-    nt_gfx_destroy_shader(fs);
-}
-
-void test_gfx_pipeline_asserts_location_out_of_range(void) {
-    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "v"});
-    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "f"});
-    nt_program_t prog = nt_gfx_make_program(vs, fs);
-
-    /* WebGL2 guarantees only 16 attribute locations; 16 is already out of range */
-    EXPECT_ASSERT(nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
-        .program = prog,
-        .layout = {.attr_count = 1, .stride = 12, .attrs = {{.location = 16, .type = NT_VERTEX_FLOAT, .count = 3}}},
-    }));
-
-    nt_gfx_destroy_shader(vs);
-    nt_gfx_destroy_shader(fs);
-}
-
-void test_gfx_pipeline_asserts_normalized_float(void) {
-    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "v"});
-    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "f"});
-    nt_program_t prog = nt_gfx_make_program(vs, fs);
-
-    /* GL ignores normalized on float types; the contract allows it on integer types only */
-    EXPECT_ASSERT(nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
-        .program = prog,
-        .layout = {.attr_count = 1, .stride = 12, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 3, .normalized = true}}},
-    }));
-
-    nt_gfx_destroy_shader(vs);
-    nt_gfx_destroy_shader(fs);
-}
-
-void test_gfx_pipeline_asserts_misaligned_offset(void) {
-    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "v"});
-    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "f"});
-    nt_program_t prog = nt_gfx_make_program(vs, fs);
-    /* f32 attr at offset 2: WebGL2 requires offset % 4 == 0 */
-    EXPECT_ASSERT(nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
-        .program = prog,
-        .layout = {.attr_count = 1, .stride = 16, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 3, .offset = 2}}},
-    }));
-    nt_gfx_destroy_shader(vs);
-    nt_gfx_destroy_shader(fs);
-}
-
-void test_gfx_pipeline_asserts_misaligned_stride(void) {
-    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "v"});
-    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "f"});
-    nt_program_t prog = nt_gfx_make_program(vs, fs);
-    /* stride 13 with an f32 attr: WebGL2 requires stride % 4 == 0 */
-    EXPECT_ASSERT(nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
-        .program = prog,
-        .layout = {.attr_count = 1, .stride = 13, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 3}}},
-    }));
-    nt_gfx_destroy_shader(vs);
-    nt_gfx_destroy_shader(fs);
-}
-
-void test_gfx_pipeline_asserts_bad_instance_layout(void) {
-    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "v"});
-    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "f"});
-    nt_program_t prog = nt_gfx_make_program(vs, fs);
-    /* Pins that the instance layout goes through the same WebGL2 asserts */
-    EXPECT_ASSERT(nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
-        .program = prog,
-        .layout = {.attr_count = 1, .stride = 12, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 3}}},
-        .instance_layout = {.attr_count = 1, .stride = 16, .attrs = {{.location = 16, .type = NT_VERTEX_FLOAT, .count = 4}}},
-    }));
-    nt_gfx_destroy_shader(vs);
-    nt_gfx_destroy_shader(fs);
-}
-
 void test_gfx_pipeline_asserts_null_desc(void) { EXPECT_ASSERT(nt_gfx_make_pipeline(NULL)); }
 
 /* Context loss is what zeroes a program's backend, so it must not read as the
@@ -746,20 +673,6 @@ void test_gfx_pipeline_context_lost_returns_invalid(void) {
     TEST_ASSERT_TRUE(nt_gfx_program_valid(prog));
     TEST_ASSERT_FALSE(nt_gfx_program_ready(prog));
     TEST_ASSERT_EQUAL_UINT32(0, pip.id);
-}
-
-void test_gfx_pipeline_asserts_too_many_attrs(void) {
-    nt_shader_t vs = make_test_vs();
-    nt_shader_t fs = make_test_fs();
-    nt_program_t prog = nt_gfx_make_program(vs, fs);
-    EXPECT_ASSERT(nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
-        .program = prog,
-        .layout = {.attr_count = NT_GFX_MAX_VERTEX_ATTRS + 1, .stride = 4},
-    }));
-    EXPECT_ASSERT(nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
-        .program = prog,
-        .instance_layout = {.attr_count = NT_GFX_MAX_VERTEX_ATTRS + 1, .stride = 4},
-    }));
 }
 
 void test_gfx_pipeline_pool_full_asserts(void) {
@@ -785,28 +698,6 @@ void test_gfx_pipeline_backend_failure_returns_invalid(void) {
     TEST_ASSERT_NOT_EQUAL_UINT32(0, retry.id);
     nt_gfx_destroy_pipeline(retry);
     nt_gfx_stub_test_reset();
-}
-
-void test_gfx_pipeline_stride_255_boundary(void) {
-    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "v"});
-    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "f"});
-    nt_program_t prog = nt_gfx_make_program(vs, fs);
-
-    /* WebGL2 caps vertexAttribPointer stride at 255; u8 attr keeps 255 alignment-legal */
-    nt_pipeline_t ok = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
-        .program = prog,
-        .layout = {.attr_count = 1, .stride = 255, .attrs = {{.location = 0, .type = NT_VERTEX_UINT8, .count = 4, .normalized = true}}},
-    });
-    TEST_ASSERT_NOT_EQUAL_UINT32(0, ok.id);
-    nt_gfx_destroy_pipeline(ok);
-
-    EXPECT_ASSERT(nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
-        .program = prog,
-        .layout = {.attr_count = 1, .stride = 256, .attrs = {{.location = 0, .type = NT_VERTEX_UINT8, .count = 4, .normalized = true}}},
-    }));
-
-    nt_gfx_destroy_shader(vs);
-    nt_gfx_destroy_shader(fs);
 }
 
 void test_gfx_pipeline_rejects_invalid_blend_factor(void) {
@@ -1720,54 +1611,6 @@ void test_update_buffer_rejects_out_of_range(void) {
     nt_gfx_destroy_buffer(buf);
 }
 
-void test_bind_instance_buffer_rejects_unaligned_offset(void) {
-    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "v"});
-    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "f"});
-    nt_program_t prog = nt_gfx_make_program(vs, fs);
-    nt_pipeline_t pip = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
-        .program = prog,
-        .layout = {.attr_count = 1, .stride = 12, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 3}}},
-    });
-    TEST_ASSERT_NOT_EQUAL_UINT32(0, pip.id);
-    nt_gfx_bind_pipeline(pip);
-    nt_buffer_t buf = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 256});
-    nt_gfx_bind_instance_buffer(buf, 4);
-    TEST_ASSERT_EQUAL_UINT32(4, nt_gfx_stub_test_last_instance_offset()); /* aligned offset reached the backend */
-    EXPECT_ASSERT(nt_gfx_bind_instance_buffer(buf, 1));                   /* WebGL2 rejects unaligned attrib offsets */
-    nt_gfx_destroy_buffer(buf);
-    nt_gfx_destroy_pipeline(pip);
-    nt_gfx_destroy_shader(vs);
-    nt_gfx_destroy_shader(fs);
-}
-
-void test_bind_instance_buffer_requires_pipeline_each_frame(void) {
-    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "v"});
-    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "f"});
-    nt_program_t prog = nt_gfx_make_program(vs, fs);
-    nt_pipeline_t pip = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
-        .program = prog,
-        .layout = {.attr_count = 1, .stride = 12, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 3}}},
-    });
-    TEST_ASSERT_NOT_EQUAL_UINT32(0, pip.id);
-    nt_buffer_t buf = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 256});
-
-    nt_gfx_begin_frame();
-    nt_gfx_bind_pipeline(pip);
-    nt_gfx_bind_instance_buffer(buf, 0); /* bound this frame: passes */
-    nt_gfx_end_frame();
-
-    /* Backend drops its pipeline cache per frame — a bind without re-binding
-     * the pipeline must trap, not silently skip attrib setup. */
-    nt_gfx_begin_frame();
-    EXPECT_ASSERT(nt_gfx_bind_instance_buffer(buf, 0));
-    nt_gfx_end_frame();
-
-    nt_gfx_destroy_buffer(buf);
-    nt_gfx_destroy_pipeline(pip);
-    nt_gfx_destroy_shader(vs);
-    nt_gfx_destroy_shader(fs);
-}
-
 void test_update_buffer_rejects_immutable(void) {
     uint8_t initial[64] = {0};
     nt_buffer_t buf = nt_gfx_make_buffer(&(nt_buffer_desc_t){
@@ -1982,7 +1825,6 @@ void test_gfx_restored_frame_rejects_draws(void) {
     nt_program_t prog = nt_gfx_make_program(vs, fs);
     nt_pipeline_t pip = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
         .program = prog,
-        .layout = {.attr_count = 1, .stride = 12, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 3}}},
     });
 
     /* Lose it, then let begin_frame see the context back: that frame is the
@@ -1998,7 +1840,6 @@ void test_gfx_restored_frame_rejects_draws(void) {
 
     nt_pipeline_t rebuilt = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
         .program = nt_gfx_make_program(make_test_vs(), make_test_fs()),
-        .layout = {.attr_count = 1, .stride = 12, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 3}}},
     });
     nt_gfx_bind_pipeline(rebuilt);
     EXPECT_ASSERT(nt_gfx_draw(0, 0));
@@ -2013,6 +1854,7 @@ void test_gfx_restored_frame_rejects_draws(void) {
     TEST_ASSERT_FALSE(g_nt_gfx.context_restored);
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
     nt_gfx_bind_pipeline(rebuilt);
+    bind_test_vertex_input();
     nt_gfx_draw(0, 0);
     TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_get_frame_draw_calls());
     nt_gfx_end_pass();
@@ -2029,7 +1871,6 @@ void test_gfx_failed_bind_drops_the_previous_pipeline(void) {
     nt_program_t prog = nt_gfx_make_program(vs, fs);
     nt_pipeline_desc_t desc = {
         .program = prog,
-        .layout = {.attr_count = 1, .stride = 12, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 3}}},
     };
     nt_pipeline_t live = nt_gfx_make_pipeline(&desc);
     nt_pipeline_t dead = nt_gfx_make_pipeline(&desc);
@@ -2039,6 +1880,7 @@ void test_gfx_failed_bind_drops_the_previous_pipeline(void) {
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
 
     nt_gfx_bind_pipeline(live);
+    bind_test_vertex_input();
     nt_gfx_draw(0, 0);
     TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_get_frame_draw_calls());
 
@@ -2066,7 +1908,6 @@ void test_gfx_frame_draw_calls(void) {
     nt_program_t prog = nt_gfx_make_program(vs, fs);
     nt_pipeline_t pip = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
         .program = prog,
-        .layout = {.attr_count = 1, .stride = 12, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 3}}},
     });
     TEST_ASSERT_NOT_EQUAL_UINT32(0, pip.id);
 
@@ -2079,6 +1920,7 @@ void test_gfx_frame_draw_calls(void) {
 
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
     nt_gfx_bind_pipeline(pip);
+    bind_test_vertex_input();
 
     /* Fire each of the 4 entry points exactly once. */
     nt_gfx_draw(0, 0);
@@ -2147,16 +1989,8 @@ int main(void) {
     RUN_TEST(test_gfx_register_global_block_after_program_is_allowed);
     RUN_TEST(test_gfx_pipeline_asserts_null_desc);
     RUN_TEST(test_gfx_pipeline_context_lost_returns_invalid);
-    RUN_TEST(test_gfx_pipeline_asserts_too_many_attrs);
     RUN_TEST(test_gfx_pipeline_pool_full_asserts);
     RUN_TEST(test_gfx_pipeline_backend_failure_returns_invalid);
-    RUN_TEST(test_gfx_pipeline_stride_255_boundary);
-    RUN_TEST(test_gfx_pipeline_asserts_duplicate_location);
-    RUN_TEST(test_gfx_pipeline_asserts_normalized_float);
-    RUN_TEST(test_gfx_pipeline_asserts_location_out_of_range);
-    RUN_TEST(test_gfx_pipeline_asserts_misaligned_offset);
-    RUN_TEST(test_gfx_pipeline_asserts_misaligned_stride);
-    RUN_TEST(test_gfx_pipeline_asserts_bad_instance_layout);
     RUN_TEST(test_activate_mesh_rejects_misaligned_offset);
     RUN_TEST(test_activate_texture_bad_version);
     RUN_TEST(test_activate_mesh_rejects_misaligned_stream);
@@ -2225,8 +2059,6 @@ int main(void) {
     RUN_TEST(test_update_buffer_at_offset);
     RUN_TEST(test_update_buffer_rejects_out_of_range);
     RUN_TEST(test_update_buffer_rejects_immutable);
-    RUN_TEST(test_bind_instance_buffer_rejects_unaligned_offset);
-    RUN_TEST(test_bind_instance_buffer_requires_pipeline_each_frame);
     RUN_TEST(test_destroy_uniform_buffer);
     /* Global block registration tests */
     RUN_TEST(test_register_global_block);

--- a/tests/unit/test_gfx.c
+++ b/tests/unit/test_gfx.c
@@ -1816,6 +1816,36 @@ void test_gfx_update_texture_invalid_handle(void) {
     nt_gfx_update_texture(tex, 0, 0, 1, 1, data); /* should log error, not crash */
 }
 
+/* Pipelines are baked objects: loss frees their slots outright (the vertex-
+ * input rule), the handle goes stale, the bind is the ordinary invalid path,
+ * and every slot is allocatable again. */
+void test_gfx_pipeline_slots_freed_by_context_loss(void) {
+    nt_program_t prog = nt_gfx_make_program(make_test_vs(), make_test_fs());
+    nt_pipeline_t pip = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = prog});
+
+    nt_gfx_stub_test_set_context_lost(true);
+    nt_gfx_begin_frame(); /* latches the loss, frees pipeline slots */
+    nt_gfx_stub_test_set_context_lost(false);
+    nt_gfx_begin_frame(); /* recovery completes */
+
+    TEST_ASSERT_FALSE(nt_gfx_pipeline_valid(pip));
+    nt_gfx_bind_pipeline(pip);    /* stale: ordinary invalid path, no trap */
+    nt_gfx_destroy_pipeline(pip); /* stale: tolerated no-op */
+
+    /* Programs survive as husks; relink before building new pipelines. */
+    nt_gfx_destroy_program(prog);
+    nt_program_t fresh = nt_gfx_make_program(make_test_vs(), make_test_fs());
+    nt_pipeline_t pips[4];
+    for (uint32_t i = 0; i < 4; i++) {
+        pips[i] = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = fresh});
+        TEST_ASSERT_NOT_EQUAL_UINT32(0, pips[i].id);
+    }
+    for (uint32_t i = 0; i < 4; i++) {
+        nt_gfx_destroy_pipeline(pips[i]);
+    }
+    nt_gfx_end_frame();
+}
+
 /* ---- Per-frame draw call counter ---- */
 
 /* Restore invalidates earlier render decisions, so the restored frame permits clears but rejects draws. */
@@ -2081,6 +2111,7 @@ int main(void) {
     RUN_TEST(test_gfx_update_texture_valid);
     RUN_TEST(test_gfx_update_texture_full);
     RUN_TEST(test_gfx_update_texture_invalid_handle);
+    RUN_TEST(test_gfx_pipeline_slots_freed_by_context_loss);
     RUN_TEST(test_gfx_restored_frame_rejects_draws);
     RUN_TEST(test_gfx_failed_bind_drops_the_previous_pipeline);
     RUN_TEST(test_gfx_frame_draw_calls);

--- a/tests/unit/test_gfx.c
+++ b/tests/unit/test_gfx.c
@@ -50,7 +50,9 @@ static const uint16_t s_test_rg16ui_4x4[4 * 4 * 2] = {
     1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32,
 };
 
-void setUp(void) { nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 8, .max_textures = 8, .max_meshes = 8, .max_render_targets = 16}); }
+void setUp(void) {
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 8, .max_textures = 8, .max_meshes = 8, .max_vertex_inputs = 8, .max_render_targets = 16});
+}
 
 void tearDown(void) {
     nt_assert_handler = NULL;
@@ -152,7 +154,7 @@ void test_gfx_init_shutdown(void) {
     nt_gfx_shutdown();
     TEST_ASSERT_FALSE(g_nt_gfx.initialized);
     /* Re-init for tearDown */
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 8, .max_textures = 8, .max_meshes = 8, .max_render_targets = 16});
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 8, .max_textures = 8, .max_meshes = 8, .max_vertex_inputs = 8, .max_render_targets = 16});
 }
 
 /* ---- High-level: make/destroy shader ---- */
@@ -192,7 +194,7 @@ void test_gfx_defaults_applied(void) {
 
     /* Re-init for tearDown */
     nt_gfx_shutdown();
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 8, .max_textures = 8, .max_meshes = 8, .max_render_targets = 16});
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 8, .max_textures = 8, .max_meshes = 8, .max_vertex_inputs = 8, .max_render_targets = 16});
 }
 
 /* ---- Pipeline: create with valid shaders, destroy ---- */
@@ -1830,7 +1832,7 @@ void test_register_global_block_max(void) {
 void test_register_global_block_cleared_on_shutdown(void) {
     nt_gfx_register_global_block("Globals", 0);
     nt_gfx_shutdown();
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 8, .max_textures = 8, .max_meshes = 8, .max_render_targets = 16});
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 8, .max_textures = 8, .max_meshes = 8, .max_vertex_inputs = 8, .max_render_targets = 16});
     const nt_global_block_t *blocks;
     uint32_t count;
     nt_gfx_get_global_blocks(&blocks, &count);

--- a/tests/unit/test_gfx_vertex_input.c
+++ b/tests/unit/test_gfx_vertex_input.c
@@ -1,0 +1,379 @@
+#include "core/nt_assert.h"
+#include "graphics/nt_gfx.h"
+#include "graphics/nt_gfx_internal.h"
+#include "nt_mesh_format.h"
+#include "unity.h"
+
+#include <setjmp.h>
+#include <string.h>
+
+/* --- Assert catching (setjmp/longjmp via hookable handler) --- */
+
+static jmp_buf s_assert_jmp;
+
+static void test_assert_handler(const char *expr, const char *file, int line) {
+    (void)expr;
+    (void)file;
+    (void)line;
+    longjmp(s_assert_jmp, 1);
+}
+
+#define EXPECT_ASSERT(code)                                                                                                                                                                            \
+    do {                                                                                                                                                                                               \
+        nt_assert_handler = test_assert_handler;                                                                                                                                                       \
+        if (setjmp(s_assert_jmp) == 0) {                                                                                                                                                               \
+            code;                                                                                                                                                                                      \
+            nt_assert_handler = NULL;                                                                                                                                                                  \
+            TEST_FAIL_MESSAGE("Expected NT_ASSERT to fire");                                                                                                                                           \
+        }                                                                                                                                                                                              \
+        nt_assert_handler = NULL;                                                                                                                                                                      \
+    } while (0)
+
+void setUp(void) {
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 8, .max_textures = 4, .max_meshes = 4, .max_vertex_inputs = 4, .max_render_targets = 4});
+    nt_gfx_stub_test_reset();
+}
+
+void tearDown(void) {
+    nt_assert_handler = NULL;
+    nt_gfx_shutdown();
+    nt_gfx_stub_test_reset();
+}
+
+/* --- Fixtures --- */
+
+static const float s_verts[9] = {0};
+static const uint16_t s_indices[3] = {0, 1, 2};
+
+static nt_buffer_t make_vbo(void) { return nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_IMMUTABLE, .data = s_verts, .size = sizeof(s_verts)}); }
+
+static nt_buffer_t make_ibo(void) {
+    return nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_INDEX, .usage = NT_USAGE_IMMUTABLE, .data = s_indices, .size = sizeof(s_indices), .index_type = NT_INDEX_UINT16});
+}
+
+static nt_vertex_layout_t pos_layout(void) { return (nt_vertex_layout_t){.attr_count = 1, .stride = 12, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 3}}}; }
+
+static nt_vertex_layout_t inst_layout(void) { return (nt_vertex_layout_t){.attr_count = 1, .stride = 16, .attrs = {{.location = 4, .type = NT_VERTEX_FLOAT, .count = 4}}}; }
+
+static nt_vertex_input_t make_vi(nt_buffer_t vbo, nt_buffer_t ibo) { return nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout(), .vertex_buffer = vbo, .index_buffer = ibo}); }
+
+static nt_pipeline_t make_test_pipeline(void) {
+    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "v"});
+    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "f"});
+    return nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = nt_gfx_make_program(vs, fs)});
+}
+
+/* --- Lifecycle --- */
+
+void test_vi_make_valid_destroy(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, vi.id);
+    TEST_ASSERT_TRUE(nt_gfx_vertex_input_valid(vi));
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_stub_test_vertex_input_create_count());
+    nt_gfx_destroy_vertex_input(vi);
+    TEST_ASSERT_FALSE(nt_gfx_vertex_input_valid(vi));
+}
+
+void test_vi_destroy_invalid_and_stale_are_noops(void) {
+    nt_gfx_destroy_vertex_input(NT_VERTEX_INPUT_INVALID); /* no trap, no log side effects to check */
+    nt_buffer_t vbo = make_vbo();
+    nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
+    nt_gfx_destroy_vertex_input(vi);
+    nt_gfx_destroy_vertex_input(vi); /* stale: second destroy is a no-op */
+    TEST_ASSERT_FALSE(nt_gfx_vertex_input_valid(vi));
+}
+
+void test_vi_slot_reuse_bumps_generation(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_vertex_input_t first = make_vi(vbo, (nt_buffer_t){0});
+    nt_gfx_destroy_vertex_input(first);
+    nt_vertex_input_t second = make_vi(vbo, (nt_buffer_t){0});
+    TEST_ASSERT_NOT_EQUAL_UINT32(first.id, second.id);
+    TEST_ASSERT_FALSE(nt_gfx_vertex_input_valid(first));
+    TEST_ASSERT_TRUE(nt_gfx_vertex_input_valid(second));
+}
+
+void test_vi_empty_layout_is_attributeless(void) {
+    nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){0});
+    TEST_ASSERT_TRUE(nt_gfx_vertex_input_valid(vi));
+    nt_gfx_destroy_vertex_input(vi);
+}
+
+void test_vi_backend_failure_returns_invalid(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_gfx_stub_test_fail_next_vertex_input_create();
+    nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
+    TEST_ASSERT_EQUAL_UINT32(0, vi.id);
+    /* The reserved pool slot was released: the next create succeeds. */
+    TEST_ASSERT_TRUE(nt_gfx_vertex_input_valid(make_vi(vbo, (nt_buffer_t){0})));
+}
+
+void test_vi_pool_exhaustion_asserts(void) {
+    nt_buffer_t vbo = make_vbo();
+    for (int i = 0; i < 4; i++) {
+        TEST_ASSERT_NOT_EQUAL_UINT32(0, make_vi(vbo, (nt_buffer_t){0}).id);
+    }
+    EXPECT_ASSERT(make_vi(vbo, (nt_buffer_t){0}));
+}
+
+/* --- Creation validation --- */
+
+void test_vi_creation_asserts_on_caller_errors(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_buffer_t ibo = make_ibo();
+
+    /* Location used twice across vertex/instance layouts. */
+    EXPECT_ASSERT(nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){
+        .layout = pos_layout(),
+        .instance_layout = (nt_vertex_layout_t){.attr_count = 1, .stride = 16, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 4}}},
+        .vertex_buffer = vbo,
+    }));
+    /* Nonempty layout without a vertex buffer, and the reverse. */
+    EXPECT_ASSERT(nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout()}));
+    EXPECT_ASSERT(nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.vertex_buffer = vbo}));
+    /* Wrong buffer types both ways. */
+    EXPECT_ASSERT(nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout(), .vertex_buffer = ibo}));
+    EXPECT_ASSERT(nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout(), .vertex_buffer = vbo, .index_buffer = vbo}));
+}
+
+void test_vi_creation_asserts_on_untyped_index_buffer(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_buffer_t untyped_ibo = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_INDEX, .usage = NT_USAGE_IMMUTABLE, .data = s_indices, .size = sizeof(s_indices)});
+    EXPECT_ASSERT(nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout(), .vertex_buffer = vbo, .index_buffer = untyped_ibo}));
+}
+
+/* --- Destroy cascade --- */
+
+void test_destroy_vbo_cascades_to_vi(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_buffer_t other_vbo = make_vbo();
+    nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
+    nt_vertex_input_t untouched = make_vi(other_vbo, (nt_buffer_t){0});
+    nt_gfx_destroy_buffer(vbo);
+    TEST_ASSERT_FALSE(nt_gfx_vertex_input_valid(vi));
+    TEST_ASSERT_TRUE(nt_gfx_vertex_input_valid(untouched));
+}
+
+void test_destroy_ibo_cascades_to_vi(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_buffer_t ibo = make_ibo();
+    nt_vertex_input_t vi = make_vi(vbo, ibo);
+    nt_gfx_destroy_buffer(ibo);
+    TEST_ASSERT_FALSE(nt_gfx_vertex_input_valid(vi));
+    /* The vertex buffer is untouched and usable for a fresh vertex input. */
+    TEST_ASSERT_TRUE(nt_gfx_vertex_input_valid(make_vi(vbo, (nt_buffer_t){0})));
+}
+
+void test_deactivate_mesh_cascades_to_vi(void) {
+    uint8_t blob[sizeof(NtMeshAssetHeader) + sizeof(NtStreamDesc) + 12 + 6];
+    memset(blob, 0, sizeof(blob));
+    NtMeshAssetHeader *hdr = (NtMeshAssetHeader *)blob;
+    hdr->magic = NT_MESH_MAGIC;
+    hdr->version = NT_MESH_VERSION;
+    hdr->stream_count = 1;
+    hdr->index_type = 1;
+    hdr->vertex_count = 1;
+    hdr->index_count = 3;
+    hdr->vertex_data_size = 12;
+    hdr->index_data_size = 6;
+    NtStreamDesc *sd = (NtStreamDesc *)(blob + sizeof(NtMeshAssetHeader));
+    sd->name_hash = 0x12345678;
+    sd->type = NT_STREAM_FLOAT32;
+    sd->count = 3;
+
+    uint32_t handle = nt_gfx_activate_mesh(blob, (uint32_t)sizeof(blob));
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, handle);
+    const nt_gfx_mesh_info_t *info = nt_gfx_get_mesh_info((nt_mesh_t){handle});
+    nt_vertex_input_t vi = make_vi(info->vbo, info->ibo);
+    TEST_ASSERT_TRUE(nt_gfx_vertex_input_valid(vi));
+    nt_gfx_deactivate_mesh(handle);
+    TEST_ASSERT_FALSE(nt_gfx_vertex_input_valid(vi));
+}
+
+/* --- Binding and mirrors --- */
+
+void test_bind_vi_reaches_backend(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
+    nt_gfx_bind_vertex_input(vi);
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_stub_test_bind_vertex_input_count());
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_vertex_input());
+}
+
+void test_bind_invalid_vi_unbinds(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_destroy_vertex_input(vi);
+    nt_gfx_bind_vertex_input(vi); /* stale: clears the binding instead of trapping */
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_vertex_input());
+}
+
+void test_bind_pipeline_clears_bound_vi(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
+    nt_pipeline_t pip = make_test_pipeline();
+    nt_gfx_bind_vertex_input(vi);
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_vertex_input());
+    nt_gfx_bind_pipeline(pip);
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_vertex_input());
+    /* The frontend mirror is cleared too: with no pipeline-side instance
+     * layout the instance bind still runs the legacy pipeline path. */
+    nt_buffer_t stream = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
+    nt_gfx_bind_instance_buffer(stream, 0); /* no assert: pipeline fallback */
+}
+
+void test_destroy_while_bound_clears_mirrors(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_destroy_vertex_input(vi);
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_vertex_input());
+    /* With the vertex-input mirror cleared and no pipeline, the instance
+     * bind has nothing to point with -- it must trap, not use stale state. */
+    nt_buffer_t stream = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
+    EXPECT_ASSERT(nt_gfx_bind_instance_buffer(stream, 0));
+}
+
+void test_begin_frame_clears_bound_vi(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout(), .instance_layout = inst_layout(), .vertex_buffer = vbo});
+    nt_buffer_t stream = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
+
+    nt_gfx_begin_frame();
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_bind_instance_buffer(stream, 0); /* bound this frame: passes */
+    nt_gfx_end_frame();
+
+    nt_gfx_begin_frame();
+    EXPECT_ASSERT(nt_gfx_bind_instance_buffer(stream, 0)); /* mirror cleared, no pipeline */
+    nt_gfx_end_frame();
+}
+
+/* --- Instance buffer via bound vertex input --- */
+
+void test_bind_instance_buffer_uses_bound_vi(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout(), .instance_layout = inst_layout(), .vertex_buffer = vbo});
+    nt_buffer_t stream = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_bind_instance_buffer(stream, 16); /* no pipeline needed on this path */
+    TEST_ASSERT_EQUAL_UINT32(16, nt_gfx_stub_test_last_instance_offset());
+}
+
+void test_bind_instance_buffer_asserts_without_instance_layout(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
+    nt_buffer_t stream = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
+    nt_gfx_bind_vertex_input(vi);
+    EXPECT_ASSERT(nt_gfx_bind_instance_buffer(stream, 0));
+}
+
+/* --- Draw invariants (transitional: enforced when a vertex input is bound) --- */
+
+void test_draw_indexed_asserts_on_non_indexed_vi(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_buffer_t ibo = make_ibo();
+    nt_vertex_input_t indexed = make_vi(vbo, ibo);
+    nt_vertex_input_t non_indexed = make_vi(vbo, (nt_buffer_t){0});
+    nt_pipeline_t pip = make_test_pipeline();
+
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(indexed);
+    nt_gfx_draw_indexed(0, 3, 3); /* index type captured from the IBO */
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_get_frame_draw_calls());
+    /* A non-indexed vertex input CLEARS the index type -- indexed draw traps
+     * instead of silently reusing the previous binding's type. */
+    nt_gfx_bind_vertex_input(non_indexed);
+    EXPECT_ASSERT(nt_gfx_draw_indexed(0, 3, 3));
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+}
+
+void test_instanced_draw_asserts_before_instance_pointing(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout(), .instance_layout = inst_layout(), .vertex_buffer = vbo});
+    nt_buffer_t stream = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
+    nt_pipeline_t pip = make_test_pipeline();
+
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi);
+    /* Enabled-but-unpointed instance attribs would fail silently in GL. */
+    EXPECT_ASSERT(nt_gfx_draw_instanced(0, 3, 2));
+    nt_gfx_bind_instance_buffer(stream, 0);
+    nt_gfx_draw_instanced(0, 3, 2);
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_get_frame_draw_calls());
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+}
+
+void test_attributeless_vi_draws(void) {
+    nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){0});
+    nt_pipeline_t pip = make_test_pipeline();
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_draw(0, 3); /* gl_VertexID path: no buffers, no attribs */
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_get_frame_draw_calls());
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+}
+
+/* --- Context loss --- */
+
+void test_vi_make_during_context_loss_returns_invalid(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_gfx_stub_test_set_context_lost(true);
+    nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
+    TEST_ASSERT_EQUAL_UINT32(0, vi.id);
+    nt_gfx_stub_test_set_context_lost(false);
+}
+
+void test_vi_bind_after_context_loss_asserts(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
+
+    nt_gfx_stub_test_set_context_lost(true);
+    nt_gfx_begin_frame(); /* latches the loss, wipes backend tables */
+    nt_gfx_stub_test_set_context_lost(false);
+    nt_gfx_begin_frame(); /* recovery completes */
+
+    /* The pool slot survives the loss but its GPU object is gone. */
+    TEST_ASSERT_TRUE(nt_gfx_vertex_input_valid(vi));
+    EXPECT_ASSERT(nt_gfx_bind_vertex_input(vi));
+    nt_gfx_end_frame();
+}
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_vi_make_valid_destroy);
+    RUN_TEST(test_vi_destroy_invalid_and_stale_are_noops);
+    RUN_TEST(test_vi_slot_reuse_bumps_generation);
+    RUN_TEST(test_vi_empty_layout_is_attributeless);
+    RUN_TEST(test_vi_backend_failure_returns_invalid);
+    RUN_TEST(test_vi_pool_exhaustion_asserts);
+    RUN_TEST(test_vi_creation_asserts_on_caller_errors);
+    RUN_TEST(test_vi_creation_asserts_on_untyped_index_buffer);
+    RUN_TEST(test_destroy_vbo_cascades_to_vi);
+    RUN_TEST(test_destroy_ibo_cascades_to_vi);
+    RUN_TEST(test_deactivate_mesh_cascades_to_vi);
+    RUN_TEST(test_bind_vi_reaches_backend);
+    RUN_TEST(test_bind_invalid_vi_unbinds);
+    RUN_TEST(test_bind_pipeline_clears_bound_vi);
+    RUN_TEST(test_destroy_while_bound_clears_mirrors);
+    RUN_TEST(test_begin_frame_clears_bound_vi);
+    RUN_TEST(test_bind_instance_buffer_uses_bound_vi);
+    RUN_TEST(test_bind_instance_buffer_asserts_without_instance_layout);
+    RUN_TEST(test_draw_indexed_asserts_on_non_indexed_vi);
+    RUN_TEST(test_instanced_draw_asserts_before_instance_pointing);
+    RUN_TEST(test_attributeless_vi_draws);
+    RUN_TEST(test_vi_make_during_context_loss_returns_invalid);
+    RUN_TEST(test_vi_bind_after_context_loss_asserts);
+    return UNITY_END();
+}

--- a/tests/unit/test_gfx_vertex_input.c
+++ b/tests/unit/test_gfx_vertex_input.c
@@ -143,6 +143,44 @@ void test_vi_creation_asserts_on_untyped_index_buffer(void) {
     EXPECT_ASSERT(nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout(), .vertex_buffer = vbo, .index_buffer = untyped_ibo}));
 }
 
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+void test_vi_creation_asserts_webgl2_rules(void) {
+    nt_buffer_t vbo = make_vbo();
+    /* WebGL2 guarantees only 16 attribute locations; 16 is already out of range */
+    EXPECT_ASSERT(
+        nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = {.attr_count = 1, .stride = 12, .attrs = {{.location = 16, .type = NT_VERTEX_FLOAT, .count = 3}}}, .vertex_buffer = vbo}));
+    /* GL ignores normalized on float types; the contract allows it on integer types only */
+    EXPECT_ASSERT(nt_gfx_make_vertex_input(
+        &(nt_vertex_input_desc_t){.layout = {.attr_count = 1, .stride = 12, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 3, .normalized = true}}}, .vertex_buffer = vbo}));
+    /* f32 attr at offset 2: WebGL2 requires offset % 4 == 0 */
+    EXPECT_ASSERT(nt_gfx_make_vertex_input(
+        &(nt_vertex_input_desc_t){.layout = {.attr_count = 1, .stride = 16, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 3, .offset = 2}}}, .vertex_buffer = vbo}));
+    /* stride 13 with an f32 attr: WebGL2 requires stride % 4 == 0 */
+    EXPECT_ASSERT(
+        nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = {.attr_count = 1, .stride = 13, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 3}}}, .vertex_buffer = vbo}));
+    /* The instance layout goes through the same rules */
+    EXPECT_ASSERT(nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){
+        .layout = pos_layout(),
+        .instance_layout = {.attr_count = 1, .stride = 16, .attrs = {{.location = 16, .type = NT_VERTEX_FLOAT, .count = 4}}},
+        .vertex_buffer = vbo,
+    }));
+    /* Attr-count caps */
+    EXPECT_ASSERT(nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = {.attr_count = NT_GFX_MAX_VERTEX_ATTRS + 1, .stride = 4}, .vertex_buffer = vbo}));
+    EXPECT_ASSERT(nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.instance_layout = {.attr_count = NT_GFX_MAX_VERTEX_ATTRS + 1, .stride = 4}}));
+}
+
+void test_vi_stride_255_boundary(void) {
+    nt_buffer_t vbo = make_vbo();
+    /* WebGL2 caps vertexAttribPointer stride at 255; u8 attr keeps 255 alignment-legal */
+    nt_vertex_input_t ok = nt_gfx_make_vertex_input(
+        &(nt_vertex_input_desc_t){.layout = {.attr_count = 1, .stride = 255, .attrs = {{.location = 0, .type = NT_VERTEX_UINT8, .count = 4, .normalized = true}}}, .vertex_buffer = vbo});
+    TEST_ASSERT_TRUE(nt_gfx_vertex_input_valid(ok));
+    nt_gfx_destroy_vertex_input(ok);
+
+    EXPECT_ASSERT(nt_gfx_make_vertex_input(
+        &(nt_vertex_input_desc_t){.layout = {.attr_count = 1, .stride = 256, .attrs = {{.location = 0, .type = NT_VERTEX_UINT8, .count = 4, .normalized = true}}}, .vertex_buffer = vbo}));
+}
+
 /* --- Destroy cascade --- */
 
 void test_destroy_vbo_cascades_to_vi(void) {
@@ -210,18 +248,19 @@ void test_bind_invalid_vi_unbinds(void) {
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_vertex_input());
 }
 
-void test_bind_pipeline_clears_bound_vi(void) {
+void test_bind_pipeline_preserves_bound_vi(void) {
     nt_buffer_t vbo = make_vbo();
-    nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
+    nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout(), .instance_layout = inst_layout(), .vertex_buffer = vbo});
     nt_pipeline_t pip = make_test_pipeline();
     nt_gfx_bind_vertex_input(vi);
-    TEST_ASSERT_NOT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_vertex_input());
+    uint32_t bound = nt_gfx_stub_test_bound_vertex_input();
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, bound);
     nt_gfx_bind_pipeline(pip);
-    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_vertex_input());
-    /* The frontend mirror is cleared too: with no pipeline-side instance
-     * layout the instance bind still runs the legacy pipeline path. */
+    /* Orthogonal state: a pipeline change must not disturb the geometry bind. */
+    TEST_ASSERT_EQUAL_UINT32(bound, nt_gfx_stub_test_bound_vertex_input());
     nt_buffer_t stream = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
-    nt_gfx_bind_instance_buffer(stream, 0); /* no assert: pipeline fallback */
+    nt_gfx_bind_instance_buffer(stream, 16); /* still points into the bound vertex input */
+    TEST_ASSERT_EQUAL_UINT32(16, nt_gfx_stub_test_last_instance_offset());
 }
 
 void test_destroy_while_bound_clears_mirrors(void) {
@@ -325,46 +364,58 @@ void test_attributeless_vi_draws(void) {
     nt_gfx_end_frame();
 }
 
-/* Transitional dual path: a migrated (vertex-input) draw and a legacy
- * (pipeline-VAO) draw must coexist in one frame. bind_pipeline clears the
- * bound vertex input, so the legacy instance bind falls back to the
- * pipeline's instance layout instead of writing into the vertex input. */
-void test_interleave_migrated_then_legacy_in_one_frame(void) {
+/* Pipelines and vertex inputs bind orthogonally: switching pipelines over one
+ * vertex input and switching vertex inputs under one pipeline both draw. */
+void test_pipeline_and_vertex_input_bind_orthogonally(void) {
     nt_buffer_t vbo = make_vbo();
     nt_buffer_t ibo = make_ibo();
-    nt_buffer_t stream = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
-    nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout(), .instance_layout = inst_layout(), .vertex_buffer = vbo});
-    nt_pipeline_t migrated_pip = make_test_pipeline();
-    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "v"});
-    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "f"});
-    nt_pipeline_t legacy_pip = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = nt_gfx_make_program(vs, fs), .layout = pos_layout(), .instance_layout = inst_layout()});
+    nt_vertex_input_t vi_indexed = make_vi(vbo, ibo);
+    nt_vertex_input_t vi_plain = make_vi(vbo, (nt_buffer_t){0});
+    nt_pipeline_t pip_a = make_test_pipeline();
+    nt_pipeline_t pip_b = make_test_pipeline();
 
     nt_gfx_begin_frame();
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
 
-    /* Migrated renderer pattern: pipeline -> vertex input -> instance bind. */
-    nt_gfx_bind_pipeline(migrated_pip);
-    nt_gfx_bind_vertex_input(vi);
-    nt_gfx_bind_instance_buffer(stream, 16);
-    nt_gfx_draw_instanced(0, 3, 2);
+    nt_gfx_bind_pipeline(pip_a);
+    nt_gfx_bind_vertex_input(vi_indexed);
+    nt_gfx_draw_indexed(0, 3, 3);
 
-    /* Legacy renderer in the same frame. */
-    nt_gfx_bind_pipeline(legacy_pip);
-    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_vertex_input());
-    nt_gfx_bind_vertex_buffer(vbo);
-    nt_gfx_bind_index_buffer(ibo);
-    nt_gfx_bind_instance_buffer(stream, 32); /* pipeline-layout fallback path */
-    TEST_ASSERT_EQUAL_UINT32(32, nt_gfx_stub_test_last_instance_offset());
-    nt_gfx_draw_indexed_instanced(0, 3, 3, 2);
+    /* Pipeline switch under the same geometry: no re-bind of the vertex input. */
+    nt_gfx_bind_pipeline(pip_b);
+    nt_gfx_draw_indexed(0, 3, 3);
 
-    /* Migrated again after the legacy draw. */
-    nt_gfx_bind_pipeline(migrated_pip);
-    nt_gfx_bind_vertex_input(vi);
-    nt_gfx_bind_instance_buffer(stream, 48);
-    TEST_ASSERT_EQUAL_UINT32(48, nt_gfx_stub_test_last_instance_offset());
-    nt_gfx_draw_instanced(0, 3, 2);
+    /* Geometry switch under the same pipeline. */
+    nt_gfx_bind_vertex_input(vi_plain);
+    nt_gfx_draw(0, 3);
 
     TEST_ASSERT_EQUAL_UINT32(3, nt_gfx_get_frame_draw_calls());
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+}
+
+/* WebGL2 rejects unaligned attrib offsets; the byte offset is asserted. */
+void test_bind_instance_buffer_rejects_unaligned_offset(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout(), .instance_layout = inst_layout(), .vertex_buffer = vbo});
+    nt_buffer_t stream = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_bind_instance_buffer(stream, 4);
+    TEST_ASSERT_EQUAL_UINT32(4, nt_gfx_stub_test_last_instance_offset()); /* aligned offset reached the backend */
+    EXPECT_ASSERT(nt_gfx_bind_instance_buffer(stream, 1));
+}
+
+/* Every draw variant requires a bound vertex input. */
+void test_draw_without_vertex_input_asserts(void) {
+    nt_pipeline_t pip = make_test_pipeline();
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+    nt_gfx_bind_pipeline(pip);
+    EXPECT_ASSERT(nt_gfx_draw(0, 3));
+    EXPECT_ASSERT(nt_gfx_draw_indexed(0, 3, 3));
+    EXPECT_ASSERT(nt_gfx_draw_instanced(0, 3, 1));
+    EXPECT_ASSERT(nt_gfx_draw_indexed_instanced(0, 3, 3, 1));
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_get_frame_draw_calls());
     nt_gfx_end_pass();
     nt_gfx_end_frame();
 }
@@ -404,12 +455,14 @@ int main(void) {
     RUN_TEST(test_vi_pool_exhaustion_asserts);
     RUN_TEST(test_vi_creation_asserts_on_caller_errors);
     RUN_TEST(test_vi_creation_asserts_on_untyped_index_buffer);
+    RUN_TEST(test_vi_creation_asserts_webgl2_rules);
+    RUN_TEST(test_vi_stride_255_boundary);
     RUN_TEST(test_destroy_vbo_cascades_to_vi);
     RUN_TEST(test_destroy_ibo_cascades_to_vi);
     RUN_TEST(test_deactivate_mesh_cascades_to_vi);
     RUN_TEST(test_bind_vi_reaches_backend);
     RUN_TEST(test_bind_invalid_vi_unbinds);
-    RUN_TEST(test_bind_pipeline_clears_bound_vi);
+    RUN_TEST(test_bind_pipeline_preserves_bound_vi);
     RUN_TEST(test_destroy_while_bound_clears_mirrors);
     RUN_TEST(test_begin_frame_clears_bound_vi);
     RUN_TEST(test_bind_instance_buffer_uses_bound_vi);
@@ -417,7 +470,9 @@ int main(void) {
     RUN_TEST(test_draw_indexed_asserts_on_non_indexed_vi);
     RUN_TEST(test_instanced_draw_asserts_before_instance_pointing);
     RUN_TEST(test_attributeless_vi_draws);
-    RUN_TEST(test_interleave_migrated_then_legacy_in_one_frame);
+    RUN_TEST(test_pipeline_and_vertex_input_bind_orthogonally);
+    RUN_TEST(test_bind_instance_buffer_rejects_unaligned_offset);
+    RUN_TEST(test_draw_without_vertex_input_asserts);
     RUN_TEST(test_vi_make_during_context_loss_returns_invalid);
     RUN_TEST(test_vi_bind_after_context_loss_asserts);
     return UNITY_END();

--- a/tests/unit/test_gfx_vertex_input.c
+++ b/tests/unit/test_gfx_vertex_input.c
@@ -495,18 +495,33 @@ void test_bind_instance_buffer_asserts_on_stale_buffer(void) {
     nt_gfx_end_frame();
 }
 
-void test_vi_bind_after_context_loss_asserts(void) {
+/* Loss frees vertex-input slots outright: the handle goes stale, the bind is
+ * the ordinary invalid-handle path, and every slot is allocatable again. */
+void test_vi_slots_freed_by_context_loss(void) {
     nt_buffer_t vbo = make_vbo();
     nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
 
     nt_gfx_stub_test_set_context_lost(true);
-    nt_gfx_begin_frame(); /* latches the loss, wipes backend tables */
+    nt_gfx_begin_frame(); /* latches the loss, frees vertex-input slots */
     nt_gfx_stub_test_set_context_lost(false);
     nt_gfx_begin_frame(); /* recovery completes */
 
-    /* The pool slot survives the loss but its GPU object is gone. */
-    TEST_ASSERT_TRUE(nt_gfx_vertex_input_valid(vi));
-    EXPECT_ASSERT(nt_gfx_bind_vertex_input(vi));
+    TEST_ASSERT_FALSE(nt_gfx_vertex_input_valid(vi));
+    nt_gfx_bind_vertex_input(vi); /* stale: ordinary invalid path, no trap */
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_vertex_input());
+    nt_gfx_destroy_vertex_input(vi); /* stale: tolerated no-op */
+
+    /* Buffers survive as husks; recreate before baking new vertex inputs. */
+    nt_gfx_destroy_buffer(vbo);
+    nt_buffer_t fresh = make_vbo();
+    nt_vertex_input_t vis[TEST_MAX_VERTEX_INPUTS];
+    for (uint32_t i = 0; i < TEST_MAX_VERTEX_INPUTS; i++) {
+        vis[i] = make_vi(fresh, (nt_buffer_t){0});
+        TEST_ASSERT_NOT_EQUAL_UINT32(0, vis[i].id);
+    }
+    for (uint32_t i = 0; i < TEST_MAX_VERTEX_INPUTS; i++) {
+        nt_gfx_destroy_vertex_input(vis[i]);
+    }
     nt_gfx_end_frame();
 }
 
@@ -541,6 +556,6 @@ int main(void) {
     RUN_TEST(test_vi_make_during_context_loss_returns_invalid);
     RUN_TEST(test_destroying_instance_buffer_unpoints_dependents);
     RUN_TEST(test_bind_instance_buffer_asserts_on_stale_buffer);
-    RUN_TEST(test_vi_bind_after_context_loss_asserts);
+    RUN_TEST(test_vi_slots_freed_by_context_loss);
     return UNITY_END();
 }

--- a/tests/unit/test_gfx_vertex_input.c
+++ b/tests/unit/test_gfx_vertex_input.c
@@ -7,6 +7,8 @@
 #include <setjmp.h>
 #include <string.h>
 
+#define TEST_MAX_VERTEX_INPUTS 4
+
 /* --- Assert catching (setjmp/longjmp via hookable handler) --- */
 
 static jmp_buf s_assert_jmp;
@@ -32,7 +34,8 @@ static void test_assert_handler(const char *expr, const char *file, int line) {
     } while (0)
 
 void setUp(void) {
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 8, .max_textures = 4, .max_meshes = 4, .max_vertex_inputs = 4, .max_render_targets = 4});
+    nt_gfx_init(&(nt_gfx_desc_t){
+        .max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 8, .max_textures = 4, .max_meshes = 4, .max_vertex_inputs = TEST_MAX_VERTEX_INPUTS, .max_render_targets = 4});
     nt_gfx_stub_test_reset();
 }
 
@@ -102,18 +105,20 @@ void test_vi_empty_layout_is_attributeless(void) {
     nt_gfx_destroy_vertex_input(vi);
 }
 
-void test_vi_backend_failure_returns_invalid(void) {
+void test_vi_backend_failure_releases_reserved_slot(void) {
     nt_buffer_t vbo = make_vbo();
     nt_gfx_stub_test_fail_next_vertex_input_create();
     nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
     TEST_ASSERT_EQUAL_UINT32(0, vi.id);
-    /* The reserved pool slot was released: the next create succeeds. */
-    TEST_ASSERT_TRUE(nt_gfx_vertex_input_valid(make_vi(vbo, (nt_buffer_t){0})));
+    /* Filling the whole pool exposes even one leaked reservation. */
+    for (int i = 0; i < TEST_MAX_VERTEX_INPUTS; i++) {
+        TEST_ASSERT_TRUE(nt_gfx_vertex_input_valid(make_vi(vbo, (nt_buffer_t){0})));
+    }
 }
 
 void test_vi_pool_exhaustion_asserts(void) {
     nt_buffer_t vbo = make_vbo();
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < TEST_MAX_VERTEX_INPUTS; i++) {
         TEST_ASSERT_NOT_EQUAL_UINT32(0, make_vi(vbo, (nt_buffer_t){0}).id);
     }
     EXPECT_ASSERT(make_vi(vbo, (nt_buffer_t){0}));
@@ -511,7 +516,7 @@ int main(void) {
     RUN_TEST(test_vi_destroy_invalid_and_stale_are_noops);
     RUN_TEST(test_vi_slot_reuse_bumps_generation);
     RUN_TEST(test_vi_empty_layout_is_attributeless);
-    RUN_TEST(test_vi_backend_failure_returns_invalid);
+    RUN_TEST(test_vi_backend_failure_releases_reserved_slot);
     RUN_TEST(test_vi_pool_exhaustion_asserts);
     RUN_TEST(test_vi_creation_asserts_on_caller_errors);
     RUN_TEST(test_vi_creation_asserts_on_untyped_index_buffer);

--- a/tests/unit/test_gfx_vertex_input.c
+++ b/tests/unit/test_gfx_vertex_input.c
@@ -325,6 +325,50 @@ void test_attributeless_vi_draws(void) {
     nt_gfx_end_frame();
 }
 
+/* Transitional dual path: a migrated (vertex-input) draw and a legacy
+ * (pipeline-VAO) draw must coexist in one frame. bind_pipeline clears the
+ * bound vertex input, so the legacy instance bind falls back to the
+ * pipeline's instance layout instead of writing into the vertex input. */
+void test_interleave_migrated_then_legacy_in_one_frame(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_buffer_t ibo = make_ibo();
+    nt_buffer_t stream = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
+    nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout(), .instance_layout = inst_layout(), .vertex_buffer = vbo});
+    nt_pipeline_t migrated_pip = make_test_pipeline();
+    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = "v"});
+    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = "f"});
+    nt_pipeline_t legacy_pip = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = nt_gfx_make_program(vs, fs), .layout = pos_layout(), .instance_layout = inst_layout()});
+
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+
+    /* Migrated renderer pattern: pipeline -> vertex input -> instance bind. */
+    nt_gfx_bind_pipeline(migrated_pip);
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_bind_instance_buffer(stream, 16);
+    nt_gfx_draw_instanced(0, 3, 2);
+
+    /* Legacy renderer in the same frame. */
+    nt_gfx_bind_pipeline(legacy_pip);
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_vertex_input());
+    nt_gfx_bind_vertex_buffer(vbo);
+    nt_gfx_bind_index_buffer(ibo);
+    nt_gfx_bind_instance_buffer(stream, 32); /* pipeline-layout fallback path */
+    TEST_ASSERT_EQUAL_UINT32(32, nt_gfx_stub_test_last_instance_offset());
+    nt_gfx_draw_indexed_instanced(0, 3, 3, 2);
+
+    /* Migrated again after the legacy draw. */
+    nt_gfx_bind_pipeline(migrated_pip);
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_bind_instance_buffer(stream, 48);
+    TEST_ASSERT_EQUAL_UINT32(48, nt_gfx_stub_test_last_instance_offset());
+    nt_gfx_draw_instanced(0, 3, 2);
+
+    TEST_ASSERT_EQUAL_UINT32(3, nt_gfx_get_frame_draw_calls());
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+}
+
 /* --- Context loss --- */
 
 void test_vi_make_during_context_loss_returns_invalid(void) {
@@ -373,6 +417,7 @@ int main(void) {
     RUN_TEST(test_draw_indexed_asserts_on_non_indexed_vi);
     RUN_TEST(test_instanced_draw_asserts_before_instance_pointing);
     RUN_TEST(test_attributeless_vi_draws);
+    RUN_TEST(test_interleave_migrated_then_legacy_in_one_frame);
     RUN_TEST(test_vi_make_during_context_loss_returns_invalid);
     RUN_TEST(test_vi_bind_after_context_loss_asserts);
     return UNITY_END();

--- a/tests/unit/test_gfx_vertex_input.c
+++ b/tests/unit/test_gfx_vertex_input.c
@@ -446,6 +446,50 @@ void test_vi_make_during_context_loss_returns_invalid(void) {
     nt_gfx_stub_test_set_context_lost(false);
 }
 
+/* Destroying a pointed instance buffer unpoints dependents: the next
+ * instanced draw without a re-point traps instead of silently reading the
+ * dead buffer through the VAO's dangling attachment. */
+void test_destroying_instance_buffer_unpoints_dependents(void) {
+    nt_buffer_t vbo = make_vbo();
+    nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout(), .instance_layout = inst_layout(), .vertex_buffer = vbo});
+    nt_buffer_t stream = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
+    nt_pipeline_t pip = make_test_pipeline();
+
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_bind_instance_buffer(stream, 0);
+    nt_gfx_draw_instanced(0, 3, 2);
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_get_frame_draw_calls());
+
+    nt_gfx_destroy_buffer(stream);
+    TEST_ASSERT_TRUE(nt_gfx_vertex_input_valid(vi)); /* instance buffers do not cascade-destroy */
+    EXPECT_ASSERT(nt_gfx_draw_instanced(0, 3, 2));
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+}
+
+/* Pool slots survive context loss: a stale instance-buffer handle must trap,
+ * not silently point the VAO at a zeroed backend. */
+void test_bind_instance_buffer_asserts_on_stale_buffer(void) {
+    nt_buffer_t stale = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
+
+    nt_gfx_stub_test_set_context_lost(true);
+    nt_gfx_begin_frame(); /* latches the loss, wipes backend tables */
+    nt_gfx_stub_test_set_context_lost(false);
+    nt_gfx_begin_frame(); /* recovery completes */
+    nt_gfx_end_frame();
+    nt_gfx_begin_frame();
+
+    nt_buffer_t vbo = make_vbo();
+    nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout(), .instance_layout = inst_layout(), .vertex_buffer = vbo});
+    nt_gfx_bind_vertex_input(vi);
+    /* The stale handle is still pool-valid; only its backend is gone. */
+    EXPECT_ASSERT(nt_gfx_bind_instance_buffer(stale, 0));
+    nt_gfx_end_frame();
+}
+
 void test_vi_bind_after_context_loss_asserts(void) {
     nt_buffer_t vbo = make_vbo();
     nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
@@ -490,6 +534,8 @@ int main(void) {
     RUN_TEST(test_bind_instance_buffer_rejects_unaligned_offset);
     RUN_TEST(test_draw_without_vertex_input_asserts);
     RUN_TEST(test_vi_make_during_context_loss_returns_invalid);
+    RUN_TEST(test_destroying_instance_buffer_unpoints_dependents);
+    RUN_TEST(test_bind_instance_buffer_asserts_on_stale_buffer);
     RUN_TEST(test_vi_bind_after_context_loss_asserts);
     return UNITY_END();
 }

--- a/tests/unit/test_gfx_vertex_input.c
+++ b/tests/unit/test_gfx_vertex_input.c
@@ -11,10 +11,12 @@
 
 static jmp_buf s_assert_jmp;
 
+static const char *s_last_assert_expr;
+
 static void test_assert_handler(const char *expr, const char *file, int line) {
-    (void)expr;
     (void)file;
     (void)line;
+    s_last_assert_expr = expr;
     longjmp(s_assert_jmp, 1);
 }
 
@@ -164,9 +166,21 @@ void test_vi_creation_asserts_webgl2_rules(void) {
         .instance_layout = {.attr_count = 1, .stride = 16, .attrs = {{.location = 16, .type = NT_VERTEX_FLOAT, .count = 4}}},
         .vertex_buffer = vbo,
     }));
-    /* Attr-count caps */
+    /* Attr-count caps. The expr checks pin WHICH assert fired: without them
+     * a removed cap would still trap downstream on the zeroed attrs. */
     EXPECT_ASSERT(nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = {.attr_count = NT_GFX_MAX_VERTEX_ATTRS + 1, .stride = 4}, .vertex_buffer = vbo}));
+    TEST_ASSERT_NOT_NULL(strstr(s_last_assert_expr, "NT_GFX_MAX_VERTEX_ATTRS"));
     EXPECT_ASSERT(nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.instance_layout = {.attr_count = NT_GFX_MAX_INSTANCE_ATTRS + 1, .stride = 4}}));
+    TEST_ASSERT_NOT_NULL(strstr(s_last_assert_expr, "NT_GFX_MAX_INSTANCE_ATTRS"));
+    /* Exactly NT_GFX_MAX_INSTANCE_ATTRS is accepted and survives the
+     * backend's compact per-slot copy. */
+    nt_vertex_layout_t inst_full = {.attr_count = NT_GFX_MAX_INSTANCE_ATTRS, .stride = 32};
+    for (uint8_t i = 0; i < NT_GFX_MAX_INSTANCE_ATTRS; i++) {
+        inst_full.attrs[i] = (nt_vertex_attr_t){.location = (uint8_t)(8 + i), .type = NT_VERTEX_FLOAT, .count = 1, .offset = (uint16_t)(i * 4)};
+    }
+    nt_vertex_input_t max_inst = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout(), .instance_layout = inst_full, .vertex_buffer = vbo});
+    TEST_ASSERT_TRUE(nt_gfx_vertex_input_valid(max_inst));
+    nt_gfx_destroy_vertex_input(max_inst);
 }
 
 void test_vi_stride_255_boundary(void) {

--- a/tests/unit/test_gfx_vertex_input.c
+++ b/tests/unit/test_gfx_vertex_input.c
@@ -166,7 +166,7 @@ void test_vi_creation_asserts_webgl2_rules(void) {
     }));
     /* Attr-count caps */
     EXPECT_ASSERT(nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = {.attr_count = NT_GFX_MAX_VERTEX_ATTRS + 1, .stride = 4}, .vertex_buffer = vbo}));
-    EXPECT_ASSERT(nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.instance_layout = {.attr_count = NT_GFX_MAX_VERTEX_ATTRS + 1, .stride = 4}}));
+    EXPECT_ASSERT(nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.instance_layout = {.attr_count = NT_GFX_MAX_INSTANCE_ATTRS + 1, .stride = 4}}));
 }
 
 void test_vi_stride_255_boundary(void) {
@@ -309,7 +309,7 @@ void test_bind_instance_buffer_asserts_without_instance_layout(void) {
     EXPECT_ASSERT(nt_gfx_bind_instance_buffer(stream, 0));
 }
 
-/* --- Draw invariants (transitional: enforced when a vertex input is bound) --- */
+/* --- Draw invariants --- */
 
 void test_draw_indexed_asserts_on_non_indexed_vi(void) {
     nt_buffer_t vbo = make_vbo();
@@ -342,8 +342,10 @@ void test_instanced_draw_asserts_before_instance_pointing(void) {
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
     nt_gfx_bind_pipeline(pip);
     nt_gfx_bind_vertex_input(vi);
-    /* Enabled-but-unpointed instance attribs would fail silently in GL. */
+    /* Enabled-but-unpointed instance attribs would fail silently in GL --
+     * for ANY draw with this VAO, not only instanced ones. */
     EXPECT_ASSERT(nt_gfx_draw_instanced(0, 3, 2));
+    EXPECT_ASSERT(nt_gfx_draw(0, 3));
     nt_gfx_bind_instance_buffer(stream, 0);
     nt_gfx_draw_instanced(0, 3, 2);
     TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_get_frame_draw_calls());

--- a/tests/unit/test_helpers/ui_walker_fixture.c
+++ b/tests/unit/test_helpers/ui_walker_fixture.c
@@ -48,7 +48,8 @@ void ui_walker_fixture_init(ui_walker_fixture_t *fx, void *arena, size_t arena_s
 
     nt_hash_init(&(nt_hash_desc_t){0});
     nt_mem_scratch_init((size_t)64U * 1024U); /* NT_UI_DATA_LAYER / NT_UI_DATA_FULL allocate here. */
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_programs = 16, .max_pipelines = 16, .max_buffers = 64, .max_textures = 32, .max_meshes = 16, .max_render_targets = 16});
+    nt_gfx_init(
+        &(nt_gfx_desc_t){.max_shaders = 32, .max_programs = 16, .max_pipelines = 16, .max_buffers = 64, .max_textures = 32, .max_meshes = 16, .max_vertex_inputs = 16, .max_render_targets = 16});
     nt_resource_init(&(nt_resource_desc_t){0});
     nt_atlas_init();
     nt_font_init(&(nt_font_desc_t){.max_fonts = 16}); /* rich multi-face tests create >4 distinct stub fonts */

--- a/tests/unit/test_mesh_renderer.c
+++ b/tests/unit/test_mesh_renderer.c
@@ -24,6 +24,8 @@
 #include "unity.h"
 /* clang-format on */
 
+#define TEST_MAX_VERTEX_INPUTS 160
+
 /* ---- Virtual pack counter (unique per test) ---- */
 
 static uint32_t s_program_warnings;
@@ -196,7 +198,7 @@ void setUp(void) {
         .max_buffers = 256,
         .max_textures = 32,
         .max_meshes = 32,
-        .max_vertex_inputs = 160,
+        .max_vertex_inputs = TEST_MAX_VERTEX_INPUTS,
         .max_render_targets = 16,
     });
     nt_resource_init(&(nt_resource_desc_t){0});
@@ -757,6 +759,12 @@ void test_bufferless_vertex_input_purged_on_mesh_slot_reuse(void) {
         TEST_ASSERT_NOT_EQUAL(old_id, mesh.id);
         *nt_mesh_comp_handle(e) = mesh;
         *nt_mesh_comp_handle(e_colored) = mesh;
+    }
+
+    /* Two cached versions and the neighbor own three slots; all others must be free. */
+    for (uint32_t i = 3; i < TEST_MAX_VERTEX_INPUTS; i++) {
+        nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){0});
+        TEST_ASSERT_TRUE(nt_gfx_vertex_input_valid(vi));
     }
 }
 

--- a/tests/unit/test_mesh_renderer.c
+++ b/tests/unit/test_mesh_renderer.c
@@ -166,6 +166,7 @@ void setUp(void) {
         .max_buffers = 256,
         .max_textures = 32,
         .max_meshes = 32,
+        .max_vertex_inputs = 160,
         .max_render_targets = 16,
     });
     nt_resource_init(&(nt_resource_desc_t){0});

--- a/tests/unit/test_mesh_renderer.c
+++ b/tests/unit/test_mesh_renderer.c
@@ -663,6 +663,20 @@ void test_vertex_input_shared_for_same_derived_layout(void) {
     TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_vertex_input_count());
 }
 
+/* A material mapping none of the mesh's streams derives an empty layout: the
+ * attribute-less gl_VertexID path draws through a vertex input with no VBO. */
+void test_vertex_input_empty_derived_layout_draws(void) {
+    nt_mesh_t mesh = create_test_mesh();
+    nt_material_t mat = create_test_material_with_attr(create_test_program(), NT_COLOR_MODE_NONE, "not_a_mesh_stream", 0, nt_blend_opaque());
+    nt_entity_t e = create_test_entity(mesh, mat);
+    nt_render_item_t items[1] = {{.sort_key = 0, .entity = e.id, .batch_key = nt_mesh_renderer_batch_key(mat, mesh)}};
+
+    nt_mesh_renderer_draw_list(items, 1);
+
+    TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_draw_call_count());
+    TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_vertex_input_count());
+}
+
 /* Mesh slot reuse must not alias the stale vertex input: the versions table
  * stores the full generation-checked handle. */
 void test_vertex_input_survives_mesh_slot_reuse(void) {
@@ -1012,6 +1026,7 @@ int main(void) {
     RUN_TEST(test_vertex_input_reused_across_draw_list_calls);
     RUN_TEST(test_vertex_input_distinct_per_mesh);
     RUN_TEST(test_vertex_input_shared_for_same_derived_layout);
+    RUN_TEST(test_vertex_input_empty_derived_layout_draws);
     RUN_TEST(test_vertex_input_survives_mesh_slot_reuse);
     RUN_TEST(test_vertex_input_versions_overflow_asserts);
     RUN_TEST(test_restore_gpu);

--- a/tests/unit/test_mesh_renderer.c
+++ b/tests/unit/test_mesh_renderer.c
@@ -241,6 +241,24 @@ void test_init_shutdown(void) {
     nt_mesh_renderer_init(&desc);
 }
 
+void test_init_retries_after_buffer_creation_failure(void) {
+    nt_mesh_renderer_shutdown();
+    nt_mesh_renderer_desc_t desc = {.max_instances = 2, .max_pipelines = 2, .max_mesh_layouts = 2};
+    nt_gfx_stub_test_fail_buffer_creates(1);
+    TEST_ASSERT_EQUAL(NT_ERR_INIT_FAILED, nt_mesh_renderer_init(&desc));
+    TEST_ASSERT_FALSE(nt_mesh_renderer_test_initialized());
+    TEST_ASSERT_EQUAL(NT_OK, nt_mesh_renderer_restore_gpu());
+    TEST_ASSERT_FALSE(nt_mesh_renderer_test_initialized());
+
+    TEST_ASSERT_EQUAL(NT_OK, nt_mesh_renderer_init(&desc));
+    nt_mesh_t mesh = create_test_mesh();
+    nt_material_t mat = create_test_material();
+    nt_entity_t entity = create_test_entity(mesh, mat);
+    nt_render_item_t item = {.entity = entity.id, .batch_key = nt_mesh_renderer_batch_key(mat, mesh)};
+    nt_mesh_renderer_draw_list(&item, 1);
+    TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_draw_call_count());
+}
+
 /* ---- Test 2: draw_list with count=0 is a no-op ---- */
 
 void test_draw_list_empty(void) {
@@ -823,6 +841,37 @@ void test_restore_gpu(void) {
     TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_draw_call_count());
 }
 
+void test_restore_gpu_retries_after_context_loss(void) {
+    nt_mesh_renderer_shutdown();
+    nt_mesh_renderer_desc_t desc = {.max_instances = 2, .max_pipelines = 2, .max_mesh_layouts = 2};
+    TEST_ASSERT_EQUAL(NT_OK, nt_mesh_renderer_init(&desc));
+    nt_mesh_t mesh = create_test_mesh();
+    nt_material_t mat = create_test_material_ex(NT_COLOR_MODE_FLOAT4);
+    nt_entity_t entity = create_test_entity(mesh, mat);
+    nt_render_item_t item = {.entity = entity.id, .batch_key = nt_mesh_renderer_batch_key(mat, mesh)};
+    nt_mesh_renderer_draw_list(&item, 1);
+    TEST_ASSERT_GREATER_THAN_UINT32(0, nt_mesh_renderer_test_ring_cursor());
+
+    nt_gfx_stub_test_set_context_lost(true);
+    nt_result_t result = nt_mesh_renderer_restore_gpu();
+    nt_gfx_stub_test_set_context_lost(false);
+
+    TEST_ASSERT_EQUAL(NT_ERR_INIT_FAILED, result);
+    TEST_ASSERT_TRUE(nt_mesh_renderer_test_initialized());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_mesh_renderer_test_ring_cursor());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_mesh_renderer_test_pipeline_cache_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_mesh_renderer_test_vertex_input_count());
+
+    NT_TEST_EXPECT_ASSERT(nt_mesh_renderer_draw_list(&item, 1));
+    TEST_ASSERT_EQUAL(NT_OK, nt_mesh_renderer_restore_gpu());
+    nt_render_item_t items[3] = {item, item, item};
+    nt_mesh_renderer_draw_list(items, 3);
+    TEST_ASSERT_EQUAL_UINT32(2, nt_mesh_renderer_test_draw_call_count());
+    TEST_ASSERT_EQUAL_UINT32(3, nt_mesh_renderer_test_instance_total());
+    TEST_ASSERT_EQUAL_UINT32(NT_INSTANCE_STRIDE_MAX, nt_mesh_renderer_test_ring_cursor());
+    TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_vertex_input_count());
+}
+
 /* ---- Test 10: stream -> vertex type mapping is total over all stream types ---- */
 
 /* The restore contract is "every ACTIVE renderer". Without the entry guard this
@@ -834,7 +883,7 @@ void test_restore_on_inactive_renderer_does_nothing(void) {
     nt_mesh_renderer_shutdown();
     TEST_ASSERT_FALSE(nt_mesh_renderer_test_initialized());
 
-    nt_mesh_renderer_restore_gpu();
+    TEST_ASSERT_EQUAL(NT_OK, nt_mesh_renderer_restore_gpu());
 
     /* The live assertion: init would have set this. The trap on a zeroed desc
      * aborts before ever reaching here, so it cannot be what pins the guard. */
@@ -1067,6 +1116,7 @@ int main(void) {
     UNITY_BEGIN();
 
     RUN_TEST(test_init_shutdown);
+    RUN_TEST(test_init_retries_after_buffer_creation_failure);
     RUN_TEST(test_draw_list_empty);
     RUN_TEST(test_draw_list_null_items_asserts_when_nonempty);
     RUN_TEST(test_unready_program_warns_once_and_rearms_after_pipeline_creation);
@@ -1096,6 +1146,7 @@ int main(void) {
     RUN_TEST(test_vertex_input_survives_mesh_slot_reuse);
     RUN_TEST(test_vertex_input_versions_overflow_asserts);
     RUN_TEST(test_restore_gpu);
+    RUN_TEST(test_restore_gpu_retries_after_context_loss);
     /* Color mode tests */
     RUN_TEST(test_draw_list_color_mode_float4);
     RUN_TEST(test_draw_list_color_mode_rgba8);

--- a/tests/unit/test_mesh_renderer.c
+++ b/tests/unit/test_mesh_renderer.c
@@ -83,6 +83,36 @@ static nt_mesh_t create_test_mesh(void) {
     return (nt_mesh_t){.id = handle};
 }
 
+/* Non-indexed variant: 3 vertices, no index data (index_type NONE). */
+static nt_mesh_t create_test_mesh_nonindexed(void) {
+    uint32_t vdata_size = 3 * 3 * (uint32_t)sizeof(float);
+    uint32_t blob_size = (uint32_t)sizeof(NtMeshAssetHeader) + (uint32_t)sizeof(NtStreamDesc) + vdata_size;
+    uint8_t blob[sizeof(NtMeshAssetHeader) + sizeof(NtStreamDesc) + 36];
+    memset(blob, 0, sizeof(blob));
+
+    NtMeshAssetHeader *hdr = (NtMeshAssetHeader *)blob;
+    hdr->magic = NT_MESH_MAGIC;
+    hdr->version = NT_MESH_VERSION;
+    hdr->stream_count = 1;
+    hdr->index_type = 0; /* none */
+    hdr->vertex_count = 3;
+    hdr->index_count = 0;
+    hdr->vertex_data_size = vdata_size;
+    hdr->index_data_size = 0;
+
+    NtStreamDesc *sd = (NtStreamDesc *)(blob + sizeof(NtMeshAssetHeader));
+    sd->name_hash = nt_hash32_str("position").value;
+    sd->type = NT_STREAM_FLOAT32;
+    sd->count = 3;
+
+    float *verts = (float *)(blob + sizeof(NtMeshAssetHeader) + sizeof(NtStreamDesc));
+    verts[3] = 1.0F;
+    verts[7] = 1.0F;
+
+    uint32_t handle = nt_gfx_activate_mesh(blob, blob_size);
+    return (nt_mesh_t){.id = handle};
+}
+
 /* ---- Helper: link a real GFX program, then create a material on it ---- */
 
 static nt_program_t create_test_program(void) {
@@ -677,6 +707,26 @@ void test_vertex_input_empty_derived_layout_draws(void) {
     TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_vertex_input_count());
 }
 
+/* Bufferless vertex inputs (empty derived layout + non-indexed mesh) have no
+ * destroy-cascade hook: stale-generation entries are purged on lookup, so
+ * mesh recreate cycles cannot exhaust the versions row. */
+void test_bufferless_vertex_input_purged_on_mesh_slot_reuse(void) {
+    nt_material_t mat = create_test_material_with_attr(create_test_program(), NT_COLOR_MODE_NONE, "not_a_mesh_stream", 0, nt_blend_opaque());
+    nt_mesh_t mesh = create_test_mesh_nonindexed();
+    nt_entity_t e = create_test_entity(mesh, mat);
+    nt_render_item_t items[1];
+    /* More cycles than max_mesh_layouts (default 4): without the purge the
+     * live-vi count climbs and the 5th lookup trips the row-overflow assert. */
+    for (int cycle = 0; cycle < 6; cycle++) {
+        items[0] = (nt_render_item_t){.sort_key = 0, .entity = e.id, .batch_key = nt_mesh_renderer_batch_key(mat, mesh)};
+        nt_mesh_renderer_draw_list(items, 1);
+        TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_vertex_input_count());
+        nt_gfx_deactivate_mesh(mesh.id);
+        mesh = create_test_mesh_nonindexed(); /* reuses the freed pool slot */
+        *nt_mesh_comp_handle(e) = mesh;
+    }
+}
+
 /* Mesh slot reuse must not alias the stale vertex input: the versions table
  * stores the full generation-checked handle. */
 void test_vertex_input_survives_mesh_slot_reuse(void) {
@@ -1027,6 +1077,7 @@ int main(void) {
     RUN_TEST(test_vertex_input_distinct_per_mesh);
     RUN_TEST(test_vertex_input_shared_for_same_derived_layout);
     RUN_TEST(test_vertex_input_empty_derived_layout_draws);
+    RUN_TEST(test_bufferless_vertex_input_purged_on_mesh_slot_reuse);
     RUN_TEST(test_vertex_input_survives_mesh_slot_reuse);
     RUN_TEST(test_vertex_input_versions_overflow_asserts);
     RUN_TEST(test_restore_gpu);

--- a/tests/unit/test_mesh_renderer.c
+++ b/tests/unit/test_mesh_renderer.c
@@ -707,23 +707,38 @@ void test_vertex_input_empty_derived_layout_draws(void) {
     TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_vertex_input_count());
 }
 
-/* Bufferless vertex inputs (empty derived layout + non-indexed mesh) have no
- * destroy-cascade hook: stale-generation entries are purged on lookup, so
- * mesh recreate cycles cannot exhaust the versions row. */
+/* Bufferless versions survive buffer destruction and need row-wide cleanup. */
 void test_bufferless_vertex_input_purged_on_mesh_slot_reuse(void) {
-    nt_material_t mat = create_test_material_with_attr(create_test_program(), NT_COLOR_MODE_NONE, "not_a_mesh_stream", 0, nt_blend_opaque());
+    nt_program_t program = create_test_program();
+    nt_material_t mat = create_test_material_with_attr(program, NT_COLOR_MODE_NONE, "not_a_mesh_stream", 0, nt_blend_opaque());
+    nt_material_t colored = create_test_material_with_attr(program, NT_COLOR_MODE_RGBA8, "not_a_mesh_stream", 0, nt_blend_opaque());
     nt_mesh_t mesh = create_test_mesh_nonindexed();
     nt_entity_t e = create_test_entity(mesh, mat);
-    nt_render_item_t items[1];
-    /* More cycles than max_mesh_layouts (default 4): without the purge the
-     * live-vi count climbs and the 5th lookup trips the row-overflow assert. */
+    nt_entity_t e_colored = create_test_entity(mesh, colored);
+    nt_mesh_t neighbor = create_test_mesh_nonindexed();
+    nt_entity_t e_neighbor = create_test_entity(neighbor, mat);
+    nt_render_item_t neighbor_item = {.entity = e_neighbor.id, .batch_key = nt_mesh_renderer_batch_key(mat, neighbor)};
+    nt_gfx_stub_test_reset();
+    nt_mesh_renderer_draw_list(&neighbor_item, 1);
+
     for (int cycle = 0; cycle < 6; cycle++) {
-        items[0] = (nt_render_item_t){.sort_key = 0, .entity = e.id, .batch_key = nt_mesh_renderer_batch_key(mat, mesh)};
+        nt_render_item_t items[2] = {
+            {.entity = e.id, .batch_key = nt_mesh_renderer_batch_key(mat, mesh)},
+            {.entity = e_colored.id, .batch_key = nt_mesh_renderer_batch_key(colored, mesh)},
+        };
         nt_mesh_renderer_draw_list(items, 1);
-        TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_vertex_input_count());
+        TEST_ASSERT_EQUAL_UINT32(2, nt_mesh_renderer_test_vertex_input_count());
+        nt_mesh_renderer_draw_list(items, 2);
+        nt_mesh_renderer_draw_list(&neighbor_item, 1);
+        TEST_ASSERT_EQUAL_UINT32(3, nt_mesh_renderer_test_vertex_input_count());
+        TEST_ASSERT_EQUAL_UINT32(1 + (2 * (cycle + 1)), nt_gfx_stub_test_vertex_input_create_count());
+        const uint32_t old_id = mesh.id;
         nt_gfx_deactivate_mesh(mesh.id);
         mesh = create_test_mesh_nonindexed(); /* reuses the freed pool slot */
+        TEST_ASSERT_EQUAL_UINT32(nt_pool_slot_index(old_id), nt_pool_slot_index(mesh.id));
+        TEST_ASSERT_NOT_EQUAL(old_id, mesh.id);
         *nt_mesh_comp_handle(e) = mesh;
+        *nt_mesh_comp_handle(e_colored) = mesh;
     }
 }
 

--- a/tests/unit/test_mesh_renderer.c
+++ b/tests/unit/test_mesh_renderer.c
@@ -572,6 +572,9 @@ void test_pipeline_cache_shared_program_collapses(void) {
     TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_pipeline_cache_count());
 }
 
+/* Same program and state with different attr_maps used to split pipelines;
+ * layouts now live on the vertex-input versions, so the pipeline collapses
+ * to one and the derived layouts split vertex inputs instead. */
 void test_pipeline_cache_different_material_attr_maps(void) {
     nt_mesh_t mesh = create_test_mesh();
     nt_program_t shared = create_test_program();
@@ -586,7 +589,132 @@ void test_pipeline_cache_different_material_attr_maps(void) {
 
     nt_mesh_renderer_draw_list(items, 2);
 
-    TEST_ASSERT_EQUAL_UINT32(2, nt_mesh_renderer_test_pipeline_cache_count());
+    TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_pipeline_cache_count());
+    TEST_ASSERT_EQUAL_UINT32(2, nt_mesh_renderer_test_vertex_input_count());
+}
+
+/* ---- Vertex-input versions: reuse, dedup, identity, overflow ---- */
+
+void test_vertex_input_reused_across_draw_list_calls(void) {
+    nt_mesh_t mesh = create_test_mesh();
+    nt_material_t mat = create_test_material();
+    nt_entity_t e = create_test_entity(mesh, mat);
+    nt_render_item_t items[1] = {{.sort_key = 0, .entity = e.id, .batch_key = nt_mesh_renderer_batch_key(mat, mesh)}};
+
+    nt_gfx_stub_test_reset();
+    nt_mesh_renderer_draw_list(items, 1);
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_stub_test_vertex_input_create_count());
+    nt_mesh_renderer_draw_list(items, 1);
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_stub_test_vertex_input_create_count());
+    TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_vertex_input_count());
+}
+
+void test_vertex_input_distinct_per_mesh(void) {
+    nt_mesh_t mesh_a = create_test_mesh();
+    nt_mesh_t mesh_b = create_test_mesh();
+    nt_material_t mat = create_test_material();
+    nt_entity_t e0 = create_test_entity(mesh_a, mat);
+    nt_entity_t e1 = create_test_entity(mesh_b, mat);
+    nt_render_item_t items[2] = {
+        {.sort_key = 0, .entity = e0.id, .batch_key = nt_mesh_renderer_batch_key(mat, mesh_a)},
+        {.sort_key = 1, .entity = e1.id, .batch_key = nt_mesh_renderer_batch_key(mat, mesh_b)},
+    };
+
+    nt_mesh_renderer_draw_list(items, 2);
+
+    /* One material state: one pipeline; two meshes: two vertex inputs. */
+    TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_pipeline_cache_count());
+    TEST_ASSERT_EQUAL_UINT32(2, nt_mesh_renderer_test_vertex_input_count());
+}
+
+/* An attr_map entry matching none of the mesh's streams must not split the
+ * vertex input: the DERIVED layout (streams x attr_map) is the identity. */
+void test_vertex_input_shared_for_same_derived_layout(void) {
+    nt_mesh_t mesh = create_test_mesh();
+    nt_program_t shared = create_test_program();
+    nt_material_t mat_a = create_test_material_with_attr(shared, NT_COLOR_MODE_NONE, "position", 0, nt_blend_opaque());
+
+    nt_material_create_desc_t desc;
+    memset(&desc, 0, sizeof(desc));
+    desc.program = shared;
+    desc.attr_map[0].stream_name = "position";
+    desc.attr_map[0].location = 0;
+    desc.attr_map[1].stream_name = "not_a_mesh_stream";
+    desc.attr_map[1].location = 5;
+    desc.attr_map_count = 2;
+    desc.depth_test = true;
+    desc.depth_write = true;
+    desc.blend = nt_blend_opaque();
+    desc.cull_mode = NT_CULL_BACK;
+    desc.color_mode = NT_COLOR_MODE_NONE;
+    desc.label = "extra_attr_material";
+    nt_material_t mat_b = nt_material_create(&desc);
+    nt_material_step();
+
+    nt_entity_t e0 = create_test_entity(mesh, mat_a);
+    nt_entity_t e1 = create_test_entity(mesh, mat_b);
+    nt_render_item_t items[2] = {
+        {.sort_key = 0, .entity = e0.id, .batch_key = nt_mesh_renderer_batch_key(mat_a, mesh)},
+        {.sort_key = 1, .entity = e1.id, .batch_key = nt_mesh_renderer_batch_key(mat_b, mesh)},
+    };
+
+    nt_mesh_renderer_draw_list(items, 2);
+
+    TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_vertex_input_count());
+}
+
+/* Mesh slot reuse must not alias the stale vertex input: the versions table
+ * stores the full generation-checked handle. */
+void test_vertex_input_survives_mesh_slot_reuse(void) {
+    nt_mesh_t mesh_a = create_test_mesh();
+    nt_material_t mat = create_test_material();
+    nt_entity_t e = create_test_entity(mesh_a, mat);
+    nt_render_item_t items[1] = {{.sort_key = 0, .entity = e.id, .batch_key = nt_mesh_renderer_batch_key(mat, mesh_a)}};
+
+    nt_gfx_stub_test_reset();
+    nt_mesh_renderer_draw_list(items, 1);
+    TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_vertex_input_count());
+
+    /* Deactivation destroys the mesh buffers; the cascade kills the vi. */
+    nt_gfx_deactivate_mesh(mesh_a.id);
+    TEST_ASSERT_EQUAL_UINT32(0, nt_mesh_renderer_test_vertex_input_count());
+
+    nt_mesh_t mesh_b = create_test_mesh(); /* reuses the freed pool slot */
+    TEST_ASSERT_EQUAL_UINT32(nt_pool_slot_index(mesh_a.id), nt_pool_slot_index(mesh_b.id));
+    *nt_mesh_comp_handle(e) = mesh_b;
+    items[0].batch_key = nt_mesh_renderer_batch_key(mat, mesh_b);
+
+    nt_mesh_renderer_draw_list(items, 1);
+    TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_draw_call_count());
+    TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_vertex_input_count());
+    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_stub_test_vertex_input_create_count()); /* fresh vi, not the stale one */
+}
+
+/* Exceeding max_mesh_layouts asserts (crash-early over silent eviction). */
+void test_vertex_input_versions_overflow_asserts(void) {
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+    nt_mesh_renderer_shutdown();
+    nt_mesh_renderer_desc_t small = {.max_instances = 4, .max_pipelines = 8, .max_mesh_layouts = 2};
+    TEST_ASSERT_EQUAL_INT(0, (int)nt_mesh_renderer_init(&small));
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+
+    nt_mesh_t mesh = create_test_mesh();
+    nt_program_t shared = create_test_program();
+    nt_render_item_t item;
+    for (uint8_t loc = 0; loc < 2; loc++) {
+        nt_material_t mat = create_test_material_with_attr(shared, NT_COLOR_MODE_NONE, "position", loc, nt_blend_opaque());
+        nt_entity_t e = create_test_entity(mesh, mat);
+        item = (nt_render_item_t){.sort_key = 0, .entity = e.id, .batch_key = nt_mesh_renderer_batch_key(mat, mesh)};
+        nt_mesh_renderer_draw_list(&item, 1);
+    }
+    TEST_ASSERT_EQUAL_UINT32(2, nt_mesh_renderer_test_vertex_input_count());
+
+    nt_material_t mat3 = create_test_material_with_attr(shared, NT_COLOR_MODE_NONE, "position", 2, nt_blend_opaque());
+    nt_entity_t e3 = create_test_entity(mesh, mat3);
+    item = (nt_render_item_t){.sort_key = 0, .entity = e3.id, .batch_key = nt_mesh_renderer_batch_key(mat3, mesh)};
+    NT_TEST_EXPECT_ASSERT(nt_mesh_renderer_draw_list(&item, 1));
 }
 
 /* ---- Test 9: restore_gpu clears cache and subsequent draw still works ---- */
@@ -797,7 +925,7 @@ void test_ring_cursor_advances_and_wraps(void) {
      * NT_INSTANCE_STRIDE_MAX, so per-call delta divides capacity exactly and
      * the exact-fit boundary (cursor == capacity must NOT wrap early) is hit. */
     nt_mesh_renderer_shutdown();
-    nt_mesh_renderer_desc_t small = {.max_instances = 4, .max_pipelines = 8};
+    nt_mesh_renderer_desc_t small = {.max_instances = 4, .max_pipelines = 8, .max_mesh_layouts = 4};
     TEST_ASSERT_EQUAL_INT(0, (int)nt_mesh_renderer_init(&small));
 
     nt_mesh_t mesh = create_test_mesh();
@@ -881,6 +1009,11 @@ int main(void) {
     RUN_TEST(test_pipeline_cache_skips_failed_pipeline);
     RUN_TEST(test_pipeline_cache_shared_program_collapses);
     RUN_TEST(test_pipeline_cache_different_material_attr_maps);
+    RUN_TEST(test_vertex_input_reused_across_draw_list_calls);
+    RUN_TEST(test_vertex_input_distinct_per_mesh);
+    RUN_TEST(test_vertex_input_shared_for_same_derived_layout);
+    RUN_TEST(test_vertex_input_survives_mesh_slot_reuse);
+    RUN_TEST(test_vertex_input_versions_overflow_asserts);
     RUN_TEST(test_restore_gpu);
     /* Color mode tests */
     RUN_TEST(test_draw_list_color_mode_float4);

--- a/tests/unit/test_mesh_renderer.c
+++ b/tests/unit/test_mesh_renderer.c
@@ -622,9 +622,7 @@ void test_pipeline_cache_shared_program_collapses(void) {
     TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_pipeline_cache_count());
 }
 
-/* Same program and state with different attr_maps used to split pipelines;
- * layouts now live on the vertex-input versions, so the pipeline collapses
- * to one and the derived layouts split vertex inputs instead. */
+/* Equal program/state share a pipeline; distinct attr_maps derive separate VIs. */
 void test_pipeline_cache_different_material_attr_maps(void) {
     nt_mesh_t mesh = create_test_mesh();
     nt_program_t shared = create_test_program();

--- a/tests/unit/test_nt_font_measure_bench.c
+++ b/tests/unit/test_nt_font_measure_bench.c
@@ -150,7 +150,7 @@ static void test_assert_handler(const char *expr, const char *file, int line) {
 
 void setUp(void) {
     nt_assert_handler = test_assert_handler;
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 8, .max_textures = 32, .max_meshes = 8, .max_render_targets = 16});
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 8, .max_textures = 32, .max_meshes = 8, .max_vertex_inputs = 16, .max_render_targets = 16});
     nt_hash_init(&(nt_hash_desc_t){0});
     nt_resource_init(&(nt_resource_desc_t){0});
     nt_font_init(&(nt_font_desc_t){.max_fonts = 4});

--- a/tests/unit/test_nt_gfx_bind_mirrors_native.c
+++ b/tests/unit/test_nt_gfx_bind_mirrors_native.c
@@ -1,7 +1,10 @@
-/* A stale pipeline mirror lets the next buffer bind corrupt the live VAO.
- * Real-GL pixels verify that a rejected bind preserves its vertex input. */
+/* Real-GL pixel tests for owned vertex inputs: alternating binds under one
+ * pipeline, index-data ops that must not rewire the bound VAO, orphaning
+ * under a live vertex input, and bind-preservation across rejected or
+ * failed operations. */
 
 #include "graphics/nt_gfx.h"
+#include "graphics/nt_gfx_internal.h"
 #include "unity.h"
 #include "window/nt_window.h"
 
@@ -25,13 +28,15 @@ static const float s_full[6] = {-1.0F, -1.0F, 3.0F, -1.0F, -1.0F, 3.0F};
 /* Degenerate: every vertex on one point, so it rasterizes nothing. */
 static const float s_empty[6] = {0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F};
 
+static const uint16_t s_tri_indices[3] = {0, 1, 2};
+static const uint16_t s_degenerate_indices[3] = {0, 0, 0};
+
 void setUp(void) {
     TEST_ASSERT_TRUE_MESSAGE(glfwInit(), "glfwInit failed");
     glfwWindowHint(GLFW_VISIBLE, GLFW_FALSE);
     g_nt_window = (nt_window_t){.max_dpr = 1.0F, .resizable = false, .width = 16, .height = 16};
     nt_window_init();
     nt_gfx_desc_t desc = nt_gfx_desc_defaults();
-    desc.max_pipelines = 2;
     nt_gfx_init(&desc);
     TEST_ASSERT_TRUE(g_nt_gfx.initialized);
 }
@@ -50,97 +55,189 @@ static nt_buffer_t make_vbo(const float *data) {
     });
 }
 
+static nt_vertex_layout_t pos2_layout(void) { return (nt_vertex_layout_t){.attr_count = 1, .stride = 8, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 2}}}; }
+
+static nt_vertex_input_t make_vi(nt_buffer_t vbo, nt_buffer_t ibo) { return nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos2_layout(), .vertex_buffer = vbo, .index_buffer = ibo}); }
+
+static nt_pipeline_t make_red_pipeline(void) {
+    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = s_vs_src});
+    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = s_fs_src});
+    return nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = nt_gfx_make_program(vs, fs)});
+}
+
 static uint8_t center_red(void) {
     uint8_t px[4] = {0, 0, 0, 0};
     TEST_ASSERT_TRUE(nt_gfx_read_pixels(8, 8, 1, 1, px, sizeof(px)));
     return px[0];
 }
 
-static void test_rejected_bind_does_not_rewire_the_previous_vao(void) {
-    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = s_vs_src});
-    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = s_fs_src});
-    nt_program_t prog = nt_gfx_make_program(vs, fs);
-    nt_pipeline_desc_t desc = {
-        .program = prog,
-        .layout = {.attr_count = 1, .stride = 8, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 2}}},
-    };
-    nt_pipeline_t pip = nt_gfx_make_pipeline(&desc);
-    TEST_ASSERT_NOT_EQUAL_UINT32(0, pip.id);
+static void begin_black_pass(void) { nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_color = {0.0F, 0.0F, 0.0F, 1.0F}, .clear_depth = 1.0F}); }
 
-    /* A second pipeline whose program is then destroyed: the cascade takes the
-     * pipeline with it, so this handle is stale and its bind gets rejected. */
-    nt_program_t doomed = nt_gfx_make_program(nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = s_vs_src}),
-                                              nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = s_fs_src}));
-    nt_pipeline_desc_t doomed_desc = desc;
-    doomed_desc.program = doomed;
-    nt_pipeline_t stale = nt_gfx_make_pipeline(&doomed_desc);
-    nt_gfx_destroy_program(doomed);
-    TEST_ASSERT_FALSE(nt_gfx_pipeline_valid(stale));
-
-    nt_buffer_t full = make_vbo(s_full);
-    nt_buffer_t empty = make_vbo(s_empty);
+/* One glBindVertexArray selects the whole geometry: two meshes alternate under
+ * a single pipeline with no per-switch attribute re-pointing. */
+static void test_vertex_inputs_alternate_under_one_pipeline(void) {
+    nt_pipeline_t pip = make_red_pipeline();
+    nt_vertex_input_t vi_full = make_vi(make_vbo(s_full), (nt_buffer_t){0});
+    nt_vertex_input_t vi_empty = make_vi(make_vbo(s_empty), (nt_buffer_t){0});
 
     nt_gfx_begin_frame();
-    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_color = {0.0F, 0.0F, 0.0F, 1.0F}, .clear_depth = 1.0F});
-
-    /* Baseline: the pipeline's VAO reads the full-screen triangle. */
+    begin_black_pass();
     nt_gfx_bind_pipeline(pip);
-    nt_gfx_bind_vertex_buffer(full);
+    nt_gfx_bind_vertex_input(vi_full);
     nt_gfx_draw(0, 3);
     TEST_ASSERT_UINT8_WITHIN(1, 255, center_red());
-
-    /* Rejected bind, then a different buffer. A stale slot mirror would rewire
-     * the live VAO's attributes onto the degenerate triangle here. */
-    nt_gfx_bind_pipeline(stale);
-    nt_gfx_bind_vertex_buffer(empty);
-
-    /* Re-bind and draw WITHOUT re-binding the full buffer: the VAO must still
-     * hold the attributes it had, so the full-screen triangle covers again. */
     nt_gfx_end_pass();
-    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_color = {0.0F, 0.0F, 0.0F, 1.0F}, .clear_depth = 1.0F});
+
+    begin_black_pass();
     nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi_empty);
+    nt_gfx_draw(0, 3);
+    TEST_ASSERT_UINT8_WITHIN(1, 0, center_red());
+
+    /* Switch geometry WITHOUT touching the pipeline. */
+    nt_gfx_bind_vertex_input(vi_full);
     nt_gfx_draw(0, 3);
     TEST_ASSERT_UINT8_WITHIN(1, 255, center_red());
-
     nt_gfx_end_pass();
     nt_gfx_end_frame();
 }
 
-static void test_creating_pipeline_preserves_bound_pipeline(void) {
-    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = s_vs_src});
-    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = s_fs_src});
-    nt_pipeline_desc_t desc = {
-        .program = nt_gfx_make_program(vs, fs),
-        .layout = {.attr_count = 1, .stride = 16, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 2}}},
-    };
-    nt_pipeline_t first = nt_gfx_make_pipeline(&desc);
-    static const float vertices[12] = {-1.0F, -1.0F, 0.0F, 0.0F, 3.0F, -1.0F, 0.0F, 0.0F, -1.0F, 3.0F, 0.0F, 0.0F};
-    nt_buffer_t full = nt_gfx_make_buffer(&(nt_buffer_desc_t){
-        .type = NT_BUFFER_VERTEX,
-        .usage = NT_USAGE_IMMUTABLE,
-        .size = sizeof(vertices),
-        .data = vertices,
-    });
+/* Steady state: the static half of vertex-input setup is baked at creation, so
+ * a whole frame of draws issues zero divisor-0 glVertexAttribPointer calls. */
+static void test_second_frame_issues_no_static_attrib_pointers(void) {
+    nt_pipeline_t pip = make_red_pipeline();
+    nt_vertex_input_t vi_full = make_vi(make_vbo(s_full), (nt_buffer_t){0});
+    nt_vertex_input_t vi_empty = make_vi(make_vbo(s_empty), (nt_buffer_t){0});
 
     nt_gfx_begin_frame();
-    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_color = {0.0F, 0.0F, 0.0F, 1.0F}, .clear_depth = 1.0F});
-    nt_gfx_bind_pipeline(first);
-    nt_gfx_bind_vertex_buffer(full);
-    GLint first_vao = 0;
-    glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &first_vao);
-    TEST_ASSERT_NOT_EQUAL_INT(0, first_vao);
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi_full);
+    nt_gfx_draw(0, 3);
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
 
-    desc.layout.attrs[0].offset = 8;
-    nt_pipeline_t second = nt_gfx_make_pipeline(&desc);
-    TEST_ASSERT_TRUE(nt_gfx_pipeline_valid(second));
+    nt_gfx_gl_test_reset_counters();
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi_full);
+    nt_gfx_draw(0, 3);
+    nt_gfx_bind_vertex_input(vi_empty);
+    nt_gfx_draw(0, 3);
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_gl_test_static_attrib_pointer_calls());
+}
+
+/* GL_ELEMENT_ARRAY_BUFFER binding is VAO state: data ops on OTHER index
+ * buffers must not silently rewire the bound vertex input's index binding. */
+static void test_index_data_ops_do_not_rewire_bound_vertex_input(void) {
+    nt_pipeline_t pip = make_red_pipeline();
+    nt_buffer_t ibo_a =
+        nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_INDEX, .usage = NT_USAGE_IMMUTABLE, .data = s_tri_indices, .size = sizeof(s_tri_indices), .index_type = NT_INDEX_UINT16});
+    nt_vertex_input_t vi_a = make_vi(make_vbo(s_full), ibo_a);
+    nt_buffer_t ibo_b =
+        nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_INDEX, .usage = NT_USAGE_DYNAMIC, .data = s_tri_indices, .size = sizeof(s_tri_indices), .index_type = NT_INDEX_UINT16});
+
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi_a);
+    nt_gfx_draw_indexed(0, 3, 3);
+    TEST_ASSERT_UINT8_WITHIN(1, 255, center_red());
+
+    /* Both data-op flavors on buffer B while A's vertex input stays bound. */
+    nt_gfx_update_buffer(ibo_b, 0, s_degenerate_indices, sizeof(s_degenerate_indices));
+    nt_gfx_orphan_buffer(ibo_b, s_degenerate_indices, sizeof(s_degenerate_indices));
+
+    nt_gfx_end_pass();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_draw_indexed(0, 3, 3); /* still A's triangle indices, not B */
+    TEST_ASSERT_UINT8_WITHIN(1, 255, center_red());
+    TEST_ASSERT_EQUAL_UINT32(GL_NO_ERROR, glGetError());
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+}
+
+/* orphan_buffer keeps the GL buffer name, so the baked VAO attachment stays
+ * live -- the per-flush orphaning pattern sprite/text rely on. */
+static void test_orphan_under_live_vertex_input_renders(void) {
+    nt_pipeline_t pip = make_red_pipeline();
+    nt_buffer_t vbo = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_DYNAMIC, .data = s_empty, .size = sizeof(s_empty)});
+    nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
+
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_orphan_buffer(vbo, s_full, sizeof(s_full));
+    nt_gfx_draw(0, 3);
+    TEST_ASSERT_UINT8_WITHIN(1, 255, center_red());
+    nt_gfx_end_pass();
+
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_orphan_buffer(vbo, s_empty, sizeof(s_empty));
+    nt_gfx_draw(0, 3);
+    TEST_ASSERT_UINT8_WITHIN(1, 0, center_red());
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+}
+
+/* A rejected pipeline bind clears the program selection but must not disturb
+ * the orthogonal vertex-input binding. */
+static void test_rejected_pipeline_bind_preserves_vertex_input(void) {
+    nt_pipeline_t pip = make_red_pipeline();
+    nt_program_t doomed = nt_gfx_make_program(nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = s_vs_src}),
+                                              nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = s_fs_src}));
+    nt_pipeline_t stale = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = doomed});
+    nt_gfx_destroy_program(doomed);
+    TEST_ASSERT_FALSE(nt_gfx_pipeline_valid(stale));
+
+    nt_vertex_input_t vi_full = make_vi(make_vbo(s_full), (nt_buffer_t){0});
+
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi_full);
+    nt_gfx_draw(0, 3);
+    TEST_ASSERT_UINT8_WITHIN(1, 255, center_red());
+
+    nt_gfx_bind_pipeline(stale); /* rejected: drops the pipeline only */
+
+    nt_gfx_end_pass();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_draw(0, 3); /* no vertex-input re-bind needed */
+    TEST_ASSERT_UINT8_WITHIN(1, 255, center_red());
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+}
+
+/* Creation must restore the previously bound VAO (creation binds its own). */
+static void test_creating_vertex_input_preserves_bound_one(void) {
+    nt_pipeline_t pip = make_red_pipeline();
+    nt_vertex_input_t vi_full = make_vi(make_vbo(s_full), (nt_buffer_t){0});
+
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi_full);
+    GLint bound_vao = 0;
+    glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &bound_vao);
+    TEST_ASSERT_NOT_EQUAL_INT(0, bound_vao);
+
+    nt_vertex_input_t other = make_vi(make_vbo(s_empty), (nt_buffer_t){0});
+    TEST_ASSERT_TRUE(nt_gfx_vertex_input_valid(other));
     GLint current_vao = 0;
     glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &current_vao);
-    TEST_ASSERT_EQUAL_INT(first_vao, current_vao);
-    nt_gfx_bind_vertex_buffer(full);
+    TEST_ASSERT_EQUAL_INT(bound_vao, current_vao);
+
     nt_gfx_draw(0, 3);
     TEST_ASSERT_EQUAL_UINT32(GL_NO_ERROR, glGetError());
     TEST_ASSERT_UINT8_WITHIN(1, 255, center_red());
-
     nt_gfx_end_pass();
     nt_gfx_end_frame();
 }
@@ -151,52 +248,46 @@ static void GLAD_API_PTR fail_gen_vertex_arrays(GLsizei count, GLuint *arrays) {
     }
 }
 
-static void test_failed_vao_creation_preserves_bound_pipeline_and_pool_slot(void) {
-    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = s_vs_src});
-    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = s_fs_src});
-    nt_pipeline_desc_t desc = {
-        .program = nt_gfx_make_program(vs, fs),
-        .layout = {.attr_count = 1, .stride = 8, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 2}}},
-    };
-    nt_pipeline_t first = nt_gfx_make_pipeline(&desc);
+static void test_failed_vao_creation_returns_invalid_and_preserves_binding(void) {
+    nt_pipeline_t pip = make_red_pipeline();
     nt_buffer_t full = make_vbo(s_full);
-    nt_gfx_begin_frame();
-    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_color = {0.0F, 0.0F, 0.0F, 1.0F}, .clear_depth = 1.0F});
-    nt_gfx_bind_pipeline(first);
-    nt_gfx_bind_vertex_buffer(full);
-    GLint first_vao = 0;
-    glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &first_vao);
+    nt_vertex_input_t vi_full = make_vi(full, (nt_buffer_t){0});
 
-    nt_pipeline_desc_t failed_desc = {.program = desc.program};
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi_full);
+    GLint bound_vao = 0;
+    glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &bound_vao);
+
     PFNGLGENVERTEXARRAYSPROC saved_gen = glad_glGenVertexArrays;
     glad_glGenVertexArrays = fail_gen_vertex_arrays;
-    nt_pipeline_t failed = nt_gfx_make_pipeline(&failed_desc);
+    nt_vertex_input_t failed = make_vi(full, (nt_buffer_t){0});
     glad_glGenVertexArrays = saved_gen;
     TEST_ASSERT_EQUAL_UINT32(0, failed.id);
     TEST_ASSERT_EQUAL_UINT32(GL_NO_ERROR, glGetError());
-    nt_gfx_draw(0, 3);
-    TEST_ASSERT_UINT8_WITHIN(1, 255, center_red());
+
     GLint current_vao = 0;
     glGetIntegerv(GL_VERTEX_ARRAY_BINDING, &current_vao);
-    TEST_ASSERT_EQUAL_INT(first_vao, current_vao);
-
-    nt_pipeline_t retry = nt_gfx_make_pipeline(&desc);
-    TEST_ASSERT_TRUE(nt_gfx_pipeline_valid(retry));
-    nt_gfx_end_pass();
-    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_color = {0.0F, 0.0F, 0.0F, 1.0F}, .clear_depth = 1.0F});
-    nt_gfx_bind_pipeline(retry);
-    nt_gfx_bind_vertex_buffer(full);
+    TEST_ASSERT_EQUAL_INT(bound_vao, current_vao);
     nt_gfx_draw(0, 3);
-    TEST_ASSERT_EQUAL_UINT32(GL_NO_ERROR, glGetError());
     TEST_ASSERT_UINT8_WITHIN(1, 255, center_red());
+
+    /* The pool slot went back, so the retry succeeds. */
+    nt_vertex_input_t retry = make_vi(full, (nt_buffer_t){0});
+    TEST_ASSERT_TRUE(nt_gfx_vertex_input_valid(retry));
     nt_gfx_end_pass();
     nt_gfx_end_frame();
 }
 
 int main(void) {
     UNITY_BEGIN();
-    RUN_TEST(test_rejected_bind_does_not_rewire_the_previous_vao);
-    RUN_TEST(test_creating_pipeline_preserves_bound_pipeline);
-    RUN_TEST(test_failed_vao_creation_preserves_bound_pipeline_and_pool_slot);
+    RUN_TEST(test_vertex_inputs_alternate_under_one_pipeline);
+    RUN_TEST(test_second_frame_issues_no_static_attrib_pointers);
+    RUN_TEST(test_index_data_ops_do_not_rewire_bound_vertex_input);
+    RUN_TEST(test_orphan_under_live_vertex_input_renders);
+    RUN_TEST(test_rejected_pipeline_bind_preserves_vertex_input);
+    RUN_TEST(test_creating_vertex_input_preserves_bound_one);
+    RUN_TEST(test_failed_vao_creation_returns_invalid_and_preserves_binding);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_gfx_bind_mirrors_native.c
+++ b/tests/unit/test_nt_gfx_bind_mirrors_native.c
@@ -1,7 +1,5 @@
-/* Real-GL pixel tests for owned vertex inputs: alternating binds under one
- * pipeline, index-data ops that must not rewire the bound VAO, orphaning
- * under a live vertex input, and bind-preservation across rejected or
- * failed operations. */
+/* Real-GL coverage for VI switching, isolated EBO data operations, orphaning,
+ * and binding preservation across rejected or failed operations. */
 
 #include "graphics/nt_gfx.h"
 #include "graphics/nt_gfx_internal.h"

--- a/tests/unit/test_nt_gfx_bind_mirrors_native.c
+++ b/tests/unit/test_nt_gfx_bind_mirrors_native.c
@@ -150,10 +150,13 @@ static void test_second_frame_issues_no_static_attrib_pointers(void) {
     nt_gfx_bind_instance_buffer(inst_buf, 0);
     nt_gfx_draw_instanced(0, 3, 1);
     nt_gfx_end_pass();
-    /* begin_frame's cache reset (VAO 0) + one bind per vertex-input switch. */
-    TEST_ASSERT_EQUAL_UINT32(4, nt_gfx_gl_test_vao_binds());
+    /* Captured before end_frame so teardown binds cannot pollute it. */
+    uint32_t frame_vao_binds = nt_gfx_gl_test_vao_binds();
     nt_gfx_end_frame();
+    /* Restore before any assert -- a failure longjmps past this line. */
     glad_glVertexAttribPointer = s_saved_attrib_pointer;
+    /* begin_frame's cache reset (VAO 0) + one bind per vertex-input switch. */
+    TEST_ASSERT_EQUAL_UINT32(4, frame_vao_binds);
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_gl_test_static_attrib_pointer_calls());
     TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_gl_test_instance_attrib_pointer_calls());
     TEST_ASSERT_EQUAL_UINT32(1, s_real_attrib_pointer_calls); /* just the instance re-point */
@@ -275,6 +278,31 @@ static void test_creating_vertex_input_preserves_bound_one(void) {
     nt_gfx_end_frame();
 }
 
+static const char *s_vertexid_vs_src = "precision mediump float;\n"
+                                       "void main() {\n"
+                                       "    vec2 p = vec2(gl_VertexID == 1 ? 3.0 : -1.0, gl_VertexID == 2 ? 3.0 : -1.0);\n"
+                                       "    gl_Position = vec4(p, 0.0, 1.0);\n"
+                                       "}\n";
+
+/* Attribute-less draws (gl_VertexID) go through an empty vertex input: a
+ * bound VAO with zero enabled arrays must rasterize on real core GL. */
+static void test_empty_vertex_input_draws_fullscreen(void) {
+    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = s_vertexid_vs_src});
+    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = s_fs_src});
+    nt_pipeline_t pip = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = nt_gfx_make_program(vs, fs)});
+    nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){0});
+
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_draw(0, 3);
+    TEST_ASSERT_EQUAL_UINT32(GL_NO_ERROR, glGetError());
+    TEST_ASSERT_UINT8_WITHIN(1, 255, center_red());
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+}
+
 static void GLAD_API_PTR fail_gen_vertex_arrays(GLsizei count, GLuint *arrays) {
     for (GLsizei i = 0; i < count; i++) {
         arrays[i] = 0;
@@ -319,6 +347,7 @@ int main(void) {
     RUN_TEST(test_second_frame_issues_no_static_attrib_pointers);
     RUN_TEST(test_index_data_ops_do_not_rewire_bound_vertex_input);
     RUN_TEST(test_orphan_under_live_vertex_input_renders);
+    RUN_TEST(test_empty_vertex_input_draws_fullscreen);
     RUN_TEST(test_rejected_pipeline_bind_preserves_vertex_input);
     RUN_TEST(test_creating_vertex_input_preserves_bound_one);
     RUN_TEST(test_failed_vao_creation_returns_invalid_and_preserves_binding);

--- a/tests/unit/test_nt_gfx_bind_mirrors_native.c
+++ b/tests/unit/test_nt_gfx_bind_mirrors_native.c
@@ -102,12 +102,30 @@ static void test_vertex_inputs_alternate_under_one_pipeline(void) {
     nt_gfx_end_frame();
 }
 
+/* Counts REAL glVertexAttribPointer calls via glad-pointer swap, so a
+ * reintroduced re-pointing path is caught even if it bypasses the source
+ * counters in nt_gfx_gl.c. */
+static uint32_t s_real_attrib_pointer_calls;
+static PFNGLVERTEXATTRIBPOINTERPROC s_saved_attrib_pointer;
+static void GLAD_API_PTR counting_vertex_attrib_pointer(GLuint index, GLint size, GLenum type, GLboolean normalized, GLsizei stride, const void *pointer) {
+    s_real_attrib_pointer_calls++;
+    s_saved_attrib_pointer(index, size, type, normalized, stride, pointer);
+}
+
 /* Steady state: the static half of vertex-input setup is baked at creation, so
- * a whole frame of draws issues zero divisor-0 glVertexAttribPointer calls. */
+ * a whole frame of draws issues zero divisor-0 glVertexAttribPointer calls --
+ * the only pointer calls left are the per-draw instance re-points, and VAO
+ * binds stay one per vertex-input switch (delta-checked). */
 static void test_second_frame_issues_no_static_attrib_pointers(void) {
     nt_pipeline_t pip = make_red_pipeline();
     nt_vertex_input_t vi_full = make_vi(make_vbo(s_full), (nt_buffer_t){0});
     nt_vertex_input_t vi_empty = make_vi(make_vbo(s_empty), (nt_buffer_t){0});
+    nt_vertex_input_t vi_inst = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){
+        .layout = pos2_layout(),
+        .instance_layout = {.attr_count = 1, .stride = 8, .attrs = {{.location = 1, .type = NT_VERTEX_FLOAT, .count = 2}}},
+        .vertex_buffer = make_vbo(s_full),
+    });
+    nt_buffer_t inst_buf = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
 
     nt_gfx_begin_frame();
     begin_black_pass();
@@ -118,6 +136,9 @@ static void test_second_frame_issues_no_static_attrib_pointers(void) {
     nt_gfx_end_frame();
 
     nt_gfx_gl_test_reset_counters();
+    s_real_attrib_pointer_calls = 0;
+    s_saved_attrib_pointer = glad_glVertexAttribPointer;
+    glad_glVertexAttribPointer = counting_vertex_attrib_pointer;
     nt_gfx_begin_frame();
     begin_black_pass();
     nt_gfx_bind_pipeline(pip);
@@ -125,9 +146,17 @@ static void test_second_frame_issues_no_static_attrib_pointers(void) {
     nt_gfx_draw(0, 3);
     nt_gfx_bind_vertex_input(vi_empty);
     nt_gfx_draw(0, 3);
+    nt_gfx_bind_vertex_input(vi_inst);
+    nt_gfx_bind_instance_buffer(inst_buf, 0);
+    nt_gfx_draw_instanced(0, 3, 1);
     nt_gfx_end_pass();
+    /* begin_frame's cache reset (VAO 0) + one bind per vertex-input switch. */
+    TEST_ASSERT_EQUAL_UINT32(4, nt_gfx_gl_test_vao_binds());
     nt_gfx_end_frame();
+    glad_glVertexAttribPointer = s_saved_attrib_pointer;
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_gl_test_static_attrib_pointer_calls());
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_gl_test_instance_attrib_pointer_calls());
+    TEST_ASSERT_EQUAL_UINT32(1, s_real_attrib_pointer_calls); /* just the instance re-point */
 }
 
 /* GL_ELEMENT_ARRAY_BUFFER binding is VAO state: data ops on OTHER index
@@ -147,9 +176,13 @@ static void test_index_data_ops_do_not_rewire_bound_vertex_input(void) {
     nt_gfx_draw_indexed(0, 3, 3);
     TEST_ASSERT_UINT8_WITHIN(1, 255, center_red());
 
-    /* Both data-op flavors on buffer B while A's vertex input stays bound. */
+    /* All three data-op flavors on other index buffers while A's vertex input
+     * stays bound: update, orphan, and creation-with-data. */
     nt_gfx_update_buffer(ibo_b, 0, s_degenerate_indices, sizeof(s_degenerate_indices));
     nt_gfx_orphan_buffer(ibo_b, s_degenerate_indices, sizeof(s_degenerate_indices));
+    nt_buffer_t ibo_c = nt_gfx_make_buffer(
+        &(nt_buffer_desc_t){.type = NT_BUFFER_INDEX, .usage = NT_USAGE_IMMUTABLE, .data = s_degenerate_indices, .size = sizeof(s_degenerate_indices), .index_type = NT_INDEX_UINT16});
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, ibo_c.id);
 
     nt_gfx_end_pass();
     begin_black_pass();

--- a/tests/unit/test_nt_gfx_render_target.c
+++ b/tests/unit/test_nt_gfx_render_target.c
@@ -36,6 +36,7 @@ void setUp(void) {
         .max_buffers = 8,
         .max_textures = 8,
         .max_meshes = 4,
+        .max_vertex_inputs = 8,
         .max_render_targets = 4,
     });
     nt_gfx_stub_test_reset();

--- a/tests/unit/test_nt_gfx_render_target_native.c
+++ b/tests/unit/test_nt_gfx_render_target_native.c
@@ -180,7 +180,7 @@ typedef struct {
 
 static uint8_t ramp_at(const uint8_t *row, int column) { return row[(size_t)(unsigned)column * 4U]; }
 
-static nt_pipeline_t make_test_pipeline(const char *vs_src, const char *fs_src, bool depth_write, const nt_vertex_layout_t *layout) {
+static nt_pipeline_t make_test_pipeline(const char *vs_src, const char *fs_src, bool depth_write) {
     nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = vs_src});
     nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = fs_src});
     nt_program_t prog = nt_gfx_make_program(vs, fs);
@@ -188,7 +188,6 @@ static nt_pipeline_t make_test_pipeline(const char *vs_src, const char *fs_src, 
     TEST_ASSERT_NOT_EQUAL_UINT32(0, fs.id);
     nt_pipeline_t pip = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
         .program = prog,
-        .layout = *layout,
         .depth_test = depth_write,
         .depth_write = depth_write,
         .depth_func = NT_DEPTH_ALWAYS,
@@ -196,6 +195,15 @@ static nt_pipeline_t make_test_pipeline(const char *vs_src, const char *fs_src, 
     TEST_ASSERT_NOT_EQUAL_UINT32(0, pip.id);
     return pip;
 }
+
+static nt_vertex_input_t make_test_vertex_input(const nt_vertex_layout_t *layout, nt_buffer_t vbo) {
+    nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = *layout, .vertex_buffer = vbo});
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, vi.id);
+    return vi;
+}
+
+/* gl_VertexID draws still need a bound vertex input: the empty one. */
+static void bind_empty_vertex_input(void) { nt_gfx_bind_vertex_input(nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){0})); }
 
 static void test_custom_blend_state_reaches_gl_unchanged(void) {
     nt_blend_state_t blend = nt_blend_alpha();
@@ -334,7 +342,6 @@ static void test_multiply_blend_multiplies_rgb_and_preserves_destination_alpha(v
     nt_program_t prog = nt_gfx_make_program(vs, fs);
     nt_pipeline_t pipeline = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
         .program = prog,
-        .layout = layout,
         .blend = nt_blend_multiply(),
     });
     nt_buffer_t vertices = nt_gfx_make_buffer(&(nt_buffer_desc_t){
@@ -343,6 +350,7 @@ static void test_multiply_blend_multiplies_rgb_and_preserves_destination_alpha(v
         .data = fullscreen_tri,
         .size = sizeof(fullscreen_tri),
     });
+    nt_vertex_input_t vertex_input = make_test_vertex_input(&layout, vertices);
     nt_render_target_t target = nt_gfx_make_render_target(&(nt_render_target_desc_t){
         .width = 4,
         .height = 4,
@@ -361,7 +369,7 @@ static void test_multiply_blend_multiplies_rgb_and_preserves_destination_alpha(v
     nt_gfx_begin_frame();
     nt_gfx_begin_pass(&(nt_pass_desc_t){.target = target, .clear_color = {0.2F, 0.4F, 0.8F, 0.6F}});
     nt_gfx_bind_pipeline(pipeline);
-    nt_gfx_bind_vertex_buffer(vertices);
+    nt_gfx_bind_vertex_input(vertex_input);
     nt_gfx_draw(0, 3);
     TEST_ASSERT_TRUE(nt_gfx_read_pixels(0, 0, 4, 4, pixels, sizeof(pixels)));
     nt_gfx_end_pass();
@@ -369,6 +377,7 @@ static void test_multiply_blend_multiplies_rgb_and_preserves_destination_alpha(v
 
     assert_rgba(pixels, 16, 26, 26, 153, 153);
     nt_gfx_destroy_render_target(target);
+    nt_gfx_destroy_vertex_input(vertex_input);
     nt_gfx_destroy_buffer(vertices);
     nt_gfx_destroy_pipeline(pipeline);
     nt_gfx_destroy_shader(fs);
@@ -425,9 +434,11 @@ static void test_depth_comparison_sampler_blends_comparison_results(void) {
     };
     nt_buffer_t depth_vbo = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_IMMUTABLE, .data = right_half_quad, .size = sizeof(right_half_quad)});
     nt_buffer_t fullscreen_vbo = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_IMMUTABLE, .data = fullscreen_tri, .size = sizeof(fullscreen_tri)});
-    nt_pipeline_t depth_pip = make_test_pipeline(s_depth_vs, s_depth_fs, true, &depth_layout);
-    nt_pipeline_t shadow_pip = make_test_pipeline(s_fullscreen_vs, s_shadow_fs, false, &fullscreen_layout);
-    nt_pipeline_t raw_pip = make_test_pipeline(s_fullscreen_vs, s_raw_fs, false, &fullscreen_layout);
+    nt_pipeline_t depth_pip = make_test_pipeline(s_depth_vs, s_depth_fs, true);
+    nt_pipeline_t shadow_pip = make_test_pipeline(s_fullscreen_vs, s_shadow_fs, false);
+    nt_pipeline_t raw_pip = make_test_pipeline(s_fullscreen_vs, s_raw_fs, false);
+    nt_vertex_input_t depth_vi = make_test_vertex_input(&depth_layout, depth_vbo);
+    nt_vertex_input_t fullscreen_vi = make_test_vertex_input(&fullscreen_layout, fullscreen_vbo);
 
     nt_sampler_t comparison = nt_gfx_make_sampler(&(nt_sampler_desc_t){
         .min_filter = NT_FILTER_LINEAR,
@@ -450,7 +461,7 @@ static void test_depth_comparison_sampler_blends_comparison_results(void) {
     nt_gfx_begin_frame();
     nt_gfx_begin_pass(&(nt_pass_desc_t){.target = shadow_map, .clear_color = {0, 0, 0, 1}, .clear_depth = 0.2F});
     nt_gfx_bind_pipeline(depth_pip);
-    nt_gfx_bind_vertex_buffer(depth_vbo);
+    nt_gfx_bind_vertex_input(depth_vi);
     nt_gfx_draw(0, 6);
     nt_gfx_end_pass();
 
@@ -460,7 +471,7 @@ static void test_depth_comparison_sampler_blends_comparison_results(void) {
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_color = {0, 0, 0, 1}, .clear_depth = 1.0F});
     nt_gfx_set_viewport(0, 0, RAMP_WIDTH, (int)g_nt_window.fb_height);
     nt_gfx_bind_pipeline(shadow_pip);
-    nt_gfx_bind_vertex_buffer(fullscreen_vbo);
+    nt_gfx_bind_vertex_input(fullscreen_vi);
     nt_gfx_bind_texture(depth_tex, 0);
     nt_gfx_bind_sampler(comparison, 0);
     nt_gfx_set_uniform_int("u_shadow", 0);
@@ -487,7 +498,7 @@ static void test_depth_comparison_sampler_blends_comparison_results(void) {
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_color = {0, 0, 0, 1}, .clear_depth = 1.0F});
     nt_gfx_set_viewport(0, 0, RAMP_WIDTH, (int)g_nt_window.fb_height);
     nt_gfx_bind_pipeline(raw_pip);
-    nt_gfx_bind_vertex_buffer(fullscreen_vbo);
+    nt_gfx_bind_vertex_input(fullscreen_vi);
     nt_gfx_bind_texture(depth_tex, 0);
     nt_gfx_bind_sampler(raw, 0);
     nt_gfx_set_uniform_int("u_depth", 0);
@@ -714,6 +725,7 @@ static void test_uniform_values_are_shared_by_pipelines_on_one_program(void) {
     const float green[4] = {0.0F, 1.0F, 0.0F, 1.0F};
     nt_gfx_set_uniform_vec4("u_color", green);
     nt_gfx_bind_pipeline(pip_b);
+    bind_empty_vertex_input();
     nt_gfx_draw(0, 3);
 
     uint8_t pixels[4 * 4 * 4] = {0};
@@ -774,6 +786,7 @@ static void test_each_pipeline_binds_its_own_program(void) {
 
     nt_gfx_begin_pass(&(nt_pass_desc_t){.target = target, .clear_color = {0.0F, 0.0F, 0.0F, 1.0F}, .clear_depth = 1.0F});
     nt_gfx_bind_pipeline(pip_red);
+    bind_empty_vertex_input();
     nt_gfx_draw(0, 3);
     TEST_ASSERT_TRUE(nt_gfx_read_pixels(0, 0, 4, 4, pixels, sizeof(pixels)));
     assert_rgba(pixels, 16, 255, 0, 0, 255);
@@ -781,6 +794,7 @@ static void test_each_pipeline_binds_its_own_program(void) {
 
     nt_gfx_begin_pass(&(nt_pass_desc_t){.target = target, .clear_color = {0.0F, 0.0F, 0.0F, 1.0F}, .clear_depth = 1.0F});
     nt_gfx_bind_pipeline(pip_blue);
+    bind_empty_vertex_input();
     nt_gfx_draw(0, 3);
     TEST_ASSERT_TRUE(nt_gfx_read_pixels(0, 0, 4, 4, pixels, sizeof(pixels)));
     assert_rgba(pixels, 16, 0, 0, 255, 255);
@@ -838,6 +852,7 @@ static void test_destroying_one_pipeline_leaves_the_shared_program_alive(void) {
     nt_gfx_begin_frame();
     nt_gfx_begin_pass(&(nt_pass_desc_t){.target = target, .clear_color = {0.0F, 0.0F, 0.0F, 1.0F}, .clear_depth = 1.0F});
     nt_gfx_bind_pipeline(pip_b);
+    bind_empty_vertex_input();
     nt_gfx_draw(0, 3);
     TEST_ASSERT_TRUE(nt_gfx_read_pixels(0, 0, 4, 4, pixels, sizeof(pixels)));
     assert_rgba(pixels, 16, 0, 255, 0, 255);

--- a/tests/unit/test_nt_gfx_scissor.c
+++ b/tests/unit/test_nt_gfx_scissor.c
@@ -15,6 +15,7 @@ void setUp(void) {
         .max_buffers = 8,
         .max_textures = 4,
         .max_meshes = 4,
+        .max_vertex_inputs = 8,
         .max_render_targets = 16,
     });
     TEST_ASSERT_TRUE(g_nt_gfx.initialized);

--- a/tests/unit/test_nt_postfx_blur.c
+++ b/tests/unit/test_nt_postfx_blur.c
@@ -360,7 +360,7 @@ static void test_blur_lifecycle_misuse_asserts(void) {
     nt_postfx_blur_shutdown();
     /* Restoring an inactive module is a no-op, not a trap: a game restores every
      * module it might own without tracking which ones it turned off. */
-    TEST_ASSERT_EQUAL_INT(NT_ERR_INIT_FAILED, nt_postfx_blur_restore_gpu());
+    TEST_ASSERT_EQUAL_INT(NT_OK, nt_postfx_blur_restore_gpu());
     NT_TEST_EXPECT_ASSERT(nt_postfx_blur_gaussian(NULL));
 }
 

--- a/tests/unit/test_nt_postfx_blur.c
+++ b/tests/unit/test_nt_postfx_blur.c
@@ -51,6 +51,7 @@ void setUp(void) {
         .max_buffers = 8,
         .max_textures = 12,
         .max_meshes = 4,
+        .max_vertex_inputs = 8,
         .max_render_targets = 4,
     });
     nt_gfx_stub_test_reset();

--- a/tests/unit/test_nt_sprite_renderer_emit_region.c
+++ b/tests/unit/test_nt_sprite_renderer_emit_region.c
@@ -255,7 +255,8 @@ void setUp(void) {
     s_vpack_counter = 0;
 
     nt_hash_init(&(nt_hash_desc_t){0});
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_programs = 16, .max_pipelines = 16, .max_buffers = 64, .max_textures = 32, .max_meshes = 16, .max_render_targets = 16});
+    nt_gfx_init(
+        &(nt_gfx_desc_t){.max_shaders = 32, .max_programs = 16, .max_pipelines = 16, .max_buffers = 64, .max_textures = 32, .max_meshes = 16, .max_vertex_inputs = 16, .max_render_targets = 16});
     nt_resource_init(&(nt_resource_desc_t){0});
     nt_atlas_init();
 

--- a/tests/unit/test_nt_ui_measure_cb.c
+++ b/tests/unit/test_nt_ui_measure_cb.c
@@ -134,7 +134,7 @@ static nt_font_t make_resolved_test_font(const char *name, uint8_t **out_blob) {
 
 void setUp(void) {
     nt_test_assert_install();
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 8, .max_textures = 32, .max_meshes = 8, .max_render_targets = 16});
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 8, .max_textures = 32, .max_meshes = 8, .max_vertex_inputs = 16, .max_render_targets = 16});
     nt_hash_init(&(nt_hash_desc_t){0});
     nt_resource_init(&(nt_resource_desc_t){0});
     nt_font_init(&(nt_font_desc_t){.max_fonts = 4});

--- a/tests/unit/test_nt_ui_pointer_state.c
+++ b/tests/unit/test_nt_ui_pointer_state.c
@@ -18,7 +18,7 @@ static const nt_ui_create_desc_t s_ui_desc = {.max_elements = NT_UI_DEFAULT_MAX_
 
 void setUp(void) {
     /* gfx pulled in transitively via nt_font/nt_resource; stub is fine. */
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 4, .max_programs = 4, .max_pipelines = 4, .max_buffers = 4, .max_textures = 4, .max_meshes = 4, .max_render_targets = 16});
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 4, .max_programs = 4, .max_pipelines = 4, .max_buffers = 4, .max_textures = 4, .max_meshes = 4, .max_vertex_inputs = 8, .max_render_targets = 16});
     nt_ui_module_init();
 }
 

--- a/tests/unit/test_shape.c
+++ b/tests/unit/test_shape.c
@@ -10,7 +10,8 @@
 static bool float_near(float a, float b, float epsilon) { return fabsf(a - b) <= epsilon; }
 
 void setUp(void) {
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_programs = 32, .max_pipelines = 32, .max_buffers = 128, .max_textures = 32, .max_meshes = 32, .max_render_targets = 16});
+    nt_gfx_init(
+        &(nt_gfx_desc_t){.max_shaders = 32, .max_programs = 32, .max_pipelines = 32, .max_buffers = 128, .max_textures = 32, .max_meshes = 32, .max_vertex_inputs = 32, .max_render_targets = 16});
     nt_gfx_stub_test_reset();
     nt_shape_renderer_init();
     /* Enter frame/pass so flush->draw_indexed doesn't assert */

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -838,11 +838,8 @@ void test_sprite_renderer_extended_layout_from_attr_map(void) {
     TEST_ASSERT_EQUAL_UINT32(4, ext_layout.locations[3]);
 }
 
-/* A base material and an attr_map material that share vs/fs/state and differ
- * ONLY in their vertex layout now SHARE one pipeline (layouts live on the
- * owned vertex inputs, not the pipeline) and resolve to two distinct vertex
- * inputs — the layout discriminator moved from the pipeline key to the
- * vertex-input cache key. */
+/* Equal program/state share a pipeline; base and extended layouts use
+ * separate vertex inputs. */
 void test_sprite_renderer_layout_splits_vertex_inputs_not_pipelines(void) {
     nt_sprite_renderer_desc_t desc = nt_sprite_renderer_desc_defaults();
     TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&desc));

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -390,7 +390,8 @@ void setUp(void) {
     s_radial_shared_program = NT_PROGRAM_INVALID;
 
     nt_hash_init(&(nt_hash_desc_t){0});
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 32, .max_programs = 16, .max_pipelines = 16, .max_buffers = 64, .max_textures = 32, .max_meshes = 16, .max_render_targets = 16});
+    nt_gfx_init(
+        &(nt_gfx_desc_t){.max_shaders = 32, .max_programs = 16, .max_pipelines = 16, .max_buffers = 64, .max_textures = 32, .max_meshes = 16, .max_vertex_inputs = 16, .max_render_targets = 16});
     nt_resource_init(&(nt_resource_desc_t){0});
     nt_atlas_init();
 

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -807,11 +807,12 @@ void test_sprite_renderer_extended_layout_from_attr_map(void) {
     TEST_ASSERT_EQUAL_UINT32(4, ext_layout.locations[3]);
 }
 
-/* A base material and an attr_map material that share
- * vs/fs/state and differ ONLY in their vertex layout must resolve to TWO
- * distinct pipelines — proving the layout discriminator is folded into the
- * cache key (the base must never alias the extended pipeline). */
-void test_sprite_renderer_layout_in_pipeline_key(void) {
+/* A base material and an attr_map material that share vs/fs/state and differ
+ * ONLY in their vertex layout now SHARE one pipeline (layouts live on the
+ * owned vertex inputs, not the pipeline) and resolve to two distinct vertex
+ * inputs — the layout discriminator moved from the pipeline key to the
+ * vertex-input cache key. */
+void test_sprite_renderer_layout_splits_vertex_inputs_not_pipelines(void) {
     nt_sprite_renderer_desc_t desc = nt_sprite_renderer_desc_defaults();
     TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&desc));
 
@@ -823,8 +824,9 @@ void test_sprite_renderer_layout_in_pipeline_key(void) {
     nt_sprite_renderer_set_material(mat_base);
     nt_sprite_renderer_set_material(mat_radial);
 
-    /* Same vs/fs/state, different layout → must NOT collide. */
-    TEST_ASSERT_EQUAL_UINT32(2, nt_sprite_renderer_test_pipeline_cache_count());
+    /* Same vs/fs/state: one pipeline; different layout: two vertex inputs. */
+    TEST_ASSERT_EQUAL_UINT32(1, nt_sprite_renderer_test_pipeline_cache_count());
+    TEST_ASSERT_EQUAL_UINT32(2, nt_sprite_renderer_test_vertex_input_cache_count());
 }
 
 /* The custom-attr emit path bakes the per-widget float block into
@@ -1231,7 +1233,7 @@ int main(void) {
     RUN_TEST(test_sprite_renderer_splits_run_on_actual_page_change);
     RUN_TEST(test_sprite_renderer_polygon_emit);
     RUN_TEST(test_sprite_renderer_extended_layout_from_attr_map);
-    RUN_TEST(test_sprite_renderer_layout_in_pipeline_key);
+    RUN_TEST(test_sprite_renderer_layout_splits_vertex_inputs_not_pipelines);
     RUN_TEST(test_sprite_renderer_custom_attr_emit_bakes_per_vertex);
     RUN_TEST(test_sprite_renderer_flip_mirrors_around_pivot);
     RUN_TEST(test_sprite_renderer_restore_gpu_cycle);

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -455,6 +455,37 @@ void test_sprite_renderer_init_shutdown(void) {
     TEST_ASSERT_TRUE(nt_sprite_renderer_test_initialized());
 }
 
+static void assert_all_buffer_slots_available(void) {
+    nt_buffer_t buffers[64];
+    for (uint32_t i = 0; i < 64; i++) {
+        buffers[i] = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_DYNAMIC, .size = 16});
+        TEST_ASSERT_NOT_EQUAL_UINT32(0, buffers[i].id);
+    }
+    for (uint32_t i = 0; i < 64; i++) {
+        nt_gfx_destroy_buffer(buffers[i]);
+    }
+}
+
+void test_sprite_renderer_init_retries_after_buffer_creation_failure(void) {
+    nt_sprite_renderer_desc_t desc = nt_sprite_renderer_desc_defaults();
+    for (uint8_t mask = 1; mask <= 2; mask++) {
+        nt_gfx_stub_test_fail_buffer_creates(mask);
+        TEST_ASSERT_EQUAL(NT_ERR_INIT_FAILED, nt_sprite_renderer_init(&desc));
+        TEST_ASSERT_FALSE(nt_sprite_renderer_test_initialized());
+        TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_restore_gpu());
+        TEST_ASSERT_FALSE(nt_sprite_renderer_test_initialized());
+        assert_all_buffer_slots_available();
+    }
+
+    TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&desc));
+    s_atlas_res = register_test_atlas(0xCBULL);
+    nt_material_t mat = create_test_material();
+    nt_entity_t entity = create_sprite_entity(s_atlas_res, FIXTURE_R0_HASH, mat);
+    nt_render_item_t item = {.entity = entity.id, .batch_key = sprite_batch_key(entity, mat)};
+    nt_sprite_renderer_draw_list(&item, 1);
+    TEST_ASSERT_EQUAL_UINT32(1, nt_sprite_renderer_test_draw_call_count());
+}
+
 /* ---- Test: vertex size assert ---- */
 
 /* The actual contract is enforced by the _Static_assert in nt_sprite_renderer.h.
@@ -986,6 +1017,70 @@ void test_sprite_renderer_restore_gpu_cycle(void) {
     TEST_ASSERT_EQUAL_UINT32(1, nt_sprite_renderer_test_draw_call_count());
 }
 
+void test_sprite_renderer_restore_retries_after_context_loss(void) {
+    nt_sprite_renderer_desc_t desc = nt_sprite_renderer_desc_defaults();
+    desc.max_vertices = 16;
+    desc.max_indices = 24;
+    desc.custom_max_vertices = 16;
+    TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&desc));
+    s_atlas_res = register_test_atlas(0xC9ULL);
+    nt_material_t mat = create_test_material();
+    nt_entity_t entity = create_sprite_entity(s_atlas_res, FIXTURE_R0_HASH, mat);
+    nt_render_item_t item = {.entity = entity.id, .batch_key = sprite_batch_key(entity, mat)};
+    nt_sprite_renderer_set_material(mat);
+    nt_sprite_renderer_emit_region(s_atlas_res, 0, NT_MATH_MAT4_IDENTITY, 0, 0, 0xFFFFFFFFU, 0);
+    TEST_ASSERT_EQUAL_UINT32(4, nt_sprite_renderer_test_vertex_count());
+
+    nt_gfx_stub_test_set_context_lost(true);
+    nt_result_t result = nt_sprite_renderer_restore_gpu();
+    nt_gfx_stub_test_set_context_lost(false);
+
+    TEST_ASSERT_EQUAL(NT_ERR_INIT_FAILED, result);
+    TEST_ASSERT_TRUE(nt_sprite_renderer_test_initialized());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_sprite_renderer_test_cmd_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_sprite_renderer_test_vertex_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_sprite_renderer_test_pipeline_cache_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_sprite_renderer_test_vertex_input_cache_count());
+
+    NT_TEST_EXPECT_ASSERT(nt_sprite_renderer_set_material(mat));
+    TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_restore_gpu());
+    nt_render_item_t items[5] = {item, item, item, item, item};
+    nt_sprite_renderer_draw_list(items, 5);
+    TEST_ASSERT_EQUAL_UINT32(2, nt_sprite_renderer_test_draw_call_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_sprite_renderer_test_cmd_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_sprite_renderer_test_vertex_count());
+}
+
+void test_sprite_renderer_restore_on_inactive_renderer_does_nothing(void) {
+    TEST_ASSERT_FALSE(nt_sprite_renderer_test_initialized());
+    TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_restore_gpu());
+    TEST_ASSERT_FALSE(nt_sprite_renderer_test_initialized());
+}
+
+void test_sprite_renderer_restore_cleans_up_after_index_buffer_failure(void) {
+    nt_sprite_renderer_desc_t desc = nt_sprite_renderer_desc_defaults();
+    TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&desc));
+    s_atlas_res = register_test_atlas(0xCAULL);
+    nt_material_t mat = create_test_material();
+    nt_entity_t entity = create_sprite_entity(s_atlas_res, FIXTURE_R0_HASH, mat);
+    nt_render_item_t item = {.entity = entity.id, .batch_key = sprite_batch_key(entity, mat)};
+    nt_sprite_renderer_draw_list(&item, 1);
+
+    nt_gfx_stub_test_fail_buffer_creates(2);
+    TEST_ASSERT_EQUAL(NT_ERR_INIT_FAILED, nt_sprite_renderer_restore_gpu());
+    TEST_ASSERT_TRUE(nt_sprite_renderer_test_initialized());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_sprite_renderer_test_cmd_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_sprite_renderer_test_vertex_input_cache_count());
+
+    /* Every slot must be available before retry; no partial VBO may linger. */
+    assert_all_buffer_slots_available();
+
+    TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_restore_gpu());
+    nt_sprite_renderer_draw_list(&item, 1);
+    TEST_ASSERT_EQUAL_UINT32(1, nt_sprite_renderer_test_draw_call_count());
+    TEST_ASSERT_EQUAL_UINT32(1, nt_sprite_renderer_test_vertex_input_cache_count());
+}
+
 /* ---- Test: pipeline cache full → NT_ASSERT ----
  *
  * Death-test on cache overflow is not exercised at runtime to keep the test
@@ -1247,6 +1342,7 @@ void test_emit_slice9_degrades_when_dst_smaller_than_borders(void) {
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_sprite_renderer_init_shutdown);
+    RUN_TEST(test_sprite_renderer_init_retries_after_buffer_creation_failure);
     RUN_TEST(test_sprite_renderer_vertex_size_assert);
     RUN_TEST(test_sprite_renderer_batch_key_packs_material_and_page_slots);
     RUN_TEST(test_sprite_renderer_batch_key_ignores_handle_generations);
@@ -1268,6 +1364,9 @@ int main(void) {
     RUN_TEST(test_sprite_renderer_custom_attr_emit_bakes_per_vertex);
     RUN_TEST(test_sprite_renderer_flip_mirrors_around_pivot);
     RUN_TEST(test_sprite_renderer_restore_gpu_cycle);
+    RUN_TEST(test_sprite_renderer_restore_retries_after_context_loss);
+    RUN_TEST(test_sprite_renderer_restore_on_inactive_renderer_does_nothing);
+    RUN_TEST(test_sprite_renderer_restore_cleans_up_after_index_buffer_failure);
     RUN_TEST(test_sprite_renderer_pipeline_cache_capacity);
     RUN_TEST(test_sprite_renderer_sampler_override_does_not_stick);
     RUN_TEST(test_emit_slice9_null_src_scale_one_matches_atlas);

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -829,6 +829,31 @@ void test_sprite_renderer_layout_splits_vertex_inputs_not_pipelines(void) {
     TEST_ASSERT_EQUAL_UINT32(2, nt_sprite_renderer_test_vertex_input_cache_count());
 }
 
+void test_sprite_renderer_retries_vertex_input_after_backend_failure(void) {
+    nt_sprite_renderer_desc_t desc = nt_sprite_renderer_desc_defaults();
+    TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&desc));
+    s_atlas_res = register_test_atlas(0xA7ULL);
+    nt_material_t mat = create_test_material();
+    nt_entity_t e = create_sprite_entity(s_atlas_res, FIXTURE_R0_HASH, mat);
+    nt_render_item_t item = {.entity = e.id, .batch_key = sprite_batch_key(e, mat)};
+
+    nt_gfx_stub_test_reset();
+    nt_gfx_stub_test_fail_next_vertex_input_create();
+    nt_sprite_renderer_draw_list(&item, 1);
+    TEST_ASSERT_EQUAL_UINT32(0, nt_sprite_renderer_test_vertex_input_cache_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_sprite_renderer_test_draw_call_count());
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_stub_test_vertex_input_create_count());
+
+    nt_sprite_renderer_draw_list(&item, 1);
+    TEST_ASSERT_EQUAL_UINT32(1, nt_sprite_renderer_test_vertex_input_cache_count());
+    TEST_ASSERT_EQUAL_UINT32(1, nt_sprite_renderer_test_draw_call_count());
+    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_stub_test_vertex_input_create_count());
+
+    nt_sprite_renderer_draw_list(&item, 1);
+    TEST_ASSERT_EQUAL_UINT32(1, nt_sprite_renderer_test_draw_call_count());
+    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_stub_test_vertex_input_create_count());
+}
+
 /* The custom-attr emit path bakes the per-widget float block into
  * EVERY vertex it emits (like color), into a separate byte-staging buffer at
  * the extended stride — read back via the radial test accessor. */
@@ -928,7 +953,7 @@ void test_sprite_renderer_flip_mirrors_around_pivot(void) {
     assert_pos_close(2.0F, -28.0F, p, "flip-both v3");
 }
 
-/* ---- Test: restore_gpu re-cycle clears pipeline cache ---- */
+/* ---- Test: restore_gpu clears both caches before recreating buffers ---- */
 
 void test_sprite_renderer_restore_gpu_cycle(void) {
     nt_sprite_renderer_desc_t desc = nt_sprite_renderer_desc_defaults();
@@ -943,16 +968,21 @@ void test_sprite_renderer_restore_gpu_cycle(void) {
     items[0].entity = e.id;
     items[0].batch_key = sprite_batch_key(e, mat);
 
+    nt_gfx_stub_test_reset();
     nt_sprite_renderer_draw_list(items, 1);
     TEST_ASSERT_EQUAL_UINT32(1, nt_sprite_renderer_test_pipeline_cache_count());
+    TEST_ASSERT_EQUAL_UINT32(1, nt_sprite_renderer_test_vertex_input_cache_count());
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_stub_test_vertex_input_create_count());
 
     nt_sprite_renderer_restore_gpu();
     TEST_ASSERT_TRUE(nt_sprite_renderer_test_initialized());
     TEST_ASSERT_EQUAL_UINT32(0, nt_sprite_renderer_test_pipeline_cache_count());
 
-    /* Subsequent draws still work — pipeline is rebuilt lazily */
+    TEST_ASSERT_EQUAL_UINT32(0, nt_sprite_renderer_test_vertex_input_cache_count());
     nt_sprite_renderer_draw_list(items, 1);
     TEST_ASSERT_EQUAL_UINT32(1, nt_sprite_renderer_test_pipeline_cache_count());
+    TEST_ASSERT_EQUAL_UINT32(1, nt_sprite_renderer_test_vertex_input_cache_count());
+    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_stub_test_vertex_input_create_count());
     TEST_ASSERT_EQUAL_UINT32(1, nt_sprite_renderer_test_draw_call_count());
 }
 
@@ -1234,6 +1264,7 @@ int main(void) {
     RUN_TEST(test_sprite_renderer_polygon_emit);
     RUN_TEST(test_sprite_renderer_extended_layout_from_attr_map);
     RUN_TEST(test_sprite_renderer_layout_splits_vertex_inputs_not_pipelines);
+    RUN_TEST(test_sprite_renderer_retries_vertex_input_after_backend_failure);
     RUN_TEST(test_sprite_renderer_custom_attr_emit_bakes_per_vertex);
     RUN_TEST(test_sprite_renderer_flip_mirrors_around_pivot);
     RUN_TEST(test_sprite_renderer_restore_gpu_cycle);

--- a/tests/unit/test_text_renderer.c
+++ b/tests/unit/test_text_renderer.c
@@ -436,6 +436,25 @@ void test_flush_stops_after_program_cleared(void) {
     nt_gfx_end_frame();
 }
 
+/* A recoverable vertex-input creation failure must not disable text until the
+ * next restore: flush retries the creation lazily, like the pipeline cache. */
+void test_flush_retries_vertex_input_after_backend_failure(void) {
+    nt_material_t material = create_test_material_with_blend(nt_blend_alpha());
+    nt_text_renderer_set_material(material);
+
+    /* Buffers recreate fine; the vertex input creation fails once. */
+    nt_gfx_stub_test_fail_next_vertex_input_create();
+    nt_text_renderer_restore_gpu();
+
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+    nt_text_renderer_draw("AB", s_identity, 32.0F, s_white, 0.0F, 0.0F);
+    nt_text_renderer_flush(); /* without the retry this discards the glyphs */
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_text_renderer_test_nonempty_flush_calls());
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+}
+
 /* Two materials on one program and one render state are one pipeline: the key is
  * the pipeline signature, not the material's identity. */
 void test_materials_sharing_a_program_share_one_pipeline(void) {
@@ -1310,6 +1329,7 @@ int main(void) {
     RUN_TEST(test_measure_width_increases);
     RUN_TEST(test_draw_newline_advances_to_next_line);
     RUN_TEST(test_flush_stops_after_program_cleared);
+    RUN_TEST(test_flush_retries_vertex_input_after_backend_failure);
     RUN_TEST(test_flush_discards_glyphs_on_a_destroyed_program);
     RUN_TEST(test_restore_cycle_reuses_the_material_and_rebuilds_the_pipeline);
     RUN_TEST(test_materials_sharing_a_program_share_one_pipeline);

--- a/tests/unit/test_text_renderer.c
+++ b/tests/unit/test_text_renderer.c
@@ -243,7 +243,7 @@ static void test_assert_handler(const char *expr, const char *file, int line) {
 void setUp(void) {
     nt_assert_handler = test_assert_handler;
     nt_gfx_stub_test_reset();
-    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 16, .max_textures = 32, .max_meshes = 8, .max_render_targets = 16});
+    nt_gfx_init(&(nt_gfx_desc_t){.max_shaders = 8, .max_programs = 4, .max_pipelines = 4, .max_buffers = 16, .max_textures = 32, .max_meshes = 8, .max_vertex_inputs = 16, .max_render_targets = 16});
     nt_hash_init(&(nt_hash_desc_t){0});
     nt_resource_init(&(nt_resource_desc_t){0});
     nt_material_init(&(nt_material_desc_t){.max_materials = 4});

--- a/tests/unit/test_text_renderer.c
+++ b/tests/unit/test_text_renderer.c
@@ -456,6 +456,24 @@ void test_flush_retries_vertex_input_after_backend_failure(void) {
     nt_gfx_end_frame();
 }
 
+/* Restore contract: failure releases partial GPU resources (resource.md). */
+void test_failed_restore_releases_partial_buffers(void) {
+    nt_gfx_stub_test_fail_buffer_creates(2); /* vbo succeeds, ibo fails */
+    TEST_ASSERT_EQUAL_INT(NT_ERR_INIT_FAILED, nt_text_renderer_restore_gpu());
+
+    /* The orphaned vbo would hold one of the 16 buffer pool slots. */
+    nt_buffer_t buffers[16];
+    for (uint32_t i = 0; i < 16; i++) {
+        buffers[i] = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_DYNAMIC, .size = 16});
+        TEST_ASSERT_NOT_EQUAL_UINT32(0, buffers[i].id);
+    }
+    for (uint32_t i = 0; i < 16; i++) {
+        nt_gfx_destroy_buffer(buffers[i]);
+    }
+
+    TEST_ASSERT_EQUAL_INT(NT_OK, nt_text_renderer_restore_gpu());
+}
+
 /* Two materials on one program and one render state are one pipeline: the key is
  * the pipeline signature, not the material's identity. */
 void test_materials_sharing_a_program_share_one_pipeline(void) {
@@ -1331,6 +1349,7 @@ int main(void) {
     RUN_TEST(test_draw_newline_advances_to_next_line);
     RUN_TEST(test_flush_stops_after_program_cleared);
     RUN_TEST(test_flush_retries_vertex_input_after_backend_failure);
+    RUN_TEST(test_failed_restore_releases_partial_buffers);
     RUN_TEST(test_flush_discards_glyphs_on_a_destroyed_program);
     RUN_TEST(test_restore_cycle_reuses_the_material_and_rebuilds_the_pipeline);
     RUN_TEST(test_materials_sharing_a_program_share_one_pipeline);

--- a/tests/unit/test_text_renderer.c
+++ b/tests/unit/test_text_renderer.c
@@ -442,9 +442,10 @@ void test_flush_retries_vertex_input_after_backend_failure(void) {
     nt_material_t material = create_test_material_with_blend(nt_blend_alpha());
     nt_text_renderer_set_material(material);
 
-    /* Buffers recreate fine; the vertex input creation fails once. */
+    /* Buffers recreate fine; the vertex input creation fails once. A failed
+     * vertex-input bake alone does not fail the restore -- flush retries it. */
     nt_gfx_stub_test_fail_next_vertex_input_create();
-    nt_text_renderer_restore_gpu();
+    TEST_ASSERT_EQUAL_INT(NT_OK, nt_text_renderer_restore_gpu());
 
     nt_gfx_begin_frame();
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
@@ -852,7 +853,7 @@ void test_restore_cycle_reuses_the_material_and_rebuilds_the_pipeline(void) {
     /* Restore frame: reset the renderer, drop the program, keep the material. */
     nt_gfx_stub_test_set_context_lost(false);
     nt_gfx_begin_frame();
-    nt_text_renderer_restore_gpu();
+    TEST_ASSERT_EQUAL_INT(NT_OK, nt_text_renderer_restore_gpu());
     TEST_ASSERT_EQUAL_UINT32(0U, nt_text_renderer_test_glyph_count());
     nt_gfx_destroy_program(first);
     nt_gfx_end_frame();


### PR DESCRIPTION
Closes #355.

## What

Vertex-input state (vertex layout + instance layout + VBO [+IBO]) becomes an owned public object, `nt_vertex_input_t`, backed by a GL VAO — the Godot GLES3 model, chosen for the web-first case where per-mesh-switch pointer rewrites genuinely change every switch and a prebuilt VAO turns the switch into one `glBindVertexArray`. Pipelines slim down to program + fixed render state (completing the #377 split); pipeline and vertex-input binding are orthogonal.

## Semantics

- **Destroy cascade**: `nt_gfx_destroy_buffer` destroys every vertex input referencing the buffer as VBO or IBO, so `nt_gfx_deactivate_mesh` reclaims dependent vertex inputs without a renderer callback. The cascade makes stale handles routine, so `nt_gfx_destroy_vertex_input` tolerates stale/INVALID. Renderer caches revalidate handles on lookup.
- **EBO side-channel fix**: index-buffer data ops (create/update/orphan) run inside a dedicated service upload VAO in the GL backend — the element-array binding is VAO state and would otherwise be silently rewired into whichever vertex input is bound (reachable every sprite/shape flush); binding it with VAO 0 is itself invalid on the native core-3.3 context, which also covers index-buffer creation at startup (a pre-branch latent bug).
- **Crash-early draw invariants**: every draw asserts a bound vertex input (attribute-less draws bind an empty one — the `gl_VertexID` path); indexed draws assert a captured index type; instanced draws assert the instance attribs were pointed at least once (enabled-but-unpointed attribs fail silently in GL).
- **Mesh renderer versions** (the payoff): per-mesh table `[nt_gfx_max_meshes()][max_mesh_layouts]`, entry identity = derived-layout hash (mesh streams × attr_map) + color mode + the full generation-checked mesh handle. Exhausting a row **asserts**, naming the knob (`nt_mesh_renderer_desc_t.max_mesh_layouts`, default 4) — silent eviction would hide VAO re-creation thrash as an invisible perf regression.
- **Pipeline caches** simplify to program × render_state_hash everywhere (the text-renderer pattern): far fewer pipelines — per material state, not per mesh-layout × material. Sprite custom layouts now share one pipeline and split vertex inputs instead.

## Fixed along the way

Shape template and line index buffers were created without `index_type`; the legacy path drew them as UINT16 only by backend default. The new creation assert caught it.

## Tests

- Stub-backed suite `test_gfx_vertex_input.c`: lifecycle, validation (WebGL2 rules moved from pipelines), cascade, bind mirrors, draw invariants, context loss, bind orthogonality.
- Real-GL pixel tests (`test_nt_gfx_bind_mirrors_native.c` rewritten): vertex inputs alternating under one pipeline, **zero static `glVertexAttribPointer` calls in a steady-state frame**, the EBO data-op regression, orphan under a live vertex input, bind preservation across rejected/failed operations.
- Mesh renderer: vi reuse/dedup (same derived layout from different attr_maps shares), mesh-slot-reuse identity, versions-overflow assert trip.
- Browser: the smoke app gains an instanced mesh probe (owned vertex input over an in-code mesh, instance buffer re-pointed at a nonzero byte offset), pixel-verified by `context_loss.spec.ts` at baseline and after both loss/restore cycles.
- `devapi.spec.ts` now runs in its own Playwright project against a second static server rooted at the devapi_host build, so a plain `npx playwright test` covers all four specs locally; the dedicated CI job drops its `NT_SHOWCASE_DIR` export.

## Review rounds (3, all findings fixed)

- **Round 1** (4 review lenses, `ba1e27f6`): instance-attrib assert broadened to all draws; text flush gates on vertex-input validity; backend stores a compact per-slot instance-attr copy (`NT_GFX_MAX_INSTANCE_ATTRS = 8`, halves the table); `max_vertex_inputs` default 560; dead `layout_hash` removed; mesh vi key hashes only used attrs; stale transitional comments deleted; steady-state test counts real `glVertexAttribPointer` via glad-pointer swap and pins VAO-bind/instance re-point counts; browser probe samples both instanced quads.
- **Round 2** (external review, `9e44001e`): EBO data ops moved into the service upload VAO (core-profile fix above); text renderer lazily retries vertex-input creation in flush after a recoverable backend failure; a material mapping none of a mesh's streams derives an empty layout and takes the attribute-less `gl_VertexID` path (was an assert-trip); restored-frame negative test binds full draw state first.
- **Round 3** (re-review lenses, `b39a8db1`): dead-generation entries purged from a mesh's versions row on lookup — a bufferless vertex input (empty layout + non-indexed mesh) has no cascade hook and could exhaust the row across recreate cycles; `make_buffer` gains the uniform lost-context guard and the backend rejects `glGenBuffers` name 0 (kills lost-frame slot aliasing); compact instance copy clamped in OFF; upload-VAO delete skipped on a dead context; cap asserts pinned by expression content; real-GL attribute-less pixel test; text retry pinned via the stub fail-next hook.

## Measurements

- Steady-state static-attrib-pointer count is pinned to zero by a real-GL test; draw-call counts are unchanged (existing draw-trace tests).
- bench_shapes (native, 2000 shapes): 0.86 ms vs 0.88 ms CPU submission — parity within noise, as expected for the shape workload; the win case is mesh-heavy scenes (unique meshes / instancing), to be sampled in Chrome on bunnymark/sponza.

## Spec

`docs/spec/render/architecture.md`: the vertex-layout section becomes the vertex-input section (ownership, cascade + tolerant stale destroy, bind orthogonality, static-half-immutable / instance-pointers-mutable contract, VAO0 rule for index data ops); cache-identity section documents the simplified pipeline keys and the per-mesh vertex-input versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BEHVidPD1MGjp4YPBPiojo
