### PR TITLE
gfx: persistent GL state cache, pass-scoped bound state, GL-mirror-only backend (#358)

### DIFF
--- a/docs/spec/core/api-contracts.md
+++ b/docs/spec/core/api-contracts.md
@@ -260,7 +260,9 @@ default sampler state; it does not preserve pixels. Consumers must redraw
 offscreen contents after resize or context restore.
 While the backend reports a lost context, `nt_gfx_begin_frame` skips the frame
 without attempting recreation. Recreation starts only after the backend leaves
-the lost state; a failed recreation is retried on a later frame.
+the lost state; a failed backend-context recreation is retried on a later frame.
+After the context recovers, each render target is recreated once. A failed target
+remains unready; its owner destroys and recreates it, or uses a fallback.
 
 Render-target descriptors explicitly separate depth storage from depth format.
 `NONE` has no depth format or attachment, `BUFFER` has a non-sampleable depth

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -127,8 +127,8 @@ share every uniform value, and binding one does not reset what the other set —
 each consumer sets every uniform it needs on every material transition inside
 one `draw_list` call or flush. Renderer-tracked bound state is discarded at the
 end of that call; across calls the GL backend deduplicates program, VAO,
-texture, viewport and clear-value binds, while sampler binds and uniform writes
-are always issued. The
+texture, viewport and clear-value binds (scissor-enable is deduplicated by the
+front-end mirror), while sampler binds and uniform writes are always issued. The
 backend GL cache persists across passes and frames; ground state is issued once
 at backend init and at context restore. A uniform a material
 does not declare retains the value last written on that program; this applies

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -124,7 +124,9 @@ share every uniform value, and binding one does not reset what the other set —
 each consumer sets every uniform it needs on every material transition inside
 one `draw_list` call or flush. Renderer-tracked bound state is discarded at the
 end of that call; across calls the GL backend deduplicates program, VAO and
-texture binds, while sampler binds and uniform writes are always issued. A uniform a material
+texture binds, while sampler binds and uniform writes are always issued. The
+backend GL cache persists across passes and frames; ground state is issued once
+at backend init and at context restore. A uniform a material
 does not declare retains the value last written on that program; this applies
 to sampler units and material params. Planned fixes are fixed sampler-unit
 assignments per program (#359) and per-material param UBOs bound at material
@@ -209,7 +211,10 @@ bind or unbind render-target state outside the pass descriptor.
 
 Pass color and depth clears are pass-owned operations. In particular,
 `clear_depth` is applied independently of the previous pipeline's `depth_write`
-state; pipeline write masks affect draws, not the next pass initialization.
+state; pipeline write masks affect draws, not the next pass initialization. Bound
+pipeline and vertex input are pass-scoped: `begin_pass` discards them; binds,
+uniform writes and draws outside a pass assert. The clear forces the depth mask
+on and leaves it on; the pass's first pipeline bind sets its own mask.
 
 Render-target color and sampleable depth attachments are exposed as normal
 `nt_texture_t` handles for later sampling. Backend FBO/renderbuffer ids stay

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -113,7 +113,8 @@ loss frees their pool slots outright. Primary resources (buffers, textures,
 shaders, programs) instead survive a loss as husks — pool slot alive,
 backend gone — because per-frame code keeps operating on them through the
 loss window and the restore recipe has their owners destroy the old handles
-explicitly.
+explicitly. Binding a husk texture reports once and leaves the unit as it was;
+binding a husk buffer, or writing into any husk, asserts.
 
 **Program / pipeline split.** A program is the linked (vertex, fragment) pair
 and owns everything that follows from linking: uniform locations, uniform
@@ -127,7 +128,7 @@ share every uniform value, and binding one does not reset what the other set —
 each consumer sets every uniform it needs on every material transition inside
 one `draw_list` call or flush. Renderer-tracked bound state is discarded at the
 end of that call; across calls the GL backend deduplicates program, VAO,
-texture, viewport and clear-value binds (scissor-enable is deduplicated by the
+pipeline state, texture, viewport and clear-value binds (scissor-enable is deduplicated by the
 front-end mirror), while sampler binds and uniform writes are always issued. The
 backend GL cache persists across passes and frames; ground state is issued once
 at backend init and at context restore. A uniform a material

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -126,8 +126,9 @@ re-binding the other. Two pipelines on one program
 share every uniform value, and binding one does not reset what the other set —
 each consumer sets every uniform it needs on every material transition inside
 one `draw_list` call or flush. Renderer-tracked bound state is discarded at the
-end of that call; across calls the GL backend deduplicates program, VAO and
-texture binds, while sampler binds and uniform writes are always issued. The
+end of that call; across calls the GL backend deduplicates program, VAO,
+texture, viewport and clear-value binds, while sampler binds and uniform writes
+are always issued. The
 backend GL cache persists across passes and frames; ground state is issued once
 at backend init and at context restore. A uniform a material
 does not declare retains the value last written on that program; this applies
@@ -215,9 +216,11 @@ bind or unbind render-target state outside the pass descriptor.
 Pass color and depth clears are pass-owned operations. In particular,
 `clear_depth` is applied independently of the previous pipeline's `depth_write`
 state; pipeline write masks affect draws, not the next pass initialization. Bound
-pipeline and vertex input are pass-scoped: `begin_pass` discards them; binds,
-uniform writes and draws outside a pass assert. The clear forces the depth mask
-on and leaves it on; the pass's first pipeline bind sets its own mask.
+pipeline and vertex input are pass-scoped: `begin_pass` discards them; pipeline
+and vertex-input binds, instance-buffer re-pointing, uniform writes and draws
+outside a pass assert. Texture, sampler and uniform-buffer binds are context
+state — they are not pass-scoped and do not assert. The clear forces the depth
+mask on and leaves it on; the pass's first pipeline bind sets its own mask.
 
 Render-target color and sampleable depth attachments are exposed as normal
 `nt_texture_t` handles for later sampling. Backend FBO/renderbuffer ids stay

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -62,7 +62,8 @@ draws; per mesh switch that is a single `glBindVertexArray` instead of
 buffer re-binds plus per-attribute `glVertexAttribPointer` rewrites. The
 object's *static* half — vertex attributes and the index binding — is
 immutable after creation; its *instance* attribute pointers are re-specified
-into the bound object by each `nt_gfx_bind_instance_buffer` (WebGL2 has no
+by each `nt_gfx_bind_instance_buffer` into the vertex input the front-end
+names explicitly to the backend (WebGL2 has no
 baseInstance, so per-draw instance re-pointing stays). An empty layout with
 no buffers is the attribute-less `gl_VertexID` path; every draw asserts a
 bound vertex input.
@@ -116,7 +117,9 @@ explicitly.
 
 **Program / pipeline split.** A program is the linked (vertex, fragment) pair
 and owns everything that follows from linking: uniform locations, uniform
-values, and global UBO block bindings. A pipeline is fixed-function render
+values, and global UBO block bindings. A uniform write requires a bound
+pipeline and addresses that pipeline's program at the backend boundary; a
+write with nothing bound asserts. A pipeline is fixed-function render
 state that *borrows* a program handle — it owns no vertex-input state, and
 pipeline and vertex-input binding are orthogonal: either may change without
 re-binding the other. Two pipelines on one program

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -625,11 +625,6 @@ void nt_gfx_backend_end_segment(void) {
 // #endregion
 
 void nt_gfx_backend_begin_frame(void) {
-    /* Reset GL state cache so all pipeline binds re-issue GL calls.
-     * Required because window resize (Windows modal loop) or driver
-     * may change GL state without going through nt_gfx API, leaving
-     * the cache stale. */
-    nt_gfx_gl_cache_ground_state();
     s_bound_pipeline_slot = 0;
     s_bound_vertex_input_slot = 0;
 
@@ -765,15 +760,13 @@ void nt_gfx_backend_begin_pass(const nt_pass_desc_t *desc, uint32_t render_targe
     glViewport(0, 0, viewport_w, viewport_h);
     glClearColor(desc->clear_color[0], desc->clear_color[1], desc->clear_color[2], desc->clear_color[3]);
     nt_gl_clear_depth(desc->clear_depth);
-    /* Pass clears must not inherit the previous pipeline's depth-write mask. */
-    bool restore_depth_write = !s_gl_cache.depth_write_enabled;
-    if (restore_depth_write) {
+    /* The clear must not inherit the previous pipeline's depth-write mask, and
+     * leaves it on: the pass's first pipeline bind re-applies its own. */
+    if (!s_gl_cache.depth_write_enabled) {
         glDepthMask(GL_TRUE);
+        s_gl_cache.depth_write_enabled = true;
     }
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
-    if (restore_depth_write) {
-        glDepthMask(GL_FALSE);
-    }
 }
 
 void nt_gfx_backend_end_pass(void) {

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -369,7 +369,10 @@ static GLenum map_blend_op(nt_blend_op_t op) {
     }
 }
 
-static bool float4_equal(const float a[4], const float b[4]) { return a[0] == b[0] && a[1] == b[1] && a[2] == b[2] && a[3] == b[3]; }
+/* Bitwise, not ==: -0.0 and +0.0 compare equal as floats but are distinct
+ * clear/blend values on a float render target, so the dedup must re-issue. */
+// NOLINTNEXTLINE(bugprone-suspicious-memory-comparison,cert-exp42-c,cert-flp37-c) -- distinguishing the bit patterns is the point
+static bool float4_equal(const float a[4], const float b[4]) { return memcmp(a, b, 4 * sizeof(float)) == 0; }
 
 static GLenum map_depth_func(nt_depth_func_t f) {
     switch (f) {
@@ -825,12 +828,8 @@ bool nt_gfx_backend_read_pixels(int x, int y, int w, int h, void *out_rgba8) {
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_gfx_backend_bind_pipeline(uint32_t backend_handle) {
-    /* The front-end saying nothing is bound: no backend state to drop. */
-    if (backend_handle == 0) {
-        return;
-    }
-    NT_ASSERT(backend_handle <= s_init_desc.max_pipelines && "bind_pipeline: handle out of range");
-    if (backend_handle > s_init_desc.max_pipelines) {
+    NT_ASSERT(backend_handle != 0 && backend_handle <= s_init_desc.max_pipelines && "bind_pipeline: handle out of range");
+    if (backend_handle == 0 || backend_handle > s_init_desc.max_pipelines) {
         return;
     }
     nt_gfx_gl_pipeline_t *pip = &s_pipelines[backend_handle];
@@ -1433,6 +1432,8 @@ void nt_gfx_backend_bind_instance_buffer(uint32_t vertex_input_backend, uint32_t
     NT_ASSERT(buffer_backend != 0 && buffer_backend <= s_init_desc.max_buffers && s_buffer_gl[buffer_backend] != 0 && "bind_instance_buffer: requires a live buffer");
     NT_ASSERT(vertex_input_backend != 0 && vertex_input_backend <= s_init_desc.max_vertex_inputs && s_vertex_inputs[vertex_input_backend].vao != 0 &&
               "bind_instance_buffer: requires a live vertex input");
+    /* The pointers land in whatever VAO is bound, so the named one must be it. */
+    NT_ASSERT(s_vertex_inputs[vertex_input_backend].vao == s_gl_cache.vao && "bind_instance_buffer: named vertex input is not the bound VAO");
     GLuint buf = s_buffer_gl[buffer_backend];
     glBindBuffer(GL_ARRAY_BUFFER, buf);
 

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -508,6 +508,8 @@ bool nt_gfx_backend_init(const nt_gfx_desc_t *desc) {
     s_buffer_targets = (GLenum *)calloc(s_init_desc.max_buffers + 1, sizeof(GLenum));
     s_texture_gl = (GLuint *)calloc(s_init_desc.max_textures + 1, sizeof(GLuint));
     s_render_targets = (nt_gfx_gl_render_target_t *)calloc(s_init_desc.max_render_targets + 1, sizeof(nt_gfx_gl_render_target_t));
+    /* Init-time OOM on a few KB of tables is not a state a game can recover from. */
+    NT_ASSERT(s_programs && s_pipelines && s_vertex_inputs && s_buffer_gl && s_buffer_targets && s_texture_gl && s_render_targets && "gfx backend init: out of memory");
 
     s_bound_framebuffer = 0;
     nt_gfx_gl_cache_ground_state();

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -181,9 +181,10 @@ static uint32_t s_transcode_buf_idle = 0;
  * Every direct GL call that changes a field here mirrors it or invalidates the
  * entry at the call site; ground state only at init and context restore. */
 
-/* Uploads bind here instead of on a sampling unit. WebGL2 and GL 3.3 both
- * guarantee at least 16 fragment texture units, so this one always exists. */
+/* Uploads bind here instead of on a sampling unit: unit NT_GFX_MAX_TEXTURE_SLOTS
+ * is below the 16 fragment units WebGL2/GL 3.3 guarantee. */
 #define NT_GFX_GL_UPLOAD_TEXTURE_UNIT ((GLenum)(GL_TEXTURE0 + NT_GFX_MAX_TEXTURE_SLOTS))
+_Static_assert(NT_GFX_MAX_TEXTURE_SLOTS < 16, "scratch upload unit must stay inside the guaranteed unit range");
 
 static struct {
     GLuint vao;

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -1156,7 +1156,11 @@ uint32_t nt_gfx_backend_create_program(uint32_t vs_backend, uint32_t fs_backend)
 }
 
 void nt_gfx_backend_destroy_program(uint32_t backend_handle) {
-    if (backend_handle == 0 || backend_handle > s_init_desc.max_programs) {
+    if (backend_handle == 0) {
+        return;
+    }
+    NT_ASSERT(backend_handle <= s_init_desc.max_programs && "destroy_program: handle out of range");
+    if (backend_handle > s_init_desc.max_programs) {
         return;
     }
     GLuint program = s_programs[backend_handle].program;
@@ -1205,7 +1209,11 @@ uint32_t nt_gfx_backend_create_pipeline(const nt_pipeline_desc_t *desc, uint32_t
 }
 
 void nt_gfx_backend_destroy_pipeline(uint32_t backend_handle) {
-    if (backend_handle == 0 || backend_handle > s_init_desc.max_pipelines) {
+    if (backend_handle == 0) {
+        return;
+    }
+    NT_ASSERT(backend_handle <= s_init_desc.max_pipelines && "destroy_pipeline: handle out of range");
+    if (backend_handle > s_init_desc.max_pipelines) {
         return;
     }
     /* The program is not ours to delete -- it outlives every pipeline built
@@ -1266,7 +1274,11 @@ uint32_t nt_gfx_backend_create_vertex_input(const nt_vertex_input_desc_t *desc, 
 }
 
 void nt_gfx_backend_destroy_vertex_input(uint32_t backend_handle) {
-    if (backend_handle == 0 || backend_handle > s_init_desc.max_vertex_inputs) {
+    if (backend_handle == 0) {
+        return;
+    }
+    NT_ASSERT(backend_handle <= s_init_desc.max_vertex_inputs && "destroy_vertex_input: handle out of range");
+    if (backend_handle > s_init_desc.max_vertex_inputs) {
         return;
     }
     nt_gfx_gl_vertex_input_t *vi = &s_vertex_inputs[backend_handle];
@@ -1283,16 +1295,33 @@ void nt_gfx_backend_destroy_vertex_input(uint32_t backend_handle) {
     memset(vi, 0, sizeof(*vi));
 }
 
+/* Drop the vertex-input selection and the GL binding together. */
+static void unbind_vertex_input_state(void) {
+    s_bound_vertex_input_slot = 0;
+    if (s_gl_cache.vao != 0) {
+        gl_bind_vao(0);
+        s_gl_cache.vao = 0;
+    }
+}
+
 void nt_gfx_backend_bind_vertex_input(uint32_t backend_handle) {
-    if (backend_handle == 0 || backend_handle > s_init_desc.max_vertex_inputs || s_vertex_inputs[backend_handle].vao == 0) {
-        s_bound_vertex_input_slot = 0;
-        if (s_gl_cache.vao != 0) {
-            gl_bind_vao(0);
-            s_gl_cache.vao = 0;
-        }
+    if (backend_handle == 0) {
+        unbind_vertex_input_state();
+        return;
+    }
+    NT_ASSERT(backend_handle <= s_init_desc.max_vertex_inputs && "bind_vertex_input: handle out of range");
+    if (backend_handle > s_init_desc.max_vertex_inputs) {
+        unbind_vertex_input_state();
         return;
     }
     GLuint vao = s_vertex_inputs[backend_handle].vao;
+    /* A zeroed record (context loss, destroyed vertex input) would leave the
+     * previous VAO bound and draw the wrong geometry. */
+    NT_ASSERT(vao != 0 && "bind_vertex_input: record without a live VAO");
+    if (vao == 0) {
+        unbind_vertex_input_state();
+        return;
+    }
     if (s_gl_cache.vao != vao) {
         gl_bind_vao(vao);
         s_gl_cache.vao = vao;
@@ -1351,7 +1380,11 @@ uint32_t nt_gfx_backend_create_buffer(const nt_buffer_desc_t *desc) {
 }
 
 void nt_gfx_backend_destroy_buffer(uint32_t backend_handle) {
-    if (backend_handle == 0 || backend_handle > s_init_desc.max_buffers) {
+    if (backend_handle == 0) {
+        return;
+    }
+    NT_ASSERT(backend_handle <= s_init_desc.max_buffers && "destroy_buffer: handle out of range");
+    if (backend_handle > s_init_desc.max_buffers) {
         return;
     }
     GLuint buf = s_buffer_gl[backend_handle];
@@ -1402,9 +1435,7 @@ void nt_gfx_backend_orphan_buffer(uint32_t backend_handle, const void *data, uin
 }
 
 void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle, uint32_t byte_offset) {
-    if (backend_handle == 0 || backend_handle > s_init_desc.max_buffers) {
-        return;
-    }
+    NT_ASSERT(backend_handle != 0 && backend_handle <= s_init_desc.max_buffers && s_buffer_gl[backend_handle] != 0 && "bind_instance_buffer: requires a live buffer");
     GLuint buf = s_buffer_gl[backend_handle];
     glBindBuffer(GL_ARRAY_BUFFER, buf);
 
@@ -1427,9 +1458,7 @@ void nt_gfx_backend_set_vertex_attrib_default(uint8_t location, float x, float y
 /* ---- Uniform buffer ---- */
 
 void nt_gfx_backend_bind_uniform_buffer(uint32_t backend_handle, uint32_t slot) {
-    if (backend_handle == 0 || backend_handle > s_init_desc.max_buffers) {
-        return;
-    }
+    NT_ASSERT(backend_handle != 0 && backend_handle <= s_init_desc.max_buffers && s_buffer_gl[backend_handle] != 0 && "bind_uniform_buffer: requires a live buffer");
     GLuint buf = s_buffer_gl[backend_handle];
     glBindBufferBase(GL_UNIFORM_BUFFER, slot, buf);
 }
@@ -1649,6 +1678,9 @@ uint32_t nt_gfx_backend_create_texture_compressed(const uint8_t *basis_data, uin
 
     GLuint tex;
     glGenTextures(1, &tex);
+    if (tex == 0) {
+        return 0; /* lost context: storing name 0 would alias the free-slot sentinel */
+    }
     if (!nt_gfx_gl_begin_texture_upload(tex)) {
         glDeleteTextures(1, &tex);
         return 0;
@@ -1729,7 +1761,11 @@ uint32_t nt_gfx_backend_create_texture_compressed(const uint8_t *basis_data, uin
 }
 
 void nt_gfx_backend_destroy_texture(uint32_t backend_handle) {
-    if (backend_handle == 0 || backend_handle > s_init_desc.max_textures) {
+    if (backend_handle == 0) {
+        return;
+    }
+    NT_ASSERT(backend_handle <= s_init_desc.max_textures && "destroy_texture: handle out of range");
+    if (backend_handle > s_init_desc.max_textures) {
         return;
     }
     GLuint tex = s_texture_gl[backend_handle];
@@ -1988,9 +2024,8 @@ bool nt_gfx_backend_resize_render_target(uint32_t backend_handle, const nt_rende
 }
 
 void nt_gfx_backend_bind_texture(uint32_t backend_handle, uint32_t slot) {
-    if (backend_handle == 0 || backend_handle > s_init_desc.max_textures) {
-        return;
-    }
+    NT_ASSERT(slot < NT_GFX_MAX_TEXTURE_SLOTS && "bind_texture: slot out of range");
+    NT_ASSERT(backend_handle != 0 && backend_handle <= s_init_desc.max_textures && s_texture_gl[backend_handle] != 0 && "bind_texture: requires a live texture");
     GLuint tex = s_texture_gl[backend_handle];
     if (s_gl_cache.bound_textures[slot] == tex) {
         return; /* already bound to this slot */

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -1415,7 +1415,6 @@ void nt_gfx_backend_bind_instance_buffer(uint32_t vertex_input_backend, uint32_t
     GLuint buf = s_buffer_gl[buffer_backend];
     glBindBuffer(GL_ARRAY_BUFFER, buf);
 
-    /* Re-specify the named vertex input's instance pointers into its VAO. */
     const nt_gfx_gl_vertex_input_t *vi = &s_vertex_inputs[vertex_input_backend];
     for (uint8_t i = 0; i < vi->instance_attr_count; i++) {
         const nt_vertex_attr_t *attr = &vi->instance_attrs[i];

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -203,6 +203,9 @@ static struct {
     float polygon_offset_units;
     GLenum active_texture_unit;
     GLuint bound_textures[NT_GFX_MAX_TEXTURE_SLOTS]; /* GL name per slot */
+    int viewport[4];
+    float clear_color[4];
+    float clear_depth;
 } s_gl_cache;
 
 /* ---- Per-pipeline uniform location lookup ---- */
@@ -260,6 +263,15 @@ static void ebo_upload_end(void) {
     gl_bind_vao(s_gl_cache.vao);
 }
 
+static void gl_set_viewport(int x, int y, int w, int h) {
+    const int rect[4] = {x, y, w, h};
+    if (memcmp(s_gl_cache.viewport, rect, sizeof(rect)) == 0) {
+        return;
+    }
+    memcpy(s_gl_cache.viewport, rect, sizeof(rect));
+    glViewport(x, y, (GLsizei)w, (GLsizei)h);
+}
+
 /* Real GL calls, not cache defaults: the native context outlives init cycles and
  * restore reuses it. */
 static void nt_gfx_gl_cache_ground_state(void) {
@@ -277,6 +289,11 @@ static void nt_gfx_gl_cache_ground_state(void) {
     glPolygonOffset(0.0F, 0.0F);
     glDisable(GL_SCISSOR_TEST);
     glActiveTexture(GL_TEXTURE0);
+    /* A zero-size viewport is legal GL and never equals a real pass, so the first
+     * pass after grounding always re-issues. */
+    glViewport(0, 0, 0, 0);
+    glClearColor(0.0F, 0.0F, 0.0F, 0.0F);
+    nt_gl_clear_depth(1.0F);
 
     s_gl_cache.vao = 0;
     s_gl_cache.program = 0;
@@ -297,6 +314,9 @@ static void nt_gfx_gl_cache_ground_state(void) {
     s_gl_cache.polygon_offset_units = 0.0F;
     s_gl_cache.active_texture_unit = GL_TEXTURE0;
     memset(s_gl_cache.bound_textures, 0, sizeof(s_gl_cache.bound_textures));
+    memset(s_gl_cache.viewport, 0, sizeof(s_gl_cache.viewport));
+    memset(s_gl_cache.clear_color, 0, sizeof(s_gl_cache.clear_color));
+    s_gl_cache.clear_depth = 1.0F;
 }
 
 /* ---- Helpers: enum mapping ---- */
@@ -355,7 +375,7 @@ static GLenum map_blend_op(nt_blend_op_t op) {
     }
 }
 
-static bool blend_constant_color_equal(const float a[4], const float b[4]) { return a[0] == b[0] && a[1] == b[1] && a[2] == b[2] && a[3] == b[3]; }
+static bool float4_equal(const float a[4], const float b[4]) { return a[0] == b[0] && a[1] == b[1] && a[2] == b[2] && a[3] == b[3]; }
 
 static GLenum map_depth_func(nt_depth_func_t f) {
     switch (f) {
@@ -757,9 +777,15 @@ void nt_gfx_backend_begin_pass(const nt_pass_desc_t *desc, uint32_t render_targe
         glBindFramebuffer(GL_FRAMEBUFFER, fbo);
         s_bound_framebuffer = fbo;
     }
-    glViewport(0, 0, viewport_w, viewport_h);
-    glClearColor(desc->clear_color[0], desc->clear_color[1], desc->clear_color[2], desc->clear_color[3]);
-    nt_gl_clear_depth(desc->clear_depth);
+    gl_set_viewport(0, 0, (int)viewport_w, (int)viewport_h);
+    if (!float4_equal(s_gl_cache.clear_color, desc->clear_color)) {
+        memcpy(s_gl_cache.clear_color, desc->clear_color, sizeof(s_gl_cache.clear_color));
+        glClearColor(desc->clear_color[0], desc->clear_color[1], desc->clear_color[2], desc->clear_color[3]);
+    }
+    if (s_gl_cache.clear_depth != desc->clear_depth) {
+        s_gl_cache.clear_depth = desc->clear_depth;
+        nt_gl_clear_depth(desc->clear_depth);
+    }
     /* The clear must not inherit the previous pipeline's depth-write mask, and
      * leaves it on: the pass's first pipeline bind re-applies its own. */
     if (!s_gl_cache.depth_write_enabled) {
@@ -781,6 +807,7 @@ void nt_gfx_backend_end_pass(void) {
  * Raw GL bottom-left convention. Callers are expected to y-flip if they
  * think in top-left space. */
 
+/* Uncached: the UI emits a distinct rect per clipped element, so a diff never hits. */
 void nt_gfx_backend_set_scissor(int x, int y, int w, int h) { glScissor(x, y, (GLsizei)w, (GLsizei)h); }
 
 void nt_gfx_backend_set_scissor_enabled(bool enabled) {
@@ -791,7 +818,7 @@ void nt_gfx_backend_set_scissor_enabled(bool enabled) {
     }
 }
 
-void nt_gfx_backend_set_viewport(int x, int y, int w, int h) { glViewport(x, y, (GLsizei)w, (GLsizei)h); }
+void nt_gfx_backend_set_viewport(int x, int y, int w, int h) { gl_set_viewport(x, y, w, h); }
 
 /* Raw GL readback, bottom-left origin. Y-flip to top-left is done once in
  * the shared layer (nt_gfx_read_pixels). rgba8 rows are 4*w bytes -> already
@@ -891,7 +918,7 @@ void nt_gfx_backend_bind_pipeline(uint32_t backend_handle) {
         s_gl_cache.blend_op_rgb = pip->blend_op_rgb;
         s_gl_cache.blend_op_alpha = pip->blend_op_alpha;
     }
-    if (pip->blend_enabled && !blend_constant_color_equal(s_gl_cache.blend_constant_color, pip->blend_constant_color)) {
+    if (pip->blend_enabled && !float4_equal(s_gl_cache.blend_constant_color, pip->blend_constant_color)) {
         glBlendColor(pip->blend_constant_color[0], pip->blend_constant_color[1], pip->blend_constant_color[2], pip->blend_constant_color[3]);
         memcpy(s_gl_cache.blend_constant_color, pip->blend_constant_color, sizeof(pip->blend_constant_color));
     }

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -302,6 +302,7 @@ static void nt_gfx_gl_cache_ground_state(void) {
     glClearColor(0.0F, 0.0F, 0.0F, 0.0F);
     nt_gl_clear_depth(1.0F);
 
+    s_bound_framebuffer = 0;
     s_gl_cache.vao = 0;
     s_gl_cache.program = 0;
     s_gl_cache.depth_test_enabled = false;
@@ -511,7 +512,6 @@ bool nt_gfx_backend_init(const nt_gfx_desc_t *desc) {
     /* Init-time OOM on a few KB of tables is not a state a game can recover from. */
     NT_ASSERT(s_programs && s_pipelines && s_vertex_inputs && s_buffer_gl && s_buffer_targets && s_texture_gl && s_render_targets && "gfx backend init: out of memory");
 
-    s_bound_framebuffer = 0;
     nt_gfx_gl_cache_ground_state();
 
     nt_gfx_gl_init_context_features();
@@ -844,16 +844,10 @@ bool nt_gfx_backend_read_pixels(int x, int y, int w, int h, void *out_rgba8) {
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_gfx_backend_bind_pipeline(uint32_t backend_handle) {
     NT_ASSERT(backend_handle != 0 && backend_handle <= s_init_desc.max_pipelines && "bind_pipeline: handle out of range");
-    if (backend_handle == 0 || backend_handle > s_init_desc.max_pipelines) {
-        return;
-    }
     nt_gfx_gl_pipeline_t *pip = &s_pipelines[backend_handle];
     /* A zeroed record (context loss, destroyed pipeline) would bind program 0
      * and turn every following draw into a silent GL_INVALID_OPERATION. */
     NT_ASSERT(pip->program_slot != 0 && pip->program_slot <= s_init_desc.max_programs && "bind_pipeline: pipeline record without a live program");
-    if (pip->program_slot == 0 || pip->program_slot > s_init_desc.max_programs) {
-        return;
-    }
 
     GLuint program = s_programs[pip->program_slot].program;
     if (s_gl_cache.program != program) {
@@ -1181,9 +1175,6 @@ void nt_gfx_backend_destroy_program(uint32_t backend_handle) {
         return;
     }
     NT_ASSERT(backend_handle <= s_init_desc.max_programs && "destroy_program: handle out of range");
-    if (backend_handle > s_init_desc.max_programs) {
-        return;
-    }
     GLuint program = s_programs[backend_handle].program;
     if (program == 0) {
         return;
@@ -1231,9 +1222,6 @@ void nt_gfx_backend_destroy_pipeline(uint32_t backend_handle) {
         return;
     }
     NT_ASSERT(backend_handle <= s_init_desc.max_pipelines && "destroy_pipeline: handle out of range");
-    if (backend_handle > s_init_desc.max_pipelines) {
-        return;
-    }
     /* The program is not ours to delete -- it outlives every pipeline built
      * on it; the pipeline owns no GL objects of its own. */
     memset(&s_pipelines[backend_handle], 0, sizeof(s_pipelines[backend_handle]));
@@ -1293,9 +1281,6 @@ void nt_gfx_backend_destroy_vertex_input(uint32_t backend_handle) {
         return;
     }
     NT_ASSERT(backend_handle <= s_init_desc.max_vertex_inputs && "destroy_vertex_input: handle out of range");
-    if (backend_handle > s_init_desc.max_vertex_inputs) {
-        return;
-    }
     nt_gfx_gl_vertex_input_t *vi = &s_vertex_inputs[backend_handle];
     /* Deleting the bound VAO reverts the GL binding to 0 -- mirror it. */
     if (vi->vao && s_gl_cache.vao == vi->vao) {
@@ -1307,31 +1292,11 @@ void nt_gfx_backend_destroy_vertex_input(uint32_t backend_handle) {
     memset(vi, 0, sizeof(*vi));
 }
 
-static void unbind_vertex_input_state(void) {
-    if (s_gl_cache.vao != 0) {
-        gl_bind_vao(0);
-        s_gl_cache.vao = 0;
-    }
-}
-
 void nt_gfx_backend_bind_vertex_input(uint32_t backend_handle) {
-    if (backend_handle == 0) {
-        unbind_vertex_input_state();
-        return;
-    }
-    NT_ASSERT(backend_handle <= s_init_desc.max_vertex_inputs && "bind_vertex_input: handle out of range");
-    if (backend_handle > s_init_desc.max_vertex_inputs) {
-        unbind_vertex_input_state();
-        return;
-    }
-    GLuint vao = s_vertex_inputs[backend_handle].vao;
     /* A zeroed record (context loss, destroyed vertex input) would leave the
      * previous VAO bound and draw the wrong geometry. */
-    NT_ASSERT(vao != 0 && "bind_vertex_input: record without a live VAO");
-    if (vao == 0) {
-        unbind_vertex_input_state();
-        return;
-    }
+    NT_ASSERT(backend_handle != 0 && backend_handle <= s_init_desc.max_vertex_inputs && s_vertex_inputs[backend_handle].vao != 0 && "bind_vertex_input: requires a live vertex input");
+    GLuint vao = s_vertex_inputs[backend_handle].vao;
     if (s_gl_cache.vao != vao) {
         gl_bind_vao(vao);
         s_gl_cache.vao = vao;
@@ -1393,9 +1358,6 @@ void nt_gfx_backend_destroy_buffer(uint32_t backend_handle) {
         return;
     }
     NT_ASSERT(backend_handle <= s_init_desc.max_buffers && "destroy_buffer: handle out of range");
-    if (backend_handle > s_init_desc.max_buffers) {
-        return;
-    }
     GLuint buf = s_buffer_gl[backend_handle];
     if (buf) {
         glDeleteBuffers(1, &buf);
@@ -1772,9 +1734,6 @@ void nt_gfx_backend_destroy_texture(uint32_t backend_handle) {
         return;
     }
     NT_ASSERT(backend_handle <= s_init_desc.max_textures && "destroy_texture: handle out of range");
-    if (backend_handle > s_init_desc.max_textures) {
-        return;
-    }
     GLuint tex = s_texture_gl[backend_handle];
     if (tex) {
         nt_gfx_gl_forget_texture(tex);
@@ -1895,11 +1854,7 @@ void nt_gfx_backend_destroy_render_target(uint32_t backend_handle) {
     if (backend_handle == 0) {
         return;
     }
-    bool valid_backend = backend_handle <= s_init_desc.max_render_targets && s_render_targets != NULL;
-    NT_ASSERT(valid_backend && "destroy_render_target: invalid GL backend handle");
-    if (!valid_backend) {
-        return;
-    }
+    NT_ASSERT(backend_handle <= s_init_desc.max_render_targets && s_render_targets != NULL && "destroy_render_target: invalid GL backend handle");
     nt_gfx_gl_render_target_t *rt = &s_render_targets[backend_handle];
     if (s_bound_framebuffer == rt->fbo) {
         glBindFramebuffer(GL_FRAMEBUFFER, 0);
@@ -2123,7 +2078,6 @@ bool nt_gfx_backend_recreate_all_resources(void) {
     if (s_render_targets) {
         memset(s_render_targets, 0, (s_init_desc.max_render_targets + 1) * sizeof(nt_gfx_gl_render_target_t));
     }
-    s_bound_framebuffer = 0;
     nt_gfx_gl_cache_ground_state();
     nt_gfx_gl_init_context_features();
     return true;

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -119,8 +119,6 @@ typedef struct {
 
 /* ---- File-scope state ---- */
 
-static uint32_t s_bound_pipeline_slot;     /* currently bound pipeline index */
-static uint32_t s_bound_vertex_input_slot; /* currently bound vertex-input index */
 /* Service VAO for index-buffer data ops: the ELEMENT_ARRAY_BUFFER bind is VAO
  * state, and core profile rejects it with VAO 0 bound (INVALID_OPERATION). */
 static GLuint s_ebo_upload_vao;
@@ -208,17 +206,13 @@ static struct {
     float clear_depth;
 } s_gl_cache;
 
-/* ---- Per-pipeline uniform location lookup ---- */
+/* ---- Per-program uniform location lookup ---- */
 
-static GLint pipeline_get_uniform_h(uint32_t name_hash) {
-    if (s_bound_pipeline_slot == 0 || s_bound_pipeline_slot > s_init_desc.max_pipelines) {
-        return -1;
-    }
-    uint32_t program_slot = s_pipelines[s_bound_pipeline_slot].program_slot;
-    if (program_slot == 0 || program_slot > s_init_desc.max_programs) {
-        return -1;
-    }
-    const nt_gfx_gl_program_t *prog = &s_programs[program_slot];
+static GLint program_get_uniform_h(uint32_t program_backend, uint32_t name_hash) {
+    NT_ASSERT(program_backend != 0 && program_backend <= s_init_desc.max_programs && s_programs[program_backend].program != 0 && "set_uniform: requires a live program");
+    /* glUniform* writes into the current program, so the named one must be it. */
+    NT_ASSERT(s_programs[program_backend].program == s_gl_cache.program && "uniform write targets a program that is not current");
+    const nt_gfx_gl_program_t *prog = &s_programs[program_backend];
     for (uint8_t i = 0; i < prog->uniform_count; i++) {
         if (prog->uniforms[i].name_hash == name_hash) {
             return prog->uniforms[i].location;
@@ -499,8 +493,6 @@ bool nt_gfx_backend_init(const nt_gfx_desc_t *desc) {
     s_texture_gl = (GLuint *)calloc(s_init_desc.max_textures + 1, sizeof(GLuint));
     s_render_targets = (nt_gfx_gl_render_target_t *)calloc(s_init_desc.max_render_targets + 1, sizeof(nt_gfx_gl_render_target_t));
 
-    s_bound_pipeline_slot = 0;
-    s_bound_vertex_input_slot = 0;
     s_bound_framebuffer = 0;
     nt_gfx_gl_cache_ground_state();
 
@@ -536,8 +528,6 @@ void nt_gfx_backend_shutdown(void) {
     s_transcode_buf = NULL;
     s_transcode_buf_size = 0;
 
-    s_bound_pipeline_slot = 0;
-    s_bound_vertex_input_slot = 0;
     s_bound_framebuffer = 0;
     /* A dead context already reclaimed the name; a GL call here would run
      * without a current context on web. */
@@ -645,9 +635,6 @@ void nt_gfx_backend_end_segment(void) {
 // #endregion
 
 void nt_gfx_backend_begin_frame(void) {
-    s_bound_pipeline_slot = 0;
-    s_bound_vertex_input_slot = 0;
-
     /* GL_GPU_DISJOINT_EXT exists only in EXT_disjoint_timer_query_webgl2 (and
      * GLES variants). Native ARB_timer_query has no disjoint concept — GPU
      * clock is reliable by spec there. Reading 0x8FBB on the desktop driver
@@ -836,19 +823,14 @@ bool nt_gfx_backend_read_pixels(int x, int y, int w, int h, void *out_rgba8) {
 
 /* ---- Pipeline bind ---- */
 
-/* Clear the pipeline selection so later uniform writes cannot target a stale
- * program. Vertex-input state is orthogonal and stays bound. */
-static void unbind_pipeline_state(void) { s_bound_pipeline_slot = 0; }
-
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_gfx_backend_bind_pipeline(uint32_t backend_handle) {
+    /* The front-end saying nothing is bound: no backend state to drop. */
     if (backend_handle == 0) {
-        unbind_pipeline_state();
         return;
     }
     NT_ASSERT(backend_handle <= s_init_desc.max_pipelines && "bind_pipeline: handle out of range");
     if (backend_handle > s_init_desc.max_pipelines) {
-        unbind_pipeline_state();
         return;
     }
     nt_gfx_gl_pipeline_t *pip = &s_pipelines[backend_handle];
@@ -856,7 +838,6 @@ void nt_gfx_backend_bind_pipeline(uint32_t backend_handle) {
      * and turn every following draw into a silent GL_INVALID_OPERATION. */
     NT_ASSERT(pip->program_slot != 0 && pip->program_slot <= s_init_desc.max_programs && "bind_pipeline: pipeline record without a live program");
     if (pip->program_slot == 0 || pip->program_slot > s_init_desc.max_programs) {
-        unbind_pipeline_state();
         return;
     }
 
@@ -865,7 +846,6 @@ void nt_gfx_backend_bind_pipeline(uint32_t backend_handle) {
         glUseProgram(program);
         s_gl_cache.program = program;
     }
-    s_bound_pipeline_slot = backend_handle;
 
     /* Depth test */
     if (s_gl_cache.depth_test_enabled != pip->depth_test_enabled) {
@@ -941,29 +921,29 @@ void nt_gfx_backend_bind_pipeline(uint32_t backend_handle) {
 
 /* ---- Uniforms ---- */
 
-void nt_gfx_backend_set_uniform_mat4(uint32_t name_hash, const float *matrix) {
-    GLint loc = pipeline_get_uniform_h(name_hash);
+void nt_gfx_backend_set_uniform_mat4(uint32_t program_backend, uint32_t name_hash, const float *matrix) {
+    GLint loc = program_get_uniform_h(program_backend, name_hash);
     if (loc >= 0) {
         glUniformMatrix4fv(loc, 1, GL_FALSE, matrix);
     }
 }
 
-void nt_gfx_backend_set_uniform_vec4(uint32_t name_hash, const float *vec) {
-    GLint loc = pipeline_get_uniform_h(name_hash);
+void nt_gfx_backend_set_uniform_vec4(uint32_t program_backend, uint32_t name_hash, const float *vec) {
+    GLint loc = program_get_uniform_h(program_backend, name_hash);
     if (loc >= 0) {
         glUniform4fv(loc, 1, vec);
     }
 }
 
-void nt_gfx_backend_set_uniform_float(uint32_t name_hash, float val) {
-    GLint loc = pipeline_get_uniform_h(name_hash);
+void nt_gfx_backend_set_uniform_float(uint32_t program_backend, uint32_t name_hash, float val) {
+    GLint loc = program_get_uniform_h(program_backend, name_hash);
     if (loc >= 0) {
         glUniform1f(loc, val);
     }
 }
 
-void nt_gfx_backend_set_uniform_int(uint32_t name_hash, int val) {
-    GLint loc = pipeline_get_uniform_h(name_hash);
+void nt_gfx_backend_set_uniform_int(uint32_t program_backend, uint32_t name_hash, int val) {
+    GLint loc = program_get_uniform_h(program_backend, name_hash);
     if (loc >= 0) {
         glUniform1i(loc, val);
     }
@@ -1199,9 +1179,6 @@ void nt_gfx_backend_destroy_program(uint32_t backend_handle) {
     if (s_gl_cache.program == program) {
         s_gl_cache.program = 0;
     }
-    if (s_bound_pipeline_slot != 0 && s_pipelines[s_bound_pipeline_slot].program_slot == backend_handle) {
-        s_bound_pipeline_slot = 0;
-    }
     glDeleteProgram(program);
     memset(&s_programs[backend_handle], 0, sizeof(s_programs[backend_handle]));
 }
@@ -1245,9 +1222,6 @@ void nt_gfx_backend_destroy_pipeline(uint32_t backend_handle) {
     }
     /* The program is not ours to delete -- it outlives every pipeline built
      * on it; the pipeline owns no GL objects of its own. */
-    if (s_bound_pipeline_slot == backend_handle) {
-        s_bound_pipeline_slot = 0;
-    }
     memset(&s_pipelines[backend_handle], 0, sizeof(s_pipelines[backend_handle]));
 }
 
@@ -1316,15 +1290,10 @@ void nt_gfx_backend_destroy_vertex_input(uint32_t backend_handle) {
     if (vi->vao) {
         glDeleteVertexArrays(1, &vi->vao);
     }
-    if (s_bound_vertex_input_slot == backend_handle) {
-        s_bound_vertex_input_slot = 0;
-    }
     memset(vi, 0, sizeof(*vi));
 }
 
-/* Drop the vertex-input selection and the GL binding together. */
 static void unbind_vertex_input_state(void) {
-    s_bound_vertex_input_slot = 0;
     if (s_gl_cache.vao != 0) {
         gl_bind_vao(0);
         s_gl_cache.vao = 0;
@@ -1353,7 +1322,6 @@ void nt_gfx_backend_bind_vertex_input(uint32_t backend_handle) {
         gl_bind_vao(vao);
         s_gl_cache.vao = vao;
     }
-    s_bound_vertex_input_slot = backend_handle;
 }
 
 uint32_t nt_gfx_backend_create_buffer(const nt_buffer_desc_t *desc) {
@@ -1461,22 +1429,22 @@ void nt_gfx_backend_orphan_buffer(uint32_t backend_handle, const void *data, uin
     }
 }
 
-void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle, uint32_t byte_offset) {
-    NT_ASSERT(backend_handle != 0 && backend_handle <= s_init_desc.max_buffers && s_buffer_gl[backend_handle] != 0 && "bind_instance_buffer: requires a live buffer");
-    GLuint buf = s_buffer_gl[backend_handle];
+void nt_gfx_backend_bind_instance_buffer(uint32_t vertex_input_backend, uint32_t buffer_backend, uint32_t byte_offset) {
+    NT_ASSERT(buffer_backend != 0 && buffer_backend <= s_init_desc.max_buffers && s_buffer_gl[buffer_backend] != 0 && "bind_instance_buffer: requires a live buffer");
+    NT_ASSERT(vertex_input_backend != 0 && vertex_input_backend <= s_init_desc.max_vertex_inputs && s_vertex_inputs[vertex_input_backend].vao != 0 &&
+              "bind_instance_buffer: requires a live vertex input");
+    GLuint buf = s_buffer_gl[buffer_backend];
     glBindBuffer(GL_ARRAY_BUFFER, buf);
 
-    /* Re-specify the bound vertex input's instance pointers into its VAO. */
-    if (s_bound_vertex_input_slot != 0 && s_bound_vertex_input_slot <= s_init_desc.max_vertex_inputs) {
-        const nt_gfx_gl_vertex_input_t *vi = &s_vertex_inputs[s_bound_vertex_input_slot];
-        for (uint8_t i = 0; i < vi->instance_attr_count; i++) {
-            const nt_vertex_attr_t *attr = &vi->instance_attrs[i];
-            glVertexAttribPointer(attr->location, attr->count, map_vertex_type(attr->type), attr->normalized ? GL_TRUE : GL_FALSE, (GLsizei)vi->instance_stride,
-                                  (void *)(uintptr_t)(attr->offset + byte_offset)); // NOLINT(performance-no-int-to-ptr)
+    /* Re-specify the named vertex input's instance pointers into its VAO. */
+    const nt_gfx_gl_vertex_input_t *vi = &s_vertex_inputs[vertex_input_backend];
+    for (uint8_t i = 0; i < vi->instance_attr_count; i++) {
+        const nt_vertex_attr_t *attr = &vi->instance_attrs[i];
+        glVertexAttribPointer(attr->location, attr->count, map_vertex_type(attr->type), attr->normalized ? GL_TRUE : GL_FALSE, (GLsizei)vi->instance_stride,
+                              (void *)(uintptr_t)(attr->offset + byte_offset)); // NOLINT(performance-no-int-to-ptr)
 #ifdef NT_TEST_ACCESS
-            s_test_instance_attrib_pointer_calls++;
+        s_test_instance_attrib_pointer_calls++;
 #endif
-        }
     }
 }
 
@@ -2143,8 +2111,6 @@ bool nt_gfx_backend_recreate_all_resources(void) {
     if (s_render_targets) {
         memset(s_render_targets, 0, (s_init_desc.max_render_targets + 1) * sizeof(nt_gfx_gl_render_target_t));
     }
-    s_bound_pipeline_slot = 0;
-    s_bound_vertex_input_slot = 0;
     s_bound_framebuffer = 0;
     nt_gfx_gl_cache_ground_state();
     nt_gfx_gl_init_context_features();

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -241,6 +241,14 @@ void nt_gfx_gl_test_reset_counters(void) {
 uint32_t nt_gfx_gl_test_static_attrib_pointer_calls(void) { return s_test_static_attrib_pointer_calls; }
 uint32_t nt_gfx_gl_test_instance_attrib_pointer_calls(void) { return s_test_instance_attrib_pointer_calls; }
 uint32_t nt_gfx_gl_test_vao_binds(void) { return s_test_vao_binds; }
+
+uint32_t nt_gfx_gl_test_cached_vao(void) { return s_gl_cache.vao; }
+uint32_t nt_gfx_gl_test_cached_program(void) { return s_gl_cache.program; }
+
+uint32_t nt_gfx_gl_test_cached_texture(uint32_t slot) {
+    NT_ASSERT(slot < NT_GFX_MAX_TEXTURE_SLOTS && "cached_texture: slot out of range");
+    return s_gl_cache.bound_textures[slot];
+}
 #endif
 // #endregion
 

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -179,7 +179,9 @@ static uint8_t *s_transcode_buf = NULL;
 static uint32_t s_transcode_buf_size = 0;
 static uint32_t s_transcode_buf_idle = 0;
 
-/* ---- GL state cache (skip redundant JS interop calls) ---- */
+/* ---- GL state cache (skip redundant JS interop calls) ----
+ * Every direct GL call that changes a field here mirrors it or invalidates the
+ * entry at the call site; ground state only at init and context restore. */
 
 static struct {
     GLuint vao;
@@ -258,7 +260,9 @@ static void ebo_upload_end(void) {
     gl_bind_vao(s_gl_cache.vao);
 }
 
-static void nt_gfx_gl_cache_reset(void) {
+/* Real GL calls, not cache defaults: the native context outlives init cycles and
+ * restore reuses it. */
+static void nt_gfx_gl_cache_ground_state(void) {
     gl_bind_vao(0);
     glUseProgram(0);
     glDisable(GL_DEPTH_TEST);
@@ -271,6 +275,7 @@ static void nt_gfx_gl_cache_reset(void) {
     glBlendColor(0.0F, 0.0F, 0.0F, 0.0F);
     glDisable(GL_POLYGON_OFFSET_FILL);
     glPolygonOffset(0.0F, 0.0F);
+    glDisable(GL_SCISSOR_TEST);
     glActiveTexture(GL_TEXTURE0);
 
     s_gl_cache.vao = 0;
@@ -477,7 +482,7 @@ bool nt_gfx_backend_init(const nt_gfx_desc_t *desc) {
     s_bound_pipeline_slot = 0;
     s_bound_vertex_input_slot = 0;
     s_bound_framebuffer = 0;
-    nt_gfx_gl_cache_reset();
+    nt_gfx_gl_cache_ground_state();
 
     nt_gfx_gl_init_context_features();
     return true;
@@ -624,7 +629,7 @@ void nt_gfx_backend_begin_frame(void) {
      * Required because window resize (Windows modal loop) or driver
      * may change GL state without going through nt_gfx API, leaving
      * the cache stale. */
-    nt_gfx_gl_cache_reset();
+    nt_gfx_gl_cache_ground_state();
     s_bound_pipeline_slot = 0;
     s_bound_vertex_input_slot = 0;
 
@@ -817,13 +822,19 @@ static void unbind_pipeline_state(void) { s_bound_pipeline_slot = 0; }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_gfx_backend_bind_pipeline(uint32_t backend_handle) {
-    if (backend_handle == 0 || backend_handle > s_init_desc.max_pipelines) {
+    if (backend_handle == 0) {
+        unbind_pipeline_state();
+        return;
+    }
+    NT_ASSERT(backend_handle <= s_init_desc.max_pipelines && "bind_pipeline: handle out of range");
+    if (backend_handle > s_init_desc.max_pipelines) {
         unbind_pipeline_state();
         return;
     }
     nt_gfx_gl_pipeline_t *pip = &s_pipelines[backend_handle];
     /* A zeroed record (context loss, destroyed pipeline) would bind program 0
      * and turn every following draw into a silent GL_INVALID_OPERATION. */
+    NT_ASSERT(pip->program_slot != 0 && pip->program_slot <= s_init_desc.max_programs && "bind_pipeline: pipeline record without a live program");
     if (pip->program_slot == 0 || pip->program_slot > s_init_desc.max_programs) {
         unbind_pipeline_state();
         return;
@@ -1499,6 +1510,15 @@ static void nt_gfx_gl_forget_texture(GLuint tex) {
     }
 }
 
+/* Invalidation belongs at the bind: a later early return can then never leave the
+ * cache naming a texture the active unit no longer has bound. */
+static void nt_gfx_gl_bind_texture_for_upload(GLuint tex) {
+    glBindTexture(GL_TEXTURE_2D, tex);
+    nt_gfx_gl_invalidate_active_texture_binding();
+}
+
+/* For upload paths that check glGetError afterwards — a stale error would be
+ * misattributed to this upload. */
 static bool nt_gfx_gl_begin_texture_upload(GLuint tex) {
     GLenum pending_error = glGetError();
     NT_ASSERT(pending_error == GL_NO_ERROR && "pending GL error before texture upload");
@@ -1506,8 +1526,7 @@ static bool nt_gfx_gl_begin_texture_upload(GLuint tex) {
         NT_LOG_ERROR("pending GL error before texture upload: 0x%04X", (unsigned)pending_error);
         return false;
     }
-    glBindTexture(GL_TEXTURE_2D, tex);
-    nt_gfx_gl_invalidate_active_texture_binding();
+    nt_gfx_gl_bind_texture_for_upload(tex);
     return true;
 }
 
@@ -1586,7 +1605,7 @@ void nt_gfx_backend_update_texture(uint32_t backend_handle, uint16_t x, uint16_t
     GLuint tex = s_texture_gl[backend_handle];
     NT_ASSERT(tex != 0 && "backend_update_texture: no GL texture at handle");
 
-    glBindTexture(GL_TEXTURE_2D, tex);
+    nt_gfx_gl_bind_texture_for_upload(tex);
 
     nt_gfx_gl_fmt_t gl = nt_gfx_gl_texture_format(format);
 
@@ -1598,12 +1617,6 @@ void nt_gfx_backend_update_texture(uint32_t backend_handle, uint16_t x, uint16_t
 
     if (!gl.align4) {
         glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
-    }
-
-    /* Invalidate state cache: glBindTexture dirtied the active unit's binding */
-    uint32_t active_slot = s_gl_cache.active_texture_unit - GL_TEXTURE0;
-    if (active_slot < NT_GFX_MAX_TEXTURE_SLOTS) {
-        s_gl_cache.bound_textures[active_slot] = 0;
     }
 }
 
@@ -1643,7 +1656,10 @@ uint32_t nt_gfx_backend_create_texture_compressed(const uint8_t *basis_data, uin
 
     GLuint tex;
     glGenTextures(1, &tex);
-    glBindTexture(GL_TEXTURE_2D, tex);
+    if (!nt_gfx_gl_begin_texture_upload(tex)) {
+        glDeleteTextures(1, &tex);
+        return 0;
+    }
 
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, (GLint)map_texture_filter(min_filter));
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, (GLint)map_texture_filter(mag_filter));
@@ -1715,12 +1731,6 @@ uint32_t nt_gfx_backend_create_texture_compressed(const uint8_t *basis_data, uin
         return 0;
     }
     s_texture_gl[slot] = tex;
-
-    /* Invalidate cache */
-    uint32_t active_slot = s_gl_cache.active_texture_unit - GL_TEXTURE0;
-    if (active_slot < NT_GFX_MAX_TEXTURE_SLOTS) {
-        s_gl_cache.bound_textures[active_slot] = 0;
-    }
 
     return slot;
 }
@@ -2081,7 +2091,7 @@ bool nt_gfx_backend_recreate_all_resources(void) {
     s_bound_pipeline_slot = 0;
     s_bound_vertex_input_slot = 0;
     s_bound_framebuffer = 0;
-    nt_gfx_gl_cache_reset();
+    nt_gfx_gl_cache_ground_state();
     nt_gfx_gl_init_context_features();
     return true;
 }

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -181,6 +181,10 @@ static uint32_t s_transcode_buf_idle = 0;
  * Every direct GL call that changes a field here mirrors it or invalidates the
  * entry at the call site; ground state only at init and context restore. */
 
+/* Uploads bind here instead of on a sampling unit. WebGL2 and GL 3.3 both
+ * guarantee at least 16 fragment texture units, so this one always exists. */
+#define NT_GFX_GL_UPLOAD_TEXTURE_UNIT ((GLenum)(GL_TEXTURE0 + NT_GFX_MAX_TEXTURE_SLOTS))
+
 static struct {
     GLuint vao;
     GLuint program;
@@ -200,7 +204,8 @@ static struct {
     float polygon_offset_factor;
     float polygon_offset_units;
     GLenum active_texture_unit;
-    GLuint bound_textures[NT_GFX_MAX_TEXTURE_SLOTS]; /* GL name per slot */
+    /* GL name per sampling slot; uploads use the scratch unit and never touch these. */
+    GLuint bound_textures[NT_GFX_MAX_TEXTURE_SLOTS];
     int viewport[4];
     float clear_color[4];
     float clear_depth;
@@ -1513,13 +1518,6 @@ static nt_gfx_gl_fmt_t nt_gfx_gl_texture_format(nt_texture_format_t fmt) {
     }
 }
 
-static void nt_gfx_gl_invalidate_active_texture_binding(void) {
-    uint32_t active_slot = s_gl_cache.active_texture_unit - GL_TEXTURE0;
-    if (active_slot < NT_GFX_MAX_TEXTURE_SLOTS) {
-        s_gl_cache.bound_textures[active_slot] = 0;
-    }
-}
-
 static void nt_gfx_gl_forget_texture(GLuint tex) {
     for (uint32_t i = 0; i < NT_GFX_MAX_TEXTURE_SLOTS; i++) {
         if (s_gl_cache.bound_textures[i] == tex) {
@@ -1528,11 +1526,14 @@ static void nt_gfx_gl_forget_texture(GLuint tex) {
     }
 }
 
-/* Invalidation belongs at the bind: a later early return can then never leave the
- * cache naming a texture the active unit no longer has bound. */
+/* Data and parameter ops go to the scratch unit, so no sampling slot is disturbed
+ * and the cache stays truthful without invalidation. */
 static void nt_gfx_gl_bind_texture_for_upload(GLuint tex) {
+    if (s_gl_cache.active_texture_unit != NT_GFX_GL_UPLOAD_TEXTURE_UNIT) {
+        glActiveTexture(NT_GFX_GL_UPLOAD_TEXTURE_UNIT);
+        s_gl_cache.active_texture_unit = NT_GFX_GL_UPLOAD_TEXTURE_UNIT;
+    }
     glBindTexture(GL_TEXTURE_2D, tex);
-    nt_gfx_gl_invalidate_active_texture_binding();
 }
 
 /* For upload paths that check glGetError afterwards — a stale error would be

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -1188,9 +1188,9 @@ void nt_gfx_backend_destroy_program(uint32_t backend_handle) {
     if (program == 0) {
         return;
     }
-    /* glDeleteProgram + glCreateProgram usually reuse the GL name, so a stale
-     * mirror would send the next uniform write into a different program. */
+    /* GL defers deletion while a program remains current. */
     if (s_gl_cache.program == program) {
+        glUseProgram(0);
         s_gl_cache.program = 0;
     }
     glDeleteProgram(program);

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -124,9 +124,7 @@ static struct {
 
     uint32_t *shader_backends; /* backend handles parallel to pool slots */
     uint32_t *program_backends;
-    uint32_t *pipeline_backends;
     uint32_t *pipeline_programs; /* full program handle each pipeline borrows */
-    uint32_t *vertex_input_backends;
     uint32_t *buffer_backends;
     uint32_t *texture_backends;
     uint32_t *render_target_backends;
@@ -146,7 +144,7 @@ static struct {
 
     nt_gfx_render_state_t render_state;
     bool context_restore_retry;
-    uint32_t bound_pipeline;     /* currently bound pipeline backend handle */
+    uint32_t bound_pipeline;     /* pool slot of the bound pipeline, 0 = none */
     uint32_t bound_vertex_input; /* full handle of the bound vertex input, 0 = none */
     uint32_t bound_texture_ids[NT_GFX_MAX_TEXTURE_SLOTS];
     uint8_t bound_index_type; /* from the bound vertex input; NT_INDEX_NONE = non-indexed or none bound */
@@ -255,9 +253,7 @@ void nt_gfx_init(const nt_gfx_desc_t *desc) {
 
     s_gfx.shader_backends = (uint32_t *)calloc(desc->max_shaders + 1, sizeof(uint32_t));
     s_gfx.program_backends = (uint32_t *)calloc(desc->max_programs + 1, sizeof(uint32_t));
-    s_gfx.pipeline_backends = (uint32_t *)calloc(desc->max_pipelines + 1, sizeof(uint32_t));
     s_gfx.pipeline_programs = (uint32_t *)calloc(desc->max_pipelines + 1, sizeof(uint32_t));
-    s_gfx.vertex_input_backends = (uint32_t *)calloc(desc->max_vertex_inputs + 1, sizeof(uint32_t));
     s_gfx.buffer_backends = (uint32_t *)calloc(desc->max_buffers + 1, sizeof(uint32_t));
     s_gfx.texture_backends = (uint32_t *)calloc(desc->max_textures + 1, sizeof(uint32_t));
     s_gfx.render_target_backends = (uint32_t *)calloc(max_render_targets + 1, sizeof(uint32_t));
@@ -273,8 +269,8 @@ void nt_gfx_init(const nt_gfx_desc_t *desc) {
     nt_pool_init(&s_gfx.mesh_pool, desc->max_meshes);
     s_gfx.mesh_table = (nt_gfx_mesh_info_t *)calloc((size_t)desc->max_meshes + 1, sizeof(nt_gfx_mesh_info_t));
     /* Init-time OOM on a few KB of tables is not a state a game can recover from. */
-    NT_ASSERT(s_gfx.shader_backends && s_gfx.program_backends && s_gfx.pipeline_backends && s_gfx.pipeline_programs && s_gfx.vertex_input_backends && s_gfx.buffer_backends && s_gfx.texture_backends &&
-              s_gfx.render_target_backends && s_gfx.buffer_metas && s_gfx.vertex_input_metas && s_gfx.texture_metas && s_gfx.render_target_metas && s_gfx.mesh_table && "gfx init: out of memory");
+    NT_ASSERT(s_gfx.shader_backends && s_gfx.program_backends && s_gfx.pipeline_programs && s_gfx.buffer_backends && s_gfx.texture_backends && s_gfx.render_target_backends && s_gfx.buffer_metas &&
+              s_gfx.vertex_input_metas && s_gfx.texture_metas && s_gfx.render_target_metas && s_gfx.mesh_table && "gfx init: out of memory");
 
     if (!nt_gfx_backend_init(desc)) {
         NT_LOG_ERROR("backend init failed");
@@ -306,16 +302,6 @@ void nt_gfx_shutdown(void) {
         }
     }
 
-    /* Destroy active mesh-table buffers */
-    for (uint32_t i = 1; i <= s_gfx.mesh_pool.capacity; i++) {
-        if (nt_pool_slot_alive(&s_gfx.mesh_pool, i) && s_gfx.mesh_table[i].vbo.id != 0) {
-            nt_gfx_backend_destroy_buffer(s_gfx.buffer_backends[nt_pool_slot_index(s_gfx.mesh_table[i].vbo.id)]);
-            if (s_gfx.mesh_table[i].ibo.id != 0) {
-                nt_gfx_backend_destroy_buffer(s_gfx.buffer_backends[nt_pool_slot_index(s_gfx.mesh_table[i].ibo.id)]);
-            }
-        }
-    }
-
     /* Release cached sampler backends */
     for (uint32_t i = 0; i < s_gfx.sampler_count; i++) {
         if (s_gfx.sampler_cache[i].backend != 0) {
@@ -324,14 +310,16 @@ void nt_gfx_shutdown(void) {
     }
 
     /* The native context survives backend teardown, so release remaining GL objects.
-     * Backend destroys clear entries; owned attachments and mesh buffers are safe
-     * to revisit. Vertex inputs own the VAOs; pipelines own no GL objects and
-     * never their programs. */
+     * Buffer slots include mesh storage; cleared attachment entries are safe to revisit. */
     for (uint32_t i = 1; i <= s_gfx.vertex_input_pool.capacity; i++) {
-        nt_gfx_backend_destroy_vertex_input(s_gfx.vertex_input_backends[i]);
+        if (nt_pool_slot_alive(&s_gfx.vertex_input_pool, i)) {
+            nt_gfx_backend_destroy_vertex_input(i);
+        }
     }
     for (uint32_t i = 1; i <= s_gfx.pipeline_pool.capacity; i++) {
-        nt_gfx_backend_destroy_pipeline(s_gfx.pipeline_backends[i]);
+        if (nt_pool_slot_alive(&s_gfx.pipeline_pool, i)) {
+            nt_gfx_backend_destroy_pipeline(i);
+        }
     }
     for (uint32_t i = 1; i <= s_gfx.program_pool.capacity; i++) {
         nt_gfx_backend_destroy_program(s_gfx.program_backends[i]);
@@ -359,9 +347,7 @@ void nt_gfx_shutdown(void) {
 
     free(s_gfx.shader_backends);
     free(s_gfx.program_backends);
-    free(s_gfx.pipeline_backends);
     free(s_gfx.pipeline_programs);
-    free(s_gfx.vertex_input_backends);
     free(s_gfx.buffer_backends);
     free(s_gfx.texture_backends);
     free(s_gfx.render_target_backends);
@@ -577,14 +563,12 @@ void nt_gfx_begin_frame(void) {
             if (nt_pool_slot_alive(&s_gfx.pipeline_pool, i)) {
                 nt_pool_free(&s_gfx.pipeline_pool, s_gfx.pipeline_pool.slots[i].id);
             }
-            s_gfx.pipeline_backends[i] = 0;
             s_gfx.pipeline_programs[i] = 0;
         }
         for (uint32_t i = 1; i <= s_gfx.vertex_input_pool.capacity; i++) {
             if (nt_pool_slot_alive(&s_gfx.vertex_input_pool, i)) {
                 nt_pool_free(&s_gfx.vertex_input_pool, s_gfx.vertex_input_pool.slots[i].id);
             }
-            s_gfx.vertex_input_backends[i] = 0;
             memset(&s_gfx.vertex_input_metas[i], 0, sizeof(nt_gfx_vertex_input_meta_t));
         }
         for (uint32_t i = 1; i <= s_gfx.buffer_pool.capacity; i++) {
@@ -946,11 +930,9 @@ nt_pipeline_t nt_gfx_make_pipeline(const nt_pipeline_desc_t *desc) {
         nt_pool_free(&s_gfx.pipeline_pool, id);
         return result;
     }
-    /* uniform_target_program and destroy_pipeline address the backend record by
-     * this slot, so the mirror must be 1:1. */
+    /* Backend records are addressed directly by pool slot. */
     NT_ASSERT(backend == slot && "create_pipeline: backend must mirror the pool slot");
 
-    s_gfx.pipeline_backends[slot] = backend;
     s_gfx.pipeline_programs[slot] = desc->program.id;
 
     result.id = id;
@@ -1013,7 +995,6 @@ nt_vertex_input_t nt_gfx_make_vertex_input(const nt_vertex_input_desc_t *desc) {
     }
     NT_ASSERT(backend == slot && "create_vertex_input: backend must mirror the pool slot");
 
-    s_gfx.vertex_input_backends[slot] = backend;
     s_gfx.vertex_input_metas[slot] = (nt_gfx_vertex_input_meta_t){
         .vbo_id = desc->vertex_buffer.id,
         .ibo_id = desc->index_buffer.id,
@@ -1297,11 +1278,10 @@ void nt_gfx_destroy_pipeline(nt_pipeline_t pip) {
         return;
     }
     uint32_t slot = nt_pool_slot_index(pip.id);
-    if (s_gfx.bound_pipeline == s_gfx.pipeline_backends[slot]) {
+    if (s_gfx.bound_pipeline == slot) {
         s_gfx.bound_pipeline = 0;
     }
-    nt_gfx_backend_destroy_pipeline(s_gfx.pipeline_backends[slot]);
-    s_gfx.pipeline_backends[slot] = 0;
+    nt_gfx_backend_destroy_pipeline(slot);
     s_gfx.pipeline_programs[slot] = 0;
     nt_pool_free(&s_gfx.pipeline_pool, pip.id);
 }
@@ -1317,8 +1297,7 @@ void nt_gfx_destroy_vertex_input(nt_vertex_input_t vi) {
         s_gfx.bound_vertex_input = 0;
         s_gfx.bound_index_type = NT_INDEX_NONE;
     }
-    nt_gfx_backend_destroy_vertex_input(s_gfx.vertex_input_backends[slot]);
-    s_gfx.vertex_input_backends[slot] = 0;
+    nt_gfx_backend_destroy_vertex_input(slot);
     memset(&s_gfx.vertex_input_metas[slot], 0, sizeof(nt_gfx_vertex_input_meta_t));
     nt_pool_free(&s_gfx.vertex_input_pool, vi.id);
 }
@@ -1491,8 +1470,7 @@ void nt_gfx_bind_pipeline(nt_pipeline_t pip) {
     }
     uint32_t slot = nt_pool_slot_index(pip.id);
     /* Loss frees pipeline slots, so a live slot always has a backend. */
-    NT_ASSERT(s_gfx.pipeline_backends[slot] != 0 && "bind_pipeline: live slot without backend");
-    s_gfx.bound_pipeline = s_gfx.pipeline_backends[slot];
+    s_gfx.bound_pipeline = slot;
 #ifdef NT_TEST_ACCESS
     s_test_bound_pipeline = pip;
 #endif
@@ -1519,11 +1497,10 @@ void nt_gfx_bind_vertex_input(nt_vertex_input_t vi) {
     }
     uint32_t slot = nt_pool_slot_index(vi.id);
     /* Loss frees vertex-input slots, so a live slot always has a backend. */
-    NT_ASSERT(s_gfx.vertex_input_backends[slot] != 0 && "bind_vertex_input: live slot without backend");
     s_gfx.bound_vertex_input = vi.id;
     /* NT_INDEX_NONE for a non-indexed vertex input: cleared, not stale. */
     s_gfx.bound_index_type = s_gfx.vertex_input_metas[slot].index_type;
-    nt_gfx_backend_bind_vertex_input(s_gfx.vertex_input_backends[slot]);
+    nt_gfx_backend_bind_vertex_input(slot);
 }
 
 void nt_gfx_bind_texture(nt_texture_t tex, uint32_t slot) {
@@ -1784,20 +1761,10 @@ void nt_gfx_set_viewport(int x, int y, int w, int h) {
 
 /* ---- Uniforms ---- */
 
-/* Uniform values are program state, so a write addresses the bound pipeline's
- * program. Returns 0 when there is nothing legal to write into. The bound
- * pipeline handle is its pool slot, which indexes pipeline_programs. */
-static uint32_t uniform_target_program(const char *fn) {
+/* The bound pipeline is a pool slot; uniforms belong to its borrowed program. */
+static uint32_t uniform_target_program(void) {
     NT_ASSERT(s_gfx.render_state == NT_GFX_STATE_PASS && "set_uniform: must be called inside a pass");
-    if (s_gfx.render_state != NT_GFX_STATE_PASS) {
-        NT_LOG_ERROR("%s called outside PASS state", fn);
-        return 0;
-    }
     NT_ASSERT(s_gfx.bound_pipeline != 0 && "set_uniform: no pipeline bound");
-    if (s_gfx.bound_pipeline == 0) {
-        NT_LOG_ERROR("%s called with no pipeline bound", fn);
-        return 0;
-    }
     return s_gfx.program_backends[nt_pool_slot_index(s_gfx.pipeline_programs[s_gfx.bound_pipeline])];
 }
 
@@ -1806,10 +1773,7 @@ void nt_gfx_set_uniform_mat4(nt_hash32_t name, const float *matrix) {
         return;
     }
     NT_ASSERT(matrix != NULL);
-    uint32_t program_backend = uniform_target_program("set_uniform_mat4");
-    if (program_backend != 0) {
-        nt_gfx_backend_set_uniform_mat4(program_backend, name.value, matrix);
-    }
+    nt_gfx_backend_set_uniform_mat4(uniform_target_program(), name.value, matrix);
 }
 
 void nt_gfx_set_uniform_vec4(nt_hash32_t name, const float *vec) {
@@ -1817,30 +1781,21 @@ void nt_gfx_set_uniform_vec4(nt_hash32_t name, const float *vec) {
         return;
     }
     NT_ASSERT(vec != NULL);
-    uint32_t program_backend = uniform_target_program("set_uniform_vec4");
-    if (program_backend != 0) {
-        nt_gfx_backend_set_uniform_vec4(program_backend, name.value, vec);
-    }
+    nt_gfx_backend_set_uniform_vec4(uniform_target_program(), name.value, vec);
 }
 
 void nt_gfx_set_uniform_float(nt_hash32_t name, float val) {
     if (g_nt_gfx.context_lost) {
         return;
     }
-    uint32_t program_backend = uniform_target_program("set_uniform_float");
-    if (program_backend != 0) {
-        nt_gfx_backend_set_uniform_float(program_backend, name.value, val);
-    }
+    nt_gfx_backend_set_uniform_float(uniform_target_program(), name.value, val);
 }
 
 void nt_gfx_set_uniform_int(nt_hash32_t name, int val) {
     if (g_nt_gfx.context_lost) {
         return;
     }
-    uint32_t program_backend = uniform_target_program("set_uniform_int");
-    if (program_backend != 0) {
-        nt_gfx_backend_set_uniform_int(program_backend, name.value, val);
-    }
+    nt_gfx_backend_set_uniform_int(uniform_target_program(), name.value, val);
 }
 
 /* ---- Draw calls ---- */
@@ -2022,7 +1977,7 @@ void nt_gfx_bind_instance_buffer(nt_buffer_t buf, uint32_t byte_offset) {
     NT_ASSERT(s_gfx.vertex_input_metas[vi_slot].instance_attr_count > 0 && "bind_instance_buffer: bound vertex input declares no instance layout");
     s_gfx.vertex_input_metas[vi_slot].instance_pointed = true;
     s_gfx.vertex_input_metas[vi_slot].inst_buf_id = buf.id;
-    nt_gfx_backend_bind_instance_buffer(s_gfx.vertex_input_backends[vi_slot], s_gfx.buffer_backends[slot], byte_offset);
+    nt_gfx_backend_bind_instance_buffer(vi_slot, s_gfx.buffer_backends[slot], byte_offset);
 }
 
 void nt_gfx_set_vertex_attrib_default(uint8_t location, float x, float y, float z, float w) {

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -1774,54 +1774,63 @@ void nt_gfx_set_viewport(int x, int y, int w, int h) {
 
 /* ---- Uniforms ---- */
 
+/* Uniform values are program state, so a write addresses the bound pipeline's
+ * program. Returns 0 when there is nothing legal to write into. The bound
+ * pipeline handle is its pool slot, which indexes pipeline_programs. */
+static uint32_t uniform_target_program(const char *fn) {
+    NT_ASSERT(s_gfx.render_state == NT_GFX_STATE_PASS && "set_uniform: must be called inside a pass");
+    if (s_gfx.render_state != NT_GFX_STATE_PASS) {
+        NT_LOG_ERROR("%s called outside PASS state", fn);
+        return 0;
+    }
+    NT_ASSERT(s_gfx.bound_pipeline != 0 && "set_uniform: no pipeline bound");
+    if (s_gfx.bound_pipeline == 0) {
+        NT_LOG_ERROR("%s called with no pipeline bound", fn);
+        return 0;
+    }
+    return s_gfx.program_backends[nt_pool_slot_index(s_gfx.pipeline_programs[s_gfx.bound_pipeline])];
+}
+
 void nt_gfx_set_uniform_mat4(nt_hash32_t name, const float *matrix) {
     if (g_nt_gfx.context_lost) {
         return;
     }
-    NT_ASSERT(s_gfx.render_state == NT_GFX_STATE_PASS && "set_uniform_mat4: must be called inside a pass");
-    if (s_gfx.render_state != NT_GFX_STATE_PASS) {
-        NT_LOG_ERROR("set_uniform_mat4 called outside PASS state");
-        return;
-    }
     NT_ASSERT(matrix != NULL);
-    nt_gfx_backend_set_uniform_mat4(name.value, matrix);
+    uint32_t program_backend = uniform_target_program("set_uniform_mat4");
+    if (program_backend != 0) {
+        nt_gfx_backend_set_uniform_mat4(program_backend, name.value, matrix);
+    }
 }
 
 void nt_gfx_set_uniform_vec4(nt_hash32_t name, const float *vec) {
     if (g_nt_gfx.context_lost) {
         return;
     }
-    NT_ASSERT(s_gfx.render_state == NT_GFX_STATE_PASS && "set_uniform_vec4: must be called inside a pass");
-    if (s_gfx.render_state != NT_GFX_STATE_PASS) {
-        NT_LOG_ERROR("set_uniform_vec4 called outside PASS state");
-        return;
-    }
     NT_ASSERT(vec != NULL);
-    nt_gfx_backend_set_uniform_vec4(name.value, vec);
+    uint32_t program_backend = uniform_target_program("set_uniform_vec4");
+    if (program_backend != 0) {
+        nt_gfx_backend_set_uniform_vec4(program_backend, name.value, vec);
+    }
 }
 
 void nt_gfx_set_uniform_float(nt_hash32_t name, float val) {
     if (g_nt_gfx.context_lost) {
         return;
     }
-    NT_ASSERT(s_gfx.render_state == NT_GFX_STATE_PASS && "set_uniform_float: must be called inside a pass");
-    if (s_gfx.render_state != NT_GFX_STATE_PASS) {
-        NT_LOG_ERROR("set_uniform_float called outside PASS state");
-        return;
+    uint32_t program_backend = uniform_target_program("set_uniform_float");
+    if (program_backend != 0) {
+        nt_gfx_backend_set_uniform_float(program_backend, name.value, val);
     }
-    nt_gfx_backend_set_uniform_float(name.value, val);
 }
 
 void nt_gfx_set_uniform_int(nt_hash32_t name, int val) {
     if (g_nt_gfx.context_lost) {
         return;
     }
-    NT_ASSERT(s_gfx.render_state == NT_GFX_STATE_PASS && "set_uniform_int: must be called inside a pass");
-    if (s_gfx.render_state != NT_GFX_STATE_PASS) {
-        NT_LOG_ERROR("set_uniform_int called outside PASS state");
-        return;
+    uint32_t program_backend = uniform_target_program("set_uniform_int");
+    if (program_backend != 0) {
+        nt_gfx_backend_set_uniform_int(program_backend, name.value, val);
     }
-    nt_gfx_backend_set_uniform_int(name.value, val);
 }
 
 /* ---- Draw calls ---- */
@@ -1999,7 +2008,7 @@ void nt_gfx_bind_instance_buffer(nt_buffer_t buf, uint32_t byte_offset) {
     NT_ASSERT(s_gfx.vertex_input_metas[vi_slot].instance_attr_count > 0 && "bind_instance_buffer: bound vertex input declares no instance layout");
     s_gfx.vertex_input_metas[vi_slot].instance_pointed = true;
     s_gfx.vertex_input_metas[vi_slot].inst_buf_id = buf.id;
-    nt_gfx_backend_bind_instance_buffer(s_gfx.buffer_backends[slot], byte_offset);
+    nt_gfx_backend_bind_instance_buffer(s_gfx.vertex_input_backends[vi_slot], s_gfx.buffer_backends[slot], byte_offset);
 }
 
 void nt_gfx_set_vertex_attrib_default(uint8_t location, float x, float y, float z, float w) {

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -658,11 +658,6 @@ void nt_gfx_begin_frame(void) {
     }
     s_gfx.render_state = NT_GFX_STATE_FRAME;
     memset(&g_nt_gfx.frame_stats, 0, sizeof(g_nt_gfx.frame_stats));
-    /* Backend resets its pipeline cache per frame; mirror it so the
-     * bound-pipeline asserts stay truthful across frame boundaries. */
-    s_gfx.bound_pipeline = 0;
-    s_gfx.bound_vertex_input = 0;
-    s_gfx.bound_index_type = NT_INDEX_NONE;
     nt_gfx_backend_begin_frame();
 }
 
@@ -774,6 +769,10 @@ void nt_gfx_begin_pass(const nt_pass_desc_t *desc) {
     }
 
     s_gfx.render_state = NT_GFX_STATE_PASS;
+    /* Bound state is pass-scoped: the pass clear touches draw state. */
+    s_gfx.bound_pipeline = 0;
+    s_gfx.bound_vertex_input = 0;
+    s_gfx.bound_index_type = NT_INDEX_NONE;
     nt_gfx_backend_begin_pass(desc, render_target_backend);
 }
 
@@ -1471,6 +1470,11 @@ void nt_gfx_bind_pipeline(nt_pipeline_t pip) {
     if (g_nt_gfx.context_lost) {
         return;
     }
+    NT_ASSERT(s_gfx.render_state == NT_GFX_STATE_PASS && "bind_pipeline: must be called inside a pass");
+    if (s_gfx.render_state != NT_GFX_STATE_PASS) {
+        NT_LOG_ERROR("bind_pipeline called outside PASS state");
+        return;
+    }
     if (!nt_pool_valid(&s_gfx.pipeline_pool, pip.id)) {
         /* Clear the mirror so later draws cannot reuse the previous
          * pipeline's program. The bound vertex input is orthogonal state. */
@@ -1491,6 +1495,11 @@ void nt_gfx_bind_pipeline(nt_pipeline_t pip) {
 
 void nt_gfx_bind_vertex_input(nt_vertex_input_t vi) {
     if (g_nt_gfx.context_lost) {
+        return;
+    }
+    NT_ASSERT(s_gfx.render_state == NT_GFX_STATE_PASS && "bind_vertex_input: must be called inside a pass");
+    if (s_gfx.render_state != NT_GFX_STATE_PASS) {
+        NT_LOG_ERROR("bind_vertex_input called outside PASS state");
         return;
     }
     if (!nt_pool_valid(&s_gfx.vertex_input_pool, vi.id)) {
@@ -1573,6 +1582,10 @@ void nt_gfx_test_viewport_rect(int out[4]) {
     out[2] = s_gfx.viewport_rect[2];
     out[3] = s_gfx.viewport_rect[3];
 }
+
+uint32_t nt_gfx_test_bound_pipeline_backend(void) { return s_gfx.bound_pipeline; }
+
+uint32_t nt_gfx_test_bound_vertex_input(void) { return s_gfx.bound_vertex_input; }
 #endif
 
 /* ---- Sampler (deduplicated cache) ---- */
@@ -1755,12 +1768,22 @@ void nt_gfx_set_uniform_mat4(nt_hash32_t name, const float *matrix) {
     if (g_nt_gfx.context_lost) {
         return;
     }
+    NT_ASSERT(s_gfx.render_state == NT_GFX_STATE_PASS && "set_uniform_mat4: must be called inside a pass");
+    if (s_gfx.render_state != NT_GFX_STATE_PASS) {
+        NT_LOG_ERROR("set_uniform_mat4 called outside PASS state");
+        return;
+    }
     NT_ASSERT(matrix != NULL);
     nt_gfx_backend_set_uniform_mat4(name.value, matrix);
 }
 
 void nt_gfx_set_uniform_vec4(nt_hash32_t name, const float *vec) {
     if (g_nt_gfx.context_lost) {
+        return;
+    }
+    NT_ASSERT(s_gfx.render_state == NT_GFX_STATE_PASS && "set_uniform_vec4: must be called inside a pass");
+    if (s_gfx.render_state != NT_GFX_STATE_PASS) {
+        NT_LOG_ERROR("set_uniform_vec4 called outside PASS state");
         return;
     }
     NT_ASSERT(vec != NULL);
@@ -1771,11 +1794,21 @@ void nt_gfx_set_uniform_float(nt_hash32_t name, float val) {
     if (g_nt_gfx.context_lost) {
         return;
     }
+    NT_ASSERT(s_gfx.render_state == NT_GFX_STATE_PASS && "set_uniform_float: must be called inside a pass");
+    if (s_gfx.render_state != NT_GFX_STATE_PASS) {
+        NT_LOG_ERROR("set_uniform_float called outside PASS state");
+        return;
+    }
     nt_gfx_backend_set_uniform_float(name.value, val);
 }
 
 void nt_gfx_set_uniform_int(nt_hash32_t name, int val) {
     if (g_nt_gfx.context_lost) {
+        return;
+    }
+    NT_ASSERT(s_gfx.render_state == NT_GFX_STATE_PASS && "set_uniform_int: must be called inside a pass");
+    if (s_gfx.render_state != NT_GFX_STATE_PASS) {
+        NT_LOG_ERROR("set_uniform_int called outside PASS state");
         return;
     }
     nt_gfx_backend_set_uniform_int(name.value, val);
@@ -1925,6 +1958,11 @@ void nt_gfx_draw_indexed_instanced(uint32_t first_index, uint32_t num_indices, u
 // NOLINTNEXTLINE(readability-function-cognitive-complexity) — NT_ASSERT expansion, not real branching
 void nt_gfx_bind_instance_buffer(nt_buffer_t buf, uint32_t byte_offset) {
     if (g_nt_gfx.context_lost) {
+        return;
+    }
+    NT_ASSERT(s_gfx.render_state == NT_GFX_STATE_PASS && "bind_instance_buffer: must be called inside a pass");
+    if (s_gfx.render_state != NT_GFX_STATE_PASS) {
+        NT_LOG_ERROR("bind_instance_buffer called outside PASS state");
         return;
     }
     if (!nt_pool_valid(&s_gfx.buffer_pool, buf.id)) {

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -1487,11 +1487,9 @@ void nt_gfx_bind_vertex_input(nt_vertex_input_t vi) {
         return;
     }
     if (!nt_pool_valid(&s_gfx.vertex_input_pool, vi.id)) {
-        /* Parallel to bind_pipeline's invalid path: clear the mirrors and
-         * bind VAO 0 so later draws cannot use stale vertex-input state. */
+        /* Clearing the mirrors is the whole unbind: draws trap on it. */
         s_gfx.bound_vertex_input = 0;
         s_gfx.bound_index_type = NT_INDEX_NONE;
-        nt_gfx_backend_bind_vertex_input(0);
         NT_LOG_ERROR("bind_vertex_input: invalid handle");
         return;
     }

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -943,6 +943,9 @@ nt_pipeline_t nt_gfx_make_pipeline(const nt_pipeline_desc_t *desc) {
         nt_pool_free(&s_gfx.pipeline_pool, id);
         return result;
     }
+    /* uniform_target_program and destroy_pipeline address the backend record by
+     * this slot, so the mirror must be 1:1. */
+    NT_ASSERT(backend == slot && "create_pipeline: backend must mirror the pool slot");
 
     s_gfx.pipeline_backends[slot] = backend;
     s_gfx.pipeline_programs[slot] = desc->program.id;
@@ -1005,6 +1008,7 @@ nt_vertex_input_t nt_gfx_make_vertex_input(const nt_vertex_input_desc_t *desc) {
         nt_pool_free(&s_gfx.vertex_input_pool, id);
         return result;
     }
+    NT_ASSERT(backend == slot && "create_vertex_input: backend must mirror the pool slot");
 
     s_gfx.vertex_input_backends[slot] = backend;
     s_gfx.vertex_input_metas[slot] = (nt_gfx_vertex_input_meta_t){
@@ -1476,10 +1480,9 @@ void nt_gfx_bind_pipeline(nt_pipeline_t pip) {
         return;
     }
     if (!nt_pool_valid(&s_gfx.pipeline_pool, pip.id)) {
-        /* Clear the mirror so later draws cannot reuse the previous
-         * pipeline's program. The bound vertex input is orthogonal state. */
+        /* Clearing the mirror is the whole unbind: later draws and uniform
+         * writes trap on it. The bound vertex input is orthogonal state. */
         s_gfx.bound_pipeline = 0;
-        nt_gfx_backend_bind_pipeline(0);
         NT_LOG_ERROR("bind_pipeline: invalid handle");
         return;
     }
@@ -1536,7 +1539,11 @@ void nt_gfx_bind_texture(nt_texture_t tex, uint32_t slot) {
     /* A husk: loss zeroed the backend and neither the owner nor a render-target
      * restore refilled it. Recoverable GPU failure, not a broken invariant. */
     if (s_gfx.texture_backends[idx] == 0) {
-        NT_LOG_ERROR("bind_texture: texture has no GPU resource (restore failed)");
+        /* A batch renderer would hit this every item, and on web every log is a
+         * JS call. Clear the mirror: a following bind_sampler must not validate
+         * against the texture that stayed bound. */
+        s_gfx.bound_texture_ids[slot] = 0;
+        NT_LOG_ERROR_ONCE("bind_texture: texture has no GPU resource (restore failed)");
         return;
     }
     nt_gfx_backend_bind_texture(s_gfx.texture_backends[idx], slot);
@@ -1997,6 +2004,10 @@ void nt_gfx_bind_instance_buffer(nt_buffer_t buf, uint32_t byte_offset) {
     /* Pool slots survive context loss; pointing into a zeroed backend would
      * silently draw garbage on the restored context. */
     NT_ASSERT(s_gfx.buffer_backends[slot] != 0 && "bind_instance_buffer: buffer has no live backend -- recreate it after context restore");
+    if (s_gfx.buffer_backends[slot] == 0) {
+        NT_LOG_ERROR_ONCE("bind_instance_buffer: buffer has no live backend");
+        return;
+    }
     NT_ASSERT(byte_offset <= s_gfx.buffer_metas[slot].size && "bind_instance_buffer: offset exceeds buffer capacity");
     NT_ASSERT((byte_offset & 3U) == 0 && "bind_instance_buffer: offset must be 4-byte aligned (WebGL2 attrib rule)");
     NT_ASSERT(s_gfx.bound_vertex_input != 0 && "bind_instance_buffer: requires a bound vertex input");
@@ -2038,7 +2049,7 @@ void nt_gfx_bind_uniform_buffer(nt_buffer_t buf, uint32_t slot) {
      * the recreate contract, and binding it would feed the shader garbage. */
     NT_ASSERT(s_gfx.buffer_backends[idx] != 0 && "bind_uniform_buffer: buffer has no live backend -- recreate it after context restore");
     if (s_gfx.buffer_backends[idx] == 0) {
-        NT_LOG_ERROR("bind_uniform_buffer: buffer has no live backend");
+        NT_LOG_ERROR_ONCE("bind_uniform_buffer: buffer has no live backend");
         return;
     }
     nt_gfx_backend_bind_uniform_buffer(s_gfx.buffer_backends[idx], slot);

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -1749,6 +1749,10 @@ void nt_gfx_set_scissor_enabled(bool enabled) {
     if (g_nt_gfx.context_lost) {
         return;
     }
+    /* The mirror owns this state end to end, so the dedup lives here and the backend stays raw. */
+    if (s_gfx.scissor_enabled == enabled) {
+        return;
+    }
     s_gfx.scissor_enabled = enabled;
     nt_gfx_backend_set_scissor_enabled(enabled);
 }

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -144,7 +144,7 @@ static struct {
 
     nt_gfx_render_state_t render_state;
     bool context_restore_retry;
-    uint32_t bound_pipeline;     /* pool slot of the bound pipeline, 0 = none */
+    uint32_t bound_pipeline;     /* full handle of the bound pipeline, 0 = none */
     uint32_t bound_vertex_input; /* full handle of the bound vertex input, 0 = none */
     uint32_t bound_texture_ids[NT_GFX_MAX_TEXTURE_SLOTS];
     uint8_t bound_index_type; /* from the bound vertex input; NT_INDEX_NONE = non-indexed or none bound */
@@ -158,7 +158,6 @@ static struct {
 
 #ifdef NT_TEST_ACCESS
 static nt_gfx_test_draw_t s_test_draws[128];
-static nt_pipeline_t s_test_bound_pipeline;
 static uint32_t s_test_draw_count;
 static bool s_test_draw_enabled;
 static bool s_test_draw_overflow;
@@ -186,8 +185,8 @@ static void test_record_draw(uint32_t first_vertex, uint32_t num_vertices, uint3
         return;
     }
     s_test_draws[s_test_draw_count++] = (nt_gfx_test_draw_t){
-        .pipeline = s_test_bound_pipeline,
-        .program = {s_gfx.pipeline_programs[nt_pool_slot_index(s_test_bound_pipeline.id)]},
+        .pipeline = {s_gfx.bound_pipeline},
+        .program = {s_gfx.pipeline_programs[nt_pool_slot_index(s_gfx.bound_pipeline)]},
         .first_vertex = first_vertex,
         .num_vertices = num_vertices,
         .first_index = first_index,
@@ -1278,7 +1277,7 @@ void nt_gfx_destroy_pipeline(nt_pipeline_t pip) {
         return;
     }
     uint32_t slot = nt_pool_slot_index(pip.id);
-    if (s_gfx.bound_pipeline == slot) {
+    if (s_gfx.bound_pipeline == pip.id) {
         s_gfx.bound_pipeline = 0;
     }
     nt_gfx_backend_destroy_pipeline(slot);
@@ -1470,11 +1469,8 @@ void nt_gfx_bind_pipeline(nt_pipeline_t pip) {
     }
     uint32_t slot = nt_pool_slot_index(pip.id);
     /* Loss frees pipeline slots, so a live slot always has a backend. */
-    s_gfx.bound_pipeline = slot;
-#ifdef NT_TEST_ACCESS
-    s_test_bound_pipeline = pip;
-#endif
-    nt_gfx_backend_bind_pipeline(s_gfx.bound_pipeline);
+    s_gfx.bound_pipeline = pip.id;
+    nt_gfx_backend_bind_pipeline(slot);
 }
 
 void nt_gfx_bind_vertex_input(nt_vertex_input_t vi) {
@@ -1514,12 +1510,10 @@ void nt_gfx_bind_texture(nt_texture_t tex, uint32_t slot) {
         return;
     }
     uint32_t idx = nt_pool_slot_index(tex.id);
-    /* A husk: loss zeroed the backend and neither the owner nor a render-target
-     * restore refilled it. Recoverable GPU failure, not a broken invariant. */
+    /* Husk: loss zeroed the backend -- either an RT attachment whose restore failed
+     * (GPU failure) or a primary texture the owner never recreated. Bind cannot tell
+     * them apart, so it reports; clear the mirror so bind_sampler skips the stale one. */
     if (s_gfx.texture_backends[idx] == 0) {
-        /* A batch renderer would hit this every item, and on web every log is a
-         * JS call. Clear the mirror: a following bind_sampler must not validate
-         * against the texture that stayed bound. */
         s_gfx.bound_texture_ids[slot] = 0;
         NT_LOG_ERROR_ONCE("bind_texture: texture has no GPU resource (restore failed)");
         return;
@@ -1574,7 +1568,7 @@ void nt_gfx_test_viewport_rect(int out[4]) {
     out[3] = s_gfx.viewport_rect[3];
 }
 
-uint32_t nt_gfx_test_bound_pipeline_backend(void) { return s_gfx.bound_pipeline; }
+uint32_t nt_gfx_test_bound_pipeline(void) { return s_gfx.bound_pipeline; }
 
 uint32_t nt_gfx_test_bound_vertex_input(void) { return s_gfx.bound_vertex_input; }
 #endif
@@ -1759,11 +1753,11 @@ void nt_gfx_set_viewport(int x, int y, int w, int h) {
 
 /* ---- Uniforms ---- */
 
-/* The bound pipeline is a pool slot; uniforms belong to its borrowed program. */
+/* Uniforms belong to the bound pipeline's borrowed program. */
 static uint32_t uniform_target_program(void) {
     NT_ASSERT(s_gfx.render_state == NT_GFX_STATE_PASS && "set_uniform: must be called inside a pass");
     NT_ASSERT(s_gfx.bound_pipeline != 0 && "set_uniform: no pipeline bound");
-    return s_gfx.program_backends[nt_pool_slot_index(s_gfx.pipeline_programs[s_gfx.bound_pipeline])];
+    return s_gfx.program_backends[nt_pool_slot_index(s_gfx.pipeline_programs[nt_pool_slot_index(s_gfx.bound_pipeline)])];
 }
 
 void nt_gfx_set_uniform_mat4(nt_hash32_t name, const float *matrix) {
@@ -2027,6 +2021,7 @@ void nt_gfx_update_buffer(nt_buffer_t buf, uint32_t offset, const void *data, ui
     NT_ASSERT((data != NULL || size == 0) && "update_buffer: NULL data with nonzero size");
     NT_ASSERT(offset <= s_gfx.buffer_metas[slot].size && "update_buffer: offset exceeds buffer capacity");
     NT_ASSERT(size <= s_gfx.buffer_metas[slot].size - offset && "update_buffer: offset + size exceeds buffer capacity");
+    NT_ASSERT(s_gfx.buffer_backends[slot] != 0 && "update_buffer: buffer has no live backend -- recreate it after context restore");
     nt_gfx_backend_update_buffer(s_gfx.buffer_backends[slot], offset, data, size);
 }
 
@@ -2066,6 +2061,7 @@ void nt_gfx_orphan_buffer(nt_buffer_t buf, const void *data, uint32_t size) {
     uint32_t slot = nt_pool_slot_index(buf.id);
     NT_ASSERT(s_gfx.buffer_metas[slot].usage == NT_USAGE_DYNAMIC && "orphan_buffer: requires NT_USAGE_DYNAMIC");
     NT_ASSERT(size <= s_gfx.buffer_metas[slot].size && "orphan_buffer: size exceeds buffer capacity");
+    NT_ASSERT(s_gfx.buffer_backends[slot] != 0 && "orphan_buffer: buffer has no live backend -- recreate it after context restore");
     nt_gfx_backend_orphan_buffer(s_gfx.buffer_backends[slot], data, size);
 }
 
@@ -2103,6 +2099,9 @@ void nt_gfx_update_texture(nt_texture_t tex, uint16_t x, uint16_t y, uint16_t w,
     }
     NT_ASSERT(x + w <= s_gfx.texture_metas[slot].width && "update_texture: x+w exceeds texture width");
     NT_ASSERT(y + h <= s_gfx.texture_metas[slot].height && "update_texture: y+h exceeds texture height");
+    /* RT-owned textures are rejected above, so a husk here is a primary texture
+     * whose owner skipped the recreate contract -- a programmer error. */
+    NT_ASSERT(s_gfx.texture_backends[slot] != 0 && "update_texture: texture has no live backend -- recreate it after context restore");
     nt_gfx_backend_update_texture(s_gfx.texture_backends[slot], x, y, w, h, (nt_texture_format_t)stored_format, data);
 }
 

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -272,6 +272,9 @@ void nt_gfx_init(const nt_gfx_desc_t *desc) {
     /* Mesh pool + data table */
     nt_pool_init(&s_gfx.mesh_pool, desc->max_meshes);
     s_gfx.mesh_table = (nt_gfx_mesh_info_t *)calloc((size_t)desc->max_meshes + 1, sizeof(nt_gfx_mesh_info_t));
+    /* Init-time OOM on a few KB of tables is not a state a game can recover from. */
+    NT_ASSERT(s_gfx.shader_backends && s_gfx.program_backends && s_gfx.pipeline_backends && s_gfx.pipeline_programs && s_gfx.vertex_input_backends && s_gfx.buffer_backends && s_gfx.texture_backends &&
+              s_gfx.render_target_backends && s_gfx.buffer_metas && s_gfx.vertex_input_metas && s_gfx.texture_metas && s_gfx.render_target_metas && s_gfx.mesh_table && "gfx init: out of memory");
 
     if (!nt_gfx_backend_init(desc)) {
         NT_LOG_ERROR("backend init failed");

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -1533,6 +1533,12 @@ void nt_gfx_bind_texture(nt_texture_t tex, uint32_t slot) {
         return;
     }
     uint32_t idx = nt_pool_slot_index(tex.id);
+    /* A husk: loss zeroed the backend and neither the owner nor a render-target
+     * restore refilled it. Recoverable GPU failure, not a broken invariant. */
+    if (s_gfx.texture_backends[idx] == 0) {
+        NT_LOG_ERROR("bind_texture: texture has no GPU resource (restore failed)");
+        return;
+    }
     nt_gfx_backend_bind_texture(s_gfx.texture_backends[idx], slot);
     s_gfx.bound_texture_ids[slot] = tex.id;
     nt_gfx_bind_sampler(s_gfx.texture_metas[idx].default_sampler, slot);
@@ -2013,6 +2019,13 @@ void nt_gfx_bind_uniform_buffer(nt_buffer_t buf, uint32_t slot) {
     NT_ASSERT(s_gfx.buffer_metas[idx].type == NT_BUFFER_UNIFORM);
     if (s_gfx.buffer_metas[idx].type != NT_BUFFER_UNIFORM) {
         NT_LOG_ERROR("bind_uniform_buffer: buffer is not uniform type");
+        return;
+    }
+    /* Buffers are never auto-restored: a zeroed backend means the owner skipped
+     * the recreate contract, and binding it would feed the shader garbage. */
+    NT_ASSERT(s_gfx.buffer_backends[idx] != 0 && "bind_uniform_buffer: buffer has no live backend -- recreate it after context restore");
+    if (s_gfx.buffer_backends[idx] == 0) {
+        NT_LOG_ERROR("bind_uniform_buffer: buffer has no live backend");
         return;
     }
     nt_gfx_backend_bind_uniform_buffer(s_gfx.buffer_backends[idx], slot);

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -1512,9 +1512,8 @@ void nt_gfx_bind_texture(nt_texture_t tex, uint32_t slot) {
     uint32_t idx = nt_pool_slot_index(tex.id);
     /* Husk: loss zeroed the backend -- either an RT attachment whose restore failed
      * (GPU failure) or a primary texture the owner never recreated. Bind cannot tell
-     * them apart, so it reports; clear the mirror so bind_sampler skips the stale one. */
+     * them apart, so it reports. The mirror keeps what GL still holds on the unit. */
     if (s_gfx.texture_backends[idx] == 0) {
-        s_gfx.bound_texture_ids[slot] = 0;
         NT_LOG_ERROR_ONCE("bind_texture: texture has no GPU resource (restore failed)");
         return;
     }

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -564,11 +564,13 @@ nt_texture_format_t nt_gfx_texture_format(nt_texture_t tex);
 
 /* ---- Draw state ---- */
 
+/* Bind inside a pass; nt_gfx_begin_pass discards bound state. */
 void nt_gfx_bind_pipeline(nt_pipeline_t pip);
 /* One backend bind selects the whole vertex-input state (layout + buffers +
  * index binding) for the following draws. Orthogonal to pipeline binding --
  * either may change without re-binding the other. Every draw requires a bound
- * vertex input (asserted); attribute-less draws bind an empty one. */
+ * vertex input (asserted); attribute-less draws bind an empty one. Bind inside
+ * a pass; nt_gfx_begin_pass discards bound state. */
 void nt_gfx_bind_vertex_input(nt_vertex_input_t vi);
 void nt_gfx_bind_texture(nt_texture_t tex, uint32_t slot);
 /* Bind sampler to texture unit `slot`, after nt_gfx_bind_texture for that slot —
@@ -594,7 +596,8 @@ void nt_gfx_set_viewport(int x, int y, int w, int h);
 nt_sampler_t nt_gfx_get_texture_default_sampler(nt_texture_t tex);
 
 /* ---- Uniforms ---- The hash is the identity, as for tags and resources. Hash once
- * at init with nt_hash32_str, or inline where the cost does not matter. */
+ * at init with nt_hash32_str, or inline where the cost does not matter. Write
+ * inside a pass; nt_gfx_begin_pass discards bound state. */
 
 void nt_gfx_set_uniform_mat4(nt_hash32_t name, const float *matrix);
 void nt_gfx_set_uniform_vec4(nt_hash32_t name, const float *vec);
@@ -623,7 +626,8 @@ bool nt_gfx_read_pixels(int x, int y, int w, int h, uint8_t *out, uint32_t out_c
 /* Re-specifies instance attrib pointers at byte_offset into the bound vertex
  * input, which must declare a nonempty instance_layout; both asserted. The
  * offset must be 4-byte aligned (WebGL2 rejects unaligned attrib offsets);
- * asserted. Re-bind per draw to re-point. */
+ * asserted. Re-bind per draw to re-point. Call inside a pass;
+ * nt_gfx_begin_pass discards bound state. */
 void nt_gfx_bind_instance_buffer(nt_buffer_t buf, uint32_t byte_offset);
 void nt_gfx_set_vertex_attrib_default(uint8_t location, float x, float y, float z, float w);
 

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -565,15 +565,15 @@ bool nt_gfx_texture_size(nt_texture_t tex, uint16_t *out_width, uint16_t *out_he
 /* Returns INVALID for invalid or stale handles. */
 nt_texture_format_t nt_gfx_texture_format(nt_texture_t tex);
 
-/* ---- Draw state ---- */
+/* ---- Draw state ---- Pipeline, vertex input, instance pointers and uniforms are
+ * pass-scoped: set them inside a pass (asserted); nt_gfx_begin_pass discards them.
+ * Texture, sampler and uniform-buffer binds are context state. */
 
-/* Bind inside a pass; nt_gfx_begin_pass discards bound state. */
 void nt_gfx_bind_pipeline(nt_pipeline_t pip);
 /* One backend bind selects the whole vertex-input state (layout + buffers +
  * index binding) for the following draws. Orthogonal to pipeline binding --
  * either may change without re-binding the other. Every draw requires a bound
- * vertex input (asserted); attribute-less draws bind an empty one. Bind inside
- * a pass; nt_gfx_begin_pass discards bound state. */
+ * vertex input (asserted); attribute-less draws bind an empty one. */
 void nt_gfx_bind_vertex_input(nt_vertex_input_t vi);
 void nt_gfx_bind_texture(nt_texture_t tex, uint32_t slot);
 /* Bind sampler to texture unit `slot`, after nt_gfx_bind_texture for that slot —
@@ -599,9 +599,8 @@ void nt_gfx_set_viewport(int x, int y, int w, int h);
 nt_sampler_t nt_gfx_get_texture_default_sampler(nt_texture_t tex);
 
 /* ---- Uniforms ---- The hash is the identity, as for tags and resources. Hash once
- * at init with nt_hash32_str, or inline where the cost does not matter. Write
- * inside a pass with a pipeline bound (asserted): the value lands on that
- * pipeline's program. nt_gfx_begin_pass discards bound state. */
+ * at init with nt_hash32_str, or inline where the cost does not matter. The
+ * value lands on the bound pipeline's program (asserted). */
 
 void nt_gfx_set_uniform_mat4(nt_hash32_t name, const float *matrix);
 void nt_gfx_set_uniform_vec4(nt_hash32_t name, const float *vec);
@@ -630,8 +629,7 @@ bool nt_gfx_read_pixels(int x, int y, int w, int h, uint8_t *out, uint32_t out_c
 /* Re-specifies instance attrib pointers at byte_offset into the bound vertex
  * input, which must declare a nonempty instance_layout; both asserted. The
  * offset must be 4-byte aligned (WebGL2 rejects unaligned attrib offsets);
- * asserted. Re-bind per draw to re-point. Call inside a pass;
- * nt_gfx_begin_pass discards bound state. */
+ * asserted. Re-bind per draw to re-point. */
 void nt_gfx_bind_instance_buffer(nt_buffer_t buf, uint32_t byte_offset);
 void nt_gfx_set_vertex_attrib_default(uint8_t location, float x, float y, float z, float w);
 

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -597,7 +597,8 @@ nt_sampler_t nt_gfx_get_texture_default_sampler(nt_texture_t tex);
 
 /* ---- Uniforms ---- The hash is the identity, as for tags and resources. Hash once
  * at init with nt_hash32_str, or inline where the cost does not matter. Write
- * inside a pass; nt_gfx_begin_pass discards bound state. */
+ * inside a pass with a pipeline bound (asserted): the value lands on that
+ * pipeline's program. nt_gfx_begin_pass discards bound state. */
 
 void nt_gfx_set_uniform_mat4(nt_hash32_t name, const float *matrix);
 void nt_gfx_set_uniform_vec4(nt_hash32_t name, const float *vec);

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -538,6 +538,9 @@ bool nt_gfx_resize_render_target(nt_render_target_t rt, uint16_t width, uint16_t
 nt_texture_t nt_gfx_render_target_color(nt_render_target_t rt);
 /* Returns invalid unless the target was created with NT_RT_DEPTH_TEXTURE. */
 nt_texture_t nt_gfx_render_target_depth(nt_render_target_t rt);
+/* False after a context restore that could not recreate the target (a runtime GPU
+ * failure, same class as creation returning invalid). No automatic retry: the owner
+ * destroys and recreates it, or falls back. */
 bool nt_gfx_render_target_ready(nt_render_target_t rt);
 bool nt_gfx_texture_ready(nt_texture_t tex);
 /* Reports a live stage backend. Readiness lost to context loss never returns for that handle;

--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -76,6 +76,8 @@ void nt_gfx_backend_set_vertex_attrib_default(uint8_t location, float x, float y
  * Backend implementations:
  *   - gl/nt_gfx_gl.c: glScissor + glEnable/glDisable(GL_SCISSOR_TEST) + glViewport
  *   - stub/nt_gfx_stub.c: no-op (state cached in shared nt_gfx.c for test probes)
+ * One owner per state: the scissor-enable dedup is front-end (nt_gfx.c mirrors it),
+ * the viewport and clear-value dedup is the backend GL cache.
  */
 void nt_gfx_backend_set_scissor(int x, int y, int w, int h);
 void nt_gfx_backend_set_scissor_enabled(bool enabled);
@@ -128,6 +130,7 @@ void nt_gfx_backend_drop_timer_segments(void);
 /* Stub-only test hooks: inspect and reset bind_sampler observations. */
 uint32_t nt_gfx_stub_test_last_sampler(uint32_t slot);
 uint32_t nt_gfx_stub_test_bind_sampler_count(void);
+uint32_t nt_gfx_stub_test_set_scissor_enabled_count(void);
 uint32_t nt_gfx_stub_test_last_pass_target(void);
 uint32_t nt_gfx_stub_test_pass_target_count(void);
 uint32_t nt_gfx_stub_test_pass_target_at(uint32_t index);

--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -15,9 +15,9 @@ typedef enum {
 
 /* ---- Backend function signatures (implemented by each backend) ---- */
 
-/* destroy_* accepts 0 (no-op, as glDelete*); bind_vertex_input / bind_sampler
- * accept 0 as an explicit unbind; every other bind requires a live handle --
- * the front-end owns husk handling.
+/* destroy_* accepts 0 (no-op, as glDelete*); bind_sampler accepts 0 as an
+ * explicit unbind; every other bind requires a live handle -- the front-end
+ * owns husk handling.
  * The backend keeps GL-mirror state only: what is logically bound lives in the
  * front-end, which names the program or vertex input a call operates on. */
 
@@ -48,7 +48,6 @@ void nt_gfx_backend_destroy_pipeline(uint32_t backend_handle);
  * create_pipeline: returns `slot`, or 0 on failure. */
 uint32_t nt_gfx_backend_create_vertex_input(const nt_vertex_input_desc_t *desc, uint32_t vbo_backend, uint32_t ibo_backend, uint32_t slot);
 void nt_gfx_backend_destroy_vertex_input(uint32_t backend_handle);
-/* 0 unbinds (VAO 0). */
 void nt_gfx_backend_bind_vertex_input(uint32_t backend_handle);
 
 uint32_t nt_gfx_backend_create_buffer(const nt_buffer_desc_t *desc);

--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -15,6 +15,10 @@ typedef enum {
 
 /* ---- Backend function signatures (implemented by each backend) ---- */
 
+/* destroy_* accepts 0 (no-op, as glDelete*); bind_pipeline / bind_vertex_input /
+ * bind_sampler accept 0 as an explicit unbind; every other bind requires a live
+ * handle -- the front-end owns husk handling. */
+
 bool nt_gfx_backend_init(const nt_gfx_desc_t *desc);
 void nt_gfx_backend_shutdown(void);
 bool nt_gfx_backend_is_context_lost(void);

--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -194,6 +194,11 @@ void nt_gfx_gl_test_reset_counters(void);
 uint32_t nt_gfx_gl_test_static_attrib_pointer_calls(void);
 uint32_t nt_gfx_gl_test_instance_attrib_pointer_calls(void);
 uint32_t nt_gfx_gl_test_vao_binds(void);
+/* Raw GL-mirror reads: a test can pin that destroy cleared an entry without
+ * depending on the driver recycling the deleted GL name. */
+uint32_t nt_gfx_gl_test_cached_vao(void);
+uint32_t nt_gfx_gl_test_cached_program(void);
+uint32_t nt_gfx_gl_test_cached_texture(uint32_t slot);
 #endif
 
 #ifdef NT_TEST_ACCESS

--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -37,9 +37,9 @@ void nt_gfx_backend_destroy_shader(uint32_t backend_handle);
 uint32_t nt_gfx_backend_create_program(uint32_t vs_backend, uint32_t fs_backend);
 void nt_gfx_backend_destroy_program(uint32_t backend_handle);
 
-/* `slot` is the frontend pool slot: the pool owns allocation, the backend
- * table mirrors it 1:1 -- returns exactly `slot`, or 0 on failure. Callers
- * addressing a pipeline's program by slot depend on that identity. */
+/* `slot` is the frontend pool slot: the pool owns allocation, the backend table
+ * mirrors it 1:1 and the front-end addresses records by that slot -- returns
+ * exactly `slot`, or 0 on failure. */
 uint32_t nt_gfx_backend_create_pipeline(const nt_pipeline_desc_t *desc, uint32_t program_backend, uint32_t slot);
 void nt_gfx_backend_destroy_pipeline(uint32_t backend_handle);
 
@@ -209,7 +209,7 @@ uint32_t nt_gfx_test_sampler_backend_id(nt_sampler_t s);
 uint32_t nt_gfx_test_texture_backend_id(nt_texture_t tex);
 uint32_t nt_gfx_test_render_target_backend_id(nt_render_target_t rt);
 /* Pass-scoped bound state, read from its owner: the front-end. */
-uint32_t nt_gfx_test_bound_pipeline_backend(void);
+uint32_t nt_gfx_test_bound_pipeline(void);
 uint32_t nt_gfx_test_bound_vertex_input(void);
 #endif
 

--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -15,11 +15,9 @@ typedef enum {
 
 /* ---- Backend function signatures (implemented by each backend) ---- */
 
-/* destroy_* accepts 0 (no-op, as glDelete*); bind_sampler accepts 0 as an
- * explicit unbind; every other bind requires a live handle -- the front-end
- * owns husk handling.
- * The backend keeps GL-mirror state only: what is logically bound lives in the
- * front-end, which names the program or vertex input a call operates on. */
+/* destroy_* accepts 0 (no-op, as glDelete*); bind_sampler accepts 0 as an unbind;
+ * every other bind requires a live handle -- the front-end owns husk handling.
+ * The backend keeps GL-mirror state only; calls name the program or vertex input. */
 
 bool nt_gfx_backend_init(const nt_gfx_desc_t *desc);
 void nt_gfx_backend_shutdown(void);

--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -189,6 +189,9 @@ uint32_t nt_gfx_gl_test_vao_binds(void);
 uint32_t nt_gfx_test_sampler_backend_id(nt_sampler_t s);
 uint32_t nt_gfx_test_texture_backend_id(nt_texture_t tex);
 uint32_t nt_gfx_test_render_target_backend_id(nt_render_target_t rt);
+/* Pass-scoped bound state, read from its owner: the front-end. */
+uint32_t nt_gfx_test_bound_pipeline_backend(void);
+uint32_t nt_gfx_test_bound_vertex_input(void);
 #endif
 
 #endif /* NT_GFX_INTERNAL_H */

--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -17,7 +17,9 @@ typedef enum {
 
 /* destroy_* accepts 0 (no-op, as glDelete*); bind_pipeline / bind_vertex_input /
  * bind_sampler accept 0 as an explicit unbind; every other bind requires a live
- * handle -- the front-end owns husk handling. */
+ * handle -- the front-end owns husk handling.
+ * The backend keeps GL-mirror state only: what is logically bound lives in the
+ * front-end, which names the program or vertex input a call operates on. */
 
 bool nt_gfx_backend_init(const nt_gfx_desc_t *desc);
 void nt_gfx_backend_shutdown(void);
@@ -44,7 +46,7 @@ void nt_gfx_backend_destroy_pipeline(uint32_t backend_handle);
  * Restores the previously bound VAO before returning. Returns 0 on failure. */
 uint32_t nt_gfx_backend_create_vertex_input(const nt_vertex_input_desc_t *desc, uint32_t vbo_backend, uint32_t ibo_backend, uint32_t slot);
 void nt_gfx_backend_destroy_vertex_input(uint32_t backend_handle);
-/* 0 unbinds (VAO 0) and clears the backend's bound-vertex-input record. */
+/* 0 unbinds (VAO 0). */
 void nt_gfx_backend_bind_vertex_input(uint32_t backend_handle);
 
 uint32_t nt_gfx_backend_create_buffer(const nt_buffer_desc_t *desc);
@@ -67,9 +69,11 @@ void nt_gfx_backend_destroy_sampler(uint32_t backend_handle);
  * and reverts to the texture's own filter state. */
 void nt_gfx_backend_bind_sampler(uint32_t backend_handle, uint32_t slot);
 
+/* 0 is the front-end saying nothing is bound; the backend holds no logical
+ * bound state, so it is a no-op. */
 void nt_gfx_backend_bind_pipeline(uint32_t backend_handle);
-/* Re-points the bound vertex input's instance attribs at byte_offset. */
-void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle, uint32_t byte_offset);
+/* Re-points the named vertex input's instance attribs at byte_offset. */
+void nt_gfx_backend_bind_instance_buffer(uint32_t vertex_input_backend, uint32_t buffer_backend, uint32_t byte_offset);
 void nt_gfx_backend_set_vertex_attrib_default(uint8_t location, float x, float y, float z, float w);
 
 /* Scissor and viewport (see nt_gfx.h for convention).
@@ -91,10 +95,12 @@ bool nt_gfx_backend_read_pixels(int x, int y, int w, int h, void *out_rgba8);
 void nt_gfx_backend_bind_uniform_buffer(uint32_t backend_handle, uint32_t slot);
 void nt_gfx_backend_set_uniform_block(uint32_t program_backend, const char *block_name, uint32_t slot);
 
-void nt_gfx_backend_set_uniform_mat4(uint32_t name_hash, const float *matrix);
-void nt_gfx_backend_set_uniform_vec4(uint32_t name_hash, const float *vec);
-void nt_gfx_backend_set_uniform_float(uint32_t name_hash, float val);
-void nt_gfx_backend_set_uniform_int(uint32_t name_hash, int val);
+/* Uniform locations and values are program state, so the write names its
+ * program; it must be the one currently bound. */
+void nt_gfx_backend_set_uniform_mat4(uint32_t program_backend, uint32_t name_hash, const float *matrix);
+void nt_gfx_backend_set_uniform_vec4(uint32_t program_backend, uint32_t name_hash, const float *vec);
+void nt_gfx_backend_set_uniform_float(uint32_t program_backend, uint32_t name_hash, float val);
+void nt_gfx_backend_set_uniform_int(uint32_t program_backend, uint32_t name_hash, int val);
 
 void nt_gfx_backend_draw(uint32_t first_vertex, uint32_t num_vertices);
 void nt_gfx_backend_draw_indexed(uint32_t first_index, uint32_t num_indices, uint8_t index_type);
@@ -172,7 +178,8 @@ uint32_t nt_gfx_stub_test_last_instance_offset(void);
 nt_blend_state_t nt_gfx_stub_test_last_pipeline_blend(void);
 uint32_t nt_gfx_stub_test_vertex_input_create_count(void);
 uint32_t nt_gfx_stub_test_bind_vertex_input_count(void);
-uint32_t nt_gfx_stub_test_bound_vertex_input(void);
+uint32_t nt_gfx_stub_test_last_bound_vertex_input(void);
+uint32_t nt_gfx_stub_test_last_uniform_program(void);
 void nt_gfx_stub_test_fail_next_vertex_input_create(void);
 void nt_gfx_stub_test_reset(void);
 #endif

--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -15,9 +15,9 @@ typedef enum {
 
 /* ---- Backend function signatures (implemented by each backend) ---- */
 
-/* destroy_* accepts 0 (no-op, as glDelete*); bind_pipeline / bind_vertex_input /
- * bind_sampler accept 0 as an explicit unbind; every other bind requires a live
- * handle -- the front-end owns husk handling.
+/* destroy_* accepts 0 (no-op, as glDelete*); bind_vertex_input / bind_sampler
+ * accept 0 as an explicit unbind; every other bind requires a live handle --
+ * the front-end owns husk handling.
  * The backend keeps GL-mirror state only: what is logically bound lives in the
  * front-end, which names the program or vertex input a call operates on. */
 
@@ -38,12 +38,14 @@ uint32_t nt_gfx_backend_create_program(uint32_t vs_backend, uint32_t fs_backend)
 void nt_gfx_backend_destroy_program(uint32_t backend_handle);
 
 /* `slot` is the frontend pool slot: the pool owns allocation, the backend
- * table mirrors it 1:1 (create_* returns the slot, or 0 on failure). */
+ * table mirrors it 1:1 -- returns exactly `slot`, or 0 on failure. Callers
+ * addressing a pipeline's program by slot depend on that identity. */
 uint32_t nt_gfx_backend_create_pipeline(const nt_pipeline_desc_t *desc, uint32_t program_backend, uint32_t slot);
 void nt_gfx_backend_destroy_pipeline(uint32_t backend_handle);
 
 /* Bakes the desc's layouts and the given buffer backends into an owned VAO.
- * Restores the previously bound VAO before returning. Returns 0 on failure. */
+ * Restores the previously bound VAO before returning. Same slot contract as
+ * create_pipeline: returns `slot`, or 0 on failure. */
 uint32_t nt_gfx_backend_create_vertex_input(const nt_vertex_input_desc_t *desc, uint32_t vbo_backend, uint32_t ibo_backend, uint32_t slot);
 void nt_gfx_backend_destroy_vertex_input(uint32_t backend_handle);
 /* 0 unbinds (VAO 0). */
@@ -69,8 +71,6 @@ void nt_gfx_backend_destroy_sampler(uint32_t backend_handle);
  * and reverts to the texture's own filter state. */
 void nt_gfx_backend_bind_sampler(uint32_t backend_handle, uint32_t slot);
 
-/* 0 is the front-end saying nothing is bound; the backend holds no logical
- * bound state, so it is a no-op. */
 void nt_gfx_backend_bind_pipeline(uint32_t backend_handle);
 /* Re-points the named vertex input's instance attribs at byte_offset. */
 void nt_gfx_backend_bind_instance_buffer(uint32_t vertex_input_backend, uint32_t buffer_backend, uint32_t byte_offset);
@@ -175,6 +175,7 @@ void nt_gfx_stub_test_fail_next_render_target_resize(void);
 void nt_gfx_stub_test_set_context_lost(bool lost);
 uint32_t nt_gfx_stub_test_last_update_buffer_offset(void);
 uint32_t nt_gfx_stub_test_last_instance_offset(void);
+uint32_t nt_gfx_stub_test_last_instance_vertex_input(void);
 nt_blend_state_t nt_gfx_stub_test_last_pipeline_blend(void);
 uint32_t nt_gfx_stub_test_vertex_input_create_count(void);
 uint32_t nt_gfx_stub_test_bind_vertex_input_count(void);

--- a/engine/graphics/stub/nt_gfx_stub.c
+++ b/engine/graphics/stub/nt_gfx_stub.c
@@ -312,6 +312,7 @@ uint32_t nt_gfx_backend_create_vertex_input(const nt_vertex_input_desc_t *desc, 
 void nt_gfx_backend_destroy_vertex_input(uint32_t backend_handle) { (void)backend_handle; }
 
 void nt_gfx_backend_bind_vertex_input(uint32_t backend_handle) {
+    NT_ASSERT(backend_handle != 0 && "bind_vertex_input: requires a live handle");
 #ifdef NT_TEST_ACCESS
     s_stub_bind_vertex_input_count++;
     s_stub_last_bound_vertex_input = backend_handle;
@@ -429,6 +430,7 @@ void nt_gfx_backend_destroy_render_target(uint32_t backend_handle) {
 }
 
 void nt_gfx_backend_bind_texture(uint32_t backend_handle, uint32_t slot) {
+    NT_ASSERT(backend_handle != 0 && "bind_texture: requires a live handle");
     (void)slot;
 #ifdef NT_TEST_ACCESS
     if (s_stub_bound_texture_count < NT_GFX_STUB_HISTORY_CAPACITY) {
@@ -506,6 +508,7 @@ void nt_gfx_backend_update_texture(uint32_t backend_handle, uint16_t x, uint16_t
 }
 
 void nt_gfx_backend_bind_pipeline(uint32_t backend_handle) {
+    NT_ASSERT(backend_handle != 0 && "bind_pipeline: requires a live handle");
 #ifdef NT_TEST_ACCESS
     s_stub_bind_pipeline_count++;
 #endif
@@ -513,6 +516,7 @@ void nt_gfx_backend_bind_pipeline(uint32_t backend_handle) {
 }
 
 void nt_gfx_backend_bind_instance_buffer(uint32_t vertex_input_backend, uint32_t buffer_backend, uint32_t byte_offset) {
+    NT_ASSERT(vertex_input_backend != 0 && buffer_backend != 0 && "bind_instance_buffer: requires live handles");
     (void)buffer_backend;
 #ifdef NT_TEST_ACCESS
     s_stub_last_instance_offset = byte_offset;
@@ -532,6 +536,7 @@ void nt_gfx_backend_set_vertex_attrib_default(uint8_t location, float x, float y
 }
 
 void nt_gfx_backend_bind_uniform_buffer(uint32_t backend_handle, uint32_t slot) {
+    NT_ASSERT(backend_handle != 0 && "bind_uniform_buffer: requires a live handle");
     (void)backend_handle;
     (void)slot;
 }

--- a/engine/graphics/stub/nt_gfx_stub.c
+++ b/engine/graphics/stub/nt_gfx_stub.c
@@ -9,6 +9,7 @@
 #define NT_GFX_STUB_HISTORY_CAPACITY 16
 static uint32_t s_stub_last_sampler[NT_GFX_STUB_MAX_SLOTS];
 static uint32_t s_stub_bind_sampler_count;
+static uint32_t s_stub_set_scissor_enabled_count;
 static uint32_t s_stub_last_pass_target;
 static uint32_t s_stub_pass_targets[NT_GFX_STUB_HISTORY_CAPACITY];
 static uint32_t s_stub_pass_target_count;
@@ -64,6 +65,7 @@ uint32_t nt_gfx_stub_test_last_sampler(uint32_t slot) {
 }
 
 uint32_t nt_gfx_stub_test_bind_sampler_count(void) { return s_stub_bind_sampler_count; }
+uint32_t nt_gfx_stub_test_set_scissor_enabled_count(void) { return s_stub_set_scissor_enabled_count; }
 uint32_t nt_gfx_stub_test_last_pass_target(void) { return s_stub_last_pass_target; }
 uint32_t nt_gfx_stub_test_pass_target_count(void) { return s_stub_pass_target_count; }
 uint32_t nt_gfx_stub_test_pass_target_at(uint32_t index) { return index < s_stub_pass_target_count ? s_stub_pass_targets[index] : 0; }
@@ -124,6 +126,7 @@ void nt_gfx_stub_test_reset(void) {
         s_stub_last_sampler[i] = 0;
     }
     s_stub_bind_sampler_count = 0;
+    s_stub_set_scissor_enabled_count = 0;
     s_stub_last_pass_target = 0;
     s_stub_pass_target_count = 0;
     s_stub_bound_texture_count = 0;
@@ -208,7 +211,12 @@ void nt_gfx_backend_set_scissor(int x, int y, int w, int h) {
     (void)h;
 }
 
-void nt_gfx_backend_set_scissor_enabled(bool enabled) { (void)enabled; }
+void nt_gfx_backend_set_scissor_enabled(bool enabled) {
+    (void)enabled;
+#ifdef NT_TEST_ACCESS
+    s_stub_set_scissor_enabled_count++;
+#endif
+}
 
 void nt_gfx_backend_set_viewport(int x, int y, int w, int h) {
     (void)x;

--- a/engine/graphics/stub/nt_gfx_stub.c
+++ b/engine/graphics/stub/nt_gfx_stub.c
@@ -51,6 +51,7 @@ static bool s_stub_fail_next_render_target_create;
 static bool s_stub_fail_next_render_target_resize;
 static uint32_t s_stub_last_update_buffer_offset;
 static uint32_t s_stub_last_instance_offset;
+static uint32_t s_stub_last_instance_vertex_input; /* recorder: last VI handle bind_instance_buffer named */
 static nt_blend_state_t s_stub_last_pipeline_blend;
 static uint32_t s_stub_vertex_input_create_count;
 static uint32_t s_stub_bind_vertex_input_count;
@@ -116,6 +117,7 @@ void nt_gfx_stub_test_fail_next_backend_restore(void) { s_stub_fail_next_backend
 void nt_gfx_stub_test_set_context_lost(bool lost) { s_stub_context_lost = lost; }
 uint32_t nt_gfx_stub_test_last_update_buffer_offset(void) { return s_stub_last_update_buffer_offset; }
 uint32_t nt_gfx_stub_test_last_instance_offset(void) { return s_stub_last_instance_offset; }
+uint32_t nt_gfx_stub_test_last_instance_vertex_input(void) { return s_stub_last_instance_vertex_input; }
 nt_blend_state_t nt_gfx_stub_test_last_pipeline_blend(void) { return s_stub_last_pipeline_blend; }
 uint32_t nt_gfx_stub_test_vertex_input_create_count(void) { return s_stub_vertex_input_create_count; }
 uint32_t nt_gfx_stub_test_bind_vertex_input_count(void) { return s_stub_bind_vertex_input_count; }
@@ -153,6 +155,7 @@ void nt_gfx_stub_test_reset(void) {
     s_stub_next_texture_backend = 0;
     s_stub_last_update_buffer_offset = 0;
     s_stub_last_instance_offset = 0;
+    s_stub_last_instance_vertex_input = 0;
     s_stub_last_pipeline_blend = (nt_blend_state_t){0};
     s_stub_vertex_input_create_count = 0;
     s_stub_bind_vertex_input_count = 0;
@@ -510,12 +513,13 @@ void nt_gfx_backend_bind_pipeline(uint32_t backend_handle) {
 }
 
 void nt_gfx_backend_bind_instance_buffer(uint32_t vertex_input_backend, uint32_t buffer_backend, uint32_t byte_offset) {
-    (void)vertex_input_backend;
     (void)buffer_backend;
 #ifdef NT_TEST_ACCESS
     s_stub_last_instance_offset = byte_offset;
+    s_stub_last_instance_vertex_input = vertex_input_backend;
 #else
     (void)byte_offset;
+    (void)vertex_input_backend;
 #endif
 }
 

--- a/engine/graphics/stub/nt_gfx_stub.c
+++ b/engine/graphics/stub/nt_gfx_stub.c
@@ -54,7 +54,8 @@ static uint32_t s_stub_last_instance_offset;
 static nt_blend_state_t s_stub_last_pipeline_blend;
 static uint32_t s_stub_vertex_input_create_count;
 static uint32_t s_stub_bind_vertex_input_count;
-static uint32_t s_stub_bound_vertex_input; /* mirrors the GL backend's bound slot */
+static uint32_t s_stub_last_bound_vertex_input; /* recorder: last handle bind_vertex_input received */
+static uint32_t s_stub_last_uniform_program;    /* recorder: last program a uniform write named */
 static bool s_stub_fail_next_vertex_input_create;
 
 uint32_t nt_gfx_stub_test_last_sampler(uint32_t slot) {
@@ -118,7 +119,8 @@ uint32_t nt_gfx_stub_test_last_instance_offset(void) { return s_stub_last_instan
 nt_blend_state_t nt_gfx_stub_test_last_pipeline_blend(void) { return s_stub_last_pipeline_blend; }
 uint32_t nt_gfx_stub_test_vertex_input_create_count(void) { return s_stub_vertex_input_create_count; }
 uint32_t nt_gfx_stub_test_bind_vertex_input_count(void) { return s_stub_bind_vertex_input_count; }
-uint32_t nt_gfx_stub_test_bound_vertex_input(void) { return s_stub_bound_vertex_input; }
+uint32_t nt_gfx_stub_test_last_bound_vertex_input(void) { return s_stub_last_bound_vertex_input; }
+uint32_t nt_gfx_stub_test_last_uniform_program(void) { return s_stub_last_uniform_program; }
 void nt_gfx_stub_test_fail_next_vertex_input_create(void) { s_stub_fail_next_vertex_input_create = true; }
 
 void nt_gfx_stub_test_reset(void) {
@@ -154,7 +156,8 @@ void nt_gfx_stub_test_reset(void) {
     s_stub_last_pipeline_blend = (nt_blend_state_t){0};
     s_stub_vertex_input_create_count = 0;
     s_stub_bind_vertex_input_count = 0;
-    s_stub_bound_vertex_input = 0;
+    s_stub_last_bound_vertex_input = 0;
+    s_stub_last_uniform_program = 0;
     s_stub_fail_next_vertex_input_create = false;
     s_stub_context_lost = false;
     s_stub_backend_missing = false;
@@ -303,21 +306,12 @@ uint32_t nt_gfx_backend_create_vertex_input(const nt_vertex_input_desc_t *desc, 
     return slot;
 }
 
-void nt_gfx_backend_destroy_vertex_input(uint32_t backend_handle) {
-#ifdef NT_TEST_ACCESS
-    /* Mirror the GL backend: destroying the bound vertex input unbinds it. */
-    if (backend_handle != 0 && s_stub_bound_vertex_input == backend_handle) {
-        s_stub_bound_vertex_input = 0;
-    }
-#else
-    (void)backend_handle;
-#endif
-}
+void nt_gfx_backend_destroy_vertex_input(uint32_t backend_handle) { (void)backend_handle; }
 
 void nt_gfx_backend_bind_vertex_input(uint32_t backend_handle) {
 #ifdef NT_TEST_ACCESS
     s_stub_bind_vertex_input_count++;
-    s_stub_bound_vertex_input = backend_handle;
+    s_stub_last_bound_vertex_input = backend_handle;
 #else
     (void)backend_handle;
 #endif
@@ -515,8 +509,9 @@ void nt_gfx_backend_bind_pipeline(uint32_t backend_handle) {
     (void)backend_handle;
 }
 
-void nt_gfx_backend_bind_instance_buffer(uint32_t backend_handle, uint32_t byte_offset) {
-    (void)backend_handle;
+void nt_gfx_backend_bind_instance_buffer(uint32_t vertex_input_backend, uint32_t buffer_backend, uint32_t byte_offset) {
+    (void)vertex_input_backend;
+    (void)buffer_backend;
 #ifdef NT_TEST_ACCESS
     s_stub_last_instance_offset = byte_offset;
 #else
@@ -543,13 +538,19 @@ void nt_gfx_backend_set_uniform_block(uint32_t program_backend, const char *bloc
     (void)slot;
 }
 
-void nt_gfx_backend_set_uniform_mat4(uint32_t name_hash, const float *matrix) {
+void nt_gfx_backend_set_uniform_mat4(uint32_t program_backend, uint32_t name_hash, const float *matrix) {
+#ifdef NT_TEST_ACCESS
+    s_stub_last_uniform_program = program_backend;
+#else
+    (void)program_backend;
+#endif
     (void)name_hash;
     (void)matrix;
 }
 
-void nt_gfx_backend_set_uniform_vec4(uint32_t name_hash, const float *vec) {
+void nt_gfx_backend_set_uniform_vec4(uint32_t program_backend, uint32_t name_hash, const float *vec) {
 #ifdef NT_TEST_ACCESS
+    s_stub_last_uniform_program = program_backend;
     if (s_stub_uniform_vec4_count < NT_GFX_STUB_UNIFORM_NAMES) {
         s_stub_uniform_vec4_hashes[s_stub_uniform_vec4_count] = name_hash;
         for (uint32_t i = 0; i < 4; i++) {
@@ -557,23 +558,33 @@ void nt_gfx_backend_set_uniform_vec4(uint32_t name_hash, const float *vec) {
         }
     }
     s_stub_uniform_vec4_count++;
+#else
+    (void)program_backend;
 #endif
     (void)name_hash;
     (void)vec;
 }
 
-void nt_gfx_backend_set_uniform_float(uint32_t name_hash, float val) {
+void nt_gfx_backend_set_uniform_float(uint32_t program_backend, uint32_t name_hash, float val) {
+#ifdef NT_TEST_ACCESS
+    s_stub_last_uniform_program = program_backend;
+#else
+    (void)program_backend;
+#endif
     (void)name_hash;
     (void)val;
 }
 
-void nt_gfx_backend_set_uniform_int(uint32_t name_hash, int val) {
+void nt_gfx_backend_set_uniform_int(uint32_t program_backend, uint32_t name_hash, int val) {
 #ifdef NT_TEST_ACCESS
+    s_stub_last_uniform_program = program_backend;
     if (s_stub_uniform_int_count < NT_GFX_STUB_UNIFORM_NAMES) {
         s_stub_uniform_int_hashes[s_stub_uniform_int_count] = name_hash;
         s_stub_uniform_int_values[s_stub_uniform_int_count] = val;
     }
     s_stub_uniform_int_count++;
+#else
+    (void)program_backend;
 #endif
     (void)name_hash;
     (void)val;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -285,8 +285,10 @@ if(NOT EMSCRIPTEN)
 
     # Real OpenGL framebuffer smoke: fills every texture slot, resizes, and reads back pixels.
     # Real OpenGL: a rejected bind must clear the backend slot mirrors (stub cannot show it).
+    # No nt_basisu_transcoder_stub: the test TU supplies a transcoder fake whose
+    # failure lands mid-upload, which the loud-fail stub cannot reach.
     add_executable(test_nt_gfx_bind_mirrors_native unit/test_nt_gfx_bind_mirrors_native.c)
-    target_link_libraries(test_nt_gfx_bind_mirrors_native PRIVATE nt_gfx nt_basisu_transcoder_stub nt_window nt_input_stub nt_log unity glad nt_meshwire_stub)
+    target_link_libraries(test_nt_gfx_bind_mirrors_native PRIVATE nt_gfx nt_window nt_input_stub nt_log unity glad nt_meshwire_stub)
     nt_setup_test_target(test_nt_gfx_bind_mirrors_native)
     set_tests_properties(test_nt_gfx_bind_mirrors_native PROPERTIES LABELS "native")
 

--- a/tests/unit/test_gfx.c
+++ b/tests/unit/test_gfx.c
@@ -1848,6 +1848,51 @@ void test_gfx_pipeline_slots_freed_by_context_loss(void) {
     nt_gfx_end_frame();
 }
 
+/* Buffers have no auto-restore path, so a husk means the owner skipped the
+ * recreate contract -- the one case a bind cannot absorb. */
+void test_gfx_bind_uniform_buffer_on_husk_asserts(void) {
+    nt_buffer_t ubo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
+        .type = NT_BUFFER_UNIFORM,
+        .usage = NT_USAGE_DYNAMIC,
+        .size = 256,
+    });
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, ubo.id);
+
+    nt_gfx_stub_test_set_context_lost(true);
+    nt_gfx_begin_frame(); /* latches the loss, zeroes every backend record */
+    nt_gfx_stub_test_set_context_lost(false);
+    nt_gfx_begin_frame(); /* restore succeeds; the buffer stays a husk */
+    TEST_ASSERT_FALSE(g_nt_gfx.context_lost);
+
+    EXPECT_ASSERT(nt_gfx_bind_uniform_buffer(ubo, 0));
+    nt_gfx_end_frame();
+}
+
+/* A texture husk can also be a render-target attachment whose restore failed --
+ * a runtime GPU failure, so the bind reports it instead of trapping. */
+void test_gfx_bind_texture_on_husk_logs_and_skips_backend(void) {
+    nt_texture_t tex = nt_gfx_make_texture(&(nt_texture_desc_t){
+        .width = 4,
+        .height = 4,
+        .data = s_test_pixels_4x4,
+        .format = NT_TEXTURE_FORMAT_RGBA8,
+    });
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, tex.id);
+
+    nt_gfx_stub_test_set_context_lost(true);
+    nt_gfx_begin_frame();
+    nt_gfx_stub_test_set_context_lost(false);
+    nt_gfx_begin_frame();
+    TEST_ASSERT_FALSE(g_nt_gfx.context_lost);
+    TEST_ASSERT_FALSE(nt_gfx_texture_ready(tex));
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_test_texture_backend_id(tex));
+
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_texture_count());
+    nt_gfx_bind_texture(tex, 0); /* logs, no trap */
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_texture_count());
+    nt_gfx_end_frame();
+}
+
 /* ---- Per-frame draw call counter ---- */
 
 /* Restore invalidates earlier render decisions, so the restored frame permits clears but rejects draws. */
@@ -2185,6 +2230,8 @@ int main(void) {
     RUN_TEST(test_gfx_update_texture_full);
     RUN_TEST(test_gfx_update_texture_invalid_handle);
     RUN_TEST(test_gfx_pipeline_slots_freed_by_context_loss);
+    RUN_TEST(test_gfx_bind_uniform_buffer_on_husk_asserts);
+    RUN_TEST(test_gfx_bind_texture_on_husk_logs_and_skips_backend);
     RUN_TEST(test_gfx_restored_frame_rejects_draws);
     RUN_TEST(test_gfx_failed_bind_drops_the_previous_pipeline);
     RUN_TEST(test_gfx_frame_draw_calls);

--- a/tests/unit/test_gfx.c
+++ b/tests/unit/test_gfx.c
@@ -1895,6 +1895,68 @@ void test_gfx_bind_texture_on_husk_logs_and_skips_backend(void) {
     nt_gfx_end_frame();
 }
 
+/* Render-target attachments are rejected earlier, so an update reaching a husk
+ * is always a primary texture the owner never recreated. */
+void test_gfx_update_texture_on_husk_asserts(void) {
+    nt_texture_t tex = nt_gfx_make_texture(&(nt_texture_desc_t){
+        .width = 4,
+        .height = 4,
+        .data = s_test_pixels_4x4,
+        .format = NT_TEXTURE_FORMAT_RGBA8,
+    });
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, tex.id);
+
+    nt_gfx_stub_test_set_context_lost(true);
+    nt_gfx_begin_frame();
+    nt_gfx_stub_test_set_context_lost(false);
+    nt_gfx_begin_frame();
+    TEST_ASSERT_FALSE(g_nt_gfx.context_lost);
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_test_texture_backend_id(tex));
+
+    EXPECT_ASSERT(nt_gfx_update_texture(tex, 0, 0, 4, 4, s_test_pixels_4x4));
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_update_texture_count());
+    nt_gfx_end_frame();
+}
+
+/* A husk write is the same owner bug as a husk bind, so it traps the same way. */
+void test_gfx_update_buffer_on_husk_asserts(void) {
+    nt_buffer_t vbo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
+        .type = NT_BUFFER_VERTEX,
+        .usage = NT_USAGE_DYNAMIC,
+        .size = 256,
+    });
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, vbo.id);
+
+    nt_gfx_stub_test_set_context_lost(true);
+    nt_gfx_begin_frame();
+    nt_gfx_stub_test_set_context_lost(false);
+    nt_gfx_begin_frame();
+    TEST_ASSERT_FALSE(g_nt_gfx.context_lost);
+
+    const uint8_t data[64] = {0};
+    EXPECT_ASSERT(nt_gfx_update_buffer(vbo, 0, data, sizeof(data)));
+    nt_gfx_end_frame();
+}
+
+void test_gfx_orphan_buffer_on_husk_asserts(void) {
+    nt_buffer_t vbo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
+        .type = NT_BUFFER_VERTEX,
+        .usage = NT_USAGE_DYNAMIC,
+        .size = 256,
+    });
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, vbo.id);
+
+    nt_gfx_stub_test_set_context_lost(true);
+    nt_gfx_begin_frame();
+    nt_gfx_stub_test_set_context_lost(false);
+    nt_gfx_begin_frame();
+    TEST_ASSERT_FALSE(g_nt_gfx.context_lost);
+
+    const uint8_t data[64] = {0};
+    EXPECT_ASSERT(nt_gfx_orphan_buffer(vbo, data, sizeof(data)));
+    nt_gfx_end_frame();
+}
+
 /* ---- Per-frame draw call counter ---- */
 
 /* Restore invalidates earlier render decisions, so the restored frame permits clears but rejects draws. */
@@ -2107,13 +2169,33 @@ void test_gfx_begin_pass_discards_bound_state(void) {
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
     nt_gfx_bind_pipeline(pip);
     bind_test_vertex_input();
-    TEST_ASSERT_NOT_EQUAL_UINT32(0, nt_gfx_test_bound_pipeline_backend());
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, nt_gfx_test_bound_pipeline());
     TEST_ASSERT_NOT_EQUAL_UINT32(0, nt_gfx_test_bound_vertex_input());
     nt_gfx_end_pass();
 
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
-    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_test_bound_pipeline_backend());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_test_bound_pipeline());
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_test_bound_vertex_input());
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+}
+
+/* Slots are recycled, so only the full handle tells a rebound pipeline apart
+ * from the destroyed one that occupied its slot. */
+void test_gfx_bound_pipeline_holds_the_generation(void) {
+    nt_program_t prog = nt_gfx_make_program(make_test_vs(), make_test_fs());
+    nt_pipeline_t old_pip = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = prog});
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, old_pip.id);
+    nt_gfx_destroy_pipeline(old_pip);
+
+    nt_pipeline_t pip = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = prog});
+    TEST_ASSERT_EQUAL_UINT32(nt_pool_slot_index(old_pip.id), nt_pool_slot_index(pip.id));
+    TEST_ASSERT_NOT_EQUAL_UINT32(old_pip.id, pip.id);
+
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+    nt_gfx_bind_pipeline(pip);
+    TEST_ASSERT_EQUAL_UINT32(pip.id, nt_gfx_test_bound_pipeline());
     nt_gfx_end_pass();
     nt_gfx_end_frame();
 }
@@ -2251,6 +2333,10 @@ int main(void) {
     RUN_TEST(test_gfx_pipeline_slots_freed_by_context_loss);
     RUN_TEST(test_gfx_bind_uniform_buffer_on_husk_asserts);
     RUN_TEST(test_gfx_bind_texture_on_husk_logs_and_skips_backend);
+    RUN_TEST(test_gfx_update_texture_on_husk_asserts);
+    RUN_TEST(test_gfx_update_buffer_on_husk_asserts);
+    RUN_TEST(test_gfx_orphan_buffer_on_husk_asserts);
+    RUN_TEST(test_gfx_bound_pipeline_holds_the_generation);
     RUN_TEST(test_gfx_restored_frame_rejects_draws);
     RUN_TEST(test_gfx_failed_bind_drops_the_previous_pipeline);
     RUN_TEST(test_gfx_frame_draw_calls);

--- a/tests/unit/test_gfx.c
+++ b/tests/unit/test_gfx.c
@@ -1890,6 +1890,8 @@ void test_gfx_bind_texture_on_husk_logs_and_skips_backend(void) {
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_texture_count());
     nt_gfx_bind_texture(tex, 0); /* logs, no trap */
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_texture_count());
+    /* The sampler bind rides on the texture bind: skipping one skips both. */
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_bind_sampler_count());
     nt_gfx_end_frame();
 }
 
@@ -1967,6 +1969,7 @@ void test_gfx_failed_bind_drops_the_previous_pipeline(void) {
     nt_gfx_bind_pipeline(dead); /* rejected: stale handle */
     EXPECT_ASSERT(nt_gfx_draw(0, 0));
     EXPECT_ASSERT(nt_gfx_draw_indexed(0, 0, 0));
+    EXPECT_ASSERT(nt_gfx_set_uniform_int(nt_hash32_str("u_tex"), 0));
     TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_get_frame_draw_calls());
 
     nt_gfx_end_pass();
@@ -2089,6 +2092,7 @@ void test_gfx_binds_outside_a_pass_trap(void) {
     nt_gfx_begin_frame();
     EXPECT_ASSERT(nt_gfx_bind_pipeline(pip));
     EXPECT_ASSERT(nt_gfx_bind_vertex_input(vi));
+    EXPECT_ASSERT(nt_gfx_bind_instance_buffer(vbo, 0));
     EXPECT_ASSERT(nt_gfx_set_uniform_vec4(nt_hash32_str("u_tint"), vec));
     nt_gfx_end_frame();
 }

--- a/tests/unit/test_gfx.c
+++ b/tests/unit/test_gfx.c
@@ -1895,6 +1895,40 @@ void test_gfx_bind_texture_on_husk_logs_and_skips_backend(void) {
     nt_gfx_end_frame();
 }
 
+/* A rejected bind leaves the previous texture on the unit, so the mirror keeps
+ * it: the next sampler is validated against what GL will actually sample. */
+void test_gfx_bind_texture_on_husk_keeps_previous_mirror(void) {
+    nt_texture_t husk = nt_gfx_make_texture(&(nt_texture_desc_t){
+        .width = 4,
+        .height = 4,
+        .data = s_test_pixels_4x4,
+        .format = NT_TEXTURE_FORMAT_RGBA8,
+    });
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, husk.id);
+
+    nt_gfx_stub_test_set_context_lost(true);
+    nt_gfx_begin_frame();
+    nt_gfx_stub_test_set_context_lost(false);
+    nt_gfx_begin_frame();
+    TEST_ASSERT_FALSE(nt_gfx_texture_ready(husk));
+
+    /* Created after the restore, so it is live while the husk is not. */
+    nt_texture_t depth = nt_gfx_make_texture(&(nt_texture_desc_t){
+        .width = 4,
+        .height = 4,
+        .format = NT_TEXTURE_FORMAT_DEPTH24,
+        .min_filter = NT_FILTER_NEAREST,
+        .mag_filter = NT_FILTER_NEAREST,
+    });
+    TEST_ASSERT_TRUE(nt_gfx_texture_ready(depth));
+    nt_gfx_bind_texture(depth, 0);
+    nt_gfx_bind_texture(husk, 0); /* rejected: unit 0 still samples the depth texture */
+
+    nt_sampler_t linear = nt_gfx_make_sampler(&(nt_sampler_desc_t){.min_filter = NT_FILTER_LINEAR, .mag_filter = NT_FILTER_LINEAR});
+    EXPECT_ASSERT(nt_gfx_bind_sampler(linear, 0)); /* LINEAR on raw depth is incomplete sampling */
+    nt_gfx_end_frame();
+}
+
 /* Render-target attachments are rejected earlier, so an update reaching a husk
  * is always a primary texture the owner never recreated. */
 void test_gfx_update_texture_on_husk_asserts(void) {
@@ -2333,6 +2367,7 @@ int main(void) {
     RUN_TEST(test_gfx_pipeline_slots_freed_by_context_loss);
     RUN_TEST(test_gfx_bind_uniform_buffer_on_husk_asserts);
     RUN_TEST(test_gfx_bind_texture_on_husk_logs_and_skips_backend);
+    RUN_TEST(test_gfx_bind_texture_on_husk_keeps_previous_mirror);
     RUN_TEST(test_gfx_update_texture_on_husk_asserts);
     RUN_TEST(test_gfx_update_buffer_on_husk_asserts);
     RUN_TEST(test_gfx_orphan_buffer_on_husk_asserts);

--- a/tests/unit/test_gfx.c
+++ b/tests/unit/test_gfx.c
@@ -1829,7 +1829,9 @@ void test_gfx_pipeline_slots_freed_by_context_loss(void) {
     nt_gfx_begin_frame(); /* recovery completes */
 
     TEST_ASSERT_FALSE(nt_gfx_pipeline_valid(pip));
-    nt_gfx_bind_pipeline(pip);    /* stale: ordinary invalid path, no trap */
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+    nt_gfx_bind_pipeline(pip); /* stale: ordinary invalid path, no trap */
+    nt_gfx_end_pass();
     nt_gfx_destroy_pipeline(pip); /* stale: tolerated no-op */
 
     /* Programs survive as husks; relink before building new pipelines. */
@@ -1984,10 +1986,17 @@ void test_gfx_frame_draw_calls(void) {
 /* The setter must reach the backend with the caller's key and value unchanged. */
 void test_gfx_uniform_records_hash_and_value(void) {
     const float vec[4] = {1.0F, 2.0F, 3.0F, 4.0F};
+    nt_program_t prog = nt_gfx_make_program(make_test_vs(), make_test_fs());
+    nt_pipeline_t pip = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = prog});
 
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+    nt_gfx_bind_pipeline(pip);
     nt_gfx_stub_test_reset();
     nt_gfx_set_uniform_int(nt_hash32_str("u_slot"), 3);
     nt_gfx_set_uniform_vec4(nt_hash32_str("u_tint"), vec);
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
 
     TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_stub_test_uniform_int_count());
     TEST_ASSERT_EQUAL_UINT32(nt_hash32_str("u_slot").value, nt_gfx_stub_test_uniform_int_hash_at(0));
@@ -2002,6 +2011,47 @@ void test_gfx_uniform_records_hash_and_value(void) {
     for (uint32_t i = 0; i < 4; i++) {
         TEST_ASSERT_EQUAL_INT32((int32_t)vec[i], (int32_t)recorded[i]);
     }
+}
+
+/* Bound state is pass-scoped: a bind or uniform write with no pass open has no
+ * draw to reach, so it traps instead of silently landing on the next pass. */
+void test_gfx_binds_outside_a_pass_trap(void) {
+    static const float verts[9] = {0};
+    const float vec[4] = {1.0F, 2.0F, 3.0F, 4.0F};
+    nt_program_t prog = nt_gfx_make_program(make_test_vs(), make_test_fs());
+    nt_pipeline_t pip = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = prog});
+    nt_buffer_t vbo = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_IMMUTABLE, .data = verts, .size = sizeof(verts)});
+    nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){
+        .layout = {.attr_count = 1, .stride = 12, .attrs = {{.location = 0, .type = NT_VERTEX_FLOAT, .count = 3}}},
+        .vertex_buffer = vbo,
+    });
+
+    nt_gfx_begin_frame();
+    EXPECT_ASSERT(nt_gfx_bind_pipeline(pip));
+    EXPECT_ASSERT(nt_gfx_bind_vertex_input(vi));
+    EXPECT_ASSERT(nt_gfx_set_uniform_vec4(nt_hash32_str("u_tint"), vec));
+    nt_gfx_end_frame();
+}
+
+/* The pass clear touches draw state, so begin_pass discards the bound pipeline
+ * and vertex input rather than letting the next pass inherit them. */
+void test_gfx_begin_pass_discards_bound_state(void) {
+    nt_program_t prog = nt_gfx_make_program(make_test_vs(), make_test_fs());
+    nt_pipeline_t pip = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = prog});
+
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+    nt_gfx_bind_pipeline(pip);
+    bind_test_vertex_input();
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, nt_gfx_test_bound_pipeline_backend());
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, nt_gfx_test_bound_vertex_input());
+    nt_gfx_end_pass();
+
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_test_bound_pipeline_backend());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_test_bound_vertex_input());
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
 }
 
 int main(void) {
@@ -2139,5 +2189,7 @@ int main(void) {
     RUN_TEST(test_gfx_failed_bind_drops_the_previous_pipeline);
     RUN_TEST(test_gfx_frame_draw_calls);
     RUN_TEST(test_gfx_uniform_records_hash_and_value);
+    RUN_TEST(test_gfx_binds_outside_a_pass_trap);
+    RUN_TEST(test_gfx_begin_pass_discards_bound_state);
     return UNITY_END();
 }

--- a/tests/unit/test_gfx.c
+++ b/tests/unit/test_gfx.c
@@ -2049,6 +2049,9 @@ void test_gfx_uniform_records_hash_and_value(void) {
 
     TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_stub_test_uniform_vec4_count());
     TEST_ASSERT_EQUAL_UINT32(nt_hash32_str("u_tint").value, nt_gfx_stub_test_uniform_vec4_hash_at(0));
+    /* Routed to the bound pipeline's program, not to 0. Which program it is
+     * needs distinct GL ids -- test_nt_gfx_bind_mirrors_native covers that. */
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, nt_gfx_stub_test_last_uniform_program());
 
     /* UNITY_EXCLUDE_FLOAT: compare the exact small integers as ints. */
     float recorded[4];
@@ -2056,6 +2059,18 @@ void test_gfx_uniform_records_hash_and_value(void) {
     for (uint32_t i = 0; i < 4; i++) {
         TEST_ASSERT_EQUAL_INT32((int32_t)vec[i], (int32_t)recorded[i]);
     }
+}
+
+/* A uniform value belongs to a program, so a write with no pipeline bound has
+ * no program to address -- it traps instead of landing nowhere. */
+void test_gfx_uniform_without_bound_pipeline_traps(void) {
+    const float vec[4] = {1.0F, 2.0F, 3.0F, 4.0F};
+
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
+    EXPECT_ASSERT(nt_gfx_set_uniform_vec4(nt_hash32_str("u_tint"), vec));
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
 }
 
 /* Bound state is pass-scoped: a bind or uniform write with no pass open has no
@@ -2236,6 +2251,7 @@ int main(void) {
     RUN_TEST(test_gfx_failed_bind_drops_the_previous_pipeline);
     RUN_TEST(test_gfx_frame_draw_calls);
     RUN_TEST(test_gfx_uniform_records_hash_and_value);
+    RUN_TEST(test_gfx_uniform_without_bound_pipeline_traps);
     RUN_TEST(test_gfx_binds_outside_a_pass_trap);
     RUN_TEST(test_gfx_begin_pass_discards_bound_state);
     return UNITY_END();

--- a/tests/unit/test_gfx_vertex_input.c
+++ b/tests/unit/test_gfx_vertex_input.c
@@ -340,6 +340,7 @@ void test_bind_instance_buffer_uses_bound_vi(void) {
     nt_gfx_bind_vertex_input(vi);
     nt_gfx_bind_instance_buffer(stream, 16); /* no pipeline needed on this path */
     TEST_ASSERT_EQUAL_UINT32(16, nt_gfx_stub_test_last_instance_offset());
+    TEST_ASSERT_EQUAL_UINT32(nt_gfx_stub_test_last_bound_vertex_input(), nt_gfx_stub_test_last_instance_vertex_input());
     nt_gfx_end_pass();
     nt_gfx_end_frame();
 }

--- a/tests/unit/test_gfx_vertex_input.c
+++ b/tests/unit/test_gfx_vertex_input.c
@@ -257,7 +257,7 @@ void test_bind_vi_reaches_backend(void) {
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
     nt_gfx_bind_vertex_input(vi);
     TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_stub_test_bind_vertex_input_count());
-    TEST_ASSERT_NOT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_vertex_input());
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, nt_gfx_stub_test_last_bound_vertex_input());
     nt_gfx_end_pass();
     nt_gfx_end_frame();
 }
@@ -270,7 +270,8 @@ void test_bind_invalid_vi_unbinds(void) {
     nt_gfx_bind_vertex_input(vi);
     nt_gfx_destroy_vertex_input(vi);
     nt_gfx_bind_vertex_input(vi); /* stale: clears the binding instead of trapping */
-    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_vertex_input());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_last_bound_vertex_input());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_test_bound_vertex_input());
     nt_gfx_end_pass();
     nt_gfx_end_frame();
 }
@@ -282,11 +283,11 @@ void test_bind_pipeline_preserves_bound_vi(void) {
     nt_gfx_begin_frame();
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
     nt_gfx_bind_vertex_input(vi);
-    uint32_t bound = nt_gfx_stub_test_bound_vertex_input();
+    uint32_t bound = nt_gfx_test_bound_vertex_input();
     TEST_ASSERT_NOT_EQUAL_UINT32(0, bound);
     nt_gfx_bind_pipeline(pip);
     /* Orthogonal state: a pipeline change must not disturb the geometry bind. */
-    TEST_ASSERT_EQUAL_UINT32(bound, nt_gfx_stub_test_bound_vertex_input());
+    TEST_ASSERT_EQUAL_UINT32(bound, nt_gfx_test_bound_vertex_input());
     nt_buffer_t stream = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
     nt_gfx_bind_instance_buffer(stream, 16); /* still points into the bound vertex input */
     TEST_ASSERT_EQUAL_UINT32(16, nt_gfx_stub_test_last_instance_offset());
@@ -301,7 +302,7 @@ void test_destroy_while_bound_clears_mirrors(void) {
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
     nt_gfx_bind_vertex_input(vi);
     nt_gfx_destroy_vertex_input(vi);
-    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_vertex_input());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_test_bound_vertex_input());
     /* With the vertex-input mirror cleared and no pipeline, the instance
      * bind has nothing to point with -- it must trap, not use stale state. */
     nt_buffer_t stream = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
@@ -542,7 +543,7 @@ void test_vi_slots_freed_by_context_loss(void) {
     TEST_ASSERT_FALSE(nt_gfx_vertex_input_valid(vi));
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
     nt_gfx_bind_vertex_input(vi); /* stale: ordinary invalid path, no trap */
-    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_vertex_input());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_test_bound_vertex_input());
     nt_gfx_end_pass();
     nt_gfx_destroy_vertex_input(vi); /* stale: tolerated no-op */
 

--- a/tests/unit/test_gfx_vertex_input.c
+++ b/tests/unit/test_gfx_vertex_input.c
@@ -253,24 +253,34 @@ void test_deactivate_mesh_cascades_to_vi(void) {
 void test_bind_vi_reaches_backend(void) {
     nt_buffer_t vbo = make_vbo();
     nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
     nt_gfx_bind_vertex_input(vi);
     TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_stub_test_bind_vertex_input_count());
     TEST_ASSERT_NOT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_vertex_input());
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
 }
 
 void test_bind_invalid_vi_unbinds(void) {
     nt_buffer_t vbo = make_vbo();
     nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
     nt_gfx_bind_vertex_input(vi);
     nt_gfx_destroy_vertex_input(vi);
     nt_gfx_bind_vertex_input(vi); /* stale: clears the binding instead of trapping */
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_vertex_input());
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
 }
 
 void test_bind_pipeline_preserves_bound_vi(void) {
     nt_buffer_t vbo = make_vbo();
     nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout(), .instance_layout = inst_layout(), .vertex_buffer = vbo});
     nt_pipeline_t pip = make_test_pipeline();
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
     nt_gfx_bind_vertex_input(vi);
     uint32_t bound = nt_gfx_stub_test_bound_vertex_input();
     TEST_ASSERT_NOT_EQUAL_UINT32(0, bound);
@@ -280,11 +290,15 @@ void test_bind_pipeline_preserves_bound_vi(void) {
     nt_buffer_t stream = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
     nt_gfx_bind_instance_buffer(stream, 16); /* still points into the bound vertex input */
     TEST_ASSERT_EQUAL_UINT32(16, nt_gfx_stub_test_last_instance_offset());
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
 }
 
 void test_destroy_while_bound_clears_mirrors(void) {
     nt_buffer_t vbo = make_vbo();
     nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
     nt_gfx_bind_vertex_input(vi);
     nt_gfx_destroy_vertex_input(vi);
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_vertex_input());
@@ -292,20 +306,25 @@ void test_destroy_while_bound_clears_mirrors(void) {
      * bind has nothing to point with -- it must trap, not use stale state. */
     nt_buffer_t stream = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
     EXPECT_ASSERT(nt_gfx_bind_instance_buffer(stream, 0));
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
 }
 
-void test_begin_frame_clears_bound_vi(void) {
+/* Bound state is pass-scoped: the next pass starts with nothing bound. */
+void test_begin_pass_clears_bound_vi(void) {
     nt_buffer_t vbo = make_vbo();
     nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout(), .instance_layout = inst_layout(), .vertex_buffer = vbo});
     nt_buffer_t stream = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
 
     nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
     nt_gfx_bind_vertex_input(vi);
-    nt_gfx_bind_instance_buffer(stream, 0); /* bound this frame: passes */
-    nt_gfx_end_frame();
+    nt_gfx_bind_instance_buffer(stream, 0); /* bound this pass: passes */
+    nt_gfx_end_pass();
 
-    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
     EXPECT_ASSERT(nt_gfx_bind_instance_buffer(stream, 0)); /* mirror cleared, no pipeline */
+    nt_gfx_end_pass();
     nt_gfx_end_frame();
 }
 
@@ -315,17 +334,25 @@ void test_bind_instance_buffer_uses_bound_vi(void) {
     nt_buffer_t vbo = make_vbo();
     nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout(), .instance_layout = inst_layout(), .vertex_buffer = vbo});
     nt_buffer_t stream = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
     nt_gfx_bind_vertex_input(vi);
     nt_gfx_bind_instance_buffer(stream, 16); /* no pipeline needed on this path */
     TEST_ASSERT_EQUAL_UINT32(16, nt_gfx_stub_test_last_instance_offset());
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
 }
 
 void test_bind_instance_buffer_asserts_without_instance_layout(void) {
     nt_buffer_t vbo = make_vbo();
     nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
     nt_buffer_t stream = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
     nt_gfx_bind_vertex_input(vi);
     EXPECT_ASSERT(nt_gfx_bind_instance_buffer(stream, 0));
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
 }
 
 /* --- Draw invariants --- */
@@ -420,10 +447,14 @@ void test_bind_instance_buffer_rejects_unaligned_offset(void) {
     nt_buffer_t vbo = make_vbo();
     nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout(), .instance_layout = inst_layout(), .vertex_buffer = vbo});
     nt_buffer_t stream = nt_gfx_make_buffer(&(nt_buffer_desc_t){.type = NT_BUFFER_VERTEX, .usage = NT_USAGE_STREAM, .size = 64});
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
     nt_gfx_bind_vertex_input(vi);
     nt_gfx_bind_instance_buffer(stream, 4);
     TEST_ASSERT_EQUAL_UINT32(4, nt_gfx_stub_test_last_instance_offset()); /* aligned offset reached the backend */
     EXPECT_ASSERT(nt_gfx_bind_instance_buffer(stream, 1));
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
 }
 
 /* Every draw variant requires a bound vertex input. */
@@ -486,12 +517,14 @@ void test_bind_instance_buffer_asserts_on_stale_buffer(void) {
     nt_gfx_begin_frame(); /* recovery completes */
     nt_gfx_end_frame();
     nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
 
     nt_buffer_t vbo = make_vbo();
     nt_vertex_input_t vi = nt_gfx_make_vertex_input(&(nt_vertex_input_desc_t){.layout = pos_layout(), .instance_layout = inst_layout(), .vertex_buffer = vbo});
     nt_gfx_bind_vertex_input(vi);
     /* The stale handle is still pool-valid; only its backend is gone. */
     EXPECT_ASSERT(nt_gfx_bind_instance_buffer(stale, 0));
+    nt_gfx_end_pass();
     nt_gfx_end_frame();
 }
 
@@ -507,8 +540,10 @@ void test_vi_slots_freed_by_context_loss(void) {
     nt_gfx_begin_frame(); /* recovery completes */
 
     TEST_ASSERT_FALSE(nt_gfx_vertex_input_valid(vi));
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
     nt_gfx_bind_vertex_input(vi); /* stale: ordinary invalid path, no trap */
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_bound_vertex_input());
+    nt_gfx_end_pass();
     nt_gfx_destroy_vertex_input(vi); /* stale: tolerated no-op */
 
     /* Buffers survive as husks; recreate before baking new vertex inputs. */
@@ -544,7 +579,7 @@ int main(void) {
     RUN_TEST(test_bind_invalid_vi_unbinds);
     RUN_TEST(test_bind_pipeline_preserves_bound_vi);
     RUN_TEST(test_destroy_while_bound_clears_mirrors);
-    RUN_TEST(test_begin_frame_clears_bound_vi);
+    RUN_TEST(test_begin_pass_clears_bound_vi);
     RUN_TEST(test_bind_instance_buffer_uses_bound_vi);
     RUN_TEST(test_bind_instance_buffer_asserts_without_instance_layout);
     RUN_TEST(test_draw_indexed_asserts_on_non_indexed_vi);

--- a/tests/unit/test_gfx_vertex_input.c
+++ b/tests/unit/test_gfx_vertex_input.c
@@ -262,15 +262,15 @@ void test_bind_vi_reaches_backend(void) {
     nt_gfx_end_frame();
 }
 
-void test_bind_invalid_vi_unbinds(void) {
+void test_bind_invalid_vi_clears_mirror(void) {
     nt_buffer_t vbo = make_vbo();
     nt_vertex_input_t vi = make_vi(vbo, (nt_buffer_t){0});
     nt_gfx_begin_frame();
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
     nt_gfx_bind_vertex_input(vi);
     nt_gfx_destroy_vertex_input(vi);
-    nt_gfx_bind_vertex_input(vi); /* stale: clears the binding instead of trapping */
-    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_stub_test_last_bound_vertex_input());
+    nt_gfx_bind_vertex_input(vi); /* stale: clears the mirror instead of trapping */
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_stub_test_bind_vertex_input_count());
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_test_bound_vertex_input());
     nt_gfx_end_pass();
     nt_gfx_end_frame();
@@ -578,7 +578,7 @@ int main(void) {
     RUN_TEST(test_destroy_ibo_cascades_to_vi);
     RUN_TEST(test_deactivate_mesh_cascades_to_vi);
     RUN_TEST(test_bind_vi_reaches_backend);
-    RUN_TEST(test_bind_invalid_vi_unbinds);
+    RUN_TEST(test_bind_invalid_vi_clears_mirror);
     RUN_TEST(test_bind_pipeline_preserves_bound_vi);
     RUN_TEST(test_destroy_while_bound_clears_mirrors);
     RUN_TEST(test_begin_pass_clears_bound_vi);

--- a/tests/unit/test_nt_gfx_bind_mirrors_native.c
+++ b/tests/unit/test_nt_gfx_bind_mirrors_native.c
@@ -580,16 +580,21 @@ static void test_failed_vao_creation_returns_invalid_and_preserves_binding(void)
     nt_gfx_end_frame();
 }
 
-static uint32_t s_real_bind_texture_calls;
-static PFNGLBINDTEXTUREPROC s_saved_bind_texture;
-static void GLAD_API_PTR counting_bind_texture(GLenum target, GLuint texture) {
-    s_real_bind_texture_calls++;
-    s_saved_bind_texture(target, texture);
+/* Reads a sampling unit without leaving the backend's active-unit mirror stale:
+ * the unit that was active is restored before returning. */
+static GLint texture_name_on_unit(uint32_t slot) {
+    GLint prev_unit = 0;
+    glGetIntegerv(GL_ACTIVE_TEXTURE, &prev_unit);
+    glActiveTexture(GL_TEXTURE0 + slot);
+    GLint name = 0;
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &name);
+    glActiveTexture((GLenum)prev_unit);
+    return name;
 }
 
-/* A compressed create that fails after binding its own texture leaves GL with a
- * different binding than before: the cache must not still name the old one, or
- * the next bind of it is skipped and the draw samples the wrong texture. */
+/* A compressed create that fails after binding its own texture uploads on the
+ * scratch unit, so slot 0 still holds A in GL and in the cache: re-binding A
+ * costs nothing and a draw still samples A. */
 static void test_failed_compressed_upload_keeps_texture_cache_truthful(void) {
     static const uint8_t pixel[4] = {255, 0, 0, 255};
     nt_texture_t tex_a = nt_gfx_make_texture(&(nt_texture_desc_t){
@@ -610,16 +615,13 @@ static void test_failed_compressed_upload_keeps_texture_cache_truthful(void) {
                                                                (uint32_t)NT_BASISU_FORMAT_RGBA32);
     TEST_ASSERT_EQUAL_UINT32(0, failed);
 
-    s_real_bind_texture_calls = 0;
-    s_saved_bind_texture = glad_glBindTexture;
-    glad_glBindTexture = counting_bind_texture;
+    install_state_counters();
     nt_gfx_bind_texture(tex_a, 0);
-    /* Restore before any assert -- a failure longjmps past this line. */
-    glad_glBindTexture = s_saved_bind_texture;
+    remove_state_counters();
 
-    GLint bound = 0;
-    glGetIntegerv(GL_TEXTURE_BINDING_2D, &bound);
-    TEST_ASSERT_EQUAL_UINT32(1, s_real_bind_texture_calls);
+    GLint bound = texture_name_on_unit(0);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.bind_texture);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.active_texture);
     TEST_ASSERT_EQUAL_INT(name_a, bound);
 }
 
@@ -1054,8 +1056,6 @@ static void test_gl_name_reuse_after_destroying_bound_texture(void) {
     TEST_ASSERT_NOT_EQUAL_UINT32(0, keep.id);
 
     nt_gfx_bind_texture(tex_a, 0);
-    /* Parking the active unit elsewhere keeps the upload-time invalidation of
-     * the new texture off slot 0, so only the destroy can clear it. */
     nt_gfx_bind_texture(keep, 1);
 
     nt_gfx_destroy_texture(tex_a);
@@ -1069,34 +1069,77 @@ static void test_gl_name_reuse_after_destroying_bound_texture(void) {
     TEST_ASSERT_EQUAL_UINT32(GL_NO_ERROR, glGetError());
 }
 
-/* update_texture uploads on the active unit, so it invalidates that slot: the
- * next bind of the texture that used to live there has to reach GL again. */
-static void test_update_texture_mid_pass_then_bind_reaches_gl(void) {
+/* update_texture uploads on the scratch unit, so the texture sampling slot 0
+ * holds stays bound there and re-binding it mid-pass costs no GL call. */
+static void test_update_texture_mid_pass_leaves_sampling_slot_bound(void) {
     static const uint8_t white[4] = {255, 255, 255, 255};
     static const uint8_t grey[4] = {128, 128, 128, 255};
     nt_texture_t tex_1 = make_pixel_texture(white);
     GLint name_1 = current_texture_name();
     nt_texture_t tex_2 = make_pixel_texture(grey);
+    GLint name_2 = current_texture_name();
     TEST_ASSERT_NOT_EQUAL_INT(0, name_1);
-    TEST_ASSERT_NOT_EQUAL_UINT32(0, tex_2.id);
+    TEST_ASSERT_NOT_EQUAL_INT(name_1, name_2);
 
     nt_gfx_begin_frame();
     begin_black_pass();
     nt_gfx_bind_texture(tex_1, 0);
     nt_gfx_update_texture(tex_2, 0, 0, 1, 1, white);
 
-    s_real_bind_texture_calls = 0;
-    s_saved_bind_texture = glad_glBindTexture;
-    glad_glBindTexture = counting_bind_texture;
+    GLint upload_unit = 0;
+    glGetIntegerv(GL_ACTIVE_TEXTURE, &upload_unit);
+    GLint upload_bound = current_texture_name();
+    GLint slot0 = texture_name_on_unit(0);
+
+    install_state_counters();
     nt_gfx_bind_texture(tex_1, 0);
-    /* Restore before any assert -- a failure longjmps past this line. */
-    glad_glBindTexture = s_saved_bind_texture;
-    GLint bound = current_texture_name();
+    remove_state_counters();
     nt_gfx_end_pass();
     nt_gfx_end_frame();
 
-    TEST_ASSERT_EQUAL_UINT32(1, s_real_bind_texture_calls);
-    TEST_ASSERT_EQUAL_INT(name_1, bound);
+    TEST_ASSERT_EQUAL_INT(GL_TEXTURE0 + NT_GFX_MAX_TEXTURE_SLOTS, upload_unit);
+    TEST_ASSERT_EQUAL_INT(name_2, upload_bound);
+    TEST_ASSERT_EQUAL_INT(name_1, slot0);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.bind_texture);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.active_texture);
+}
+
+/* A burst of uploads switches to the scratch unit once and stays there; the
+ * sampling slot it left behind still needs no GL call to re-bind. */
+static void test_upload_burst_costs_one_active_texture_switch(void) {
+    static const uint8_t white[4] = {255, 255, 255, 255};
+    static const uint8_t grey[4] = {128, 128, 128, 255};
+    static const uint8_t black[4] = {0, 0, 0, 255};
+    nt_texture_t tex_1 = make_pixel_texture(white);
+    GLint name_1 = current_texture_name();
+    nt_texture_t tex_2 = make_pixel_texture(grey);
+    nt_texture_t tex_3 = make_pixel_texture(black);
+    TEST_ASSERT_NOT_EQUAL_INT(0, name_1);
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, tex_2.id);
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, tex_3.id);
+
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_texture(tex_1, 0);
+
+    install_state_counters();
+    nt_gfx_update_texture(tex_2, 0, 0, 1, 1, white);
+    nt_gfx_update_texture(tex_3, 0, 0, 1, 1, white);
+    nt_gfx_update_texture(tex_2, 0, 0, 1, 1, grey);
+    remove_state_counters();
+    uint32_t burst_active = s_gl_calls.active_texture;
+    uint32_t burst_bind = s_gl_calls.bind_texture;
+
+    install_state_counters();
+    nt_gfx_bind_texture(tex_1, 0);
+    remove_state_counters();
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    TEST_ASSERT_EQUAL_UINT32(1, burst_active);
+    TEST_ASSERT_EQUAL_UINT32(3, burst_bind);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.bind_texture);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.active_texture);
 }
 
 /* Destroying the current program clears the cached name: a relink that reuses it
@@ -1160,7 +1203,8 @@ int main(void) {
     RUN_TEST(test_recreate_all_resources_grounds_cache);
     RUN_TEST(test_gl_name_reuse_after_destroying_bound_vertex_input);
     RUN_TEST(test_gl_name_reuse_after_destroying_bound_texture);
-    RUN_TEST(test_update_texture_mid_pass_then_bind_reaches_gl);
+    RUN_TEST(test_update_texture_mid_pass_leaves_sampling_slot_bound);
+    RUN_TEST(test_upload_burst_costs_one_active_texture_switch);
     RUN_TEST(test_destroy_current_program_then_relink_reissues_use_program);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_gfx_bind_mirrors_native.c
+++ b/tests/unit/test_nt_gfx_bind_mirrors_native.c
@@ -937,6 +937,10 @@ static void test_uniform_write_targets_bound_pipelines_program(void) {
     const float value_b[4] = {5.0F, 6.0F, 7.0F, 8.0F};
 
     nt_pipeline_t pip_a = make_pipeline_ex(vs_src, fs_src, false, true, false);
+    /* Program and pipeline slots must differ to expose wrong-slot routing. */
+    nt_program_t spare =
+        nt_gfx_make_program(nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = vs_src}), nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = fs_src}));
+    TEST_ASSERT_TRUE(nt_gfx_program_ready(spare));
     nt_pipeline_t pip_b = make_pipeline_ex(vs_src, fs_src, false, true, false);
 
     nt_gfx_begin_frame();
@@ -1150,8 +1154,7 @@ static void test_upload_burst_costs_one_active_texture_switch(void) {
     TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.active_texture);
 }
 
-/* Deterministic half: destroying the current program clears the cached name.
- * The glUseProgram count only bites when the relink recycles the deleted name. */
+/* Destruction must release the current GL program even without another bind. */
 static void test_destroy_current_program_then_relink_reissues_use_program(void) {
     nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = s_vs_src});
     nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = s_fs_src});
@@ -1167,8 +1170,21 @@ static void test_destroy_current_program_then_relink_reissues_use_program(void) 
     nt_gfx_end_pass();
     nt_gfx_end_frame();
 
+    GLint old_program = 0;
+    glGetIntegerv(GL_CURRENT_PROGRAM, &old_program);
+    TEST_ASSERT_NOT_EQUAL_INT(0, old_program);
     nt_gfx_destroy_program(prog_p); /* cascades into pip_p */
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_gl_test_cached_program());
+
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+    TEST_ASSERT_FALSE(glIsProgram((GLuint)old_program));
+    GLint current_program = -1;
+    glGetIntegerv(GL_CURRENT_PROGRAM, &current_program);
+    TEST_ASSERT_EQUAL_INT(0, current_program);
+
     nt_program_t prog_q = nt_gfx_make_program(vs, fs);
     nt_pipeline_t pip_q = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = prog_q});
     TEST_ASSERT_TRUE(nt_gfx_pipeline_valid(pip_q));

--- a/tests/unit/test_nt_gfx_bind_mirrors_native.c
+++ b/tests/unit/test_nt_gfx_bind_mirrors_native.c
@@ -169,6 +169,9 @@ static struct {
     uint32_t blend_func_separate;
     uint32_t active_texture;
     uint32_t bind_texture;
+    uint32_t viewport;
+    uint32_t clear_color;
+    uint32_t clear_depth;
 } s_gl_calls;
 
 static PFNGLUSEPROGRAMPROC s_saved_use_program;
@@ -179,6 +182,9 @@ static PFNGLDISABLEPROC s_saved_disable;
 static PFNGLBLENDFUNCSEPARATEPROC s_saved_blend_func_separate;
 static PFNGLACTIVETEXTUREPROC s_saved_active_texture;
 static PFNGLBINDTEXTUREPROC s_saved_state_bind_texture;
+static PFNGLVIEWPORTPROC s_saved_viewport;
+static PFNGLCLEARCOLORPROC s_saved_clear_color;
+static PFNGLCLEARDEPTHPROC s_saved_clear_depth;
 
 static void GLAD_API_PTR counting_use_program(GLuint program) {
     s_gl_calls.use_program++;
@@ -229,6 +235,21 @@ static void GLAD_API_PTR counting_state_bind_texture(GLenum target, GLuint textu
     s_saved_state_bind_texture(target, texture);
 }
 
+static void GLAD_API_PTR counting_viewport(GLint x, GLint y, GLsizei width, GLsizei height) {
+    s_gl_calls.viewport++;
+    s_saved_viewport(x, y, width, height);
+}
+
+static void GLAD_API_PTR counting_clear_color(GLfloat r, GLfloat g, GLfloat b, GLfloat a) {
+    s_gl_calls.clear_color++;
+    s_saved_clear_color(r, g, b, a);
+}
+
+static void GLAD_API_PTR counting_clear_depth(GLdouble depth) {
+    s_gl_calls.clear_depth++;
+    s_saved_clear_depth(depth);
+}
+
 /* nt_gfx_init reloads glad, so this must run after the init under test. */
 static void install_state_counters(void) {
     memset(&s_gl_calls, 0, sizeof(s_gl_calls));
@@ -240,6 +261,9 @@ static void install_state_counters(void) {
     s_saved_blend_func_separate = glad_glBlendFuncSeparate;
     s_saved_active_texture = glad_glActiveTexture;
     s_saved_state_bind_texture = glad_glBindTexture;
+    s_saved_viewport = glad_glViewport;
+    s_saved_clear_color = glad_glClearColor;
+    s_saved_clear_depth = glad_glClearDepth;
     glad_glUseProgram = counting_use_program;
     glad_glBindVertexArray = counting_bind_vao;
     glad_glDepthMask = counting_depth_mask;
@@ -248,6 +272,9 @@ static void install_state_counters(void) {
     glad_glBlendFuncSeparate = counting_blend_func_separate;
     glad_glActiveTexture = counting_active_texture;
     glad_glBindTexture = counting_state_bind_texture;
+    glad_glViewport = counting_viewport;
+    glad_glClearColor = counting_clear_color;
+    glad_glClearDepth = counting_clear_depth;
 }
 
 /* Must run before any assert -- a failure longjmps past the restore. */
@@ -260,6 +287,9 @@ static void remove_state_counters(void) {
     glad_glBlendFuncSeparate = s_saved_blend_func_separate;
     glad_glActiveTexture = s_saved_active_texture;
     glad_glBindTexture = s_saved_state_bind_texture;
+    glad_glViewport = s_saved_viewport;
+    glad_glClearColor = s_saved_clear_color;
+    glad_glClearDepth = s_saved_clear_depth;
 }
 
 /* One glBindVertexArray selects the whole geometry: two meshes alternate under
@@ -625,6 +655,9 @@ static void test_identical_second_frame_issues_no_bind_calls(void) {
     TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.blend_func_separate);
     TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.active_texture);
     TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.bind_texture);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.viewport);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.clear_color);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.clear_depth);
 }
 
 /* Deduplication is a diff, not a mute: a pipeline that really changes state
@@ -774,6 +807,96 @@ static void test_ground_state_after_reinit(void) {
     TEST_ASSERT_EQUAL_UINT32(1, s_gl_calls.enable_blend);
 }
 
+/* The viewport is cached like any other GL state: a repeated rect costs nothing,
+ * a real change and a framebuffer resize both reach GL. */
+static void test_viewport_dedup_and_resize(void) {
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    install_state_counters();
+    nt_gfx_set_viewport(0, 0, 8, 8);
+    nt_gfx_set_viewport(0, 0, 8, 8);
+    uint32_t after_same_rect = s_gl_calls.viewport;
+    nt_gfx_set_viewport(0, 0, 4, 4);
+    uint32_t after_new_rect = s_gl_calls.viewport;
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    const uint32_t saved_fb_width = g_nt_window.fb_width;
+    g_nt_window.fb_width = saved_fb_width + 1;
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    GLint viewport[4] = {0, 0, 0, 0};
+    glGetIntegerv(GL_VIEWPORT, viewport);
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+    remove_state_counters();
+    uint32_t after_resize = s_gl_calls.viewport;
+    g_nt_window.fb_width = saved_fb_width;
+
+    TEST_ASSERT_EQUAL_UINT32(1, after_same_rect);
+    TEST_ASSERT_EQUAL_UINT32(2, after_new_rect);
+    TEST_ASSERT_EQUAL_UINT32(3, after_resize);
+    TEST_ASSERT_EQUAL_INT((int)saved_fb_width + 1, viewport[2]);
+    TEST_ASSERT_EQUAL_INT((int)g_nt_window.fb_height, viewport[3]);
+}
+
+/* Clear color and clear depth are cached per value, so repeating a pass desc is
+ * free and changing one of them re-issues only that call. */
+static void test_clear_values_dedup(void) {
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_end_pass();
+
+    install_state_counters();
+    begin_black_pass();
+    nt_gfx_end_pass();
+    uint32_t color_after_identical_pass = s_gl_calls.clear_color;
+    uint32_t depth_after_identical_pass = s_gl_calls.clear_depth;
+
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_color = {1.0F, 0.0F, 0.0F, 1.0F}, .clear_depth = 1.0F});
+    nt_gfx_end_pass();
+    remove_state_counters();
+    nt_gfx_end_frame();
+
+    TEST_ASSERT_EQUAL_UINT32(0, color_after_identical_pass);
+    TEST_ASSERT_EQUAL_UINT32(0, depth_after_identical_pass);
+    TEST_ASSERT_EQUAL_UINT32(1, s_gl_calls.clear_color);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.clear_depth);
+}
+
+/* Ground state parks the viewport at zero size, which no real pass can match:
+ * the first pass of a fresh gfx lifetime always re-issues it. */
+static void test_ground_state_viewport_reissued_after_reinit(void) {
+    nt_pipeline_t pip = make_pipeline_ex(s_vs_src, s_fs_src, false, true, false);
+    nt_vertex_input_t vi = make_vi(make_vbo(s_full), (nt_buffer_t){0});
+
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_draw(0, 3);
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    nt_gfx_shutdown();
+    nt_gfx_desc_t desc = nt_gfx_desc_defaults();
+    nt_gfx_init(&desc);
+    TEST_ASSERT_TRUE(g_nt_gfx.initialized);
+
+    install_state_counters();
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    GLint viewport[4] = {0, 0, 0, 0};
+    glGetIntegerv(GL_VIEWPORT, viewport);
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+    remove_state_counters();
+
+    TEST_ASSERT_EQUAL_UINT32(1, s_gl_calls.viewport);
+    TEST_ASSERT_EQUAL_INT((int)g_nt_window.fb_width, viewport[2]);
+    TEST_ASSERT_EQUAL_INT((int)g_nt_window.fb_height, viewport[3]);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_vertex_inputs_alternate_under_one_pipeline);
@@ -791,5 +914,8 @@ int main(void) {
     RUN_TEST(test_pass_clear_after_depth_write_off);
     RUN_TEST(test_same_pipeline_across_passes_rebinds_for_free);
     RUN_TEST(test_ground_state_after_reinit);
+    RUN_TEST(test_viewport_dedup_and_resize);
+    RUN_TEST(test_clear_values_dedup);
+    RUN_TEST(test_ground_state_viewport_reissued_after_reinit);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_gfx_bind_mirrors_native.c
+++ b/tests/unit/test_nt_gfx_bind_mirrors_native.c
@@ -10,6 +10,7 @@
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <string.h>
 
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
@@ -22,6 +23,19 @@ static const char *s_vs_src = "precision mediump float;\n"
 static const char *s_fs_src = "precision mediump float;\n"
                               "out vec4 frag_color;\n"
                               "void main() { frag_color = vec4(1.0, 0.0, 0.0, 1.0); }\n";
+
+/* Clip-space z is baked into the shader so near/far placement needs no uniform. */
+static const char *s_vs_near_src = "precision mediump float;\n"
+                                   "layout(location = 0) in vec2 a_position;\n"
+                                   "void main() { gl_Position = vec4(a_position, -0.5, 1.0); }\n";
+
+static const char *s_vs_far_src = "precision mediump float;\n"
+                                  "layout(location = 0) in vec2 a_position;\n"
+                                  "void main() { gl_Position = vec4(a_position, 0.5, 1.0); }\n";
+
+static const char *s_fs_green_src = "precision mediump float;\n"
+                                    "out vec4 frag_color;\n"
+                                    "void main() { frag_color = vec4(0.0, 1.0, 0.0, 1.0); }\n";
 
 /* Covers the whole viewport. */
 static const float s_full[6] = {-1.0F, -1.0F, 3.0F, -1.0F, -1.0F, 3.0F};
@@ -128,7 +142,125 @@ static uint8_t center_red(void) {
     return px[0];
 }
 
+static nt_pipeline_t make_pipeline_ex(const char *vs_src, const char *fs_src, bool depth_test, bool depth_write, bool blend) {
+    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = vs_src});
+    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = fs_src});
+    return nt_gfx_make_pipeline(&(nt_pipeline_desc_t){
+        .program = nt_gfx_make_program(vs, fs),
+        .depth_test = depth_test,
+        .depth_write = depth_write,
+        .blend = blend ? nt_blend_alpha() : nt_blend_opaque(),
+    });
+}
+
 static void begin_black_pass(void) { nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_color = {0.0F, 0.0F, 0.0F, 1.0F}, .clear_depth = 1.0F}); }
+
+/* Counts the state calls a bind emits, straight off the glad pointers, so a
+ * dedup claim is measured on real GL traffic rather than on source counters. */
+static struct {
+    uint32_t use_program;
+    uint32_t bind_vao;
+    uint32_t depth_mask;
+    uint32_t depth_mask_false;
+    uint32_t enable;
+    uint32_t enable_blend;
+    uint32_t disable;
+    uint32_t disable_blend;
+    uint32_t blend_func_separate;
+    uint32_t active_texture;
+    uint32_t bind_texture;
+} s_gl_calls;
+
+static PFNGLUSEPROGRAMPROC s_saved_use_program;
+static PFNGLBINDVERTEXARRAYPROC s_saved_bind_vao;
+static PFNGLDEPTHMASKPROC s_saved_depth_mask;
+static PFNGLENABLEPROC s_saved_enable;
+static PFNGLDISABLEPROC s_saved_disable;
+static PFNGLBLENDFUNCSEPARATEPROC s_saved_blend_func_separate;
+static PFNGLACTIVETEXTUREPROC s_saved_active_texture;
+static PFNGLBINDTEXTUREPROC s_saved_state_bind_texture;
+
+static void GLAD_API_PTR counting_use_program(GLuint program) {
+    s_gl_calls.use_program++;
+    s_saved_use_program(program);
+}
+
+static void GLAD_API_PTR counting_bind_vao(GLuint array) {
+    s_gl_calls.bind_vao++;
+    s_saved_bind_vao(array);
+}
+
+static void GLAD_API_PTR counting_depth_mask(GLboolean flag) {
+    s_gl_calls.depth_mask++;
+    if (flag == GL_FALSE) {
+        s_gl_calls.depth_mask_false++;
+    }
+    s_saved_depth_mask(flag);
+}
+
+static void GLAD_API_PTR counting_enable(GLenum cap) {
+    s_gl_calls.enable++;
+    if (cap == GL_BLEND) {
+        s_gl_calls.enable_blend++;
+    }
+    s_saved_enable(cap);
+}
+
+static void GLAD_API_PTR counting_disable(GLenum cap) {
+    s_gl_calls.disable++;
+    if (cap == GL_BLEND) {
+        s_gl_calls.disable_blend++;
+    }
+    s_saved_disable(cap);
+}
+
+static void GLAD_API_PTR counting_blend_func_separate(GLenum src_rgb, GLenum dst_rgb, GLenum src_alpha, GLenum dst_alpha) {
+    s_gl_calls.blend_func_separate++;
+    s_saved_blend_func_separate(src_rgb, dst_rgb, src_alpha, dst_alpha);
+}
+
+static void GLAD_API_PTR counting_active_texture(GLenum unit) {
+    s_gl_calls.active_texture++;
+    s_saved_active_texture(unit);
+}
+
+static void GLAD_API_PTR counting_state_bind_texture(GLenum target, GLuint texture) {
+    s_gl_calls.bind_texture++;
+    s_saved_state_bind_texture(target, texture);
+}
+
+/* nt_gfx_init reloads glad, so this must run after the init under test. */
+static void install_state_counters(void) {
+    memset(&s_gl_calls, 0, sizeof(s_gl_calls));
+    s_saved_use_program = glad_glUseProgram;
+    s_saved_bind_vao = glad_glBindVertexArray;
+    s_saved_depth_mask = glad_glDepthMask;
+    s_saved_enable = glad_glEnable;
+    s_saved_disable = glad_glDisable;
+    s_saved_blend_func_separate = glad_glBlendFuncSeparate;
+    s_saved_active_texture = glad_glActiveTexture;
+    s_saved_state_bind_texture = glad_glBindTexture;
+    glad_glUseProgram = counting_use_program;
+    glad_glBindVertexArray = counting_bind_vao;
+    glad_glDepthMask = counting_depth_mask;
+    glad_glEnable = counting_enable;
+    glad_glDisable = counting_disable;
+    glad_glBlendFuncSeparate = counting_blend_func_separate;
+    glad_glActiveTexture = counting_active_texture;
+    glad_glBindTexture = counting_state_bind_texture;
+}
+
+/* Must run before any assert -- a failure longjmps past the restore. */
+static void remove_state_counters(void) {
+    glad_glUseProgram = s_saved_use_program;
+    glad_glBindVertexArray = s_saved_bind_vao;
+    glad_glDepthMask = s_saved_depth_mask;
+    glad_glEnable = s_saved_enable;
+    glad_glDisable = s_saved_disable;
+    glad_glBlendFuncSeparate = s_saved_blend_func_separate;
+    glad_glActiveTexture = s_saved_active_texture;
+    glad_glBindTexture = s_saved_state_bind_texture;
+}
 
 /* One glBindVertexArray selects the whole geometry: two meshes alternate under
  * a single pipeline with no per-switch attribute re-pointing. */
@@ -212,8 +344,8 @@ static void test_second_frame_issues_no_static_attrib_pointers(void) {
     nt_gfx_end_frame();
     /* Restore before any assert -- a failure longjmps past this line. */
     glad_glVertexAttribPointer = s_saved_attrib_pointer;
-    /* begin_frame's cache reset (VAO 0) + one bind per vertex-input switch. */
-    TEST_ASSERT_EQUAL_UINT32(4, frame_vao_binds);
+    /* The carried-over VAO dedups the first bind; one bind per vertex-input switch. */
+    TEST_ASSERT_EQUAL_UINT32(2, frame_vao_binds);
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_gl_test_static_attrib_pointer_calls());
     TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_gl_test_instance_attrib_pointer_calls());
     TEST_ASSERT_EQUAL_UINT32(1, s_real_attrib_pointer_calls); /* just the instance re-point */
@@ -247,6 +379,7 @@ static void test_index_data_ops_do_not_rewire_bound_vertex_input(void) {
     nt_gfx_end_pass();
     begin_black_pass();
     nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi_a);
     nt_gfx_draw_indexed(0, 3, 3); /* still A's triangle indices, not B */
     TEST_ASSERT_UINT8_WITHIN(1, 255, center_red());
     TEST_ASSERT_EQUAL_UINT32(GL_NO_ERROR, glGetError());
@@ -272,6 +405,7 @@ static void test_orphan_under_live_vertex_input_renders(void) {
 
     begin_black_pass();
     nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi);
     nt_gfx_orphan_buffer(vbo, s_empty, sizeof(s_empty));
     nt_gfx_draw(0, 3);
     TEST_ASSERT_UINT8_WITHIN(1, 0, center_red());
@@ -300,8 +434,6 @@ static void test_rejected_pipeline_bind_preserves_vertex_input(void) {
 
     nt_gfx_bind_pipeline(stale); /* rejected: drops the pipeline only */
 
-    nt_gfx_end_pass();
-    begin_black_pass();
     nt_gfx_bind_pipeline(pip);
     nt_gfx_draw(0, 3); /* no vertex-input re-bind needed */
     TEST_ASSERT_UINT8_WITHIN(1, 255, center_red());
@@ -456,6 +588,192 @@ static void test_ground_state_disables_scissor(void) {
     TEST_ASSERT_FALSE(nt_gfx_scissor_enabled());
 }
 
+/* The cache survives end_frame, so a frame that repeats the previous one reaches
+ * GL with no state calls at all. */
+static void test_identical_second_frame_issues_no_bind_calls(void) {
+    static const uint8_t pixel[4] = {255, 255, 255, 255};
+    nt_pipeline_t pip = make_pipeline_ex(s_vs_src, s_fs_src, false, true, false);
+    nt_vertex_input_t vi = make_vi(make_vbo(s_full), (nt_buffer_t){0});
+    nt_texture_t tex = nt_gfx_make_texture(&(nt_texture_desc_t){.width = 1, .height = 1, .data = pixel, .format = NT_TEXTURE_FORMAT_RGBA8});
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, tex.id);
+
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_bind_texture(tex, 0);
+    nt_gfx_draw(0, 3);
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    install_state_counters();
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_bind_texture(tex, 0);
+    nt_gfx_draw(0, 3);
+    nt_gfx_end_pass();
+    remove_state_counters();
+    nt_gfx_end_frame();
+
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.use_program);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.bind_vao);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.depth_mask);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.enable);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.disable);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.blend_func_separate);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.active_texture);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.bind_texture);
+}
+
+/* Deduplication is a diff, not a mute: a pipeline that really changes state
+ * still emits, and GL ends up holding the second pipeline's state. */
+static void test_state_change_mid_frame_still_emits(void) {
+    nt_pipeline_t pip_a = make_pipeline_ex(s_vs_src, s_fs_src, true, true, false);
+    nt_pipeline_t pip_b = make_pipeline_ex(s_vs_src, s_fs_src, true, false, true);
+    nt_vertex_input_t vi = make_vi(make_vbo(s_full), (nt_buffer_t){0});
+
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    install_state_counters();
+    nt_gfx_bind_pipeline(pip_a);
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_draw(0, 3);
+    nt_gfx_bind_pipeline(pip_b);
+    nt_gfx_draw(0, 3);
+    remove_state_counters();
+    GLboolean depth_write_enabled = GL_TRUE;
+    glGetBooleanv(GL_DEPTH_WRITEMASK, &depth_write_enabled);
+    GLboolean blend_enabled = glIsEnabled(GL_BLEND);
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    TEST_ASSERT_EQUAL_UINT32(1, s_gl_calls.depth_mask);
+    TEST_ASSERT_EQUAL_UINT32(1, s_gl_calls.depth_mask_false);
+    TEST_ASSERT_EQUAL_UINT32(1, s_gl_calls.enable_blend);
+    TEST_ASSERT_EQUAL_UINT32(1, s_gl_calls.blend_func_separate);
+    TEST_ASSERT_EQUAL_INT(GL_FALSE, (int)depth_write_enabled);
+    TEST_ASSERT_EQUAL_INT(GL_TRUE, (int)blend_enabled);
+}
+
+/* The pass clear forces the depth mask on and leaves it on: the depth really
+ * clears after a depth_write=false pipeline, and the pipeline that wants the
+ * mask off has to say so again inside the new pass. */
+static void test_pass_clear_after_depth_write_off(void) {
+    nt_pipeline_t near_pip = make_pipeline_ex(s_vs_near_src, s_fs_src, true, true, false);
+    nt_pipeline_t far_pip = make_pipeline_ex(s_vs_far_src, s_fs_green_src, true, true, false);
+    nt_pipeline_t no_write_pip = make_pipeline_ex(s_vs_near_src, s_fs_src, true, false, false);
+    nt_vertex_input_t vi = make_vi(make_vbo(s_full), (nt_buffer_t){0});
+
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(near_pip);
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_draw(0, 3);
+    nt_gfx_bind_pipeline(no_write_pip);
+    nt_gfx_draw(0, 3);
+    nt_gfx_end_pass();
+
+    install_state_counters();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(far_pip);
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_draw(0, 3);
+    /* One glDepthMask(GL_TRUE) for the clear, and none for the bind: a mask put
+     * back to GL_FALSE after the clear would cost two more. */
+    uint32_t depth_mask_through_far_bind = s_gl_calls.depth_mask;
+    uint8_t px[4] = {0, 0, 0, 0};
+    bool read_ok = nt_gfx_read_pixels(8, 8, 1, 1, px, sizeof(px));
+
+    nt_gfx_bind_pipeline(no_write_pip);
+    remove_state_counters();
+    GLboolean depth_write_enabled = GL_TRUE;
+    glGetBooleanv(GL_DEPTH_WRITEMASK, &depth_write_enabled);
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    /* The far quad only survives the LESS test if the clear reset depth to 1.0. */
+    TEST_ASSERT_TRUE(read_ok);
+    TEST_ASSERT_UINT8_WITHIN(1, 0, px[0]);
+    TEST_ASSERT_UINT8_WITHIN(1, 255, px[1]);
+    TEST_ASSERT_EQUAL_UINT32(1, depth_mask_through_far_bind);
+    TEST_ASSERT_EQUAL_UINT32(2, s_gl_calls.depth_mask);
+    TEST_ASSERT_EQUAL_UINT32(1, s_gl_calls.depth_mask_false);
+    TEST_ASSERT_EQUAL_INT(GL_FALSE, (int)depth_write_enabled);
+}
+
+/* Bound state is pass-scoped but the GL cache is not: re-binding the same
+ * pipeline and vertex input in the next pass costs nothing. */
+static void test_same_pipeline_across_passes_rebinds_for_free(void) {
+    nt_pipeline_t pip = make_pipeline_ex(s_vs_src, s_fs_src, false, true, false);
+    nt_vertex_input_t vi = make_vi(make_vbo(s_full), (nt_buffer_t){0});
+
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_draw(0, 3);
+    nt_gfx_end_pass();
+
+    begin_black_pass();
+    install_state_counters();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi);
+    remove_state_counters();
+    nt_gfx_draw(0, 3);
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.use_program);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.bind_vao);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.depth_mask);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.enable);
+    TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.disable);
+}
+
+/* Without a per-frame reset, init is the only grounding: state a previous gfx
+ * lifetime left on the shared native context must be off again, and the fresh
+ * cache must agree with GL rather than re-issue what is already right. */
+static void test_ground_state_after_reinit(void) {
+    nt_pipeline_t blend_pip = make_pipeline_ex(s_vs_src, s_fs_src, false, true, true);
+    nt_vertex_input_t vi = make_vi(make_vbo(s_full), (nt_buffer_t){0});
+
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(blend_pip);
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_draw(0, 3);
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+    TEST_ASSERT_EQUAL_INT(GL_TRUE, (int)glIsEnabled(GL_BLEND));
+
+    nt_gfx_shutdown();
+    nt_gfx_desc_t desc = nt_gfx_desc_defaults();
+    nt_gfx_init(&desc);
+    TEST_ASSERT_TRUE(g_nt_gfx.initialized);
+    TEST_ASSERT_EQUAL_INT(GL_FALSE, (int)glIsEnabled(GL_BLEND));
+
+    nt_pipeline_t opaque_pip = make_pipeline_ex(s_vs_src, s_fs_src, false, true, false);
+    nt_pipeline_t alpha_pip = make_pipeline_ex(s_vs_src, s_fs_src, false, true, true);
+    nt_vertex_input_t fresh_vi = make_vi(make_vbo(s_full), (nt_buffer_t){0});
+
+    install_state_counters();
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(opaque_pip);
+    uint32_t disable_blend_after_opaque = s_gl_calls.disable_blend;
+    nt_gfx_bind_pipeline(alpha_pip);
+    nt_gfx_bind_vertex_input(fresh_vi);
+    nt_gfx_draw(0, 3);
+    nt_gfx_end_pass();
+    remove_state_counters();
+    nt_gfx_end_frame();
+
+    TEST_ASSERT_EQUAL_UINT32(0, disable_blend_after_opaque);
+    TEST_ASSERT_EQUAL_UINT32(1, s_gl_calls.enable_blend);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_vertex_inputs_alternate_under_one_pipeline);
@@ -468,5 +786,10 @@ int main(void) {
     RUN_TEST(test_failed_vao_creation_returns_invalid_and_preserves_binding);
     RUN_TEST(test_failed_compressed_upload_keeps_texture_cache_truthful);
     RUN_TEST(test_ground_state_disables_scissor);
+    RUN_TEST(test_identical_second_frame_issues_no_bind_calls);
+    RUN_TEST(test_state_change_mid_frame_still_emits);
+    RUN_TEST(test_pass_clear_after_depth_write_off);
+    RUN_TEST(test_same_pipeline_across_passes_rebinds_for_free);
+    RUN_TEST(test_ground_state_after_reinit);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_gfx_bind_mirrors_native.c
+++ b/tests/unit/test_nt_gfx_bind_mirrors_native.c
@@ -1,11 +1,13 @@
 /* Real-GL coverage for VI switching, isolated EBO data operations, orphaning,
  * and binding preservation across rejected or failed operations. */
 
+#include "basisu/nt_basisu_transcoder.h"
 #include "graphics/nt_gfx.h"
 #include "graphics/nt_gfx_internal.h"
 #include "unity.h"
 #include "window/nt_window.h"
 
+#include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
 
@@ -28,6 +30,63 @@ static const float s_empty[6] = {0.0F, 0.0F, 0.0F, 0.0F, 0.0F, 0.0F};
 
 static const uint16_t s_tri_indices[3] = {0, 1, 2};
 static const uint16_t s_degenerate_indices[3] = {0, 0, 0};
+
+/* Transcoder fake in place of the loud-fail stub: level 0 describes cleanly and
+ * the session then refuses, the shape of corrupt basis data and the only way to
+ * fail a compressed create AFTER the backend bound its new texture. */
+void nt_basisu_transcoder_global_init(void) {}
+
+bool nt_basisu_validate_header(const void *basis_data, uint32_t basis_size) {
+    (void)basis_data;
+    (void)basis_size;
+    return true;
+}
+
+uint32_t nt_basisu_get_level_count(const void *basis_data, uint32_t basis_size) {
+    (void)basis_data;
+    (void)basis_size;
+    return 1;
+}
+
+bool nt_basisu_get_level_desc(const void *basis_data, uint32_t basis_size, uint32_t level_index, uint32_t *out_width, uint32_t *out_height, uint32_t *out_total_blocks) {
+    (void)basis_data;
+    (void)basis_size;
+    if (level_index != 0) {
+        return false;
+    }
+    *out_width = 4;
+    *out_height = 4;
+    *out_total_blocks = 1;
+    return true;
+}
+
+bool nt_basisu_start_transcoding(const void *basis_data, uint32_t basis_size) {
+    (void)basis_data;
+    (void)basis_size;
+    return false;
+}
+
+void nt_basisu_stop_transcoding(void) {}
+
+bool nt_basisu_transcode_level(const void *basis_data, uint32_t basis_size, uint32_t level_index, void *output, uint32_t output_blocks, nt_basisu_format_t format) {
+    (void)basis_data;
+    (void)basis_size;
+    (void)level_index;
+    (void)output;
+    (void)output_blocks;
+    (void)format;
+    return false;
+}
+
+uint32_t nt_basisu_bytes_per_block(nt_basisu_format_t format) {
+    (void)format;
+    return 16;
+}
+
+uint32_t nt_basisu_gl_internal_format(nt_basisu_format_t format) {
+    (void)format;
+    return 0;
+}
 
 void setUp(void) {
     TEST_ASSERT_TRUE_MESSAGE(glfwInit(), "glfwInit failed");
@@ -339,6 +398,64 @@ static void test_failed_vao_creation_returns_invalid_and_preserves_binding(void)
     nt_gfx_end_frame();
 }
 
+static uint32_t s_real_bind_texture_calls;
+static PFNGLBINDTEXTUREPROC s_saved_bind_texture;
+static void GLAD_API_PTR counting_bind_texture(GLenum target, GLuint texture) {
+    s_real_bind_texture_calls++;
+    s_saved_bind_texture(target, texture);
+}
+
+/* A compressed create that fails after binding its own texture leaves GL with a
+ * different binding than before: the cache must not still name the old one, or
+ * the next bind of it is skipped and the draw samples the wrong texture. */
+static void test_failed_compressed_upload_keeps_texture_cache_truthful(void) {
+    static const uint8_t pixel[4] = {255, 0, 0, 255};
+    nt_texture_t tex_a = nt_gfx_make_texture(&(nt_texture_desc_t){
+        .width = 1,
+        .height = 1,
+        .data = pixel,
+        .format = NT_TEXTURE_FORMAT_RGBA8,
+    });
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, tex_a.id);
+
+    nt_gfx_bind_texture(tex_a, 0);
+    GLint name_a = 0;
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &name_a);
+    TEST_ASSERT_NOT_EQUAL_INT(0, name_a);
+
+    static const uint8_t fake_basis[8] = {0};
+    uint32_t failed = nt_gfx_backend_create_texture_compressed(fake_basis, sizeof(fake_basis), 4, 4, 1, NT_FILTER_NEAREST, NT_FILTER_NEAREST, NT_WRAP_CLAMP_TO_EDGE, NT_WRAP_CLAMP_TO_EDGE,
+                                                               (uint32_t)NT_BASISU_FORMAT_RGBA32);
+    TEST_ASSERT_EQUAL_UINT32(0, failed);
+
+    s_real_bind_texture_calls = 0;
+    s_saved_bind_texture = glad_glBindTexture;
+    glad_glBindTexture = counting_bind_texture;
+    nt_gfx_bind_texture(tex_a, 0);
+    /* Restore before any assert -- a failure longjmps past this line. */
+    glad_glBindTexture = s_saved_bind_texture;
+
+    GLint bound = 0;
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &bound);
+    TEST_ASSERT_EQUAL_UINT32(1, s_real_bind_texture_calls);
+    TEST_ASSERT_EQUAL_INT(name_a, bound);
+}
+
+/* Ground state is real GL calls, so scissor left enabled by a previous gfx
+ * lifetime cannot survive into the next one on the same native context. */
+static void test_ground_state_disables_scissor(void) {
+    nt_gfx_set_scissor_enabled(true);
+    TEST_ASSERT_EQUAL_INT(GL_TRUE, (int)glIsEnabled(GL_SCISSOR_TEST));
+
+    nt_gfx_shutdown();
+    nt_gfx_desc_t desc = nt_gfx_desc_defaults();
+    nt_gfx_init(&desc);
+    TEST_ASSERT_TRUE(g_nt_gfx.initialized);
+
+    TEST_ASSERT_EQUAL_INT(GL_FALSE, (int)glIsEnabled(GL_SCISSOR_TEST));
+    TEST_ASSERT_FALSE(nt_gfx_scissor_enabled());
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_vertex_inputs_alternate_under_one_pipeline);
@@ -349,5 +466,7 @@ int main(void) {
     RUN_TEST(test_rejected_pipeline_bind_preserves_vertex_input);
     RUN_TEST(test_creating_vertex_input_preserves_bound_one);
     RUN_TEST(test_failed_vao_creation_returns_invalid_and_preserves_binding);
+    RUN_TEST(test_failed_compressed_upload_keeps_texture_cache_truthful);
+    RUN_TEST(test_ground_state_disables_scissor);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_gfx_bind_mirrors_native.c
+++ b/tests/unit/test_nt_gfx_bind_mirrors_native.c
@@ -112,7 +112,12 @@ void setUp(void) {
     TEST_ASSERT_TRUE(g_nt_gfx.initialized);
 }
 
+static void remove_state_counters(void);
+
 void tearDown(void) {
+    /* A failed assert inside a counting window longjmps past the restore; leaked
+     * glad pointers would then outlive this test's GL context. */
+    remove_state_counters();
     nt_gfx_shutdown();
     nt_window_shutdown();
 }
@@ -277,8 +282,12 @@ static void install_state_counters(void) {
     glad_glClearDepth = counting_clear_depth;
 }
 
-/* Must run before any assert -- a failure longjmps past the restore. */
+/* Must run before any assert -- a failure longjmps past the restore. Idempotent,
+ * so tearDown can undo an install a failed assert jumped over. */
 static void remove_state_counters(void) {
+    if (s_saved_use_program == NULL) {
+        return;
+    }
     glad_glUseProgram = s_saved_use_program;
     glad_glBindVertexArray = s_saved_bind_vao;
     glad_glDepthMask = s_saved_depth_mask;
@@ -290,6 +299,17 @@ static void remove_state_counters(void) {
     glad_glViewport = s_saved_viewport;
     glad_glClearColor = s_saved_clear_color;
     glad_glClearDepth = s_saved_clear_depth;
+    s_saved_use_program = NULL;
+    s_saved_bind_vao = NULL;
+    s_saved_depth_mask = NULL;
+    s_saved_enable = NULL;
+    s_saved_disable = NULL;
+    s_saved_blend_func_separate = NULL;
+    s_saved_active_texture = NULL;
+    s_saved_state_bind_texture = NULL;
+    s_saved_viewport = NULL;
+    s_saved_clear_color = NULL;
+    s_saved_clear_depth = NULL;
 }
 
 /* One glBindVertexArray selects the whole geometry: two meshes alternate under
@@ -645,8 +665,11 @@ static void test_identical_second_frame_issues_no_bind_calls(void) {
     nt_gfx_draw(0, 3);
     nt_gfx_end_pass();
     remove_state_counters();
+    /* Zero calls only counts if the frame still rendered what the first one did. */
+    uint8_t red = center_red();
     nt_gfx_end_frame();
 
+    TEST_ASSERT_UINT8_WITHIN(1, 255, red);
     TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.use_program);
     TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.bind_vao);
     TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.depth_mask);
@@ -737,7 +760,8 @@ static void test_pass_clear_after_depth_write_off(void) {
 }
 
 /* Bound state is pass-scoped but the GL cache is not: re-binding the same
- * pipeline and vertex input in the next pass costs nothing. */
+ * pipeline and vertex input in the next pass -- and the next frame -- costs
+ * nothing. */
 static void test_same_pipeline_across_passes_rebinds_for_free(void) {
     nt_pipeline_t pip = make_pipeline_ex(s_vs_src, s_fs_src, false, true, false);
     nt_vertex_input_t vi = make_vi(make_vbo(s_full), (nt_buffer_t){0});
@@ -748,7 +772,9 @@ static void test_same_pipeline_across_passes_rebinds_for_free(void) {
     nt_gfx_bind_vertex_input(vi);
     nt_gfx_draw(0, 3);
     nt_gfx_end_pass();
+    nt_gfx_end_frame();
 
+    nt_gfx_begin_frame();
     begin_black_pass();
     install_state_counters();
     nt_gfx_bind_pipeline(pip);
@@ -943,6 +969,173 @@ static void test_uniform_write_targets_bound_pipelines_program(void) {
     }
 }
 
+/* A raw backend recreate grounds the cache against the fresh context: state the
+ * old lifetime left on is off, and the first bind that wants it says so again. */
+static void test_recreate_all_resources_grounds_cache(void) {
+    nt_pipeline_t blend_pip = make_pipeline_ex(s_vs_src, s_fs_src, false, true, true);
+    nt_vertex_input_t vi = make_vi(make_vbo(s_full), (nt_buffer_t){0});
+
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(blend_pip);
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_draw(0, 3);
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+    TEST_ASSERT_EQUAL_INT(GL_TRUE, (int)glIsEnabled(GL_BLEND));
+
+    TEST_ASSERT_TRUE(nt_gfx_backend_recreate_all_resources());
+    TEST_ASSERT_EQUAL_INT(GL_FALSE, (int)glIsEnabled(GL_BLEND));
+
+    /* The zeroed backend tables orphan every old handle, so the frame that
+     * follows a recreate has to build its own. */
+    nt_pipeline_t fresh_blend = make_pipeline_ex(s_vs_src, s_fs_src, false, true, true);
+
+    /* After the recreate: it reloads glad and would drop the swapped pointers. */
+    install_state_counters();
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(fresh_blend);
+    nt_gfx_end_pass();
+    remove_state_counters();
+    nt_gfx_end_frame();
+
+    TEST_ASSERT_EQUAL_UINT32(1, s_gl_calls.enable_blend);
+}
+
+/* Destroying the bound vertex input clears the cached VAO name: a new VAO that
+ * reuses the deleted GL name must still reach glBindVertexArray. */
+static void test_gl_name_reuse_after_destroying_bound_vertex_input(void) {
+    nt_pipeline_t pip = make_red_pipeline();
+    nt_buffer_t vbo = make_vbo(s_full);
+    nt_vertex_input_t vi_a = make_vi(vbo, (nt_buffer_t){0});
+
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi_a);
+    nt_gfx_draw(0, 3);
+    TEST_ASSERT_UINT8_WITHIN(1, 255, center_red());
+    nt_gfx_destroy_vertex_input(vi_a); /* destroyed while bound */
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    nt_vertex_input_t vi_b = make_vi(vbo, (nt_buffer_t){0});
+    TEST_ASSERT_TRUE(nt_gfx_vertex_input_valid(vi_b));
+
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi_b);
+    nt_gfx_draw(0, 3);
+    TEST_ASSERT_EQUAL_UINT32(GL_NO_ERROR, glGetError());
+    TEST_ASSERT_UINT8_WITHIN(1, 255, center_red());
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+}
+
+static nt_texture_t make_pixel_texture(const uint8_t pixel[4]) { return nt_gfx_make_texture(&(nt_texture_desc_t){.width = 1, .height = 1, .data = pixel, .format = NT_TEXTURE_FORMAT_RGBA8}); }
+
+/* Creation leaves its own texture bound on the active unit. */
+static GLint current_texture_name(void) {
+    GLint name = 0;
+    glGetIntegerv(GL_TEXTURE_BINDING_2D, &name);
+    return name;
+}
+
+/* Same for textures: destroy clears the cache slot, so a new texture reusing the
+ * deleted GL name is not mistaken for the one still recorded there. */
+static void test_gl_name_reuse_after_destroying_bound_texture(void) {
+    static const uint8_t white[4] = {255, 255, 255, 255};
+    static const uint8_t grey[4] = {128, 128, 128, 255};
+    nt_texture_t tex_a = make_pixel_texture(white);
+    nt_texture_t keep = make_pixel_texture(grey);
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, tex_a.id);
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, keep.id);
+
+    nt_gfx_bind_texture(tex_a, 0);
+    /* Parking the active unit elsewhere keeps the upload-time invalidation of
+     * the new texture off slot 0, so only the destroy can clear it. */
+    nt_gfx_bind_texture(keep, 1);
+
+    nt_gfx_destroy_texture(tex_a);
+    nt_texture_t tex_b = make_pixel_texture(white);
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, tex_b.id);
+    GLint name_b = current_texture_name();
+    TEST_ASSERT_NOT_EQUAL_INT(0, name_b);
+
+    nt_gfx_bind_texture(tex_b, 0);
+    TEST_ASSERT_EQUAL_INT(name_b, current_texture_name());
+    TEST_ASSERT_EQUAL_UINT32(GL_NO_ERROR, glGetError());
+}
+
+/* update_texture uploads on the active unit, so it invalidates that slot: the
+ * next bind of the texture that used to live there has to reach GL again. */
+static void test_update_texture_mid_pass_then_bind_reaches_gl(void) {
+    static const uint8_t white[4] = {255, 255, 255, 255};
+    static const uint8_t grey[4] = {128, 128, 128, 255};
+    nt_texture_t tex_1 = make_pixel_texture(white);
+    GLint name_1 = current_texture_name();
+    nt_texture_t tex_2 = make_pixel_texture(grey);
+    TEST_ASSERT_NOT_EQUAL_INT(0, name_1);
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, tex_2.id);
+
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_texture(tex_1, 0);
+    nt_gfx_update_texture(tex_2, 0, 0, 1, 1, white);
+
+    s_real_bind_texture_calls = 0;
+    s_saved_bind_texture = glad_glBindTexture;
+    glad_glBindTexture = counting_bind_texture;
+    nt_gfx_bind_texture(tex_1, 0);
+    /* Restore before any assert -- a failure longjmps past this line. */
+    glad_glBindTexture = s_saved_bind_texture;
+    GLint bound = current_texture_name();
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    TEST_ASSERT_EQUAL_UINT32(1, s_real_bind_texture_calls);
+    TEST_ASSERT_EQUAL_INT(name_1, bound);
+}
+
+/* Destroying the current program clears the cached name: a relink that reuses it
+ * must still reach glUseProgram, now that the cache outlives the frame. */
+static void test_destroy_current_program_then_relink_reissues_use_program(void) {
+    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = s_vs_src});
+    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = s_fs_src});
+    nt_program_t prog_p = nt_gfx_make_program(vs, fs);
+    nt_pipeline_t pip_p = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = prog_p});
+    nt_vertex_input_t vi = make_vi(make_vbo(s_full), (nt_buffer_t){0});
+
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip_p);
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_draw(0, 3);
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    nt_gfx_destroy_program(prog_p); /* cascades into pip_p */
+    nt_program_t prog_q = nt_gfx_make_program(vs, fs);
+    nt_pipeline_t pip_q = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = prog_q});
+    TEST_ASSERT_TRUE(nt_gfx_pipeline_valid(pip_q));
+
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    install_state_counters();
+    nt_gfx_bind_pipeline(pip_q);
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_draw(0, 3);
+    remove_state_counters();
+    uint8_t red = center_red();
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    TEST_ASSERT_EQUAL_UINT32(1, s_gl_calls.use_program);
+    TEST_ASSERT_UINT8_WITHIN(1, 255, red);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_vertex_inputs_alternate_under_one_pipeline);
@@ -964,5 +1157,10 @@ int main(void) {
     RUN_TEST(test_clear_values_dedup);
     RUN_TEST(test_ground_state_viewport_reissued_after_reinit);
     RUN_TEST(test_uniform_write_targets_bound_pipelines_program);
+    RUN_TEST(test_recreate_all_resources_grounds_cache);
+    RUN_TEST(test_gl_name_reuse_after_destroying_bound_vertex_input);
+    RUN_TEST(test_gl_name_reuse_after_destroying_bound_texture);
+    RUN_TEST(test_update_texture_mid_pass_then_bind_reaches_gl);
+    RUN_TEST(test_destroy_current_program_then_relink_reissues_use_program);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_gfx_bind_mirrors_native.c
+++ b/tests/unit/test_nt_gfx_bind_mirrors_native.c
@@ -801,7 +801,7 @@ static void test_ground_state_after_reinit(void) {
     nt_vertex_input_t vi = make_vi(make_vbo(s_full), (nt_buffer_t){0});
 
     nt_gfx_begin_frame();
-    begin_black_pass();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_color = {1.0F, 0.0F, 0.0F, 1.0F}, .clear_depth = 1.0F});
     nt_gfx_bind_pipeline(blend_pip);
     nt_gfx_bind_vertex_input(vi);
     nt_gfx_draw(0, 3);
@@ -814,6 +814,16 @@ static void test_ground_state_after_reinit(void) {
     nt_gfx_init(&desc);
     TEST_ASSERT_TRUE(g_nt_gfx.initialized);
     TEST_ASSERT_EQUAL_INT(GL_FALSE, (int)glIsEnabled(GL_BLEND));
+
+    /* The fresh cache says the clear color is already {0,0,0,0}, so this pass
+     * dedups it: only a real glClearColor in ground state clears away the red
+     * the previous lifetime left in GL. */
+    nt_gfx_begin_frame();
+    nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_color = {0.0F, 0.0F, 0.0F, 0.0F}, .clear_depth = 1.0F});
+    uint8_t cleared_red = center_red();
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+    TEST_ASSERT_UINT8_WITHIN(1, 0, cleared_red);
 
     nt_pipeline_t opaque_pip = make_pipeline_ex(s_vs_src, s_fs_src, false, true, false);
     nt_pipeline_t alpha_pip = make_pipeline_ex(s_vs_src, s_fs_src, false, true, true);
@@ -1081,8 +1091,9 @@ static void test_gl_name_reuse_after_destroying_bound_texture(void) {
     TEST_ASSERT_EQUAL_UINT32(GL_NO_ERROR, glGetError());
 }
 
-/* update_texture uploads on the scratch unit, so the texture sampling slot 0
- * holds stays bound there and re-binding it mid-pass costs no GL call. */
+/* update_texture and plain creation both upload on the scratch unit, so the
+ * texture sampling slot 0 holds stays bound there and re-binding it mid-pass
+ * costs no GL call. */
 static void test_update_texture_mid_pass_leaves_sampling_slot_bound(void) {
     static const uint8_t white[4] = {255, 255, 255, 255};
     static const uint8_t grey[4] = {128, 128, 128, 255};
@@ -1096,6 +1107,10 @@ static void test_update_texture_mid_pass_leaves_sampling_slot_bound(void) {
     nt_gfx_begin_frame();
     begin_black_pass();
     nt_gfx_bind_texture(tex_1, 0);
+    /* A failed create would leave slot 0 untouched and false-pass the next line. */
+    nt_texture_t created_mid_pass = make_pixel_texture(grey);
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, created_mid_pass.id);
+    TEST_ASSERT_EQUAL_INT(name_1, texture_name_on_unit(0));
     nt_gfx_update_texture(tex_2, 0, 0, 1, 1, white);
 
     GLint upload_unit = 0;
@@ -1152,6 +1167,33 @@ static void test_upload_burst_costs_one_active_texture_switch(void) {
     TEST_ASSERT_EQUAL_UINT32(3, burst_bind);
     TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.bind_texture);
     TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.active_texture);
+}
+
+/* Resizing a render target deletes the old colour texture, so its GL name must
+ * leave the cache: old and new names are both live during the resize, so only
+ * the cache probe can see the forget. Depth NONE keeps the colour texture the
+ * one the resize touches last. */
+static void test_resize_render_target_forgets_cached_color_name(void) {
+    nt_render_target_t rt = nt_gfx_make_render_target(&(nt_render_target_desc_t){
+        .width = 4,
+        .height = 4,
+        .color_format = NT_TEXTURE_FORMAT_RGBA8,
+        .color_min_filter = NT_FILTER_NEAREST,
+        .color_mag_filter = NT_FILTER_NEAREST,
+        .color_wrap_u = NT_WRAP_CLAMP_TO_EDGE,
+        .color_wrap_v = NT_WRAP_CLAMP_TO_EDGE,
+        .depth_storage = NT_RT_DEPTH_NONE,
+    });
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, rt.id);
+
+    nt_gfx_bind_texture(nt_gfx_render_target_color(rt), 0);
+    /* Without this the probe below would pass on a texture that never cached. */
+    TEST_ASSERT_NOT_EQUAL_UINT32(0, nt_gfx_gl_test_cached_texture(0));
+
+    TEST_ASSERT_TRUE(nt_gfx_resize_render_target(rt, 6, 5));
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_gl_test_cached_texture(0));
+
+    nt_gfx_destroy_render_target(rt);
 }
 
 /* Destruction must release the current GL program even without another bind. */
@@ -1230,6 +1272,7 @@ int main(void) {
     RUN_TEST(test_gl_name_reuse_after_destroying_bound_texture);
     RUN_TEST(test_update_texture_mid_pass_leaves_sampling_slot_bound);
     RUN_TEST(test_upload_burst_costs_one_active_texture_switch);
+    RUN_TEST(test_resize_render_target_forgets_cached_color_name);
     RUN_TEST(test_destroy_current_program_then_relink_reissues_use_program);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_gfx_bind_mirrors_native.c
+++ b/tests/unit/test_nt_gfx_bind_mirrors_native.c
@@ -1005,8 +1005,8 @@ static void test_recreate_all_resources_grounds_cache(void) {
     TEST_ASSERT_EQUAL_UINT32(1, s_gl_calls.enable_blend);
 }
 
-/* Destroying the bound vertex input clears the cached VAO name: a new VAO that
- * reuses the deleted GL name must still reach glBindVertexArray. */
+/* Deterministic half: destroying the bound vertex input clears the cached VAO
+ * name. The redraw half only bites on drivers that recycle the deleted name. */
 static void test_gl_name_reuse_after_destroying_bound_vertex_input(void) {
     nt_pipeline_t pip = make_red_pipeline();
     nt_buffer_t vbo = make_vbo(s_full);
@@ -1019,6 +1019,7 @@ static void test_gl_name_reuse_after_destroying_bound_vertex_input(void) {
     nt_gfx_draw(0, 3);
     TEST_ASSERT_UINT8_WITHIN(1, 255, center_red());
     nt_gfx_destroy_vertex_input(vi_a); /* destroyed while bound */
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_gl_test_cached_vao());
     nt_gfx_end_pass();
     nt_gfx_end_frame();
 
@@ -1038,34 +1039,41 @@ static void test_gl_name_reuse_after_destroying_bound_vertex_input(void) {
 
 static nt_texture_t make_pixel_texture(const uint8_t pixel[4]) { return nt_gfx_make_texture(&(nt_texture_desc_t){.width = 1, .height = 1, .data = pixel, .format = NT_TEXTURE_FORMAT_RGBA8}); }
 
-/* Creation leaves its own texture bound on the active unit. */
+/* Creation uploads on the scratch unit and leaves it active, so this reads the
+ * new texture's GL name. */
 static GLint current_texture_name(void) {
     GLint name = 0;
     glGetIntegerv(GL_TEXTURE_BINDING_2D, &name);
     return name;
 }
 
-/* Same for textures: destroy clears the cache slot, so a new texture reusing the
- * deleted GL name is not mistaken for the one still recorded there. */
+/* Deterministic half: destroy clears the slot the texture was bound in, leaving
+ * the other slots alone. The re-bind half only bites on drivers that recycle the
+ * deleted GL name. */
 static void test_gl_name_reuse_after_destroying_bound_texture(void) {
     static const uint8_t white[4] = {255, 255, 255, 255};
     static const uint8_t grey[4] = {128, 128, 128, 255};
     nt_texture_t tex_a = make_pixel_texture(white);
     nt_texture_t keep = make_pixel_texture(grey);
+    GLint name_keep = current_texture_name();
     TEST_ASSERT_NOT_EQUAL_UINT32(0, tex_a.id);
     TEST_ASSERT_NOT_EQUAL_UINT32(0, keep.id);
+    TEST_ASSERT_NOT_EQUAL_INT(0, name_keep);
 
     nt_gfx_bind_texture(tex_a, 0);
     nt_gfx_bind_texture(keep, 1);
 
     nt_gfx_destroy_texture(tex_a);
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_gl_test_cached_texture(0));
+    TEST_ASSERT_EQUAL_UINT32((uint32_t)name_keep, nt_gfx_gl_test_cached_texture(1));
+
     nt_texture_t tex_b = make_pixel_texture(white);
     TEST_ASSERT_NOT_EQUAL_UINT32(0, tex_b.id);
     GLint name_b = current_texture_name();
     TEST_ASSERT_NOT_EQUAL_INT(0, name_b);
 
     nt_gfx_bind_texture(tex_b, 0);
-    TEST_ASSERT_EQUAL_INT(name_b, current_texture_name());
+    TEST_ASSERT_EQUAL_INT(name_b, texture_name_on_unit(0));
     TEST_ASSERT_EQUAL_UINT32(GL_NO_ERROR, glGetError());
 }
 
@@ -1142,8 +1150,8 @@ static void test_upload_burst_costs_one_active_texture_switch(void) {
     TEST_ASSERT_EQUAL_UINT32(0, s_gl_calls.active_texture);
 }
 
-/* Destroying the current program clears the cached name: a relink that reuses it
- * must still reach glUseProgram, now that the cache outlives the frame. */
+/* Deterministic half: destroying the current program clears the cached name.
+ * The glUseProgram count only bites when the relink recycles the deleted name. */
 static void test_destroy_current_program_then_relink_reissues_use_program(void) {
     nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = s_vs_src});
     nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = s_fs_src});
@@ -1160,6 +1168,7 @@ static void test_destroy_current_program_then_relink_reissues_use_program(void) 
     nt_gfx_end_frame();
 
     nt_gfx_destroy_program(prog_p); /* cascades into pip_p */
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_gl_test_cached_program());
     nt_program_t prog_q = nt_gfx_make_program(vs, fs);
     nt_pipeline_t pip_q = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = prog_q});
     TEST_ASSERT_TRUE(nt_gfx_pipeline_valid(pip_q));

--- a/tests/unit/test_nt_gfx_bind_mirrors_native.c
+++ b/tests/unit/test_nt_gfx_bind_mirrors_native.c
@@ -897,6 +897,52 @@ static void test_ground_state_viewport_reissued_after_reinit(void) {
     TEST_ASSERT_EQUAL_INT((int)g_nt_window.fb_height, viewport[3]);
 }
 
+/* Uniform values are program state: the front-end names the bound pipeline's
+ * program on every write, so two programs keep their own value. */
+static void test_uniform_write_targets_bound_pipelines_program(void) {
+    static const char *vs_src = "void main() { gl_Position = vec4(0.0, 0.0, 0.0, 1.0); }\n";
+    static const char *fs_src = "precision mediump float;\n"
+                                "uniform vec4 u_x;\n"
+                                "out vec4 frag_color;\n"
+                                "void main() { frag_color = u_x; }\n";
+    const float value_a[4] = {1.0F, 2.0F, 3.0F, 4.0F};
+    const float value_b[4] = {5.0F, 6.0F, 7.0F, 8.0F};
+
+    nt_pipeline_t pip_a = make_pipeline_ex(vs_src, fs_src, false, true, false);
+    nt_pipeline_t pip_b = make_pipeline_ex(vs_src, fs_src, false, true, false);
+
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip_a);
+    GLint program_a = 0;
+    glGetIntegerv(GL_CURRENT_PROGRAM, &program_a);
+    nt_gfx_set_uniform_vec4(nt_hash32_str("u_x"), value_a);
+
+    nt_gfx_bind_pipeline(pip_b);
+    GLint program_b = 0;
+    glGetIntegerv(GL_CURRENT_PROGRAM, &program_b);
+    nt_gfx_set_uniform_vec4(nt_hash32_str("u_x"), value_b);
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+
+    TEST_ASSERT_NOT_EQUAL_INT(0, program_a);
+    TEST_ASSERT_NOT_EQUAL_INT(program_a, program_b);
+
+    GLint location_a = glGetUniformLocation((GLuint)program_a, "u_x");
+    GLint location_b = glGetUniformLocation((GLuint)program_b, "u_x");
+    TEST_ASSERT_GREATER_OR_EQUAL_INT(0, location_a);
+    TEST_ASSERT_GREATER_OR_EQUAL_INT(0, location_b);
+
+    GLfloat read_a[4] = {0.0F, 0.0F, 0.0F, 0.0F};
+    GLfloat read_b[4] = {0.0F, 0.0F, 0.0F, 0.0F};
+    glGetUniformfv((GLuint)program_a, location_a, read_a);
+    glGetUniformfv((GLuint)program_b, location_b, read_b);
+    for (uint32_t i = 0; i < 4; i++) {
+        TEST_ASSERT_EQUAL_INT32((int32_t)value_a[i], (int32_t)read_a[i]);
+        TEST_ASSERT_EQUAL_INT32((int32_t)value_b[i], (int32_t)read_b[i]);
+    }
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_vertex_inputs_alternate_under_one_pipeline);
@@ -917,5 +963,6 @@ int main(void) {
     RUN_TEST(test_viewport_dedup_and_resize);
     RUN_TEST(test_clear_values_dedup);
     RUN_TEST(test_ground_state_viewport_reissued_after_reinit);
+    RUN_TEST(test_uniform_write_targets_bound_pipelines_program);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_gfx_render_target_native.c
+++ b/tests/unit/test_nt_gfx_render_target_native.c
@@ -584,6 +584,8 @@ static void test_depth_buffer_uses_explicit_format(void) {
     nt_gfx_destroy_render_target(target);
 }
 
+/* The clear runs with the depth mask forced on and leaves it on; the pipeline
+ * that wants it off must be re-bound inside the new pass. */
 static void test_begin_pass_clears_depth_after_depth_writes_were_disabled(void) {
     static const char *vertex_source = "void main() { gl_Position = vec4(0.0); }\n";
     static const char *fragment_source = "#ifdef GL_ES\n"
@@ -624,6 +626,7 @@ static void test_begin_pass_clears_depth_after_depth_writes_were_disabled(void) 
     glReadPixels(0, 0, 1, 1, GL_DEPTH_COMPONENT, GL_FLOAT, &depth);
     uint32_t depth_milli = (uint32_t)((depth * 1000.0F) + 0.5F);
     TEST_ASSERT_UINT32_WITHIN(1, 750, depth_milli);
+    nt_gfx_bind_pipeline(no_depth_write_pipeline);
     GLboolean depth_write_enabled = GL_TRUE;
     glGetBooleanv(GL_DEPTH_WRITEMASK, &depth_write_enabled);
     TEST_ASSERT_EQUAL_INT(GL_FALSE, depth_write_enabled);

--- a/tests/unit/test_nt_gfx_scissor.c
+++ b/tests/unit/test_nt_gfx_scissor.c
@@ -6,6 +6,7 @@
 #include "unity.h"
 
 #include "graphics/nt_gfx.h"
+#include "graphics/nt_gfx_internal.h"
 
 void setUp(void) {
     nt_gfx_init(&(nt_gfx_desc_t){
@@ -64,11 +65,22 @@ static void test_viewport_survives_scissor_toggle(void) {
     TEST_ASSERT_EQUAL_INT(600, rect[3]);
 }
 
+/* The front-end mirror owns scissor enable, so a repeated value never reaches the backend. */
+static void test_scissor_enable_dedups_before_the_backend(void) {
+    nt_gfx_stub_test_reset();
+    nt_gfx_set_scissor_enabled(true);
+    nt_gfx_set_scissor_enabled(true);
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_stub_test_set_scissor_enabled_count());
+    nt_gfx_set_scissor_enabled(false);
+    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_stub_test_set_scissor_enabled_count());
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_set_scissor_round_trips);
     RUN_TEST(test_set_scissor_enabled_round_trips);
     RUN_TEST(test_set_viewport_round_trips);
     RUN_TEST(test_viewport_survives_scissor_toggle);
+    RUN_TEST(test_scissor_enable_dedups_before_the_backend);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_gfx_scissor.c
+++ b/tests/unit/test_nt_gfx_scissor.c
@@ -75,6 +75,26 @@ static void test_scissor_enable_dedups_before_the_backend(void) {
     TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_stub_test_set_scissor_enabled_count());
 }
 
+/* Restore clears the mirror, so the same value must reach the backend again --
+ * without that reset the front-end dedup would swallow it forever. */
+static void test_context_restore_resets_the_scissor_mirror(void) {
+    nt_gfx_stub_test_reset();
+    nt_gfx_set_scissor_enabled(true);
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_stub_test_set_scissor_enabled_count());
+
+    nt_gfx_stub_test_set_context_lost(true);
+    nt_gfx_begin_frame();
+    TEST_ASSERT_TRUE(g_nt_gfx.context_lost);
+    nt_gfx_stub_test_set_context_lost(false);
+    nt_gfx_begin_frame();
+    TEST_ASSERT_FALSE(g_nt_gfx.context_lost);
+    TEST_ASSERT_FALSE(nt_gfx_scissor_enabled());
+
+    nt_gfx_set_scissor_enabled(true);
+    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_stub_test_set_scissor_enabled_count());
+    nt_gfx_end_frame();
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_set_scissor_round_trips);
@@ -82,5 +102,6 @@ int main(void) {
     RUN_TEST(test_set_viewport_round_trips);
     RUN_TEST(test_viewport_survives_scissor_toggle);
     RUN_TEST(test_scissor_enable_dedups_before_the_backend);
+    RUN_TEST(test_context_restore_resets_the_scissor_mirror);
     return UNITY_END();
 }


### PR DESCRIPTION
Closes #358.

## What

The GL state cache now describes real GL state continuously across passes and frames. Ground state is issued only where the engine genuinely loses knowledge: backend init and context restore. The per-frame reset (13 GL calls, then a full re-issue on the first bind) is gone.

The reset was never about resize or drivers. It was added in 24fddb90 to heal a stale depth mask left by a `depth_write=false` pipeline, and that bug was fixed at the source in #281. Nothing outside the backend issues GL in the runtime (verified by grep), GLFW and WebGL leave GL state alone on resize, and the viewport is written in every pass.

## Design decisions

- **Bound state is pass-scoped.** `begin_pass` discards the bound pipeline / vertex input / index type; pipeline and vertex-input binds, instance-buffer re-pointing, uniform writes and draws outside a pass assert. The pass is the only place the engine itself changes draw state, so the logical boundary sits there. The pass clear forces the depth mask on and leaves it on; the pass's first pipeline bind re-applies its own mask through the cache diff. A re-bind of the same pipeline costs zero GL calls.
- **The backend keeps GL-mirror state only.** `set_uniform_*` names its program (uniform values are program state), `bind_instance_buffer` names its vertex input; `s_bound_pipeline_slot` / `s_bound_vertex_input_slot` are deleted. The backend asserts "named program is current" and "named vertex input is the bound VAO".
- **Three backend handle contracts** instead of one blurry zero: `destroy_*` tolerates 0 (as `glDelete*`); 0 is an explicit unbind only for `bind_vertex_input` / `bind_sampler`; every other bind requires a live handle. Husks are front-end knowledge: `bind_texture` on a texture whose restore failed logs once and returns (runtime GPU failure), `bind_uniform_buffer` / `bind_instance_buffer` on a buffer husk assert (owner skipped the recreate contract).
- **Viewport, clear color and clear depth join the cache**; scissor-enable dedup lives in the front-end mirror (one owner per state). Scissor rect stays uncached: the UI emits a distinct rect per clipped element.
- **Uploads use a scratch texture unit** (`GL_TEXTURE0 + NT_GFX_MAX_TEXTURE_SLOTS`), so sampling units are never disturbed and the upload-time cache invalidation is deleted.

## Holes closed on the way

- `update_texture` and the compressed create bound raw and invalidated the cache only at function exit; every failure return in between left the cache naming a texture GL no longer had bound. The per-frame reset hid it.
- Ground state never disabled `GL_SCISSOR_TEST`; on native the context outlives `nt_gfx_shutdown`/`init`, so the front-end mirror could lie after re-init.

## Rejected

CPU-only `invalidate` API (no consumer; raw GL interop is not a contract). Web JS reset helper. Sampler bind caching (#359). `glGet*`-based cache init. Per-frame browser timing: 13 calls is microseconds; the deterministic call count is the evidence.

## Evidence

Real-GL tests count backend calls by swapping glad function pointers: an identical second frame issues 0 program/VAO/state/texture/viewport/clear calls; a state change mid-frame still emits; ground state after re-init and after `recreate_all_resources` is proven via `glIsEnabled`; the depth-clear test pins `glDepthMask == 1` across clear + first bind (3 with the old restore dance). Stub tests pin the pass-scoped traps and the husk contracts. Three name-reuse tests (VAO / texture / program after destroying the bound one) are vacuous on desktop drivers that do not recycle names and bite under Mesa on CI.

Follow-ups noted, not in this PR: `examples/devapi_host` calls `nt_ui_begin/end` outside a pass (works only because that UI emits nothing); default sampler is re-issued on every `bind_texture` (#359).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JEiWKwnMhnB7ZibTBPMPAL
