### PR TITLE
gfx: cache repeated vec4 uniform uploads

### DIFF
--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -130,7 +130,9 @@ each consumer sets every uniform it needs on every material transition inside
 one `draw_list` call or flush. Renderer-tracked bound state is discarded at the
 end of that call; across calls the GL backend deduplicates program, VAO,
 pipeline state, texture, sampler, viewport and clear-value binds (scissor-enable is deduplicated by the
-front-end mirror), while uniform writes are always issued. The
+front-end mirror). Standalone float vec4 writes are skipped when their bytes
+match the last submitted value for that program and uniform; other uniform
+writes are issued unchanged. The
 backend GL cache persists across passes and frames; ground state is issued once
 at backend init and at context restore. Sampler uniforms are not written at all:
 their units are fixed at link and belong to the program, so no material can
@@ -142,10 +144,9 @@ asserts before backend binds; inactive names are ignored before their handles
 are inspected. Context loss, a texture husk, or failed sampler recreation
 publishes no set and issues no backend bind: gfx reports the failure and skips
 the following draws of that set. A vec4 param a material
-does not declare still retains the value last written on that program; the
-planned fix is per-material param UBOs bound at material transitions (#133).
-Until that lands, two materials sharing one program must declare the same
-params. Destroying a program destroys its
+does not declare still retains the value last written on that program.
+Consumers must supply every numeric value they rely on; the vec4 cache neither
+validates material completeness nor resets omitted values. Destroying a program destroys its
 pipelines, and a context loss frees every pipeline slot; renderers remove
 dead cache records during insertion after a miss or when resetting their
 caches.

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -125,9 +125,9 @@ write with nothing bound asserts. A pipeline is fixed-function render
 state that *borrows* a program handle — it owns no vertex-input state, and
 pipeline and vertex-input binding are orthogonal: either may change without
 re-binding the other. Two pipelines on one program
-share every uniform value, and binding one does not reset what the other set —
-each consumer sets every uniform it needs on every material transition inside
-one `draw_list` call or flush. Renderer-tracked bound state is discarded at the
+share every uniform value, and binding one does not reset what the other set.
+Renderers replay declared material params on each material or pipeline transition
+inside one `draw_list` call or flush. Renderer-tracked bound state is discarded at the
 end of that call; across calls the GL backend deduplicates program, VAO,
 pipeline state, texture, sampler, viewport and clear-value binds (scissor-enable is deduplicated by the
 front-end mirror). Standalone float vec4 writes are skipped when their bytes
@@ -145,8 +145,11 @@ are inspected. Context loss, a texture husk, or failed sampler recreation
 publishes no set and issues no backend bind: gfx reports the failure and skips
 the following draws of that set. A vec4 param a material
 does not declare still retains the value last written on that program.
-Consumers must supply every numeric value they rely on; the vec4 cache neither
-validates material completeness nor resets omitted values. Destroying a program destroys its
+Before each draw, the game and renderer must ensure the program holds every
+numeric uniform value that draw needs. Materials supply only their declared
+params; any required value they omit must be explicitly established by the game
+or renderer. The vec4 cache neither validates material completeness nor resets
+omitted values. Destroying a program destroys its
 pipelines, and a context loss frees every pipeline slot; renderers remove
 dead cache records during insertion after a miss or when resetting their
 caches.

--- a/docs/spec/render/shader.md
+++ b/docs/spec/render/shader.md
@@ -73,6 +73,16 @@ setters take that hash — `nt_gfx_set_uniform_vec4(nt_hash32_t name, …)` and 
 three siblings — and there is no string form: a caller hashes the name once at
 init, or inline where the cost does not matter.
 
+For active standalone float vec4 uniforms, the backend also remembers the last
+16 submitted bytes. Bit-identical repeats skip `glUniform4fv`; the first write,
+including zero, always reaches GL. Signed zero and distinct NaN payloads are
+compared by representation, without an epsilon. Values belong to the linked
+program and survive pipeline switches, passes and frames. Recreated programs
+start with invalid cached values. All gfx vec4 writers share this cache; other
+uniform types retain their existing setter behavior, including boolean targets
+that accept float-vector conversion. Inactive names remain no-ops. Cache lookup
+and updates allocate nothing.
+
 Sampler uniforms are program state, not material state: their texture units are
 fixed at link and nobody writes them afterwards. Reflection classifies every
 active uniform by type — `sampler2D`, `sampler2DShadow`, and `usampler2D` are

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -109,6 +109,9 @@ typedef struct {
     GLuint program;
     nt_cached_uniform_t uniforms[NT_MAX_CACHED_UNIFORMS];
     uint8_t uniform_count;
+    uint16_t vec4_mask;
+    uint16_t vec4_valid;
+    uint8_t vec4_values[NT_MAX_CACHED_UNIFORMS][4 * sizeof(float)];
     /* Sampler units are program state: assigned in reflection order at link,
      * written once, never rewritten by a material. */
     nt_gfx_gl_sampler_unit_t sampler_units[NT_GFX_MAX_TEXTURE_SLOTS];
@@ -230,20 +233,20 @@ static struct {
 
 /* ---- Per-program uniform location lookup ---- */
 
-static GLint program_uniform_location(const nt_gfx_gl_program_t *prog, uint32_t name_hash) {
+static int program_uniform_index(const nt_gfx_gl_program_t *prog, uint32_t name_hash) {
     for (uint8_t i = 0; i < prog->uniform_count; i++) {
         if (prog->uniforms[i].name_hash == name_hash) {
-            return prog->uniforms[i].location;
+            return i;
         }
     }
     return -1;
 }
 
-static GLint program_get_uniform_h(uint32_t program_backend, uint32_t name_hash) {
+static int program_get_uniform_index(uint32_t program_backend, uint32_t name_hash) {
     NT_ASSERT(program_backend != 0 && program_backend <= s_init_desc.max_programs && s_programs[program_backend].program != 0 && "set_uniform: requires a live program");
     /* glUniform* writes into the current program, so the named one must be it. */
     NT_ASSERT(s_programs[program_backend].program == s_gl_cache.program && "uniform write targets a program that is not current");
-    return program_uniform_location(&s_programs[program_backend], name_hash);
+    return program_uniform_index(&s_programs[program_backend], name_hash);
 }
 
 bool nt_gfx_backend_program_sampler_info(uint32_t program_backend, uint32_t name_hash, nt_gfx_sampler_info_t *out_info) {
@@ -982,33 +985,45 @@ void nt_gfx_backend_bind_pipeline(uint32_t backend_handle) {
 /* ---- Uniforms ---- */
 
 void nt_gfx_backend_set_uniform_mat4(uint32_t program_backend, uint32_t name_hash, const float *matrix) {
-    GLint loc = program_get_uniform_h(program_backend, name_hash);
-    if (loc >= 0) {
-        glUniformMatrix4fv(loc, 1, GL_FALSE, matrix);
+    int index = program_get_uniform_index(program_backend, name_hash);
+    if (index >= 0) {
+        glUniformMatrix4fv(s_programs[program_backend].uniforms[index].location, 1, GL_FALSE, matrix);
     }
 }
 
 void nt_gfx_backend_set_uniform_vec4(uint32_t program_backend, uint32_t name_hash, const float *vec) {
-    GLint loc = program_get_uniform_h(program_backend, name_hash);
-    if (loc >= 0) {
-        glUniform4fv(loc, 1, vec);
+    int index = program_get_uniform_index(program_backend, name_hash);
+    if (index < 0) {
+        return;
+    }
+    nt_gfx_gl_program_t *prog = &s_programs[program_backend];
+    const uint16_t bit = (uint16_t)(1U << (uint32_t)index);
+    // Other setters can change boolean uniforms that also accept glUniform4fv.
+    const bool cacheable = (prog->vec4_mask & bit) != 0;
+    if (cacheable && (prog->vec4_valid & bit) != 0 && memcmp(prog->vec4_values[index], (const void *)vec, sizeof(prog->vec4_values[index])) == 0) {
+        return;
+    }
+    glUniform4fv(prog->uniforms[index].location, 1, vec);
+    if (cacheable) {
+        memcpy(prog->vec4_values[index], vec, sizeof(prog->vec4_values[index]));
+        prog->vec4_valid |= bit;
     }
 }
 
 void nt_gfx_backend_set_uniform_float(uint32_t program_backend, uint32_t name_hash, float val) {
-    GLint loc = program_get_uniform_h(program_backend, name_hash);
-    if (loc >= 0) {
-        glUniform1f(loc, val);
+    int index = program_get_uniform_index(program_backend, name_hash);
+    if (index >= 0) {
+        glUniform1f(s_programs[program_backend].uniforms[index].location, val);
     }
 }
 
 void nt_gfx_backend_set_uniform_int(uint32_t program_backend, uint32_t name_hash, int val) {
-    GLint loc = program_get_uniform_h(program_backend, name_hash);
+    int index = program_get_uniform_index(program_backend, name_hash);
     nt_gfx_sampler_info_t sampler_info = {0};
     const bool is_sampler = nt_gfx_backend_program_sampler_info(program_backend, name_hash, &sampler_info);
     NT_ASSERT(!is_sampler && "sampler uniforms are immutable; use nt_gfx_apply_texture_bindings");
-    if (loc >= 0) {
-        glUniform1i(loc, val);
+    if (index >= 0) {
+        glUniform1i(s_programs[program_backend].uniforms[index].location, val);
     }
 }
 
@@ -1214,6 +1229,8 @@ static bool nt_gfx_gl_cache_uniforms(GLuint program, nt_gfx_gl_program_t *rec) {
     nt_cached_uniform_t *out = rec->uniforms;
     uint8_t *out_count = &rec->uniform_count;
     rec->sampler_count = 0;
+    rec->vec4_mask = 0;
+    rec->vec4_valid = 0;
     *out_count = 0;
     GLint active_uniforms = -1;
     glGetProgramiv(program, GL_ACTIVE_UNIFORMS, &active_uniforms);
@@ -1261,6 +1278,9 @@ static bool nt_gfx_gl_cache_uniforms(GLuint program, nt_gfx_gl_program_t *rec) {
                     if (uniform_count < NT_MAX_CACHED_UNIFORMS) {
                         out[uniform_count].name_hash = name_hash;
                         out[uniform_count].location = loc;
+                        if (utype == GL_FLOAT_VEC4) {
+                            rec->vec4_mask |= (uint16_t)(1U << uniform_count);
+                        }
                     }
                     uniform_count++;
                 }

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -999,13 +999,12 @@ void nt_gfx_backend_set_uniform_vec4(uint32_t program_backend, uint32_t name_has
     }
     nt_gfx_gl_program_t *prog = &s_programs[program_backend];
     const uint16_t bit = (uint16_t)(1U << (uint32_t)index);
-    // Preserve uncached GL handling for other uniform types.
-    const bool cacheable = (prog->vec4_mask & bit) != 0;
-    if (cacheable && (prog->vec4_valid & bit) != 0 && memcmp(prog->vec4_values[index], (const void *)vec, sizeof(prog->vec4_values[index])) == 0) {
+    if ((prog->vec4_valid & bit) != 0 && memcmp(prog->vec4_values[index], (const void *)vec, sizeof(prog->vec4_values[index])) == 0) {
         return;
     }
     glUniform4fv(prog->uniforms[index].location, 1, vec);
-    if (cacheable) {
+    // Preserve uncached GL handling for other uniform types.
+    if ((prog->vec4_mask & bit) != 0) {
         memcpy(prog->vec4_values[index], vec, sizeof(prog->vec4_values[index]));
         prog->vec4_valid |= bit;
     }

--- a/engine/graphics/gl/nt_gfx_gl.c
+++ b/engine/graphics/gl/nt_gfx_gl.c
@@ -68,6 +68,7 @@ extern void glGetQueryObjectui64vEXT(GLuint id, GLenum pname, GLuint64 *params);
 
 /* Per-program standalone locations, including each array element. */
 #define NT_MAX_CACHED_UNIFORMS 16
+_Static_assert(NT_MAX_CACHED_UNIFORMS <= 16, "vec4_mask and vec4_valid are 16-bit");
 /* Longest reflected uniform name plus room for an expanded array index; asserted at link. */
 #define NT_GFX_GL_MAX_UNIFORM_NAME 256
 
@@ -998,7 +999,7 @@ void nt_gfx_backend_set_uniform_vec4(uint32_t program_backend, uint32_t name_has
     }
     nt_gfx_gl_program_t *prog = &s_programs[program_backend];
     const uint16_t bit = (uint16_t)(1U << (uint32_t)index);
-    // Other setters can change boolean uniforms that also accept glUniform4fv.
+    // Preserve uncached GL handling for other uniform types.
     const bool cacheable = (prog->vec4_mask & bit) != 0;
     if (cacheable && (prog->vec4_valid & bit) != 0 && memcmp(prog->vec4_values[index], (const void *)vec, sizeof(prog->vec4_values[index])) == 0) {
         return;

--- a/tests/browser/app/main.c
+++ b/tests/browser/app/main.c
@@ -116,6 +116,7 @@ static nt_pipeline_t s_mesh_pipeline;
 static nt_vertex_input_t s_mesh_vi;
 static nt_buffer_t s_mesh_instance_buf;
 static uint32_t s_mesh_handle;
+static nt_hash32_t s_mesh_color_name;
 static uint32_t s_mesh_index_count, s_mesh_vertex_count;
 
 static const char *s_mesh_vs_src = "precision mediump float;\n"
@@ -124,11 +125,13 @@ static const char *s_mesh_vs_src = "precision mediump float;\n"
                                    "void main() { gl_Position = vec4(a_position.xy * 0.1 + i_offset, 0.0, 1.0); }\n";
 static const char *s_mesh_fs_src = "precision mediump float;\n"
                                    "out vec4 frag_color;\n"
-                                   "void main() { frag_color = vec4(0.0, 1.0, 0.0, 1.0); }\n";
+                                   "uniform vec4 u_probe_color;\n"
+                                   "void main() { frag_color = u_probe_color; }\n";
 
 /* False when the context is (still) lost mid-restore: the caller retries on a
  * later frame; partial handles are {0}-safe for mesh_probe_destroy. */
 static bool mesh_probe_create(void) {
+    s_mesh_color_name = nt_hash32_str("u_probe_color");
     /* Unit quad, one float3 position stream, uint16 indices. */
     static const float verts[12] = {0.0F, 0.0F, 0.0F, 1.0F, 0.0F, 0.0F, 1.0F, 1.0F, 0.0F, 0.0F, 1.0F, 0.0F};
     static const uint16_t indices[6] = {0, 1, 2, 0, 2, 3};
@@ -201,6 +204,8 @@ static void mesh_probe_draw(void) {
     float inst[6] = {0.0F, 0.0F, 0.85F, -0.95F, 0.85F, -0.82F};
     nt_gfx_update_buffer(s_mesh_instance_buf, 0, inst, sizeof(inst));
     nt_gfx_bind_pipeline(s_mesh_pipeline);
+    const float color[4] = {0.25F, 0.5F, 0.75F, 1.0F};
+    nt_gfx_set_uniform_vec4(s_mesh_color_name, color);
     nt_gfx_bind_vertex_input(s_mesh_vi);
     nt_gfx_bind_instance_buffer(s_mesh_instance_buf, 8);
     nt_gfx_draw_indexed_instanced(0, s_mesh_index_count, s_mesh_vertex_count, 2);

--- a/tests/browser/context_loss.spec.ts
+++ b/tests/browser/context_loss.spec.ts
@@ -12,6 +12,7 @@ declare global {
     };
     __ntLossExtension?: WEBGL_lose_context;
     __ntBlockFloatLinear?: boolean;
+    __ntProbeUploads?: number;
   }
 }
 
@@ -42,11 +43,11 @@ function pixelsMatch(actual: number[], expected: number[]): boolean {
 }
 
 function expectMeshProbe(pixels: number[]): void {
-  let green = 0;
+  let colored = 0;
   for (let i = 0; i < pixels.length; i += 4) {
-    if (pixels[i] < 80 && pixels[i + 1] > 200 && pixels[i + 2] < 80) green++;
+    if (Math.abs(pixels[i] - 64) <= 1 && Math.abs(pixels[i + 1] - 128) <= 1 && Math.abs(pixels[i + 2] - 191) <= 1) colored++;
   }
-  expect(green, 'mesh probe must be solid green (instanced draw through an owned vertex input)').toBeGreaterThan((pixels.length / 4) * 0.9);
+  expect(colored, 'mesh probe must preserve its nonzero vec4 after program recreation').toBeGreaterThan((pixels.length / 4) * 0.9);
 }
 
 function expectVisibleProbes(sprite: number[], text: number[]): void {
@@ -72,6 +73,19 @@ test('context loss: both renderers restore their pixels after two loss cycles', 
     if (message.type() === 'error' || /\b(abort(?:ed)?|(?:GL_)?INVALID_\w+|(?:GL_)?OUT_OF_MEMORY)\b/i.test(text)) errors.push(text);
   });
   await page.addInitScript(() => {
+    const locations = new WeakSet<WebGLUniformLocation>();
+    const getLocation = WebGL2RenderingContext.prototype.getUniformLocation;
+    WebGL2RenderingContext.prototype.getUniformLocation = function(program, name) {
+      const location = getLocation.call(this, program, name);
+      if (name === 'u_probe_color' && location) locations.add(location);
+      return location;
+    };
+    const upload = WebGL2RenderingContext.prototype.uniform4fv;
+    window.__ntProbeUploads = 0;
+    WebGL2RenderingContext.prototype.uniform4fv = function(location, data, offset?, length?) {
+      if (location && locations.has(location)) window.__ntProbeUploads!++;
+      upload.call(this, location, data, offset, length);
+    };
     const getExtension = WebGL2RenderingContext.prototype.getExtension;
     WebGL2RenderingContext.prototype.getExtension = function(name: string) {
       if (name === 'OES_texture_float_linear' && window.__ntBlockFloatLinear) return null;
@@ -97,7 +111,7 @@ test('context loss: both renderers restore their pixels after two loss cycles', 
   // Right-side skin excludes the input text/caret; the caption is above the field.
   const spriteRect = { x: Math.round(canvas!.x + field.x + field.w / 2 - 32), y: Math.round(canvas!.y + field.y - 5), width: 20, height: 10 };
   const textRect = { x: Math.round(canvas!.x + 24), y: Math.round(canvas!.y + 24), width: 230, height: 24 };
-  // The wasm app's mesh probe: two instanced green quads in the bottom-right
+  // The wasm app's mesh probe: two instanced colored quads in the bottom-right
   // corner drawn through an owned vertex input (the WebGL2 VAO path). One rect
   // per quad -- the second (y 688..728) fails if only instance 0 is drawn.
   const meshRect = { x: Math.round(canvas!.x + 1194), y: Math.round(canvas!.y + 748), width: 40, height: 24 };
@@ -122,6 +136,8 @@ test('context loss: both renderers restore their pixels after two loss cycles', 
       expect(pixelsMatch(await capturePixels(page, textRect), textBaseline)).toBe(true);
     });
   }
+
+  expect(await page.evaluate(() => window.__ntProbeUploads)).toBe(1);
 
   for (let cycle = 0; cycle < 2; cycle++) {
     await test.step('context loss/restore ' + (cycle + 1), async () => {
@@ -150,6 +166,7 @@ test('context loss: both renderers restore their pixels after two loss cycles', 
       expectVisibleProbes(sprite, text);
       expectMeshProbe(await capturePixels(page, meshRect));
       expectMeshProbe(await capturePixels(page, meshRect2));
+      expect(await page.evaluate(() => window.__ntProbeUploads), 'first upload after each restore must reach GL once').toBe(cycle + 2);
       expect(pixelsMatch(sprite, spriteBaseline), 'sprite pixels after restore').toBe(true);
       expect(pixelsMatch(text, textBaseline), 'text pixels after restore').toBe(true);
       expect(errors, 'unexpected browser/gfx errors').toEqual([]);
@@ -158,3 +175,31 @@ test('context loss: both renderers restore their pixels after two loss cycles', 
   expect(errors, 'unexpected browser/gfx errors').toEqual([]);
 });
 
+
+
+test('vec4 pixel probe detects an omitted initial upload', async ({ page }) => {
+  await page.addInitScript(() => {
+    const locations = new WeakSet<WebGLUniformLocation>();
+    const getLocation = WebGL2RenderingContext.prototype.getUniformLocation;
+    WebGL2RenderingContext.prototype.getUniformLocation = function(program, name) {
+      const location = getLocation.call(this, program, name);
+      if (name === 'u_probe_color' && location) locations.add(location);
+      return location;
+    };
+    const upload = WebGL2RenderingContext.prototype.uniform4fv;
+    WebGL2RenderingContext.prototype.uniform4fv = function(location, data, offset?, length?) {
+      if (location && locations.has(location)) return;
+      upload.call(this, location, data, offset, length);
+    };
+  });
+  await page.goto('/index.html');
+  await page.waitForFunction(() => window.__nt?.ready && window.__nt.programs_ready() && window.__nt.drawn_frames() > 3);
+  const canvas = await page.locator('canvas').boundingBox();
+  expect(canvas).not.toBeNull();
+  const pixels = await capturePixels(page, { x: Math.round(canvas!.x + 1194), y: Math.round(canvas!.y + 748), width: 40, height: 24 });
+  let black = 0;
+  for (let i = 0; i < pixels.length; i += 4) {
+    if (pixels[i] === 0 && pixels[i + 1] === 0 && pixels[i + 2] === 0) black++;
+  }
+  expect(black, 'without the upload GL retains default zero, visibly different from the expected color').toBeGreaterThan(pixels.length / 4 * 0.9);
+});

--- a/tests/unit/test_nt_gfx_bind_mirrors_native.c
+++ b/tests/unit/test_nt_gfx_bind_mirrors_native.c
@@ -164,6 +164,7 @@ static void begin_black_pass(void) { nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_
  * dedup claim is measured on real GL traffic rather than on source counters. */
 static struct {
     uint32_t use_program;
+    uint32_t uniform_vec4;
     uint32_t bind_vao;
     uint32_t depth_mask;
     uint32_t depth_mask_false;
@@ -180,6 +181,7 @@ static struct {
 } s_gl_calls;
 
 static PFNGLUSEPROGRAMPROC s_saved_use_program;
+static PFNGLUNIFORM4FVPROC s_saved_uniform_vec4;
 static PFNGLBINDVERTEXARRAYPROC s_saved_bind_vao;
 static PFNGLDEPTHMASKPROC s_saved_depth_mask;
 static PFNGLENABLEPROC s_saved_enable;
@@ -190,6 +192,11 @@ static PFNGLBINDTEXTUREPROC s_saved_state_bind_texture;
 static PFNGLVIEWPORTPROC s_saved_viewport;
 static PFNGLCLEARCOLORPROC s_saved_clear_color;
 static PFNGLCLEARDEPTHPROC s_saved_clear_depth;
+
+static void GLAD_API_PTR counting_uniform_vec4(GLint location, GLsizei count, const GLfloat *value) {
+    s_gl_calls.uniform_vec4++;
+    s_saved_uniform_vec4(location, count, value);
+}
 
 static void GLAD_API_PTR counting_use_program(GLuint program) {
     s_gl_calls.use_program++;
@@ -259,6 +266,7 @@ static void GLAD_API_PTR counting_clear_depth(GLdouble depth) {
 static void install_state_counters(void) {
     memset(&s_gl_calls, 0, sizeof(s_gl_calls));
     s_saved_use_program = glad_glUseProgram;
+    s_saved_uniform_vec4 = glad_glUniform4fv;
     s_saved_bind_vao = glad_glBindVertexArray;
     s_saved_depth_mask = glad_glDepthMask;
     s_saved_enable = glad_glEnable;
@@ -270,6 +278,7 @@ static void install_state_counters(void) {
     s_saved_clear_color = glad_glClearColor;
     s_saved_clear_depth = glad_glClearDepth;
     glad_glUseProgram = counting_use_program;
+    glad_glUniform4fv = counting_uniform_vec4;
     glad_glBindVertexArray = counting_bind_vao;
     glad_glDepthMask = counting_depth_mask;
     glad_glEnable = counting_enable;
@@ -289,6 +298,7 @@ static void remove_state_counters(void) {
         return;
     }
     glad_glUseProgram = s_saved_use_program;
+    glad_glUniform4fv = s_saved_uniform_vec4;
     glad_glBindVertexArray = s_saved_bind_vao;
     glad_glDepthMask = s_saved_depth_mask;
     glad_glEnable = s_saved_enable;
@@ -300,6 +310,7 @@ static void remove_state_counters(void) {
     glad_glClearColor = s_saved_clear_color;
     glad_glClearDepth = s_saved_clear_depth;
     s_saved_use_program = NULL;
+    s_saved_uniform_vec4 = NULL;
     s_saved_bind_vao = NULL;
     s_saved_depth_mask = NULL;
     s_saved_enable = NULL;
@@ -1370,8 +1381,153 @@ static void test_ground_state_reissues_sampler_bind(void) {
 }
 // #endregion
 
+static void test_vec4_repeat_skips_physical_upload(void) {
+    const char *fs = "precision mediump float;\n"
+                     "uniform vec4 u_color;\n"
+                     "out vec4 frag_color;\n"
+                     "void main() { frag_color = u_color; }\n";
+    nt_pipeline_t pip = make_pipeline_ex(s_vs_src, fs, false, false, false);
+    nt_vertex_input_t vi = make_vi(make_vbo(s_full), (nt_buffer_t){0});
+    nt_hash32_t color = nt_hash32_str("u_color");
+    float value[4] = {0};
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi);
+    install_state_counters();
+    nt_gfx_set_uniform_vec4(color, value);
+    nt_gfx_set_uniform_vec4(color, value);
+    TEST_ASSERT_EQUAL_UINT32(1, s_gl_calls.uniform_vec4);
+    for (uint32_t i = 0; i < 4; i++) {
+        value[i] = (float)(i + 1U) * 0.25F;
+        nt_gfx_set_uniform_vec4(color, value);
+        nt_gfx_set_uniform_vec4(color, value);
+        TEST_ASSERT_EQUAL_UINT32(i + 2U, s_gl_calls.uniform_vec4);
+    }
+    nt_gfx_draw(0, 3);
+    uint8_t px[4] = {0};
+    TEST_ASSERT_TRUE(nt_gfx_read_pixels(8, 8, 1, 1, px, sizeof(px)));
+    const uint8_t expected[4] = {64, 128, 191, 255};
+    for (uint32_t i = 0; i < 4; i++) {
+        TEST_ASSERT_UINT8_WITHIN(1, expected[i], px[i]);
+    }
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+}
+
+static void test_vec4_cache_follows_program_lifetime(void) {
+    const char *fs_src = "precision mediump float;\n"
+                         "uniform vec4 u_color; out vec4 frag_color;\n"
+                         "void main() { frag_color = u_color; }\n";
+    nt_shader_t vs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_VERTEX, .source = s_vs_src});
+    nt_shader_t fs = nt_gfx_make_shader(&(nt_shader_desc_t){.type = NT_SHADER_FRAGMENT, .source = fs_src});
+    nt_program_t p = nt_gfx_make_program(vs, fs);
+    nt_program_t q = nt_gfx_make_program(vs, fs);
+    nt_pipeline_t pipelines[3] = {
+        nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = p}),
+        nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = q}),
+        nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = p, .depth_write = true}),
+    };
+    nt_hash32_t color = nt_hash32_str("u_color");
+    const float values[2][4] = {{0.25F, 0.5F, 0.75F, 1}, {0.75F, 0.5F, 0.25F, 1}};
+    nt_vertex_input_t vi = make_vi(make_vbo(s_full), (nt_buffer_t){0});
+    install_state_counters();
+    for (uint32_t frame = 0; frame < 2; frame++) {
+        nt_gfx_begin_frame();
+        for (uint32_t pass = 0; pass < 2; pass++) {
+            begin_black_pass();
+            nt_gfx_bind_vertex_input(vi);
+            for (uint32_t i = 0; i < 3; i++) {
+                nt_gfx_bind_pipeline(pipelines[i]);
+                nt_gfx_set_uniform_vec4(color, values[i == 1 ? 1 : 0]);
+                nt_gfx_draw(0, 3);
+                TEST_ASSERT_UINT8_WITHIN(1, i == 1 ? 191 : 64, center_red());
+            }
+            nt_gfx_end_pass();
+        }
+        nt_gfx_end_frame();
+    }
+    TEST_ASSERT_EQUAL_UINT32(2, s_gl_calls.uniform_vec4);
+    nt_gfx_destroy_program(p);
+    p = nt_gfx_make_program(vs, fs);
+    pipelines[0] = nt_gfx_make_pipeline(&(nt_pipeline_desc_t){.program = p});
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pipelines[0]);
+    nt_gfx_bind_vertex_input(vi);
+    nt_gfx_set_uniform_vec4(color, values[0]);
+    nt_gfx_draw(0, 3);
+    TEST_ASSERT_EQUAL_UINT32(3, s_gl_calls.uniform_vec4);
+    TEST_ASSERT_UINT8_WITHIN(1, 64, center_red());
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+}
+
+static void test_vec4_array_entries_and_other_types(void) {
+    const char *fs = "precision mediump float;\n"
+                     "uniform vec4 u_values[4]; uniform bvec4 u_gate; uniform int u_index;\n"
+                     "out vec4 frag_color;\n"
+                     "void main() { frag_color = u_values[u_index] * vec4(u_gate); }\n";
+    nt_pipeline_t pip = make_pipeline_ex(s_vs_src, fs, false, false, false);
+    nt_vertex_input_t vi = make_vi(make_vbo(s_full), (nt_buffer_t){0});
+    const nt_hash32_t names[4] = {nt_hash32_str("u_values[0]"), nt_hash32_str("u_values[1]"), nt_hash32_str("u_values[2]"), nt_hash32_str("u_values[3]")};
+    const float values[4][4] = {{0.25F, 0, 0, 1}, {0.5F, 0, 0, 1}, {0.75F, 0, 0, 1}, {1, 0, 0, 1}};
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip);
+    nt_gfx_bind_vertex_input(vi);
+    install_state_counters();
+    for (uint32_t i = 0; i < 4; i++) {
+        nt_gfx_set_uniform_vec4(names[i], values[i]);
+    }
+    nt_gfx_set_uniform_vec4(names[2], values[2]);
+    nt_gfx_set_uniform_vec4(nt_hash32_str("inactive"), values[0]);
+    TEST_ASSERT_EQUAL_UINT32(4, s_gl_calls.uniform_vec4);
+    const float gate[4] = {1, 1, 1, 1};
+    nt_gfx_set_uniform_vec4(nt_hash32_str("u_gate"), gate);
+    nt_gfx_set_uniform_vec4(nt_hash32_str("u_gate"), gate);
+    TEST_ASSERT_EQUAL_UINT32(6, s_gl_calls.uniform_vec4);
+    nt_gfx_set_uniform_int(nt_hash32_str("u_index"), 2);
+    nt_gfx_draw(0, 3);
+    TEST_ASSERT_EQUAL_UINT32(GL_NO_ERROR, glGetError());
+    TEST_ASSERT_UINT8_WITHIN(1, 191, center_red());
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+}
+
+static void test_vec4_cache_compares_bytes_and_last_value(void) {
+    const char *fs = "precision mediump float;\n"
+                     "uniform vec4 u_color; out vec4 frag_color;\n"
+                     "void main() { frag_color = u_color; }\n";
+    nt_pipeline_t pip = make_pipeline_ex(s_vs_src, fs, false, false, false);
+    nt_hash32_t color = nt_hash32_str("u_color");
+    float value[4] = {0};
+    nt_gfx_begin_frame();
+    begin_black_pass();
+    nt_gfx_bind_pipeline(pip);
+    install_state_counters();
+    nt_gfx_set_uniform_vec4(color, value);
+    value[0] = -0.0F;
+    nt_gfx_set_uniform_vec4(color, value);
+    nt_gfx_set_uniform_vec4(color, value);
+    TEST_ASSERT_EQUAL_UINT32(2, s_gl_calls.uniform_vec4);
+    value[0] = 0.25F;
+    nt_gfx_set_uniform_vec4(color, value);
+    value[0] = 0.75F;
+    nt_gfx_set_uniform_vec4(color, value);
+    value[0] = 0.25F;
+    nt_gfx_set_uniform_vec4(color, value);
+    TEST_ASSERT_EQUAL_UINT32(5, s_gl_calls.uniform_vec4);
+    nt_gfx_end_pass();
+    nt_gfx_end_frame();
+}
+
 int main(void) {
     UNITY_BEGIN();
+    RUN_TEST(test_vec4_repeat_skips_physical_upload);
+    RUN_TEST(test_vec4_cache_follows_program_lifetime);
+    RUN_TEST(test_vec4_array_entries_and_other_types);
+    RUN_TEST(test_vec4_cache_compares_bytes_and_last_value);
     RUN_TEST(test_vertex_inputs_alternate_under_one_pipeline);
     RUN_TEST(test_second_frame_issues_no_static_attrib_pointers);
     RUN_TEST(test_index_data_ops_do_not_rewire_bound_vertex_input);


### PR DESCRIPTION
Repeated vec4 values can be replayed across different materials, passes and frames even though the GL program already holds the requested value. Cache the last submitted value in each program's existing uniform entry and skip bit-identical `glUniform4fv` uploads.

Only reflected float vec4 uniforms are cached. First writes, program-slot reuse and context recovery start with invalid entries; array elements remain independent. Other uniform types and existing missing-parameter behavior are preserved. A compile-time assertion pins the uniform capacity to the 16-bit cache masks. No public API or material validation contract is added.

The specification documents the behavior and makes explicit that materials supply their declared params while the game or renderer establishes any other values required by a draw. Real-GL tests cover physical call suppression, changed values, program/pipeline lifetime and rendered pixels. Browser tests verify two actual context-loss/recovery cycles and independently check that the pixel probe detects an omitted upload.

Validation: full local `scripts/check.sh --push` (native tests, format/tidy, WASM debug/release and submodule consumption); dedicated browser context-loss suite (2 tests). Comparative benchmark sources, harnesses and data remain local and are excluded from this PR.

Closes #422.