### PR TITLE
material: resolve textures at draw, drop nt_material_step (#367)

### DIFF
--- a/docs/spec/core/api-contracts.md
+++ b/docs/spec/core/api-contracts.md
@@ -205,7 +205,8 @@ because the renderer substitutes the page texture there per command. A material
 declaring no textures never receives the page and is for shaders that compute
 coverage analytically. Every declared slot the program samples must resolve to a
 texture, in every material-driven renderer. The renderer submits one complete
-name-keyed set per material transition; gfx resolves backend units, validates
+name-keyed set per material transition, resolved from the material's declared
+`nt_resource_t` handles at that transition; gfx resolves backend units, validates
 coverage, and publishes only the full valid set. A rejected set discards the
 logical binding state, so a draw cannot reuse the previous material's textures.
 Register a placeholder with `nt_resource_set_placeholder_texture` to survive

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -50,7 +50,7 @@ no source-format parsers. The full picture is in
 | [render/architecture.md](render/architecture.md) | Engine/game render split, backend API shape, renderer classes |
 | [render/items-sorting-batching.md](render/items-sorting-batching.md) | Render tags, 16-byte render items, sorting policy, batching/instancing |
 | [render/shader.md](render/shader.md) | ShaderAsset interface and the four levels of shader data |
-| [render/material.md](render/material.md) | Material model, vec4 params, render state ownership |
+| [render/material.md](render/material.md) | Material model, vec4 params, render state ownership, draw-time texture resolve |
 | [assets/resource.md](assets/resource.md) | Resource registry, handles, resolve/publication, blob pinning, asset types |
 | [assets/async-loading.md](assets/async-loading.md) | Pack/asset state machines, async loading flow, retry policy |
 | [assets/ntpack.md](assets/ntpack.md) | NTPACK flat binary pack format and parsing |

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -200,8 +200,8 @@ between an immediate-mode emit and an ECS `draw_list`. The mesh renderer pays
 nothing for this: a pipeline change there always implies a material change.
 Texture and sampler travel together in one `nt_gfx_texture_binding_t`; a material
 without an override selects the texture's asset default. At every material
-transition (every sprite command), the renderer resolves the material's declared
-`nt_resource_t` texture handles and submits the complete semantic set once. The
+transition the renderer resolves the material's declared `nt_resource_t` texture
+handles, and every sprite command submits the complete semantic set once. The
 gfx front-end maps names to the bound program's canonical units,
 ignores inactive declarations, validates complete active coverage, and calls the
 backend only after the whole set resolves. The backend GL cache drops repeated

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -200,8 +200,9 @@ between an immediate-mode emit and an ECS `draw_list`. The mesh renderer pays
 nothing for this: a pipeline change there always implies a material change.
 Texture and sampler travel together in one `nt_gfx_texture_binding_t`; a material
 without an override selects the texture's asset default. At every material
-transition (every sprite command), the renderer submits the complete semantic
-set once. The gfx front-end maps names to the bound program's canonical units,
+transition (every sprite command), the renderer resolves the material's declared
+`nt_resource_t` texture handles and submits the complete semantic set once. The
+gfx front-end maps names to the bound program's canonical units,
 ignores inactive declarations, validates complete active coverage, and calls the
 backend only after the whole set resolves. The backend GL cache drops repeated
 physical binds. The text renderer draws once per flush and other renderers draw

--- a/docs/spec/render/material.md
+++ b/docs/spec/render/material.md
@@ -120,19 +120,29 @@ Material-wide params (e.g. global alpha cutoff, roughness) can be mutated at run
 A material stores the declared `nt_resource_t` for each texture slot and never a
 resolved handle. Renderers call `nt_resource_get` where they already transition
 material state: the mesh renderer at each material change inside a `draw_list`,
-the sprite renderer when a command opens (a page split copies the open command's
-snapshot and substitutes only the page). A text material declares no textures,
-so the text renderer resolves nothing. There is no material step.
+the sprite renderer when a command opens. A sprite command snapshots its
+textures at open and its params at flush, so a mid-frame `nt_material_set_param`
+also applies to queued commands. Slot 0 of a sprite material is the atlas page:
+the renderer substitutes the page into the open command before it stages any
+index (splitting the command when it already holds indices, which copies the
+snapshot), so the declared slot-0 resource is never resolved. A text material
+declares no textures, so the text renderer resolves no material textures; it
+binds the font's own textures. There is no material step.
 
-The published view of a resource changes only inside `nt_resource_step`, so a
-frame that steps resources before it renders sees one set of handles across every
-renderer, and a material created mid-frame binds its textures on its first draw.
+For a handle the game holds, the published view changes only inside
+`nt_resource_step`; `nt_resource_shutdown` unpublishes every slot, so a material
+that outlives the resource module resolves to 0 and trips the gfx coverage
+assert. A frame that steps resources before it emits or draws sees one set of
+handles across every renderer, and a material created mid-frame binds its
+textures on its first draw. Stepping resources between submissions within one
+frame is unsupported: commands already open keep the handles they resolved.
 
 Publication is not GPU lifetime. `nt_resource_invalidate` and
-`nt_resource_unmount` destroy GPU objects immediately, while the slot keeps
-publishing the dead handle until the next `nt_resource_step`. A game that
-invalidates textures — after a context restore, for instance — steps resources
-before it draws, or skips that frame.
+`nt_resource_unmount` destroy the GPU objects of file-pack assets immediately
+(virtual-pack handles stay game-owned), while the slot keeps publishing the dead
+handle until the next `nt_resource_step`. A game that invalidates textures —
+after a context restore, for instance — steps resources before it emits or
+draws, or skips that frame.
 
 ## Render state and material
 

--- a/docs/spec/render/material.md
+++ b/docs/spec/render/material.md
@@ -129,10 +129,10 @@ snapshot), so the declared slot-0 resource is never resolved. A text material
 declares no textures, so the text renderer resolves no material textures; it
 binds the font's own textures. There is no material step.
 
-For a handle the game holds, the published view changes only inside
-`nt_resource_step`; `nt_resource_shutdown` unpublishes every slot, so a material
-that outlives the resource module resolves to 0 and trips the gfx coverage
-assert. A frame that steps resources before it emits or draws sees one set of
+Between `nt_resource_init` and `nt_resource_shutdown`, the published view of a
+handle changes only inside `nt_resource_step`. `nt_resource_shutdown` unpublishes
+every slot: a material that outlives the resource module resolves to 0 and trips
+the gfx coverage assert. A frame that steps resources before it emits or draws sees one set of
 handles across every renderer, and a material created mid-frame binds its
 textures on its first draw. Stepping resources between submissions within one
 frame is unsupported: commands already open keep the handles they resolved.

--- a/docs/spec/render/material.md
+++ b/docs/spec/render/material.md
@@ -115,6 +115,25 @@ Per-entity variation (e.g. per-character color, dissolve progress) goes through 
 
 Material-wide params (e.g. global alpha cutoff, roughness) can be mutated at runtime via `nt_material_set_param` / `nt_material_set_param_component`. This changes the value for all entities sharing that material. The renderer re-reads params every frame, so a write needs no bookkeeping beyond the store. Hash-based overloads (`_h` suffix) accept a pre-computed `nt_hash32_t` to avoid per-frame string hashing.
 
+## Texture resolve
+
+A material stores the declared `nt_resource_t` for each texture slot and never a
+resolved handle. Renderers call `nt_resource_get` where they already transition
+material state: the mesh renderer at each material change inside a `draw_list`,
+the sprite renderer when a command opens (a page split copies the open command's
+snapshot and substitutes only the page). A text material declares no textures,
+so the text renderer resolves nothing. There is no material step.
+
+The published view of a resource changes only inside `nt_resource_step`, so a
+frame that steps resources before it renders sees one set of handles across every
+renderer, and a material created mid-frame binds its textures on its first draw.
+
+Publication is not GPU lifetime. `nt_resource_invalidate` and
+`nt_resource_unmount` destroy GPU objects immediately, while the slot keeps
+publishing the dead handle until the next `nt_resource_step`. A game that
+invalidates textures — after a context restore, for instance — steps resources
+before it draws, or skips that frame.
+
 ## Render state and material
 
 Material stores render state (blend state, depth test/write, cull mode) because it is a property of the surface, not the pass. Pipeline (GPU state object) is derived from material render state at render time; the mesh vertex layout is baked into a separately bound vertex-input object (see render/architecture.md).

--- a/engine/material/nt_material.c
+++ b/engine/material/nt_material.c
@@ -8,22 +8,11 @@
 #include "log/nt_log.h"
 #include "pool/nt_pool.h"
 
-/* ---- Internal slot struct ---- */
-
-typedef struct {
-    /* Read-only query data -- MUST be first member so nt_material_info_t* can alias */
-    nt_material_info_t info;
-
-    /* Creation-time resource handles (not in info) */
-    nt_resource_t tex_resources[NT_MATERIAL_MAX_TEXTURES];
-
-} nt_material_slot_t;
-
 /* ---- Module state ---- */
 
 static struct {
     nt_pool_t pool;
-    nt_material_slot_t *slots; /* [capacity+1], index 0 reserved */
+    nt_material_info_t *slots; /* [capacity+1], index 0 reserved */
     bool initialized;
 } s_mat;
 
@@ -40,7 +29,7 @@ nt_result_t nt_material_init(const nt_material_desc_t *desc) {
 
     nt_pool_init(&s_mat.pool, desc->max_materials);
 
-    s_mat.slots = (nt_material_slot_t *)calloc((size_t)desc->max_materials + 1, sizeof(nt_material_slot_t));
+    s_mat.slots = (nt_material_info_t *)calloc((size_t)desc->max_materials + 1, sizeof(nt_material_info_t));
     NT_ASSERT(s_mat.slots); /* alloc fail at init = fatal */
 
     s_mat.initialized = true;
@@ -54,27 +43,6 @@ void nt_material_shutdown(void) {
     free(s_mat.slots);
     nt_pool_shutdown(&s_mat.pool);
     memset(&s_mat, 0, sizeof(s_mat));
-}
-
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
-void nt_material_step(void) {
-    NT_ASSERT(s_mat.initialized); /* step before init is a dev mistake */
-    if (!s_mat.initialized) {
-        return;
-    }
-
-    for (uint32_t i = 1; i <= s_mat.pool.capacity; i++) {
-        if (!nt_pool_slot_alive(&s_mat.pool, i)) {
-            continue;
-        }
-
-        nt_material_slot_t *mat = &s_mat.slots[i];
-
-        /* Resolve textures */
-        for (uint8_t t = 0; t < mat->info.tex_count; t++) {
-            mat->info.resolved_tex[t] = nt_resource_get(mat->tex_resources[t]);
-        }
-    }
 }
 
 /* ---- Create / Destroy / Query ---- */
@@ -105,68 +73,68 @@ nt_material_t nt_material_create(const nt_material_create_desc_t *desc) {
     }
 
     uint32_t slot_index = nt_pool_slot_index(id);
-    nt_material_slot_t *slot = &s_mat.slots[slot_index];
+    nt_material_info_t *info = &s_mat.slots[slot_index];
 
     /* Clear slot */
-    memset(slot, 0, sizeof(*slot));
+    memset(info, 0, sizeof(*info));
 
-    slot->info.program = desc->program;
+    info->program = desc->program;
 
     /* Textures */
     NT_ASSERT(desc->texture_count <= NT_MATERIAL_MAX_TEXTURES);
-    slot->info.tex_count = desc->texture_count;
+    info->tex_count = desc->texture_count;
     for (uint8_t i = 0; i < desc->texture_count; i++) {
         /* A slot with no uniform name is a declaration nothing can bind. */
         NT_ASSERT(desc->textures[i].name != NULL && "material texture slot needs a sampler uniform name");
-        slot->tex_resources[i] = desc->textures[i].resource;
-        slot->info.tex_name_hashes[i] = nt_hash32_str(desc->textures[i].name).value;
-        slot->info.resolved_sampler[i] = desc->textures[i].sampler;
+        info->tex_resources[i] = desc->textures[i].resource;
+        info->tex_name_hashes[i] = nt_hash32_str(desc->textures[i].name).value;
+        info->tex_samplers[i] = desc->textures[i].sampler;
         for (uint8_t j = 0; j < i; j++) {
             /* Two slots on one sampler name would fight over its unit at every draw. */
-            NT_ASSERT(slot->info.tex_name_hashes[j] != slot->info.tex_name_hashes[i] && "two material texture slots name the same sampler uniform");
+            NT_ASSERT(info->tex_name_hashes[j] != info->tex_name_hashes[i] && "two material texture slots name the same sampler uniform");
         }
     }
 
     /* Params */
     NT_ASSERT(desc->param_count <= NT_MATERIAL_MAX_PARAMS);
-    slot->info.param_count = desc->param_count;
+    info->param_count = desc->param_count;
     for (uint8_t i = 0; i < desc->param_count; i++) {
         NT_ASSERT(desc->params[i].name != NULL && "material param needs a uniform name");
-        memcpy(slot->info.params[i], desc->params[i].value, sizeof(float) * 4);
-        slot->info.param_name_hashes[i] = nt_hash32_str(desc->params[i].name).value;
+        memcpy(info->params[i], desc->params[i].value, sizeof(float) * 4);
+        info->param_name_hashes[i] = nt_hash32_str(desc->params[i].name).value;
     }
 
     /* Attr map */
-    slot->info.attr_map_count = desc->attr_map_count;
+    info->attr_map_count = desc->attr_map_count;
     for (uint8_t i = 0; i < desc->attr_map_count; i++) {
-        slot->info.attr_map_hashes[i] = desc->attr_map[i].stream_name ? nt_hash32_str(desc->attr_map[i].stream_name).value : 0;
-        slot->info.attr_map_locations[i] = desc->attr_map[i].location;
+        info->attr_map_hashes[i] = desc->attr_map[i].stream_name ? nt_hash32_str(desc->attr_map[i].stream_name).value : 0;
+        info->attr_map_locations[i] = desc->attr_map[i].location;
     }
 
     /* Entity params */
     NT_ASSERT(desc->entity_param_count <= NT_MAX_PER_ENTITY_PARAMS);
-    slot->info.entity_param_count = desc->entity_param_count;
+    info->entity_param_count = desc->entity_param_count;
     for (uint8_t i = 0; i < desc->entity_param_count; i++) {
-        slot->info.entity_param_hashes[i] = desc->entity_params[i].name ? nt_hash32_str(desc->entity_params[i].name).value : 0;
+        info->entity_param_hashes[i] = desc->entity_params[i].name ? nt_hash32_str(desc->entity_params[i].name).value : 0;
     }
 
     /* Render state */
-    memcpy(slot->info.blend.constant_color, desc->blend.constant_color, sizeof(slot->info.blend.constant_color));
-    slot->info.blend.src_rgb = desc->blend.src_rgb;
-    slot->info.blend.dst_rgb = desc->blend.dst_rgb;
-    slot->info.blend.src_alpha = desc->blend.src_alpha;
-    slot->info.blend.dst_alpha = desc->blend.dst_alpha;
-    slot->info.blend.op_rgb = desc->blend.op_rgb;
-    slot->info.blend.op_alpha = desc->blend.op_alpha;
-    slot->info.blend.enabled = desc->blend.enabled;
-    slot->info.depth_test = desc->depth_test;
-    slot->info.depth_write = desc->depth_write;
-    slot->info.cull_mode = desc->cull_mode;
+    memcpy(info->blend.constant_color, desc->blend.constant_color, sizeof(info->blend.constant_color));
+    info->blend.src_rgb = desc->blend.src_rgb;
+    info->blend.dst_rgb = desc->blend.dst_rgb;
+    info->blend.src_alpha = desc->blend.src_alpha;
+    info->blend.dst_alpha = desc->blend.dst_alpha;
+    info->blend.op_rgb = desc->blend.op_rgb;
+    info->blend.op_alpha = desc->blend.op_alpha;
+    info->blend.enabled = desc->blend.enabled;
+    info->depth_test = desc->depth_test;
+    info->depth_write = desc->depth_write;
+    info->cull_mode = desc->cull_mode;
     NT_ASSERT((uint32_t)desc->color_mode <= NT_COLOR_MODE_FLOAT4 && "invalid color_mode -- use NT_COLOR_MODE_NONE/RGBA8/FLOAT4");
-    slot->info.color_mode = desc->color_mode;
+    info->color_mode = desc->color_mode;
 
     /* Debug label (caller must ensure static storage / string literal) */
-    slot->info.label = desc->label;
+    info->label = desc->label;
 
     return (nt_material_t){.id = id};
 }
@@ -195,7 +163,7 @@ static nt_material_info_t *get_mutable_info(nt_material_t mat) {
     if (!nt_pool_valid(&s_mat.pool, mat.id)) {
         return NULL;
     }
-    return &s_mat.slots[nt_pool_slot_index(mat.id)].info;
+    return &s_mat.slots[nt_pool_slot_index(mat.id)];
 }
 
 const nt_material_info_t *nt_material_get_info(nt_material_t mat) { return get_mutable_info(mat); }

--- a/engine/material/nt_material.h
+++ b/engine/material/nt_material.h
@@ -94,9 +94,11 @@ typedef struct {
      * program that died with the GL context or that its owner destroyed -- ask
      * nt_gfx_program_ready(program) before building a pipeline from it. */
     nt_program_t program;
-    uint32_t resolved_tex[NT_MATERIAL_MAX_TEXTURES];
+    /* Declared at create and never rewritten (unlike params); renderers call
+     * nt_resource_get on these at draw. */
+    nt_resource_t tex_resources[NT_MATERIAL_MAX_TEXTURES];
     uint32_t tex_name_hashes[NT_MATERIAL_MAX_TEXTURES];
-    nt_sampler_t resolved_sampler[NT_MATERIAL_MAX_TEXTURES]; /* per-binding sampler override; .id==0 means use texture's default */
+    nt_sampler_t tex_samplers[NT_MATERIAL_MAX_TEXTURES]; /* per-binding sampler override; .id==0 means use texture's default */
     uint8_t tex_count;
     float params[NT_MATERIAL_MAX_PARAMS][4];
     uint32_t param_name_hashes[NT_MATERIAL_MAX_PARAMS];
@@ -118,7 +120,6 @@ typedef struct {
 
 nt_result_t nt_material_init(const nt_material_desc_t *desc);
 void nt_material_shutdown(void);
-void nt_material_step(void);
 
 /* ---- Create / Destroy / Query ---- */
 

--- a/engine/renderers/CMakeLists.txt
+++ b/engine/renderers/CMakeLists.txt
@@ -10,7 +10,7 @@ nt_add_module(nt_mesh_renderer LOG_DOMAIN "mesh_renderer"
     nt_mesh_renderer.h
 )
 target_link_libraries(nt_mesh_renderer PUBLIC
-    nt_core nt_render nt_entity nt_transform_comp nt_mesh_comp nt_material_comp nt_drawable_comp nt_material
+    nt_core nt_render nt_entity nt_transform_comp nt_mesh_comp nt_material_comp nt_drawable_comp nt_material nt_resource
 )
 # Note: nt_gfx linkage provided by consumer (game links nt_gfx, tests link nt_gfx_fake)
 
@@ -18,7 +18,7 @@ nt_add_module(nt_text_renderer LOG_DOMAIN "text_renderer"
     nt_text_renderer.c
     nt_text_renderer.h
 )
-target_link_libraries(nt_text_renderer PUBLIC nt_core nt_font nt_material)
+target_link_libraries(nt_text_renderer PUBLIC nt_core nt_font nt_material nt_resource)
 target_link_libraries(nt_text_renderer PRIVATE nt_utf8)
 # Note: nt_gfx linkage provided by consumer (game links nt_gfx, tests link nt_gfx_fake)
 
@@ -28,6 +28,6 @@ nt_add_module(nt_sprite_renderer LOG_DOMAIN "sprite_renderer"
 )
 target_link_libraries(nt_sprite_renderer PUBLIC
     nt_core nt_render nt_atlas nt_sprite_comp nt_drawable_comp nt_material_comp
-    nt_transform_comp nt_material nt_entity
+    nt_transform_comp nt_material nt_entity nt_resource
 )
 # Note: nt_gfx linkage provided by consumer (game links nt_gfx, tests link nt_gfx_fake)

--- a/engine/renderers/CMakeLists.txt
+++ b/engine/renderers/CMakeLists.txt
@@ -18,7 +18,7 @@ nt_add_module(nt_text_renderer LOG_DOMAIN "text_renderer"
     nt_text_renderer.c
     nt_text_renderer.h
 )
-target_link_libraries(nt_text_renderer PUBLIC nt_core nt_font nt_material nt_resource)
+target_link_libraries(nt_text_renderer PUBLIC nt_core nt_font nt_material)
 target_link_libraries(nt_text_renderer PRIVATE nt_utf8)
 # Note: nt_gfx linkage provided by consumer (game links nt_gfx, tests link nt_gfx_fake)
 

--- a/engine/renderers/nt_mesh_renderer.c
+++ b/engine/renderers/nt_mesh_renderer.c
@@ -563,8 +563,7 @@ void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count) {
             }
 
             if (mat_changed) {
-                uint32_t resolved[NT_MATERIAL_MAX_TEXTURES] = {0};
-                const nt_renderer_material_view_t view = nt_renderer_material_view(mat_info, resolved);
+                const nt_renderer_material_view_t view = nt_renderer_material_view(mat_info);
                 nt_renderer_bind_pipeline(&bound, pip);
                 nt_renderer_apply_material_uniforms(&bound, run_mat.id, &view);
                 /* Mesh renderer texture slots come from the material alone. */

--- a/engine/renderers/nt_mesh_renderer.c
+++ b/engine/renderers/nt_mesh_renderer.c
@@ -563,7 +563,8 @@ void nt_mesh_renderer_draw_list(const nt_render_item_t *items, uint32_t count) {
             }
 
             if (mat_changed) {
-                const nt_renderer_material_view_t view = nt_renderer_material_view(mat_info);
+                uint32_t resolved[NT_MATERIAL_MAX_TEXTURES] = {0};
+                const nt_renderer_material_view_t view = nt_renderer_material_view(mat_info, resolved);
                 nt_renderer_bind_pipeline(&bound, pip);
                 nt_renderer_apply_material_uniforms(&bound, run_mat.id, &view);
                 /* Mesh renderer texture slots come from the material alone. */

--- a/engine/renderers/nt_renderer_shared.h
+++ b/engine/renderers/nt_renderer_shared.h
@@ -56,13 +56,14 @@ static inline nt_pipeline_t nt_renderer_pipeline_cache_insert(nt_renderer_pipeli
 }
 
 // #region bound state
-/* Borrowed from nt_material_info_t, or from a sprite cmd whose slot 0 is the atlas page.
+/* Borrowed from nt_material_info_t plus a caller-owned resolved-texture array, or from a
+ * sprite cmd whose slot 0 is the atlas page.
  * Hashes are captured so a cmd whose material died still replays its sampler units. */
 typedef struct {
     uint8_t tex_count;
-    const uint32_t *tex_name_hashes;      /* [tex_count] */
-    const uint32_t *resolved_tex;         /* [tex_count]; 0 = unresolved */
-    const nt_sampler_t *resolved_sampler; /* [tex_count]; .id == 0 = texture default */
+    const uint32_t *tex_name_hashes;  /* [tex_count] */
+    const uint32_t *resolved_tex;     /* [tex_count]; 0 = unresolved */
+    const nt_sampler_t *tex_samplers; /* [tex_count]; .id == 0 = texture default */
     uint8_t param_count;
     const uint32_t *param_name_hashes; /* [param_count] */
     const float (*params)[4];
@@ -120,18 +121,22 @@ static inline void nt_renderer_apply_texture_slots(const nt_renderer_material_vi
         bindings[t] = (nt_gfx_texture_binding_t){
             .name = {.value = v->tex_name_hashes[t]},
             .texture = {.id = v->resolved_tex[t]},
-            .sampler = v->resolved_sampler[t],
+            .sampler = v->tex_samplers[t],
         };
     }
     nt_gfx_apply_texture_bindings(bindings, v->tex_count);
 }
 
-static inline nt_renderer_material_view_t nt_renderer_material_view(const nt_material_info_t *mi) {
+/* resolved must outlive the view. */
+static inline nt_renderer_material_view_t nt_renderer_material_view(const nt_material_info_t *mi, uint32_t resolved[NT_MATERIAL_MAX_TEXTURES]) {
+    for (uint8_t t = 0; t < mi->tex_count; t++) {
+        resolved[t] = nt_resource_get(mi->tex_resources[t]);
+    }
     return (nt_renderer_material_view_t){
         .tex_count = mi->tex_count,
         .tex_name_hashes = mi->tex_name_hashes,
-        .resolved_tex = mi->resolved_tex,
-        .resolved_sampler = mi->resolved_sampler,
+        .resolved_tex = resolved,
+        .tex_samplers = mi->tex_samplers,
         .param_count = mi->param_count,
         .param_name_hashes = mi->param_name_hashes,
         .params = mi->params,

--- a/engine/renderers/nt_renderer_shared.h
+++ b/engine/renderers/nt_renderer_shared.h
@@ -5,6 +5,7 @@
 #include "graphics/nt_gfx.h"
 #include "log/nt_log.h"
 #include "material/nt_material.h"
+#include "resource/nt_resource.h"
 
 #include <stdbool.h>
 #include <stdint.h>
@@ -56,14 +57,14 @@ static inline nt_pipeline_t nt_renderer_pipeline_cache_insert(nt_renderer_pipeli
 }
 
 // #region bound state
-/* Borrowed from nt_material_info_t plus a caller-owned resolved-texture array, or from a
- * sprite cmd whose slot 0 is the atlas page.
+/* Owns its resolved texture ids by value; hashes, samplers and params are borrowed from
+ * nt_material_info_t, or from a sprite cmd whose slot 0 is the atlas page.
  * Hashes are captured so a cmd whose material died still replays its sampler units. */
 typedef struct {
     uint8_t tex_count;
-    const uint32_t *tex_name_hashes;  /* [tex_count] */
-    const uint32_t *resolved_tex;     /* [tex_count]; 0 = unresolved */
-    const nt_sampler_t *tex_samplers; /* [tex_count]; .id == 0 = texture default */
+    const uint32_t *tex_name_hashes;                 /* [tex_count] */
+    uint32_t resolved_tex[NT_MATERIAL_MAX_TEXTURES]; /* [tex_count]; 0 = unresolved */
+    const nt_sampler_t *tex_samplers;                /* [tex_count]; .id == 0 = texture default */
     uint8_t param_count;
     const uint32_t *param_name_hashes; /* [param_count] */
     const float (*params)[4];
@@ -127,20 +128,19 @@ static inline void nt_renderer_apply_texture_slots(const nt_renderer_material_vi
     nt_gfx_apply_texture_bindings(bindings, v->tex_count);
 }
 
-/* resolved must outlive the view. */
-static inline nt_renderer_material_view_t nt_renderer_material_view(const nt_material_info_t *mi, uint32_t resolved[NT_MATERIAL_MAX_TEXTURES]) {
-    for (uint8_t t = 0; t < mi->tex_count; t++) {
-        resolved[t] = nt_resource_get(mi->tex_resources[t]);
-    }
-    return (nt_renderer_material_view_t){
+static inline nt_renderer_material_view_t nt_renderer_material_view(const nt_material_info_t *mi) {
+    nt_renderer_material_view_t view = {
         .tex_count = mi->tex_count,
         .tex_name_hashes = mi->tex_name_hashes,
-        .resolved_tex = resolved,
         .tex_samplers = mi->tex_samplers,
         .param_count = mi->param_count,
         .param_name_hashes = mi->param_name_hashes,
         .params = mi->params,
     };
+    for (uint8_t t = 0; t < mi->tex_count; t++) {
+        view.resolved_tex[t] = nt_resource_get(mi->tex_resources[t]);
+    }
+    return view;
 }
 // #endregion
 

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -32,12 +32,12 @@ typedef struct {
     /* Captured independently because custom layouts may share a pipeline. */
     nt_vertex_input_t vertex_input;
     nt_material_t material; /* handle for material-param lookup at flush; param values
-                               are NOT snapshotted — material info is stable within a
-                               frame (nt_material_step ran before render) so we
-                               re-fetch via nt_material_get_info at flush time */
+                               are NOT snapshotted — they are re-fetched live via
+                               nt_material_get_info at flush time */
+    /* Snapshot taken when the cmd opens; publication changes only inside nt_resource_step. */
     uint32_t resolved_tex[NT_MATERIAL_MAX_TEXTURES];
     uint32_t tex_name_hashes[NT_MATERIAL_MAX_TEXTURES];
-    nt_sampler_t resolved_sampler[NT_MATERIAL_MAX_TEXTURES]; /* per-binding override, .id==0 keeps texture default */
+    nt_sampler_t tex_samplers[NT_MATERIAL_MAX_TEXTURES]; /* per-binding override, .id==0 keeps texture default */
     uint8_t tex_count;
     uint32_t first_index; /* offset into s_sprite.indices[] */
     uint32_t index_count;
@@ -410,10 +410,11 @@ static void open_cmd(nt_pipeline_t pip, const nt_material_info_t *mi, nt_materia
      * per-emit, so the plain fast path stays a constant 20). */
     s_sprite.cur_stride = (uint32_t)NT_SPRITE_BASE_STRIDE + s_sprite.cur_material_custom_bytes;
     c->tex_count = mi->tex_count;
+    /* Slot 0 resolves like the rest; the page substitutes into it below. */
     for (uint8_t i = 0; i < mi->tex_count; i++) {
-        c->resolved_tex[i] = mi->resolved_tex[i];
+        c->resolved_tex[i] = nt_resource_get(mi->tex_resources[i]);
         c->tex_name_hashes[i] = mi->tex_name_hashes[i];
-        c->resolved_sampler[i] = mi->resolved_sampler[i];
+        c->tex_samplers[i] = mi->tex_samplers[i];
     }
     c->first_index = s_sprite.index_count;
     c->first_vertex = s_sprite.vertex_count;
@@ -1403,7 +1404,7 @@ void nt_sprite_renderer_flush(void) {
             .tex_count = c->tex_count,
             .tex_name_hashes = c->tex_name_hashes,
             .resolved_tex = c->resolved_tex,
-            .resolved_sampler = c->resolved_sampler,
+            .tex_samplers = c->tex_samplers,
             .param_count = (mi != NULL) ? mi->param_count : 0,
             .param_name_hashes = (mi != NULL) ? mi->param_name_hashes : NULL,
             .params = (mi != NULL) ? mi->params : NULL,

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -31,9 +31,8 @@ typedef struct {
     nt_pipeline_t pipeline;
     /* Captured independently because custom layouts may share a pipeline. */
     nt_vertex_input_t vertex_input;
-    nt_material_t material; /* handle for material-param lookup at flush; param values
-                               are NOT snapshotted — they are re-fetched live via
-                               nt_material_get_info at flush time */
+    nt_material_t material; /* params stay live to flush by contract, so a game may mutate
+                               them after emit; textures are snapshotted below */
     /* Snapshot taken when the cmd opens; publication changes only inside nt_resource_step. */
     uint32_t resolved_tex[NT_MATERIAL_MAX_TEXTURES];
     uint32_t tex_name_hashes[NT_MATERIAL_MAX_TEXTURES];
@@ -410,9 +409,13 @@ static void open_cmd(nt_pipeline_t pip, const nt_material_info_t *mi, nt_materia
      * per-emit, so the plain fast path stays a constant 20). */
     s_sprite.cur_stride = (uint32_t)NT_SPRITE_BASE_STRIDE + s_sprite.cur_material_custom_bytes;
     c->tex_count = mi->tex_count;
-    /* Slot 0 resolves like the rest; the page substitutes into it below. */
-    for (uint8_t i = 0; i < mi->tex_count; i++) {
+    /* Slot 0 is the atlas page by contract: ensure_current_cmd_page_texture substitutes
+     * into it before any index is staged, so resolving the material's value is dead work. */
+    c->resolved_tex[0] = 0;
+    for (uint8_t i = 1; i < mi->tex_count; i++) {
         c->resolved_tex[i] = nt_resource_get(mi->tex_resources[i]);
+    }
+    for (uint8_t i = 0; i < mi->tex_count; i++) {
         c->tex_name_hashes[i] = mi->tex_name_hashes[i];
         c->tex_samplers[i] = mi->tex_samplers[i];
     }
@@ -1400,15 +1403,15 @@ void nt_sprite_renderer_flush(void) {
          * its units; params are read from the live material when the material or the
          * pipeline changed. */
         const nt_material_info_t *mi = (c->material.id != bound.material) ? nt_material_get_info(c->material) : NULL;
-        const nt_renderer_material_view_t view = {
+        nt_renderer_material_view_t view = {
             .tex_count = c->tex_count,
             .tex_name_hashes = c->tex_name_hashes,
-            .resolved_tex = c->resolved_tex,
             .tex_samplers = c->tex_samplers,
             .param_count = (mi != NULL) ? mi->param_count : 0,
             .param_name_hashes = (mi != NULL) ? mi->param_name_hashes : NULL,
             .params = (mi != NULL) ? mi->params : NULL,
         };
+        memcpy(view.resolved_tex, c->resolved_tex, sizeof(view.resolved_tex));
         nt_renderer_apply_material_uniforms(&bound, c->material.id, &view);
         /* Per cmd, not per material: one material's page can change on a page split.
          * Units come from the pipeline's program, so a dead material still binds right. */

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -776,7 +776,8 @@ void nt_text_renderer_flush(void) {
         const nt_material_info_t *mi = nt_material_get_info(s_text.material);
         if (mi != NULL) {
             NT_ASSERT(mi->tex_count == 0 && "text material declares textures: every sampler unit belongs to the font");
-            const nt_renderer_material_view_t view = nt_renderer_material_view(mi);
+            uint32_t resolved[NT_MATERIAL_MAX_TEXTURES] = {0};
+            const nt_renderer_material_view_t view = nt_renderer_material_view(mi, resolved);
             nt_renderer_set_material_uniforms(&view);
         }
     }

--- a/engine/renderers/nt_text_renderer.c
+++ b/engine/renderers/nt_text_renderer.c
@@ -776,8 +776,7 @@ void nt_text_renderer_flush(void) {
         const nt_material_info_t *mi = nt_material_get_info(s_text.material);
         if (mi != NULL) {
             NT_ASSERT(mi->tex_count == 0 && "text material declares textures: every sampler unit belongs to the font");
-            uint32_t resolved[NT_MATERIAL_MAX_TEXTURES] = {0};
-            const nt_renderer_material_view_t view = nt_renderer_material_view(mi, resolved);
+            const nt_renderer_material_view_t view = {.param_count = mi->param_count, .param_name_hashes = mi->param_name_hashes, .params = mi->params};
             nt_renderer_set_material_uniforms(&view);
         }
     }

--- a/examples/atlas/main.c
+++ b/examples/atlas/main.c
@@ -114,7 +114,6 @@ static void frame(void) {
 #endif
 
     nt_resource_step();
-    nt_material_step();
     link_program();
 
     /* Dump pack contents when ready */

--- a/examples/bunnymark/main.c
+++ b/examples/bunnymark/main.c
@@ -402,9 +402,10 @@ static void frame(void) {
     nt_gfx_begin_segment("frame");
 
     if (g_nt_gfx.context_restored) {
-        /* WebGL context loss recovery. mat_info / s_overlay_font handles
-         * captured above are stale (nt_resource_step / nt_font_step ran
-         * before begin_frame detected the restore). Invalidate resources
+        /* WebGL context loss recovery. The program in mat_info and the
+         * s_overlay_font handles captured above are stale (this frame's
+         * nt_resource_step / nt_font_step ran before begin_frame detected
+         * the restore). Invalidate resources
          * so the next frame's *_step calls re-resolve, recreate game-owned
          * GPU buffers, and restore both renderers. Skip rendering this
          * frame — it's safer than driving pipelines with stale handles. */
@@ -464,8 +465,9 @@ static void frame(void) {
     /* Top-left corner anchor in world coords (y-up, bottom-left origin).
      * Text renders below the model translation point by line; size is the
      * em-height in world units, which == pixels here since ortho is 1:1.
-     * Skipped on context_restored frames — the text material's program and the
-     * font handles are stale until next frame's nt_resource_step / nt_font_step. */
+     * Skipped on context_restored frames — the text program was dropped above and
+     * relinks only after a later nt_resource_step republishes the shader code; the
+     * font handles refresh in nt_font_step. */
     /* Publish demo counters into nt_metrics before the HUD reads them back via format_lines. */
     nt_metrics_count("bunnies", (uint64_t)s_bunny_count);
     nt_metrics_count("atlas_quality", s_hd_active ? 1ULL : 0ULL);

--- a/examples/bunnymark/main.c
+++ b/examples/bunnymark/main.c
@@ -284,7 +284,6 @@ static void frame(void) {
 #endif
 
     nt_resource_step();
-    nt_material_step();
     link_programs();
     nt_sprite_comp_sync_resources();
 
@@ -404,7 +403,7 @@ static void frame(void) {
 
     if (g_nt_gfx.context_restored) {
         /* WebGL context loss recovery. mat_info / s_overlay_font handles
-         * captured above are stale (nt_material_step / nt_font_step ran
+         * captured above are stale (nt_resource_step / nt_font_step ran
          * before begin_frame detected the restore). Invalidate resources
          * so the next frame's *_step calls re-resolve, recreate game-owned
          * GPU buffers, and restore both renderers. Skip rendering this
@@ -465,8 +464,8 @@ static void frame(void) {
     /* Top-left corner anchor in world coords (y-up, bottom-left origin).
      * Text renders below the model translation point by line; size is the
      * em-height in world units, which == pixels here since ortho is 1:1.
-     * Skipped on context_restored frames — text material's resolved shader
-     * handles are stale until next frame's nt_material_step / nt_font_step. */
+     * Skipped on context_restored frames — the text material's program and the
+     * font handles are stale until next frame's nt_resource_step / nt_font_step. */
     /* Publish demo counters into nt_metrics before the HUD reads them back via format_lines. */
     nt_metrics_count("bunnies", (uint64_t)s_bunny_count);
     nt_metrics_count("atlas_quality", s_hd_active ? 1ULL : 0ULL);

--- a/examples/rtt_showcase/main.c
+++ b/examples/rtt_showcase/main.c
@@ -530,7 +530,6 @@ static void frame(void) {
         }
     }
     nt_resource_step();
-    nt_material_step();
     link_programs();
     try_bind_ui_resources();
 

--- a/examples/slice9_demo/main.c
+++ b/examples/slice9_demo/main.c
@@ -333,7 +333,6 @@ static void frame(void) {
 #endif
 
     nt_resource_step();
-    nt_material_step();
     link_programs();
 
     // #region input handling

--- a/examples/sponza/main.c
+++ b/examples/sponza/main.c
@@ -376,9 +376,8 @@ static void frame(void) {
         }
     }
 
-    /* Step resource + material systems */
+    /* Step resource system */
     nt_resource_step();
-    nt_material_step();
     link_programs();
 
     /* Sequential loading chain: core -> geo -> tex -> full */

--- a/examples/text/main.c
+++ b/examples/text/main.c
@@ -223,9 +223,8 @@ static void frame(void) {
     }
 #endif
 
-    /* Step resource + material systems */
+    /* Step resource system */
     nt_resource_step();
-    nt_material_step();
     if (nt_program_ref_update(&s_text_program)) {
         nt_material_set_program(s_text_material, s_text_program.program);
     }

--- a/examples/textured_quad/main.c
+++ b/examples/textured_quad/main.c
@@ -221,9 +221,8 @@ static void frame(void) {
         print_status();
     }
 
-    /* Step resource + material systems */
+    /* Step resource system */
     nt_resource_step();
-    nt_material_step();
     link_programs();
 
     /* Dump pack contents when they become READY */

--- a/examples/ui_3d_demo/main.c
+++ b/examples/ui_3d_demo/main.c
@@ -824,7 +824,6 @@ static void frame(void) {
     s_shape_yaw += s_speed_table[s_speed_kind] * dt;
 
     nt_resource_step();
-    nt_material_step();
     link_programs();
     try_bind_resources();
 

--- a/examples/ui_showcase/main.c
+++ b/examples/ui_showcase/main.c
@@ -3649,7 +3649,6 @@ static void frame(void) {
     }
 
     nt_resource_step();
-    nt_material_step();
     link_programs();
 
     /* Auto-animate progress when its panel toggle is on. On the off->on edge, derive the ramp direction

--- a/tests/browser/app/main.c
+++ b/tests/browser/app/main.c
@@ -444,7 +444,6 @@ static void frame(void) {
     nt_mem_scratch_reset();
 
     nt_resource_step();
-    nt_material_step();
     link_programs();
 
     s_state.time += g_nt_app.dt;

--- a/tests/unit/test_helpers/ui_walker_fixture.c
+++ b/tests/unit/test_helpers/ui_walker_fixture.c
@@ -47,7 +47,6 @@ static nt_material_t make_material(bool with_page_sampler) {
     desc.label = "walker_test_material";
 
     const nt_material_t mat = nt_material_create(&desc);
-    nt_material_step();
     return mat;
 }
 

--- a/tests/unit/test_material.c
+++ b/tests/unit/test_material.c
@@ -443,10 +443,10 @@ void test_set_program_clears_to_invalid(void) {
     TEST_ASSERT_EQUAL_UINT32(0, info->program.id);
 }
 
-/* ---- Test 20: step resolves textures ---- */
+/* ---- Test 20: create stores texture resources ---- */
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-void test_step_resolves_textures(void) {
+void test_create_stores_texture_resources(void) {
     nt_resource_t tex_res = register_test_resource("test_tex", NT_ASSET_TEXTURE, 42);
     nt_resource_step();
 
@@ -456,11 +456,9 @@ void test_step_resolves_textures(void) {
     d.texture_count = 1;
     nt_material_t mat = nt_material_create(&d);
 
-    nt_material_step();
-
     const nt_material_info_t *info = nt_material_get_info(mat);
     TEST_ASSERT_NOT_NULL(info);
-    TEST_ASSERT_EQUAL_UINT32(42, info->resolved_tex[0]);
+    TEST_ASSERT_EQUAL_UINT32(tex_res.id, info->tex_resources[0].id);
 }
 
 /* ---- Test 21: get_info returns NULL for invalid handle ---- */
@@ -639,7 +637,7 @@ int main(void) {
     RUN_TEST(test_set_program_replaces_a_with_b);
     RUN_TEST(test_set_program_clears_to_invalid);
     RUN_TEST(test_set_program_on_a_destroyed_material_asserts);
-    RUN_TEST(test_step_resolves_textures);
+    RUN_TEST(test_create_stores_texture_resources);
 
     /* Query edge cases */
     RUN_TEST(test_get_info_returns_null_for_invalid);

--- a/tests/unit/test_mesh_renderer.c
+++ b/tests/unit/test_mesh_renderer.c
@@ -169,7 +169,6 @@ static nt_material_t create_test_material_with_attr(nt_program_t program, nt_col
     desc.label = "test_material";
 
     nt_material_t mat = nt_material_create(&desc);
-    nt_material_step();
     return mat;
 }
 
@@ -227,7 +226,6 @@ static nt_material_t create_test_material_on_texture(nt_program_t program, nt_bl
     desc.cull_mode = NT_CULL_BACK;
     desc.label = "test_material_textured";
     nt_material_t mat = nt_material_create(&desc);
-    nt_material_step();
     return mat;
 }
 
@@ -660,7 +658,6 @@ void test_neighbouring_programs_one_cull_step_apart_get_their_own_pipelines(void
     desc.program = p1;
     desc.cull_mode = NT_CULL_NONE;
     nt_material_t mat_b = nt_material_create(&desc);
-    nt_material_step();
 
     nt_entity_t e0 = create_test_entity(mesh, mat_a);
     nt_entity_t e1 = create_test_entity(mesh, mat_b);
@@ -693,10 +690,9 @@ void test_declared_sampler_without_a_resolved_texture_asserts(void) {
     desc.attr_map_count = 1;
     desc.label = "unresolved_tex_material";
     nt_material_t mat = nt_material_create(&desc);
-    nt_material_step();
 
     const nt_material_info_t *info = nt_material_get_info(mat);
-    TEST_ASSERT_EQUAL_UINT32(0, info->resolved_tex[0]);
+    TEST_ASSERT_EQUAL_UINT32(0, nt_resource_get(info->tex_resources[0]));
 
     nt_entity_t e = create_test_entity(mesh, mat);
     nt_render_item_t items[1] = {{.sort_key = 0, .entity = e.id, .batch_key = nt_mesh_renderer_batch_key(mat, mesh)}};
@@ -749,7 +745,6 @@ void test_texture_lands_on_the_program_sampler_unit(void) {
     desc.attr_map_count = 1;
     desc.label = "swapped_slot_material";
     nt_material_t mat = nt_material_create(&desc);
-    nt_material_step();
 
     nt_entity_t e = create_test_entity(mesh, mat);
     nt_render_item_t items[1] = {{.sort_key = 0, .entity = e.id, .batch_key = nt_mesh_renderer_batch_key(mat, mesh)}};
@@ -1182,7 +1177,6 @@ void test_mesh_vertex_input_key_one_step_changes_split_vertex_inputs_not_pipelin
     desc.blend = nt_blend_opaque();
     desc.cull_mode = NT_CULL_BACK;
     mats[3] = nt_material_create(&desc);
-    nt_material_step();
 
     nt_render_item_t items[4];
     for (uint32_t i = 0; i < 4; i++) {
@@ -1271,7 +1265,6 @@ void test_vertex_input_shared_for_same_derived_layout(void) {
     desc.color_mode = NT_COLOR_MODE_NONE;
     desc.label = "extra_attr_material";
     nt_material_t mat_b = nt_material_create(&desc);
-    nt_material_step();
 
     nt_entity_t e0 = create_test_entity(mesh, mat_a);
     nt_entity_t e1 = create_test_entity(mesh, mat_b);

--- a/tests/unit/test_mesh_renderer.c
+++ b/tests/unit/test_mesh_renderer.c
@@ -701,6 +701,64 @@ void test_declared_sampler_without_a_resolved_texture_asserts(void) {
     TEST_ASSERT_NOT_NULL(strstr(nt_test_assert_last_expr, "texture_pool"));
 }
 
+/* Textures resolve at the material transition, so a slot published after the material
+ * was created binds on its first draw, and a republished id replaces it on the next. */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+void test_texture_published_after_material_create_binds_at_next_draw(void) {
+    nt_mesh_t mesh = create_test_mesh();
+
+    /* Own pack: test_texture() latches "mesh_renderer_tex_pack" for its own slots. */
+    const nt_hash32_t pid = nt_hash32_str("mesh_renderer_late_pack");
+    const nt_hash64_t rid = nt_hash64_str("mesh_renderer_late_tex");
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pid, 0));
+
+    /* Requested before anything registers it: the slot publishes 0. */
+    nt_resource_t res = nt_resource_request(rid, NT_ASSET_TEXTURE);
+    nt_resource_step();
+    TEST_ASSERT_EQUAL_UINT32(0, nt_resource_get(res));
+
+    nt_material_create_desc_t desc;
+    memset(&desc, 0, sizeof(desc));
+    desc.program = create_test_tex_program();
+    desc.textures[0].name = "u_tex";
+    desc.textures[0].resource = res;
+    desc.texture_count = 1;
+    desc.attr_map[0].stream_name = "position";
+    desc.attr_map[0].location = 0;
+    desc.attr_map_count = 1;
+    desc.depth_test = true;
+    desc.depth_write = true;
+    desc.blend = nt_blend_opaque();
+    desc.cull_mode = NT_CULL_BACK;
+    desc.label = "late_tex_material";
+    nt_material_t mat = nt_material_create(&desc);
+
+    static const uint8_t white[4] = {255, 255, 255, 255};
+    nt_texture_t tex1 = nt_gfx_make_texture(&(nt_texture_desc_t){.width = 1, .height = 1, .data = white, .format = NT_TEXTURE_FORMAT_RGBA8, .label = "late_tex1"});
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, rid, NT_ASSET_TEXTURE, tex1.id));
+    nt_resource_step();
+
+    nt_entity_t e = create_test_entity(mesh, mat);
+    nt_render_item_t items[1] = {{.sort_key = 0, .entity = e.id, .batch_key = nt_mesh_renderer_batch_key(mat, mesh)}};
+
+    nt_gfx_fake_reset();
+    nt_mesh_renderer_draw_list(items, 1);
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_fake_bound_texture_count());
+    TEST_ASSERT_EQUAL_UINT32(nt_gfx_test_texture_backend_id(tex1), nt_gfx_fake_bound_texture_at(0));
+
+    /* Re-registering the same (pack, rid) republishes; the next transition follows it. */
+    nt_texture_t tex2 = nt_gfx_make_texture(&(nt_texture_desc_t){.width = 1, .height = 1, .data = white, .format = NT_TEXTURE_FORMAT_RGBA8, .label = "late_tex2"});
+    TEST_ASSERT_NOT_EQUAL_UINT32(tex1.id, tex2.id);
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, rid, NT_ASSET_TEXTURE, tex2.id));
+    nt_resource_step();
+    TEST_ASSERT_EQUAL_UINT32(tex2.id, nt_resource_get(res));
+
+    nt_gfx_fake_reset();
+    nt_mesh_renderer_draw_list(items, 1);
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_fake_bound_texture_count());
+    TEST_ASSERT_EQUAL_UINT32(nt_gfx_test_texture_backend_id(tex2), nt_gfx_fake_bound_texture_at(0));
+}
+
 /* The declared name is what selects the unit, so a material whose program has no such
  * sampler simply skips the slot -- and the program's empty interface stays covered. */
 void test_declared_sampler_unknown_to_the_program_is_ignored(void) {
@@ -1711,6 +1769,7 @@ int main(void) {
     RUN_TEST(test_color_modes_on_one_program_share_a_pipeline_and_split_vertex_inputs);
     RUN_TEST(test_mesh_vertex_input_key_one_step_changes_split_vertex_inputs_not_pipelines);
     RUN_TEST(test_declared_sampler_without_a_resolved_texture_asserts);
+    RUN_TEST(test_texture_published_after_material_create_binds_at_next_draw);
     RUN_TEST(test_declared_sampler_unknown_to_the_program_is_ignored);
     RUN_TEST(test_material_missing_a_program_sampler_asserts);
     RUN_TEST(test_texture_lands_on_the_program_sampler_unit);

--- a/tests/unit/test_nt_sprite_renderer_emit_region.c
+++ b/tests/unit/test_nt_sprite_renderer_emit_region.c
@@ -244,7 +244,6 @@ static nt_material_t create_test_material(void) {
     desc.label = "test_emit_region_material";
 
     nt_material_t mat = nt_material_create(&desc);
-    nt_material_step();
     return mat;
 }
 

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -1053,16 +1053,49 @@ void test_sprite_renderer_non_page_slot_resolves_at_cmd_open(void) {
     TEST_ASSERT_EQUAL_UINT32(nt_gfx_test_texture_backend_id(replacement), nt_gfx_fake_bound_texture_at(0));
     TEST_ASSERT_NOT_EQUAL_UINT32(before, nt_gfx_fake_bound_texture_at(0));
 
-    /* Batch 3: the cmd resolved at open, so a material destroyed before flush
-     * still replays slot 1 -- the resolve cannot be deferred to flush. */
+    /* Batch 3: the cmd resolved when it opened, so neither a later publication nor
+     * the material's death changes what it binds -- the resolve cannot be deferred
+     * to flush. */
     nt_gfx_fake_reset();
     nt_sprite_renderer_set_material(mat);
     nt_sprite_renderer_emit_region(s_atlas_res, 0, identity, 0, 0, 0xFFFFFFFFU, 0);
+
+    nt_texture_t third = nt_gfx_make_texture(&(nt_texture_desc_t){.width = 1, .height = 1, .data = s_white_pixel, .format = NT_TEXTURE_FORMAT_RGBA8, .label = "page1_v3"});
+    TEST_ASSERT_TRUE(third.id != 0);
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(nt_hash32_str("sprite_renderer_pages"), (nt_hash64_t){FIXTURE_PAGE1_RID}, NT_ASSET_TEXTURE, third.id));
+    nt_resource_step();
+    TEST_ASSERT_EQUAL_UINT32(third.id, nt_resource_get(nt_atlas_get_page_resource(s_atlas_res, 1)));
+
     nt_material_destroy(mat);
     nt_sprite_renderer_flush();
     TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_fake_bound_texture_count());
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_bound_texture_slot_at(0));
     TEST_ASSERT_EQUAL_UINT32(nt_gfx_test_texture_backend_id(replacement), nt_gfx_fake_bound_texture_at(0));
+    TEST_ASSERT_NOT_EQUAL_UINT32(nt_gfx_test_texture_backend_id(third), nt_gfx_fake_bound_texture_at(0));
+
+    /* Batch 4: a page split re-opens the cmd from a snapshot, so BOTH halves keep the
+     * slot-1 texture the live material resolved at open while unit 1 follows the page. */
+    nt_material_t mat2 = nt_material_create(&mdesc);
+    TEST_ASSERT_TRUE(mat2.id != 0);
+    nt_gfx_fake_reset();
+    nt_sprite_renderer_set_material(mat2);
+    /* Region 0 lives on page 0, region 1 on page 1. */
+    nt_sprite_renderer_emit_region(s_atlas_res, 0, identity, 0, 0, 0xFFFFFFFFU, 0);
+    nt_sprite_renderer_emit_region(s_atlas_res, 1, identity, 0, 0, 0xFFFFFFFFU, 0);
+    nt_sprite_renderer_flush();
+
+    TEST_ASSERT_EQUAL_UINT32(4, nt_gfx_fake_bound_texture_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_bound_texture_slot_at(0));
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_fake_bound_texture_slot_at(1));
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_bound_texture_slot_at(2));
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_fake_bound_texture_slot_at(3));
+    /* "u_other" is unit 0: the current publication, identical across the split. */
+    TEST_ASSERT_EQUAL_UINT32(nt_gfx_test_texture_backend_id(third), nt_gfx_fake_bound_texture_at(0));
+    TEST_ASSERT_EQUAL_UINT32(nt_gfx_test_texture_backend_id(third), nt_gfx_fake_bound_texture_at(2));
+    /* "u_texture" is unit 1: page 0 then page 1. */
+    TEST_ASSERT_EQUAL_UINT32(nt_gfx_test_texture_backend_id((nt_texture_t){.id = nt_resource_get(nt_atlas_get_page_resource(s_atlas_res, 0))}), nt_gfx_fake_bound_texture_at(1));
+    TEST_ASSERT_EQUAL_UINT32(nt_gfx_test_texture_backend_id((nt_texture_t){.id = nt_resource_get(nt_atlas_get_page_resource(s_atlas_res, 1))}), nt_gfx_fake_bound_texture_at(3));
+    TEST_ASSERT_NOT_EQUAL_UINT32(nt_gfx_fake_bound_texture_at(1), nt_gfx_fake_bound_texture_at(3));
 }
 
 /* A program replaced between an immediate emit and an ECS draw_list puts one

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -301,7 +301,6 @@ static nt_material_t create_test_material_with_blend(nt_blend_state_t blend) {
     desc.label = "test_sprite_material";
 
     nt_material_t mat = nt_material_create(&desc);
-    nt_material_step();
     return mat;
 }
 
@@ -324,7 +323,6 @@ static nt_material_t create_test_material_with_param(void) {
     desc.label = "test_sprite_material_param";
 
     nt_material_t mat = nt_material_create(&desc);
-    nt_material_step();
     return mat;
 }
 
@@ -340,7 +338,6 @@ static nt_material_t create_test_material_textureless(void) {
     desc.label = "test_sprite_material_textureless";
 
     nt_material_t mat = nt_material_create(&desc);
-    nt_material_step();
     return mat;
 }
 
@@ -377,7 +374,6 @@ static nt_material_t create_radial_test_material(const char *stream_name, uint8_
     }
 
     nt_material_t mat = nt_material_create(&desc);
-    nt_material_step();
     return mat;
 }
 
@@ -631,7 +627,6 @@ void test_neighbouring_programs_one_depth_write_step_apart_get_their_own_pipelin
     desc.program = p1;
     desc.depth_write = false;
     nt_material_t mat_b = nt_material_create(&desc);
-    nt_material_step();
 
     nt_entity_t e0 = create_sprite_entity(s_atlas_res, FIXTURE_R0_HASH, mat_a);
     nt_entity_t e1 = create_sprite_entity(s_atlas_res, FIXTURE_R0_HASH, mat_b);
@@ -994,7 +989,6 @@ void test_sprite_renderer_page_lands_on_its_program_unit(void) {
     mdesc.texture_count = 2;
     mdesc.label = "test_sprite_material_page_on_unit_1";
     nt_material_t mat = nt_material_create(&mdesc);
-    nt_material_step();
 
     static const float identity[16] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
     nt_gfx_fake_reset();
@@ -1069,7 +1063,6 @@ void test_sprite_renderer_flush_asserts_on_unresolved_slot_with_override(void) {
     mdesc.texture_count = 2;
     mdesc.label = "test_sprite_material_two_slots";
     nt_material_t mat = nt_material_create(&mdesc);
-    nt_material_step();
 
     static const float identity[16] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
     nt_sprite_renderer_set_material(mat);
@@ -1093,7 +1086,6 @@ void test_sprite_renderer_material_missing_a_program_sampler_asserts(void) {
     mdesc.texture_count = 1;
     mdesc.label = "test_sprite_material_missing_sampler";
     nt_material_t mat = nt_material_create(&mdesc);
-    nt_material_step();
 
     static const float identity[16] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
     nt_sprite_renderer_set_material(mat);
@@ -1117,7 +1109,6 @@ void test_sprite_renderer_unknown_sampler_name_is_ignored(void) {
     mdesc.texture_count = 1;
     mdesc.label = "test_sprite_material_unknown_sampler";
     nt_material_t mat = nt_material_create(&mdesc);
-    nt_material_step();
 
     static const float identity[16] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
     nt_gfx_fake_reset();
@@ -1498,7 +1489,6 @@ static nt_material_t create_test_material_with_sampler(nt_sampler_t override) {
     desc.textures[0].sampler = override;
     desc.label = "test_mat_override";
     nt_material_t mat = nt_material_create(&desc);
-    nt_material_step();
     return mat;
 }
 

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -1003,6 +1003,68 @@ void test_sprite_renderer_page_lands_on_its_program_unit(void) {
     TEST_ASSERT_EQUAL_UINT32(nt_gfx_test_texture_backend_id((nt_texture_t){.id = nt_resource_get(nt_atlas_get_page_resource(s_atlas_res, 0))}), nt_gfx_fake_bound_texture_at(1));
 }
 
+/* A cmd resolves its non-page slots when it opens, so a resource republished between
+ * two batches reaches the second one -- and the cmd that already opened keeps its
+ * snapshot even after its material dies. */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+void test_sprite_renderer_non_page_slot_resolves_at_cmd_open(void) {
+    nt_sprite_renderer_desc_t desc = nt_sprite_renderer_desc_defaults();
+    TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&desc));
+
+    s_atlas_res = register_test_atlas(0xEBULL);
+
+    nt_material_create_desc_t mdesc;
+    memset(&mdesc, 0, sizeof(mdesc));
+    mdesc.program = nt_gfx_fake_make_program((const char *const[]){"u_other", "u_texture"}, 2);
+    mdesc.cull_mode = NT_CULL_NONE;
+    mdesc.textures[0].name = "u_texture";
+    mdesc.textures[0].resource = NT_RESOURCE_INVALID; /* the page substitutes into slot 0 */
+    mdesc.textures[1].name = "u_other";
+    mdesc.textures[1].resource = nt_atlas_get_page_resource(s_atlas_res, 1);
+    mdesc.texture_count = 2;
+    mdesc.label = "test_sprite_material_republished_slot";
+    nt_material_t mat = nt_material_create(&mdesc);
+
+    static const float identity[16] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
+
+    /* Batch 1: slot 1 ("u_other" -> unit 0) binds the page-1 texture from setUp. */
+    nt_gfx_fake_reset();
+    nt_sprite_renderer_set_material(mat);
+    nt_sprite_renderer_emit_region(s_atlas_res, 0, identity, 0, 0, 0xFFFFFFFFU, 0);
+    nt_sprite_renderer_flush();
+    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_fake_bound_texture_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_bound_texture_slot_at(0));
+    const uint32_t before = nt_gfx_fake_bound_texture_at(0);
+
+    /* Republish that resource under a different texture. */
+    nt_texture_t replacement = nt_gfx_make_texture(&(nt_texture_desc_t){.width = 1, .height = 1, .data = s_white_pixel, .format = NT_TEXTURE_FORMAT_RGBA8, .label = "page1_v2"});
+    TEST_ASSERT_TRUE(replacement.id != 0);
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(nt_hash32_str("sprite_renderer_pages"), (nt_hash64_t){FIXTURE_PAGE1_RID}, NT_ASSET_TEXTURE, replacement.id));
+    nt_resource_step();
+    TEST_ASSERT_EQUAL_UINT32(replacement.id, nt_resource_get(nt_atlas_get_page_resource(s_atlas_res, 1)));
+
+    /* Batch 2: the flush cleared cmd_count, so set_material opens a fresh cmd. */
+    nt_gfx_fake_reset();
+    nt_sprite_renderer_set_material(mat);
+    nt_sprite_renderer_emit_region(s_atlas_res, 0, identity, 0, 0, 0xFFFFFFFFU, 0);
+    nt_sprite_renderer_flush();
+    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_fake_bound_texture_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_bound_texture_slot_at(0));
+    TEST_ASSERT_EQUAL_UINT32(nt_gfx_test_texture_backend_id(replacement), nt_gfx_fake_bound_texture_at(0));
+    TEST_ASSERT_NOT_EQUAL_UINT32(before, nt_gfx_fake_bound_texture_at(0));
+
+    /* Batch 3: the cmd resolved at open, so a material destroyed before flush
+     * still replays slot 1 -- the resolve cannot be deferred to flush. */
+    nt_gfx_fake_reset();
+    nt_sprite_renderer_set_material(mat);
+    nt_sprite_renderer_emit_region(s_atlas_res, 0, identity, 0, 0, 0xFFFFFFFFU, 0);
+    nt_material_destroy(mat);
+    nt_sprite_renderer_flush();
+    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_fake_bound_texture_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_bound_texture_slot_at(0));
+    TEST_ASSERT_EQUAL_UINT32(nt_gfx_test_texture_backend_id(replacement), nt_gfx_fake_bound_texture_at(0));
+}
+
 /* A program replaced between an immediate emit and an ECS draw_list puts one
  * material id on two programs in one flush; the uniforms must go out twice. */
 void test_sprite_renderer_program_replace_between_immediate_and_draw_list(void) {
@@ -1717,6 +1779,7 @@ int main(void) {
     RUN_TEST(test_sprite_renderer_textureless_material_emits_without_page);
     RUN_TEST(test_sprite_renderer_dead_material_cmd_binds_on_program_unit);
     RUN_TEST(test_sprite_renderer_page_lands_on_its_program_unit);
+    RUN_TEST(test_sprite_renderer_non_page_slot_resolves_at_cmd_open);
     RUN_TEST(test_sprite_renderer_program_replace_between_immediate_and_draw_list);
     RUN_TEST(test_sprite_renderer_flush_asserts_on_unresolved_slot_with_override);
     RUN_TEST(test_sprite_renderer_material_missing_a_program_sampler_asserts);

--- a/tests/unit/test_text_renderer.c
+++ b/tests/unit/test_text_renderer.c
@@ -141,7 +141,6 @@ static nt_material_t create_test_material_with_blend(nt_blend_state_t blend) {
         .blend = blend,
         .cull_mode = NT_CULL_NONE,
     });
-    nt_material_step();
     return material;
 }
 
@@ -430,7 +429,6 @@ void test_text_material_with_textures_asserts_at_flush(void) {
         .textures[0] = {.name = "u_extra", .resource = NT_RESOURCE_INVALID},
         .texture_count = 1,
     });
-    nt_material_step();
 
     nt_text_renderer_set_material(textured);
     nt_text_renderer_draw("AB", s_identity, 32.0F, s_white, 0.0F, 0.0F);
@@ -551,7 +549,6 @@ void test_materials_sharing_a_program_share_one_pipeline(void) {
     nt_program_t shared = nt_gfx_make_program(vs, fs);
     nt_material_t a = nt_material_create(&(nt_material_create_desc_t){.program = shared, .blend = nt_blend_alpha(), .cull_mode = NT_CULL_NONE});
     nt_material_t b = nt_material_create(&(nt_material_create_desc_t){.program = shared, .blend = nt_blend_alpha(), .cull_mode = NT_CULL_NONE});
-    nt_material_step();
 
     nt_gfx_fake_reset();
     nt_text_renderer_set_material(a);
@@ -570,7 +567,6 @@ void test_one_program_with_two_render_states_builds_two_pipelines(void) {
     nt_program_t shared = nt_gfx_make_program(vs, fs);
     nt_material_t opaque_mat = nt_material_create(&(nt_material_create_desc_t){.program = shared, .blend = nt_blend_opaque(), .cull_mode = NT_CULL_NONE});
     nt_material_t blended = nt_material_create(&(nt_material_create_desc_t){.program = shared, .blend = nt_blend_alpha(), .cull_mode = NT_CULL_NONE});
-    nt_material_step();
 
     nt_gfx_fake_reset();
     nt_text_renderer_set_material(opaque_mat);
@@ -594,7 +590,6 @@ void test_neighbouring_programs_one_cull_step_apart_get_their_own_pipelines(void
     TEST_ASSERT_EQUAL_UINT32(p0.id + 1, p1.id);
     nt_material_t a = nt_material_create(&(nt_material_create_desc_t){.program = p0, .blend = nt_blend_alpha(), .cull_mode = NT_CULL_BACK});
     nt_material_t b = nt_material_create(&(nt_material_create_desc_t){.program = p1, .blend = nt_blend_alpha(), .cull_mode = NT_CULL_NONE});
-    nt_material_step();
 
     nt_gfx_fake_reset();
     nt_gfx_test_draw_trace_reset(true);

--- a/tests/unit/test_ui_radial.c
+++ b/tests/unit/test_ui_radial.c
@@ -59,7 +59,6 @@ static nt_material_t make_radial_material(void) {
     desc.label = "radial_test_material";
 
     const nt_material_t mat = nt_material_create(&desc);
-    nt_material_step();
     return mat;
 }
 
@@ -453,7 +452,6 @@ static void test_image_custom_name_bound_reorder_safe(void) {
     desc.attr_map_count = 2;
     desc.label = "perm_test_material";
     const nt_material_t mat = nt_material_create(&desc);
-    nt_material_step();
 
     /* Block in attr_map order: a_layout placeholders @0..3, a_radial data @4..7. */
     const float block[8] = {0.0F, 0.0F, 0.0F, 0.0F, 7.0F, 8.0F, 9.0F, 0.0F};
@@ -555,7 +553,6 @@ static nt_material_t make_radial_image_material_mode(nt_ui_radial_reveal_mode_t 
     desc.label = "radial_image_test_material";
 
     const nt_material_t mat = nt_material_create(&desc);
-    nt_material_step();
     return mat;
 }
 


### PR DESCRIPTION
Closes #367.

## What

- `nt_material_info_t`: `resolved_tex[]` → declared `nt_resource_t tex_resources[]`; `resolved_sampler` → `tex_samplers` (it was a verbatim desc copy, nothing resolved). The view keeps `resolved_tex` because there the ids are resolved.
- `nt_material_step` removed (38 calls in 17 files: 9 examples, browser app, ui walker fixture, 6 unit tests). `nt_material_slot_t` folded into `nt_material_info_t`.
- `nt_renderer_material_view(mi, resolved)` resolves via `nt_resource_get` at the mesh material transition; the sprite renderer resolves in `open_cmd`'s existing per-slot loop (the atlas page was already resolved per item at emit); text passes a zeroed local buffer with `tex_count == 0`.
- Renderers declare `nt_resource` explicitly in CMake (was transitive via `nt_material`).

## Why

Since #356 the step only copied `nt_resource_get` results into every live material each frame — the shader change-detection it was built for in #99 is gone. Removing it deletes state and a mandatory per-frame call, and fixes the window where a material created after this frame's step bound 0 on its first draw (why test helpers called the step right after `create`).

## Correctness

`slot->runtime_handle` (what `nt_resource_get` reads) is written only by the resolve pass inside `nt_resource_step` and by `slot_alloc` for a new slot; no engine code calls `nt_resource_step`/`invalidate`. So the published view is constant for the render phase of a frame. Context loss: the step snapshotted the same dead id the draw-time resolve returns; bunnymark keeps skipping that frame. Publication vs GPU lifetime is now spelled out in `material.md`.

## Performance

Before: `capacity` alive tests + ≤4 `nt_resource_get` per live material per frame, independent of visibility. After: ≤4 per mesh material transition (bounded by items, A→B→A = 3) and per sprite cmd open; no per-item resolve added. Same cross-TU `nt_resource_get` the step called. Unmeasured.

## Tests

- mesh: a slot published after material create binds on the first draw; a re-registered id replaces it on the next transition (exact backend ids via the gfx fake).
- sprite: a non-page slot republished between two flushes reaches the next cmd; a cmd resolved at open survives its material's destroy.
- `nt_resource_invalidate` is not used in tests: it skips virtual packs and would pass vacuously.

## Spec

`render/material.md` new "Texture resolve" section; one clause each in `core/api-contracts.md` and `render/architecture.md`. `nt_material_step` was never documented in `docs/spec/`.

## Checks

`format_and_check.sh` green per commit; `check.sh --push` green (first run hit a 0xc0000409 teardown crash in `test_nt_gfx_render_target_native` after all its cases passed; the binary passes 3/3 directly and the full rerun was green — the test does not touch materials).

Plan reviewed in two rounds by 5 subagent reviewers + Codex; refuted claims recorded in the issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FL6cTwcdPinqihYAWVsoqL
