### PR TITLE
check.sh: refuse concurrent runs in one tree; keep the ctest log on disk (#388)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -139,6 +139,8 @@ Environment differences a local Windows host cannot reproduce:
 ## Test-infra & debugging gotchas
 
 - Only a fresh full `check.sh` run is authoritative — targeted builds + ctest can pass on stale binaries after an edit burst.
+- Never run two `check.sh`/`ctest` in one tree at once (agent + lead included): shared test outputs and relinked exes make builder/atlas tests fail spuriously. `check.sh` holds `build/.check.lock` and exits 2 while another run is active; `rmdir` it only if the other run is dead.
+- A failed test's name and output after `check.sh`: `build/_cmake/native-debug/check-ctest.log` (kept on disk) or `Testing/Temporary/LastTestsFailed.log` — do not rely on a `tail`-truncated terminal.
 - A failed `NT_BUILD_ASSERT` aborts the test process; if a dead process still holds the exe (next link fails with permission denied), `taskkill //F //IM <test>.exe`. Deliberate assert-trip tests: run the binary directly, not through ctest.
 - A crashing test that prints nothing: diagnose with `lldb -b -o run -o bt <exe>` (gdb absent; MSVC CRT buffers stdout to pipes and ignores stdbuf).
 - `UNITY_EXCLUDE_FLOAT` is defined — float Unity asserts compile to nothing; compare small exact values via `(int32_t)` casts.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,10 +111,10 @@ sources, delete the `.ntpack` before visual QA to force a repack.
 bash scripts/format_and_check.sh
 ```
 
-It auto-formats changed files (`fmt.sh`) and then runs the full read-only check
+It auto-formats changed files (`fmt.sh`) under the same run lock, then runs the full read-only check
 (warm: ~12 s, ~25 s when builder/atlas paths changed — the three atlas-bench
 guard tests auto-run only then; `--push`/`--full` always run them). `check.sh`
-itself never mutates files; the formatter lives in `fmt.sh`.
+direct modes never mutate files; `format_and_check.sh` opts into the formatter before the checks.
 
 It runs the cheap gates (module composition, EM_JS_DEPS, doc links + spec-index coverage, CRT-pin centralization), builds native-debug, runs ctest, then checks clang-format and clang-tidy on changed files only (falls back to full tidy when headers changed). clang-tidy uses a devapi-enabled compile DB matching the CI lint job, so devapi TUs are checked, not skipped. Vendored deps (`deps/clay`, `deps/cglm`, `deps/unity`, `deps/basisu`, `deps/glfw`, `deps/curl`, `deps/zlib`) follow upstream style and are excluded; review patches to them separately.
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
-# Unified pre-commit check (read-only — the mutating formatter is scripts/fmt.sh,
-# combined entry: scripts/format_and_check.sh). Modes:
-#   scripts/check.sh          gates + build + ctest + format/tidy on changed files
-#   scripts/check.sh --full   default + whole-tree format + full tidy
-#   scripts/check.sh --push   default + wasm-debug + wasm-release + submodule test
+# Unified pre-commit check. Direct modes are read-only; format_and_check.sh
+# opts into running the formatter under the same lock first. Modes:
+#   scripts/check.sh                    gates + build + ctest + format/tidy on changed files
+#   scripts/check.sh --full             default + whole-tree format + full tidy
+#   scripts/check.sh --push             default + wasm-debug + wasm-release + submodule test
+#   scripts/check.sh --format [--full|--push]  format changed files under the same run lock first
 # The cheap gates (module composition, EM_JS_DEPS, doc links, CRT pins) run in EVERY mode —
 # they cost seconds and previously CI-only failures came exactly from skipping them.
 # Remaining known CI-only class: GNU ld link order (Linux-specific, see AGENTS.md).
@@ -16,13 +17,19 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$ROOT_DIR"
 
+FORMAT_FIRST=0
+if [ "${1:-}" = "--format" ]; then
+    FORMAT_FIRST=1
+    shift
+fi
+
 MODE="default"
 case "${1:-}" in
     "") ;;
     --full) MODE="full" ;;
     --push) MODE="push" ;;
     *)
-        echo "usage: scripts/check.sh [--full|--push]"
+        echo "usage: scripts/check.sh [--format] [--full|--push]"
         exit 2
         ;;
 esac
@@ -71,15 +78,20 @@ print_summary() {
     else
         echo "  FAIL  $CURRENT_STEP"
         if [ "$CURRENT_STEP" = "ctest (native-debug)" ] && [ -f "${CTEST_LOG:-}" ]; then
-            # The full log survives on disk; a reader who piped this run through
-            # tail still gets the failing test names here.
-            grep -E '\(Failed\)|\(Timeout\)|\(SEGFAULT\)|\(Exception|\(Not Run\)' "$CTEST_LOG" | sed 's/^/  /' || true
+            print_ctest_failures "$CTEST_LOG"
             echo "  full ctest log: $CTEST_LOG"
         fi
         echo "RESULT: FAIL"
     fi
 }
 trap print_summary EXIT
+
+# shellcheck source=lib/check_output.sh
+source "$SCRIPT_DIR/lib/check_output.sh"
+
+if [ "$FORMAT_FIRST" -eq 1 ]; then
+    bash "$SCRIPT_DIR/fmt.sh"
+fi
 
 # #region changed files
 # shellcheck source=lib/changed_files.sh
@@ -155,6 +167,7 @@ bash scripts/check_crt_pins.sh
 ensure_tidy_ci
 bash scripts/check_tests_registered.sh "$TIDY_CI_DIR"
 python -m unittest discover -s scripts/tests -p 'test_*.py'
+bash scripts/tests/test_check.sh
 bash scripts/tests/test_tidy.sh
 ok
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -31,6 +31,15 @@ NATIVE_BUILD_DIR="build/_cmake/native-debug"
 CURRENT_STEP="startup"
 RESULTS=()
 
+# Two checks in one tree corrupt each other (shared test outputs, exes relinked
+# under a running ctest); mkdir is the atomic lock that works on every host.
+LOCK_DIR="build/.check.lock"
+mkdir -p build
+if ! mkdir "$LOCK_DIR" 2> /dev/null; then
+    echo "check.sh: another run holds $LOCK_DIR in this tree -- wait for it, or rmdir the lock if it is stale"
+    exit 2
+fi
+
 step() {
     CURRENT_STEP="$1"
     echo ""
@@ -49,8 +58,8 @@ print_summary() {
         WINPID="$(ps -p "$CTEST_PID" 2> /dev/null | awk 'NR == 2 { print $4 }' || true)"
         { [ -n "$WINPID" ] && taskkill //PID "$WINPID" //T //F > /dev/null 2>&1; } || kill "$CTEST_PID" 2> /dev/null || true
         wait "$CTEST_PID" 2> /dev/null || true
-        rm -f "${CTEST_LOG:-}"
     fi
+    rmdir "$LOCK_DIR" 2> /dev/null || true
     echo ""
     echo "=================================================="
     echo "check.sh summary (mode: $MODE)"
@@ -61,6 +70,12 @@ print_summary() {
         echo "RESULT: PASS"
     else
         echo "  FAIL  $CURRENT_STEP"
+        if [ "$CURRENT_STEP" = "ctest (native-debug)" ] && [ -f "${CTEST_LOG:-}" ]; then
+            # The full log survives on disk; a reader who piped this run through
+            # tail still gets the failing test names here.
+            grep -E '\(Failed\)|\(Timeout\)|\(SEGFAULT\)|\(Exception|\(Not Run\)' "$CTEST_LOG" | sed 's/^/  /' || true
+            echo "  full ctest log: $CTEST_LOG"
+        fi
         echo "RESULT: FAIL"
     fi
 }
@@ -170,7 +185,7 @@ if [ "$MODE" = "default" ] && ! printf '%s\n' "$CHANGED_NAMES_ALL" | grep -qE "$
     echo "(no builder/atlas paths in the change set — the 3 bench-guard tests defer to --push/--full)"
     CTEST_ARGS=(-E '^(test_atlas_hull_visual_report|test_atlas_transform_sweep_guard|test_bench_hull_tolerance_guard)$')
 fi
-CTEST_LOG="$(mktemp)"
+CTEST_LOG="$NATIVE_BUILD_DIR/check-ctest.log" # kept on disk; overwritten per run
 ctest --test-dir "$NATIVE_BUILD_DIR" -j "$(nproc)" --output-on-failure "${CTEST_ARGS[@]}" > "$CTEST_LOG" 2>&1 &
 CTEST_PID=$!
 echo "(backgrounded, pid $CTEST_PID)"
@@ -182,11 +197,9 @@ collect_ctest() {
     CTEST_PID=""
     if [ "$rc" -ne 0 ]; then
         cat "$CTEST_LOG"
-        rm -f "$CTEST_LOG"
         return "$rc"
     fi
     tail -n 3 "$CTEST_LOG"
-    rm -f "$CTEST_LOG"
     RESULTS+=("PASS  ctest (native-debug)")
 }
 

--- a/scripts/format_and_check.sh
+++ b/scripts/format_and_check.sh
@@ -3,5 +3,4 @@
 # check. check.sh modes pass through: (default) | --push | --full.
 set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-bash "$SCRIPT_DIR/fmt.sh"
-exec bash "$SCRIPT_DIR/check.sh" "$@"
+exec bash "$SCRIPT_DIR/check.sh" --format "$@"

--- a/scripts/lib/check_output.sh
+++ b/scripts/lib/check_output.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+print_ctest_failures() {
+    local log="$1"
+    sed -n '/^The following tests FAILED:/,/^Errors while running CTest/p' "$log" | sed 's/^/  /'
+}

--- a/scripts/tests/test_check.sh
+++ b/scripts/tests/test_check.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+test_wrapper_locks_before_format() {
+    local fixture="$TMP_DIR/wrapper"
+    mkdir -p "$fixture/scripts" "$fixture/build/.check.lock"
+    cp "$ROOT_DIR/scripts/check.sh" "$fixture/scripts/check.sh"
+    cp "$ROOT_DIR/scripts/format_and_check.sh" "$fixture/scripts/format_and_check.sh"
+    printf '#!/usr/bin/env bash\ntouch "$(dirname "$0")/../format-ran"\n' > "$fixture/scripts/fmt.sh"
+
+    local rc=0
+    bash "$fixture/scripts/format_and_check.sh" > "$fixture/output.log" 2>&1 || rc=$?
+    if [ "$rc" -ne 2 ]; then
+        echo "FAIL: locked format_and_check.sh returned $rc, expected 2"
+        return 1
+    fi
+    if [ -e "$fixture/format-ran" ]; then
+        echo "FAIL: format_and_check.sh formatted before checking the lock"
+        return 1
+    fi
+}
+
+test_ctest_summary_includes_exit_code_failure() {
+    # shellcheck source=../lib/check_output.sh
+    source "$ROOT_DIR/scripts/lib/check_output.sh"
+
+    local log="$TMP_DIR/ctest.log"
+    printf '%s\n' \
+        '125/133 Test #23: test_nt_gfx_render_target_native ......Exit code 0xc0000409' \
+        '***Exception: 43.59 sec' \
+        'The following tests FAILED:' \
+        '  23 - test_nt_gfx_render_target_native (Exit code 0xc0000409' \
+        ')' \
+        'Errors while running CTest' > "$log"
+
+    local output
+    output="$(print_ctest_failures "$log")"
+    if [[ "$output" != *"23 - test_nt_gfx_render_target_native"* ]]; then
+        echo "FAIL: CTest summary omitted the exit-code failure"
+        return 1
+    fi
+}
+
+test_wrapper_locks_before_format
+test_ctest_summary_includes_exit_code_failure
+echo "check.sh behavior tests: PASS"


### PR DESCRIPTION
Closes #388.

- `check.sh` takes a mkdir lock (`build/.check.lock`) and exits 2 with a message while another run is active in the same tree; released on exit. Two concurrent `ctest -j8` reproducibly fail `test_builder` (timeout), `test_atlas_hull_visual_report`, `test_atlas_bench_transforms_e2e`, `test_atlas_dedup` — shared outputs, relinked exes; `RESOURCE_LOCK gl_display` only serialises inside one ctest process.
- ctest output is kept at `build/_cmake/native-debug/check-ctest.log` (overwritten per run) instead of a deleted mktemp; on failure the summary lists the failed tests and the log path, so a `tail`-truncated terminal no longer loses the failing test.
- AGENTS.md gotchas: the two rules above.

Verified: second `check.sh` while the lock exists → exit 2; `format_and_check.sh` through the new script → PASS, lock released, log present.

Context (not fixed here, recorded in the issue): `test_nt_gfx_render_target_native` died silently twice in one day under check.sh; not reproducible in 38 targeted runs. Next occurrence is now diagnosable from the persisted log.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CRbGNPyUP1z3LXvxznqZVD