### PR TITLE
ui: floating zIndex is relative to the enclosing floating element (#433)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,7 +36,8 @@ which is not the supported environment for `scripts/*.sh`.
 git lfs pull                          # example assets are LFS pointers without this
 bash scripts/setup.sh                 # install + activate the pinned emsdk (.emsdk-version)
                                       # later sessions: source emsdk/emsdk_env.sh
-cmake --preset native-debug           # the three presets check.sh expects:
+cmake --preset native-debug           # the four presets check.sh expects:
+cmake --preset native-release
 emcmake cmake --preset wasm-debug
 emcmake cmake --preset wasm-release
 bash scripts/check.sh                 # sanity check that the environment is alive

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -132,7 +132,7 @@ direct modes never mutate files; `format_and_check.sh` opts into the formatter b
 
 It runs the cheap gates (module composition, EM_JS_DEPS, doc links + spec-index coverage, CRT-pin centralization), builds native-debug, runs ctest, then checks clang-format and clang-tidy on changed files only (falls back to full tidy when headers changed). clang-tidy uses a devapi-enabled compile DB matching the CI lint job, so devapi TUs are checked, not skipped. Vendored deps (`deps/clay`, `deps/cglm`, `deps/unity`, `deps/basisu`, `deps/glfw`, `deps/curl`, `deps/zlib`) follow upstream style and are excluded; review patches to them separately.
 
-- Before `git push`: `bash scripts/check.sh --push` — additionally builds wasm-debug (emscripten catches warnings native clang exempts), wasm-release (Closure-only failures are invisible to debug builds), and runs the submodule consumption test.
+- Before `git push`: `bash scripts/check.sh --push` — additionally builds native-release (NDEBUG drops NT_ASSERT_FULL-only code, so `-Wunused` under `-Werror` fires where no debug build sees it), wasm-debug (emscripten catches warnings native clang exempts), wasm-release (Closure-only failures are invisible to debug builds), and runs the submodule consumption test.
 - Full sweep (CI lint equivalent): `bash scripts/check.sh --full` — whole-tree format + full tidy.
 
 If any check fails — fix before committing. Do not commit code that hasn't passed.

--- a/deps/clay/clay.h
+++ b/deps/clay/clay.h
@@ -15,14 +15,12 @@
 //      in the CLIP render-command case ("shouldRender = true").
 //   4. Floating zIndex is RELATIVE to the enclosing floating element (CSS stacking
 //      context) instead of global: a floating declared inside another gets
-//      parent_z + own_z, so a widget's floating part composes anywhere without
-//      knowing its global band. openFloatingZStack + 5 sites (context field,
-//      ephemeral alloc, push+saturation report in ConfigureOpenElementPtr, pop in
-//      CloseElement, and the zIndex field's own doc comment), search "NT patch 4". DEPENDS ON the tree-root sort staying STABLE (it swaps
-//      on strict `<`): a delta-0 child paints above its floating parent only because
-//      equal-z roots keep registration order — re-run tests/unit/test_nt_ui_slider.c
-//      after a Clay bump. Clay's own debug view nests 32766 inside 32765 and would
-//      saturate; unreachable because nt_ui_begin disables it every frame.
+//      parent_z + own_z. openFloatingZStack + 5 sites (context field, ephemeral
+//      alloc, push + saturation report in ConfigureOpenElementPtr, pop in
+//      CloseElement, the zIndex field's doc comment), search "NT patch 4".
+//      DEPENDS ON the tree-root sort staying STABLE (swaps on strict `<`): a
+//      delta-0 child paints above its floating parent only because equal-z roots
+//      keep registration order — re-run tests/unit/test_nt_ui_slider.c on a bump.
 // NT DEPENDENCY: nt_ui_clay_impl.c wraps Clay__OpenElement /
 //   Clay__ConfigureOpenElement / Clay__CloseElement for the begin/end split
 //   pattern used by nt_ui widgets. Verify these internals still exist on update.

--- a/deps/clay/clay.h
+++ b/deps/clay/clay.h
@@ -16,9 +16,9 @@
 //   4. Floating zIndex is RELATIVE to the enclosing floating element (CSS stacking
 //      context) instead of global: a floating declared inside another gets
 //      parent_z + own_z, so a widget's floating part composes anywhere without
-//      knowing its global band. openFloatingZStack + 4 sites (context field,
-//      ephemeral alloc, push in ConfigureOpenElementPtr, pop in CloseElement),
-//      search "NT patch 4". DEPENDS ON the tree-root sort staying STABLE (it swaps
+//      knowing its global band. openFloatingZStack + 5 sites (context field,
+//      ephemeral alloc, push+saturation report in ConfigureOpenElementPtr, pop in
+//      CloseElement, and the zIndex field's own doc comment), search "NT patch 4". DEPENDS ON the tree-root sort staying STABLE (it swaps
 //      on strict `<`): a delta-0 child paints above its floating parent only because
 //      equal-z roots keep registration order — re-run tests/unit/test_nt_ui_slider.c
 //      after a Clay bump. Clay's own debug view nests 32766 inside 32765 and would
@@ -508,6 +508,7 @@ typedef struct Clay_FloatingElementConfig {
     uint32_t parentId;
     // Controls the z index of this floating element and all its children. Floating elements are sorted in ascending z order before output.
     // zIndex is also passed to the renderer for all elements contained within this floating element.
+    // NT patch 4: RELATIVE to the enclosing floating element — the stored value is parent_z + own_z.
     int16_t zIndex;
     // Controls how mouse pointer events like hover and click are captured or passed through to elements underneath / behind a floating element.
     // Enum is of the form CLAY_ATTACH_POINT_foo_bar. See Clay_FloatingAttachPoints for more details.

--- a/deps/clay/clay.h
+++ b/deps/clay/clay.h
@@ -2137,14 +2137,15 @@ void Clay__ConfigureOpenElementPtr(const Clay_ElementDeclaration *declaration) {
                 clipElementId = 0;
             }
             // NT patch 4: zIndex is relative to the enclosing floating element. Saturating the int16 field
-            // would silently merge two bands into one, so it is an error, not a fallback.
+            // merges two stacking bands, so it is reported (nt_ui asserts on it); an NT_ASSERT_OFF build
+            // returns from the handler and paints the merged band.
             int32_t enclosingZ = context->openFloatingZStack.length > 0 ? Clay__int32_tArray_GetValue(&context->openFloatingZStack, context->openFloatingZStack.length - 1) : 0;
             int32_t rawZ = enclosingZ + (int32_t)floatingConfig.zIndex;
             int32_t effectiveZ = CLAY__MAX(INT16_MIN, CLAY__MIN(INT16_MAX, rawZ));
             if (effectiveZ != rawZ) {
                 context->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
                         .errorType = CLAY_ERROR_TYPE_INTERNAL_ERROR,
-                        .errorText = CLAY_STRING("Nested floating zIndex saturated int16 — stacking bands merged."),
+                        .errorText = CLAY_STRING("A floating zIndex plus its enclosing band saturated int16 — declare a smaller zIndex."),
                         .userData = context->errorHandler.userData });
             }
             floatingConfig.zIndex = (int16_t)effectiveZ;

--- a/deps/clay/clay.h
+++ b/deps/clay/clay.h
@@ -14,15 +14,15 @@
 //      fold) leaves an unmatched END -> renderer scissor-stack underflow. One site
 //      in the CLIP render-command case ("shouldRender = true").
 //   4. Floating zIndex is RELATIVE to the enclosing floating element (CSS stacking
-//      context) instead of global: a floating declared inside another floating gets
-//      parent_z + own_z. Upstream sorts every root by its own zIndex, so a widget's
-//      floating part (slider thumb, input caret) sank under the modal panel it was
-//      declared in, and sorting a child root ahead of its parent also made Clay read
-//      the parent bbox one frame stale. openFloatingZStack + 4 sites (context field,
-//      ephemeral alloc, push in ConfigureOpenElementPtr, pop in CloseElement), search
-//      "NT patch 4". DEPENDS ON the tree-root sort staying STABLE (it swaps on strict
-//      `<`): a child declared with delta 0 paints above its floating parent only
-//      because equal-z roots keep registration order.
+//      context) instead of global: a floating declared inside another gets
+//      parent_z + own_z, so a widget's floating part composes anywhere without
+//      knowing its global band. openFloatingZStack + 4 sites (context field,
+//      ephemeral alloc, push in ConfigureOpenElementPtr, pop in CloseElement),
+//      search "NT patch 4". DEPENDS ON the tree-root sort staying STABLE (it swaps
+//      on strict `<`): a delta-0 child paints above its floating parent only because
+//      equal-z roots keep registration order — re-run tests/unit/test_nt_ui_slider.c
+//      after a Clay bump. Clay's own debug view nests 32766 inside 32765 and would
+//      saturate; unreachable because nt_ui_begin disables it every frame.
 // NT DEPENDENCY: nt_ui_clay_impl.c wraps Clay__OpenElement /
 //   Clay__ConfigureOpenElement / Clay__CloseElement for the begin/end split
 //   pattern used by nt_ui widgets. Verify these internals still exist on update.

--- a/deps/clay/clay.h
+++ b/deps/clay/clay.h
@@ -13,6 +13,12 @@
 //      unconditionally. Without it an offscreen clip (a field scrolled past the
 //      fold) leaves an unmatched END -> renderer scissor-stack underflow. One site
 //      in the CLIP render-command case ("shouldRender = true").
+//   4. Floating zIndex is RELATIVE to the enclosing floating element (CSS stacking
+//      context) instead of global: a floating declared inside another floating gets
+//      parent_z + own_z. Upstream sorts every root by its own zIndex, so a widget's
+//      floating part (slider thumb, input caret) sank under the modal panel it was
+//      declared in, and sorting a child root ahead of its parent also made Clay read
+//      the parent bbox one frame stale. openFloatingZStack + 3 sites, search "NT patch 4".
 // NT DEPENDENCY: nt_ui_clay_impl.c wraps Clay__OpenElement /
 //   Clay__ConfigureOpenElement / Clay__CloseElement for the begin/end split
 //   pattern used by nt_ui widgets. Verify these internals still exist on update.
@@ -1298,6 +1304,7 @@ struct Clay_Context {
     Clay__MeasuredWordArray measuredWords;
     Clay__int32_tArray measuredWordsFreeList;
     Clay__int32_tArray openClipElementStack;
+    Clay__int32_tArray openFloatingZStack; // NT patch 4: effective zIndex of each open floating ancestor
     Clay_ElementIdArray pointerOverIds;
     Clay__ScrollContainerDataInternalArray scrollContainerDatas;
     Clay__boolArray treeNodeVisited;
@@ -1830,6 +1837,7 @@ void Clay__CloseElement(void) {
             break;
         } else if (config->type == CLAY__ELEMENT_CONFIG_TYPE_FLOATING) {
             context->openClipElementStack.length--;
+            context->openFloatingZStack.length--; // NT patch 4
         }
     }
 
@@ -2120,6 +2128,11 @@ void Clay__ConfigureOpenElementPtr(const Clay_ElementDeclaration *declaration) {
             if (declaration->floating.clipTo == CLAY_CLIP_TO_NONE) {
                 clipElementId = 0;
             }
+            // NT patch 4: zIndex is relative to the enclosing floating element, clamped to the int16 field.
+            int32_t enclosingZ = context->openFloatingZStack.length > 0 ? Clay__int32_tArray_GetValue(&context->openFloatingZStack, context->openFloatingZStack.length - 1) : 0;
+            int32_t effectiveZ = CLAY__MAX(INT16_MIN, CLAY__MIN(INT16_MAX, enclosingZ + (int32_t)floatingConfig.zIndex));
+            floatingConfig.zIndex = (int16_t)effectiveZ;
+            Clay__int32_tArray_Add(&context->openFloatingZStack, effectiveZ);
             int32_t currentElementIndex = Clay__int32_tArray_GetValue(&context->openLayoutElementStack, context->openLayoutElementStack.length - 1);
             Clay__int32_tArray_Set(&context->layoutElementClipElementIds, currentElementIndex, clipElementId);
             Clay__int32_tArray_Add(&context->openClipElementStack, clipElementId);
@@ -2204,6 +2217,7 @@ void Clay__InitializeEphemeralMemory(Clay_Context* context) {
     context->treeNodeVisited = Clay__boolArray_Allocate_Arena(maxElementCount, arena);
     context->treeNodeVisited.length = context->treeNodeVisited.capacity; // This array is accessed directly rather than behaving as a list
     context->openClipElementStack = Clay__int32_tArray_Allocate_Arena(maxElementCount, arena);
+    context->openFloatingZStack = Clay__int32_tArray_Allocate_Arena(maxElementCount, arena); // NT patch 4
     context->reusableElementIndexBuffer = Clay__int32_tArray_Allocate_Arena(maxElementCount, arena);
     context->layoutElementClipElementIds = Clay__int32_tArray_Allocate_Arena(maxElementCount, arena);
     context->dynamicStringData = Clay__charArray_Allocate_Arena(maxElementCount, arena);

--- a/deps/clay/clay.h
+++ b/deps/clay/clay.h
@@ -18,7 +18,11 @@
 //      parent_z + own_z. Upstream sorts every root by its own zIndex, so a widget's
 //      floating part (slider thumb, input caret) sank under the modal panel it was
 //      declared in, and sorting a child root ahead of its parent also made Clay read
-//      the parent bbox one frame stale. openFloatingZStack + 3 sites, search "NT patch 4".
+//      the parent bbox one frame stale. openFloatingZStack + 4 sites (context field,
+//      ephemeral alloc, push in ConfigureOpenElementPtr, pop in CloseElement), search
+//      "NT patch 4". DEPENDS ON the tree-root sort staying STABLE (it swaps on strict
+//      `<`): a child declared with delta 0 paints above its floating parent only
+//      because equal-z roots keep registration order.
 // NT DEPENDENCY: nt_ui_clay_impl.c wraps Clay__OpenElement /
 //   Clay__ConfigureOpenElement / Clay__CloseElement for the begin/end split
 //   pattern used by nt_ui widgets. Verify these internals still exist on update.
@@ -1837,7 +1841,6 @@ void Clay__CloseElement(void) {
             break;
         } else if (config->type == CLAY__ELEMENT_CONFIG_TYPE_FLOATING) {
             context->openClipElementStack.length--;
-            context->openFloatingZStack.length--; // NT patch 4
         }
     }
 
@@ -1916,6 +1919,11 @@ void Clay__CloseElement(void) {
     Clay__UpdateAspectRatioBox(openLayoutElement);
 
     bool elementIsFloating = Clay__ElementHasConfig(openLayoutElement, CLAY__ELEMENT_CONFIG_TYPE_FLOATING);
+    // NT patch 4: pop here, not in the config loop above — that loop breaks on CLIP, so a config-order
+    // change upstream could silently skip the pop and leave every later floating on a stale band.
+    if (elementIsFloating) {
+        context->openFloatingZStack.length--;
+    }
 
     // Close the currently open element
     int32_t closingElementIndex = Clay__int32_tArray_RemoveSwapback(&context->openLayoutElementStack, (int)context->openLayoutElementStack.length - 1);
@@ -2128,9 +2136,17 @@ void Clay__ConfigureOpenElementPtr(const Clay_ElementDeclaration *declaration) {
             if (declaration->floating.clipTo == CLAY_CLIP_TO_NONE) {
                 clipElementId = 0;
             }
-            // NT patch 4: zIndex is relative to the enclosing floating element, clamped to the int16 field.
+            // NT patch 4: zIndex is relative to the enclosing floating element. Saturating the int16 field
+            // would silently merge two bands into one, so it is an error, not a fallback.
             int32_t enclosingZ = context->openFloatingZStack.length > 0 ? Clay__int32_tArray_GetValue(&context->openFloatingZStack, context->openFloatingZStack.length - 1) : 0;
-            int32_t effectiveZ = CLAY__MAX(INT16_MIN, CLAY__MIN(INT16_MAX, enclosingZ + (int32_t)floatingConfig.zIndex));
+            int32_t rawZ = enclosingZ + (int32_t)floatingConfig.zIndex;
+            int32_t effectiveZ = CLAY__MAX(INT16_MIN, CLAY__MIN(INT16_MAX, rawZ));
+            if (effectiveZ != rawZ) {
+                context->errorHandler.errorHandlerFunction(CLAY__INIT(Clay_ErrorData) {
+                        .errorType = CLAY_ERROR_TYPE_INTERNAL_ERROR,
+                        .errorText = CLAY_STRING("Nested floating zIndex saturated int16 — stacking bands merged."),
+                        .userData = context->errorHandler.userData });
+            }
             floatingConfig.zIndex = (int16_t)effectiveZ;
             Clay__int32_tArray_Add(&context->openFloatingZStack, effectiveZ);
             int32_t currentElementIndex = Clay__int32_tArray_GetValue(&context->openLayoutElementStack, context->openLayoutElementStack.length - 1);

--- a/docs/spec/ui/nt-ui.md
+++ b/docs/spec/ui/nt-ui.md
@@ -38,17 +38,31 @@ Upstream Clay sorts every floating element globally by its own
 `zIndex`. The vendored copy diverges (NT patch 4 in `deps/clay/clay.h`):
 a floating declared inside another floating gets `parent_z + own_z`, so
 `zIndex` reads as a stacking context, like CSS. Without it a widget's
-own floating part (the slider thumb, the input caret and text, a
-scrollbar) sank to the global band 0 and drew UNDER the modal panel it
-was declared in, and sorting a child tree root ahead of its parent also
-made Clay position it from the parent's PREVIOUS-frame bbox (a frame of
-lag, and an empty clip rect on the first frame — which the walker's
-SCISSOR assert catches). Consequences: a widget composes anywhere
-without knowing its global stacking position; the engine's overlay
-bands (`modal_zband_stride`) are declared as deltas and accumulate with
-declaration nesting, NOT with attachment (`attachTo = ROOT` still stacks
-where it was declared); a game floating that wants to escape its
-enclosing panel must be declared outside it.
+own floating part (the slider thumb, the input caret and text) sank to
+the global band 0 and drew UNDER the modal panel it was declared in;
+the scrollbar escaped that only by hand-computing the popup band from
+`active_modal_depth`, which is the workaround the patch deletes. A child
+root sorted ahead of its parent was also positioned from the parent's
+PREVIOUS-frame bbox — a frame of lag, and an empty clip rect on the
+first frame, which the walker's SCISSOR assert catches. A delta of 0
+now ties with the parent and, since the root sort is stable, paints
+after it with a same-frame bbox; a NEGATIVE delta still sorts ahead of
+its parent and still reads the parent's previous-frame bbox (the
+tooltip drop-shadow is the one such case and guards for it).
+
+Consequences: a widget composes anywhere without knowing its global
+stacking position; the engine's overlay bands (`modal_zband_stride`) are
+declared as deltas and accumulate with declaration nesting, NOT with
+attachment (`attachTo = ROOT` still stacks where it was declared), so a
+popup opened from inside another popup reaches `stride*depth` as long as
+every enclosing floating is an engine overlay; a widget's own floating
+parts (scrollbar, thumb, caret) declare delta 0 and rely on being
+declared last to paint above their container's content; a game floating
+that wants to escape its enclosing panel must be declared outside it;
+the value Clay stores and reports for a floating is the accumulated
+band, not the declared delta; and an accumulated band that would
+saturate `int16` raises a Clay error (which `nt_ui` asserts on) rather
+than silently merging two bands.
 
 ## Clay private symbols
 
@@ -348,9 +362,8 @@ missing trigger element can't trip Clay's parent-not-found); trigger-anchored
 placement with per-side edge-flip (BELOW/ABOVE/RIGHT/LEFT, CENTER for modal)
 read from the panel's previous-frame bbox; a `value_t` open/close tween; a shared
 modal-depth z-band declared as ONE `modal_zband_stride` above the enclosing
-floating (Clay accumulates the nesting — see below — so a popup opened from
-inside another popup still lands on `stride*depth`; NT_ASSERT before the push so
-a runaway nesting fails early); and a present-only, transparent light-dismiss
+floating (Clay accumulates the nesting, see "Floating zIndex is relative" above;
+NT_ASSERT before the push so a runaway nesting fails early); and a present-only, transparent light-dismiss
 catcher at `panel_z-1` (outside-click raises a close signal). A fully-closed
 popup declares NO catcher, so the base UI stays clickable; a hover-driven
 overlay (tooltip) can clear the catcher flag entirely. Dismiss is always a

--- a/docs/spec/ui/nt-ui.md
+++ b/docs/spec/ui/nt-ui.md
@@ -364,7 +364,11 @@ read from the panel's previous-frame bbox; a `value_t` open/close tween; a share
 modal-depth z-band declared as ONE `modal_zband_stride` above the enclosing
 floating (Clay accumulates the nesting, see "Floating zIndex is relative" above;
 NT_ASSERT before the push so a runaway nesting fails early); and a present-only, transparent light-dismiss
-catcher at `panel_z-1` (outside-click raises a close signal). A fully-closed
+catcher at `panel_z-1` (outside-click raises a close signal). Esc and the
+outside-click scan run on ONE overlay per frame: the one with the highest
+effective band, ties to the last declared — Clay's own root-sort key, so the
+overlay that consumes the event is always the one painted on top, even when a
+game floating shifts the band of a popup declared inside it. A fully-closed
 popup declares NO catcher, so the base UI stays clickable; a hover-driven
 overlay (tooltip) can clear the catcher flag entirely. Dismiss is always a
 SIGNAL the game acts on (Model D) — popup-core never owns the open bool. The

--- a/docs/spec/ui/nt-ui.md
+++ b/docs/spec/ui/nt-ui.md
@@ -37,41 +37,36 @@ game-side changes.
 Upstream Clay sorts every floating element globally by its own
 `zIndex`. The vendored copy diverges (NT patch 4 in `deps/clay/clay.h`):
 a floating declared inside another floating gets `parent_z + own_z`, so
-`zIndex` reads as a stacking context, like CSS. Without it a widget's
-own floating part (the slider thumb, the input caret and text) sank to
-the global band 0 and drew UNDER the modal panel it was declared in;
-the scrollbar escaped that only by hand-computing the popup band from
-`active_modal_depth`, which is the workaround the patch deletes. A child
-root sorted ahead of its parent was also positioned from the parent's
-PREVIOUS-frame bbox — a frame of lag, and an empty clip rect on the
-first frame, which the walker's SCISSOR assert catches. A delta of 0
-now ties with the parent and, since the root sort is stable, paints
-after it with a same-frame bbox; a NEGATIVE delta still sorts ahead of
-its parent and still reads the parent's previous-frame bbox (two such
-cases: the tooltip drop-shadow, which guards for it, and the inspector
-highlight, which attaches to a base-band element and so reads a
-same-frame bbox).
+`zIndex` reads as a stacking context, like CSS. A widget's floating part
+therefore composes anywhere without knowing its global band, which is
+what lets the slider thumb, the input caret and the scrollbar declare a
+bare delta instead of reading the modal subsystem's depth counter.
 
-Consequences: a widget composes anywhere without knowing its global
-stacking position; the engine's overlay bands (`modal_zband_stride`) are
-declared as deltas and accumulate with declaration nesting, NOT with
-attachment (`attachTo = ROOT` still stacks where it was declared), so a
-popup opened from inside another popup reaches `stride*depth` as long as
-every enclosing floating is an engine overlay; a widget's own floating
-parts (scrollbar, thumb, caret) declare delta 0 and rely on being
-declared last to paint above their container's content; a game floating
-that wants to escape its enclosing panel must be declared outside it;
-the value Clay stores and reports for a floating is the accumulated
-band, not the declared delta — but among RENDER COMMANDS only
-RECTANGLE, TEXT and the clip SCISSOR carry it, since Clay leaves
-`zIndex` at 0 on IMAGE, BORDER and CUSTOM; and an accumulated band that
-would saturate `int16` raises a Clay error (which `nt_ui` asserts on)
-rather than silently merging two bands, which puts a ceiling on what a
-game floating may declare: its own `zIndex` plus `modal_zband_stride`
-per overlay level nested inside it must still fit `int16`. That ceiling
-has no test — the engine's own bands cannot reach it (overlays are
-bounded by `modal_zband_stride * NT_UI_MODAL_MAX_DEPTH`, and the
-inspector root nests nothing with a positive delta).
+A delta of 0 ties with the parent and, since the root sort is stable,
+paints after it with a same-frame bbox. A NEGATIVE delta sorts ahead of
+its parent and reads the parent's PREVIOUS-frame bbox; two parts use
+one — the tooltip drop-shadow, which guards for the first frame, and the
+inspector highlight, which attaches to a base-band element and so is
+unaffected.
+
+Bands accumulate with declaration nesting, NOT with attachment:
+`attachTo = ROOT` still stacks where it was declared. Overlay bands are
+declared as one `modal_zband_stride` each, so nested overlays reach
+`stride*depth` when every enclosing floating is an engine overlay. A
+widget's own floating parts declare delta 0 and paint above their
+container's content because they are declared last. There is no way out
+of an enclosing stacking context: a game floating that must stay under
+all UI belongs at the root level.
+
+The value Clay stores and reports for a floating is the accumulated
+band, not the declared delta. Among render commands only RECTANGLE, TEXT
+and the clip SCISSOR carry it — Clay leaves `zIndex` at 0 on IMAGE,
+BORDER and CUSTOM. An accumulated band that would saturate `int16`
+raises a Clay error, which `nt_ui` asserts on rather than silently
+merging two bands. That caps what a game floating may declare: its own
+`zIndex` plus one stride per overlay level nested inside it must still
+fit `int16`.
+
 
 ## Clay private symbols
 

--- a/docs/spec/ui/nt-ui.md
+++ b/docs/spec/ui/nt-ui.md
@@ -51,8 +51,9 @@ unaffected.
 
 Bands accumulate with declaration nesting, NOT with attachment:
 `attachTo = ROOT` still stacks where it was declared. Overlay bands are
-declared as one `modal_zband_stride` each, so nested overlays reach
-`stride*depth` when every enclosing floating is an engine overlay. A
+declared as one `modal_zband_stride` each, so nested overlays accumulate
+one stride per level, themselves included, when every enclosing floating
+is an engine overlay. A
 widget's own floating parts declare delta 0 and paint above their
 container's content because they are declared last. There is no way out
 of an enclosing stacking context: a game floating that must stay under
@@ -66,7 +67,6 @@ raises a Clay error, which `nt_ui` asserts on rather than silently
 merging two bands. That caps what a game floating may declare: its own
 `zIndex` plus one stride per overlay level nested inside it must still
 fit `int16`.
-
 
 ## Clay private symbols
 
@@ -83,7 +83,7 @@ and can't be split across function boundaries. The wrappers are the
 smallest possible escape hatch.
 
 One of those wrappers reads state that exists only because of NT patch 4:
-`nt_ui_clay_priv_enclosing_floating_z` returns the top of Clay's
+`nt_ui_clay_priv_open_floating_z` returns the top of Clay's
 `openFloatingZStack`, and `nt_ui_popup` uses it to rank overlays. Re-applying
 patch 4 is therefore a precondition for overlay arbitration, not only for
 painting.

--- a/docs/spec/ui/nt-ui.md
+++ b/docs/spec/ui/nt-ui.md
@@ -53,9 +53,8 @@ Bands accumulate with declaration nesting, NOT with attachment:
 `attachTo = ROOT` still stacks where it was declared. Overlay bands are
 declared as one `modal_zband_stride` each, so nested overlays accumulate
 one stride per level, themselves included, when every enclosing floating
-is an engine overlay. A
-widget's own floating parts declare delta 0 and paint above their
-container's content because they are declared last. There is no way out
+is an engine overlay. A widget's own floating parts declare delta 0 and
+paint above their container's content because they are declared last. There is no way out
 of an enclosing stacking context: a game floating that must stay under
 all UI belongs at the root level.
 
@@ -375,12 +374,13 @@ modal-depth z-band declared as ONE `modal_zband_stride` above the enclosing
 floating (Clay accumulates the nesting, see "Floating zIndex is relative" above;
 NT_ASSERT before the push so a runaway nesting fails early); and a present-only, transparent light-dismiss
 catcher at `panel_z-1` (outside-click raises a close signal). Esc and the
-outside-click scan run on ONE CATCHER-BEARING popup per frame: the one with the
-highest effective band, ties to the last declared at the higher draw layer —
-the walker's own paint key, so the popup that consumes the event is the one
-painted on top even when a game floating shifts the band of a popup declared
-inside it. A catcher-less overlay (menu, tooltip) never claims that slot and
-runs its own dismiss; the text field's Esc-unfocus is independent of both. A fully-closed
+outside-click scan run on ONE CATCHER-BEARING popup per frame: the highest
+effective band, ties to the last declared. That is the POINTER arbiter's key,
+not the paint key, and deliberately so — the winner performs the dismissal
+through its own catcher's interaction, so a slot ranked by draw layer would
+hand the scan to a popup whose catcher never wins the click. A catcher-less
+overlay (menu, tooltip) never claims that slot and runs its own dismiss; the
+text field's Esc-unfocus is independent of both. A fully-closed
 popup declares NO catcher, so the base UI stays clickable; a hover-driven
 overlay (tooltip) can clear the catcher flag entirely. Dismiss is always a
 SIGNAL the game acts on (Model D) — popup-core never owns the open bool. The

--- a/docs/spec/ui/nt-ui.md
+++ b/docs/spec/ui/nt-ui.md
@@ -32,6 +32,24 @@ Clay's pinned API (`CLAY_PINNED_MAJOR/MINOR` enforced via
 publicly-promised surface; bumping Clay can require coordinated
 game-side changes.
 
+## Floating zIndex is relative
+
+Upstream Clay sorts every floating element globally by its own
+`zIndex`. The vendored copy diverges (NT patch 4 in `deps/clay/clay.h`):
+a floating declared inside another floating gets `parent_z + own_z`, so
+`zIndex` reads as a stacking context, like CSS. Without it a widget's
+own floating part (the slider thumb, the input caret and text, a
+scrollbar) sank to the global band 0 and drew UNDER the modal panel it
+was declared in, and sorting a child tree root ahead of its parent also
+made Clay position it from the parent's PREVIOUS-frame bbox (a frame of
+lag, and an empty clip rect on the first frame — which the walker's
+SCISSOR assert catches). Consequences: a widget composes anywhere
+without knowing its global stacking position; the engine's overlay
+bands (`modal_zband_stride`) are declared as deltas and accumulate with
+declaration nesting, NOT with attachment (`attachTo = ROOT` still stacks
+where it was declared); a game floating that wants to escape its
+enclosing panel must be declared outside it.
+
 ## Clay private symbols
 
 Even with `NT_UI_DEBUG_TOOLS=OFF`, nt_ui touches ~10 Clay **private**
@@ -329,7 +347,9 @@ attached to the ROOT (anchor-derived offset, no trigger-id dependency, so a
 missing trigger element can't trip Clay's parent-not-found); trigger-anchored
 placement with per-side edge-flip (BELOW/ABOVE/RIGHT/LEFT, CENTER for modal)
 read from the panel's previous-frame bbox; a `value_t` open/close tween; a shared
-modal-depth z-band (`modal_zband_stride*(depth+1)`, NT_ASSERT before the push so
+modal-depth z-band declared as ONE `modal_zband_stride` above the enclosing
+floating (Clay accumulates the nesting — see below — so a popup opened from
+inside another popup still lands on `stride*depth`; NT_ASSERT before the push so
 a runaway nesting fails early); and a present-only, transparent light-dismiss
 catcher at `panel_z-1` (outside-click raises a close signal). A fully-closed
 popup declares NO catcher, so the base UI stays clickable; a hover-driven

--- a/docs/spec/ui/nt-ui.md
+++ b/docs/spec/ui/nt-ui.md
@@ -47,8 +47,10 @@ PREVIOUS-frame bbox — a frame of lag, and an empty clip rect on the
 first frame, which the walker's SCISSOR assert catches. A delta of 0
 now ties with the parent and, since the root sort is stable, paints
 after it with a same-frame bbox; a NEGATIVE delta still sorts ahead of
-its parent and still reads the parent's previous-frame bbox (the
-tooltip drop-shadow is the one such case and guards for it).
+its parent and still reads the parent's previous-frame bbox (two such
+cases: the tooltip drop-shadow, which guards for it, and the inspector
+highlight, which attaches to a base-band element and so reads a
+same-frame bbox).
 
 Consequences: a widget composes anywhere without knowing its global
 stacking position; the engine's overlay bands (`modal_zband_stride`) are
@@ -60,9 +62,16 @@ parts (scrollbar, thumb, caret) declare delta 0 and rely on being
 declared last to paint above their container's content; a game floating
 that wants to escape its enclosing panel must be declared outside it;
 the value Clay stores and reports for a floating is the accumulated
-band, not the declared delta; and an accumulated band that would
-saturate `int16` raises a Clay error (which `nt_ui` asserts on) rather
-than silently merging two bands.
+band, not the declared delta — but among RENDER COMMANDS only
+RECTANGLE, TEXT and the clip SCISSOR carry it, since Clay leaves
+`zIndex` at 0 on IMAGE, BORDER and CUSTOM; and an accumulated band that
+would saturate `int16` raises a Clay error (which `nt_ui` asserts on)
+rather than silently merging two bands, which puts a ceiling on what a
+game floating may declare: its own `zIndex` plus `modal_zband_stride`
+per overlay level nested inside it must still fit `int16`. That ceiling
+has no test — the engine's own bands cannot reach it (overlays are
+bounded by `modal_zband_stride * NT_UI_MODAL_MAX_DEPTH`, and the
+inspector root nests nothing with a positive delta).
 
 ## Clay private symbols
 
@@ -77,6 +86,12 @@ calls so widget code can run between them — Clay's public macro
 bundles `Open` + `Configure` + scoped body into a single statement
 and can't be split across function boundaries. The wrappers are the
 smallest possible escape hatch.
+
+One of those wrappers reads state that exists only because of NT patch 4:
+`nt_ui_clay_priv_enclosing_floating_z` returns the top of Clay's
+`openFloatingZStack`, and `nt_ui_popup` uses it to rank overlays. Re-applying
+patch 4 is therefore a precondition for overlay arbitration, not only for
+painting.
 
 With `NT_UI_DEBUG_TOOLS=ON` this expands by ~30 more Clay private
 symbols for the verbatim Clay debug-view port (the inspector body
@@ -365,10 +380,12 @@ modal-depth z-band declared as ONE `modal_zband_stride` above the enclosing
 floating (Clay accumulates the nesting, see "Floating zIndex is relative" above;
 NT_ASSERT before the push so a runaway nesting fails early); and a present-only, transparent light-dismiss
 catcher at `panel_z-1` (outside-click raises a close signal). Esc and the
-outside-click scan run on ONE overlay per frame: the one with the highest
-effective band, ties to the last declared — Clay's own root-sort key, so the
-overlay that consumes the event is always the one painted on top, even when a
-game floating shifts the band of a popup declared inside it. A fully-closed
+outside-click scan run on ONE CATCHER-BEARING popup per frame: the one with the
+highest effective band, ties to the last declared at the higher draw layer —
+the walker's own paint key, so the popup that consumes the event is the one
+painted on top even when a game floating shifts the band of a popup declared
+inside it. A catcher-less overlay (menu, tooltip) never claims that slot and
+runs its own dismiss; the text field's Esc-unfocus is independent of both. A fully-closed
 popup declares NO catcher, so the base UI stays clickable; a hover-driven
 overlay (tooltip) can clear the catcher flag entirely. Dismiss is always a
 SIGNAL the game acts on (Model D) — popup-core never owns the open bool. The

--- a/docs/spec/ui/nt-ui.md
+++ b/docs/spec/ui/nt-ui.md
@@ -54,7 +54,10 @@ Bands accumulate with declaration nesting, NOT with attachment:
 declared as one `modal_zband_stride` each, so nested overlays accumulate
 one stride per level, themselves included, when every enclosing floating
 is an engine overlay. A widget's own floating parts declare delta 0 and
-paint above their container's content because they are declared last. There is no way out
+paint above their container's content because they are declared last —
+which also means a floating declared AFTER one of them in the same band
+paints over it, so a scrollbar yields to a tooltip opened later in the
+same panel. There is no way out
 of an enclosing stacking context: a game floating that must stay under
 all UI belongs at the root level.
 
@@ -378,7 +381,17 @@ outside-click scan run on ONE CATCHER-BEARING popup per frame: the highest
 effective band, ties to the last declared. That is the POINTER arbiter's key,
 not the paint key, and deliberately so — the winner performs the dismissal
 through its own catcher's interaction, so a slot ranked by draw layer would
-hand the scan to a popup whose catcher never wins the click. A catcher-less
+hand the scan to a popup whose catcher never wins the click and NEITHER
+would dismiss. The cost is real and accepted: two catcher-bearing popups on
+one band with different draw layers paint by layer but dismiss by
+declaration, so an outside click can close the one underneath. Ranking the
+slot by paint order requires making the pointer arbiter layer-aware first
+(`resolve_hot_if_needed` is band-only today) — until then the two must use
+one key, and this is that key. The agreement is a 2D-context property: a 3D
+ctx arbitrates the pointer by ray distance and does not rank overlays by
+band at all. The agreement is a 2D-context property: a
+3D ctx arbitrates the pointer by ray distance and does not rank overlays
+by band at all. A catcher-less
 overlay (menu, tooltip) never claims that slot and runs its own dismiss; the
 text field's Esc-unfocus is independent of both. A fully-closed
 popup declares NO catcher, so the base UI stays clickable; a hover-driven

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -470,7 +470,6 @@ void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, float dt,
     ctx->modal_top_id_prev = ctx->modal_top_id_cur;
     ctx->modal_top_id_cur = 0U;
     ctx->modal_top_z_cur = INT32_MIN;
-    ctx->modal_top_layer_cur = 0U;
     /* Reset this frame's modal presence; committed into _prev at nt_ui_end (so a game that polls
      * nt_ui_modal_active BEFORE this frame's begin still sees last frame's result). */
     ctx->modal_present_cur = false;

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -233,8 +233,10 @@ nt_ui_context_t *nt_ui_create_context(void *arena, size_t arena_size, const nt_u
     ctx->element_depth_bias_ndc = desc->element_depth_bias_ndc;
     /* Used as-is; the default comes solely from nt_ui_create_desc_defaults() (same convention as max_elements). */
     ctx->modal_zband_stride = desc->modal_zband_stride;
-    NT_ASSERT((int)ctx->modal_zband_stride > 0 && (int)ctx->modal_zband_stride * NT_UI_MODAL_MAX_DEPTH <= INT16_MAX &&
-              "nt_ui_create_context: modal_zband_stride * NT_UI_MODAL_MAX_DEPTH must fit int16");
+    /* > 1, not just > 0: an overlay's catcher sits one band UNDER its panel, so a stride of 1 puts the
+     * catcher on the base band where it stops gating base UI. */
+    NT_ASSERT((int)ctx->modal_zband_stride > 1 && (int)ctx->modal_zband_stride * NT_UI_MODAL_MAX_DEPTH <= INT16_MAX &&
+              "nt_ui_create_context: modal_zband_stride must be > 1 and stride * NT_UI_MODAL_MAX_DEPTH must fit int16");
     /* memset zeroed these; restore the gesture defaults (0 is not a valid dbl window / radius). */
     ctx->gesture_dbl_window_secs = NT_UI_GESTURE_DBL_WINDOW_SECS;
     ctx->gesture_move_radius_px = NT_UI_GESTURE_MOVE_RADIUS_PX;
@@ -548,7 +550,8 @@ void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, float dt,
     const float clay_pointer_y = primary->y;
 #endif
 
-    /* nt_ui_inspector replaces Clay's built-in debug view. */
+    /* nt_ui_inspector replaces Clay's built-in debug view. Keeping it off is also what makes NT patch 4
+     * safe there: that view nests zIndex 32766 inside 32765, which would saturate the accumulated band. */
     Clay_SetDebugModeEnabled(false);
     Clay_SetLayoutDimensions((Clay_Dimensions){.width = screen_w, .height = screen_h});
 

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -470,6 +470,7 @@ void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, float dt,
     ctx->modal_top_id_prev = ctx->modal_top_id_cur;
     ctx->modal_top_id_cur = 0U;
     ctx->modal_top_z_cur = INT32_MIN;
+    ctx->modal_top_layer_cur = 0U;
     /* Reset this frame's modal presence; committed into _prev at nt_ui_end (so a game that polls
      * nt_ui_modal_active BEFORE this frame's begin still sees last frame's result). */
     ctx->modal_present_cur = false;

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -469,7 +469,7 @@ void nt_ui_begin(nt_ui_context_t *ctx, float screen_w, float screen_h, float dt,
     /* Commit last frame's deepest modal as the close-scan target (1-frame IM lag), then reset. */
     ctx->modal_top_id_prev = ctx->modal_top_id_cur;
     ctx->modal_top_id_cur = 0U;
-    ctx->modal_max_depth_cur = 0U;
+    ctx->modal_top_z_cur = INT32_MIN;
     /* Reset this frame's modal presence; committed into _prev at nt_ui_end (so a game that polls
      * nt_ui_modal_active BEFORE this frame's begin still sees last frame's result). */
     ctx->modal_present_cur = false;

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -67,9 +67,10 @@
  * (docs/spec/ui/nt-ui.md, "Floating zIndex is relative"), so an overlay sits one stride above whatever
  * encloses it — including a game floating's own zIndex, and there is no way out of that context: a
  * game floating that must stay under all UI belongs at the root level. Budget: that game zIndex plus
- * one stride per overlay level opened inside it must fit int16, or Clay raises a fatal error.
+ * one stride per overlay level opened inside it must fit int16, or Clay clamps and reports it
+ * (nt_ui asserts; an NT_ASSERT_OFF build paints the merged band).
  * Per-context override via nt_ui_create_desc_t.modal_zband_stride (seeded from this in
- * nt_ui_create_desc_defaults; must be > 0). */
+ * nt_ui_create_desc_defaults; must be > 1 — an overlay's catcher needs the band below its panel). */
 #define NT_UI_MODAL_ZBAND_STRIDE 1000
 
 /* Bare uint8_t[N] is 1-byte aligned; create_context asserts otherwise. */
@@ -260,7 +261,7 @@ typedef struct {
     /* 3D ctx render-only depth bias. 0 = off. Positive values draw deeper hierarchy levels
      * slightly closer in NDC Z; hit-test keeps using the unbiased widget plane. */
     float element_depth_bias_ndc;
-    /* Per-depth modal z-band stride; 0 = default NT_UI_MODAL_ZBAND_STRIDE. */
+    /* Band each overlay level declares above the floating enclosing it; 0 = NT_UI_MODAL_ZBAND_STRIDE. */
     int16_t modal_zband_stride;
     /* Per-id retained-state pool size; MUST be power-of-2. 0 = default NT_UI_STATE_SLOTS. */
     uint32_t state_slots;

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -63,7 +63,11 @@
 #define NT_UI_DEFAULT_MAX_ELEMENT_COUNT 1024
 #endif
 
-/* Default per-depth modal z-band stride; each nested modal sits panel_z = stride*(depth+1).
+/* Default modal z-band stride. A floating element's zIndex is RELATIVE to the floating element it is
+ * declared inside (see docs/spec/ui/nt-ui.md, "Floating zIndex is relative"), so an overlay sits one
+ * stride above whatever encloses it: nested overlays reach stride*(depth+1), and an overlay declared
+ * inside a game floating is lifted by that floating's own zIndex too. A game floating that must stay
+ * under all UI belongs at the root level; there is no way to escape an enclosing stacking context.
  * Per-context override via nt_ui_create_desc_t.modal_zband_stride (seeded from this in
  * nt_ui_create_desc_defaults; must be > 0). */
 #define NT_UI_MODAL_ZBAND_STRIDE 1000

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -63,13 +63,11 @@
 #define NT_UI_DEFAULT_MAX_ELEMENT_COUNT 1024
 #endif
 
-/* Default modal z-band stride. A floating element's zIndex is RELATIVE to the floating element it is
- * declared inside (see docs/spec/ui/nt-ui.md, "Floating zIndex is relative"), so an overlay sits one
- * stride above whatever encloses it — one stride per enclosing overlay level, itself included, and an
- * overlay declared inside a game floating is lifted by that floating's own zIndex too. A game floating
- * that must stay under all UI belongs at the root level; there is no way out of an enclosing stacking
- * context. Budget: a game floating's zIndex plus one stride per overlay level opened inside it must fit
- * int16 — overflowing raises a fatal Clay error.
+/* Default modal z-band stride. A floating's zIndex is RELATIVE to the floating it is declared inside
+ * (docs/spec/ui/nt-ui.md, "Floating zIndex is relative"), so an overlay sits one stride above whatever
+ * encloses it — including a game floating's own zIndex, and there is no way out of that context: a
+ * game floating that must stay under all UI belongs at the root level. Budget: that game zIndex plus
+ * one stride per overlay level opened inside it must fit int16, or Clay raises a fatal error.
  * Per-context override via nt_ui_create_desc_t.modal_zband_stride (seeded from this in
  * nt_ui_create_desc_defaults; must be > 0). */
 #define NT_UI_MODAL_ZBAND_STRIDE 1000

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -65,9 +65,11 @@
 
 /* Default modal z-band stride. A floating element's zIndex is RELATIVE to the floating element it is
  * declared inside (see docs/spec/ui/nt-ui.md, "Floating zIndex is relative"), so an overlay sits one
- * stride above whatever encloses it: nested overlays reach stride*(depth+1), and an overlay declared
- * inside a game floating is lifted by that floating's own zIndex too. A game floating that must stay
- * under all UI belongs at the root level; there is no way to escape an enclosing stacking context.
+ * stride above whatever encloses it — one stride per enclosing overlay level, itself included, and an
+ * overlay declared inside a game floating is lifted by that floating's own zIndex too. A game floating
+ * that must stay under all UI belongs at the root level; there is no way out of an enclosing stacking
+ * context. Budget: a game floating's zIndex plus one stride per overlay level opened inside it must fit
+ * int16 — overflowing raises a fatal Clay error.
  * Per-context override via nt_ui_create_desc_t.modal_zband_stride (seeded from this in
  * nt_ui_create_desc_defaults; must be > 0). */
 #define NT_UI_MODAL_ZBAND_STRIDE 1000

--- a/engine/ui/nt_ui_clay_impl.c
+++ b/engine/ui/nt_ui_clay_impl.c
@@ -1670,6 +1670,9 @@ static void nt_ui_internal_emit_inspector_layout(nt_ui_context_t *ctx) {
     // #endregion
     // #region row-list
     /* RIGHT_CENTER overlay attach — engine root is full-width so side-by-side would land off-screen. */
+    /* The root band is absolute and two below int16's ceiling, so this must not be declared inside a
+     * floating: the accumulated band would saturate (public entry point, game-reachable). */
+    NT_ASSERT(nt_ui_clay_priv_open_floating_z(ctx->clay) == 0 && "nt_ui inspector must be declared at the root level");
     CLAY({.id = CLAY_ID("ntInsp_Root"),
           .layout = {.sizing = {CLAY_SIZING_FIXED(panel_w), CLAY_SIZING_FIXED(context->layoutDimensions.height)}, .layoutDirection = CLAY_TOP_TO_BOTTOM},
           .userData = NT_UI_CLAY_DATA(NT_UI_LAYER_DEBUG_PANEL_BG),

--- a/engine/ui/nt_ui_clay_impl.c
+++ b/engine/ui/nt_ui_clay_impl.c
@@ -1597,9 +1597,7 @@ static cdv_layout_data_t cdv_render_layout_elements_list(nt_ui_context_t *ctx, i
 
     // #region highlight-emit
     if (highlightedElementId) {
-        /* Declared inside ntInsp_Root (band 32765), so zIndex is relative to it: -1 lands just under the
-         * panel body it would otherwise cover, still above every game band. Nothing here may declare a
-         * delta above +2 — the band is that close to int16's ceiling. */
+        /* Relative to ntInsp_Root: -1 lands just under the panel body it would otherwise cover. */
         CLAY({.id = CLAY_ID("ntInsp_ElementHighlight"),
               .layout = {.sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0)}},
               .userData = NT_UI_CLAY_DATA(NT_UI_LAYER_DEBUG_HIGHLIGHT),

--- a/engine/ui/nt_ui_clay_impl.c
+++ b/engine/ui/nt_ui_clay_impl.c
@@ -39,6 +39,12 @@ int32_t nt_ui_clay_priv_layout_elements_length(Clay_Context *clay) {
     return clay->layoutElements.length;
 }
 
+int32_t nt_ui_clay_priv_enclosing_floating_z(Clay_Context *clay) {
+    NT_ASSERT(clay != NULL && "nt_ui_clay_priv_enclosing_floating_z: clay must be non-NULL");
+    const int32_t len = clay->openFloatingZStack.length;
+    return (len > 0) ? clay->openFloatingZStack.internalArray[len - 1] : 0;
+}
+
 float nt_ui_clay_priv_layout_width(Clay_Context *clay) {
     NT_ASSERT(clay != NULL && "nt_ui_clay_priv_layout_width: clay must be non-NULL");
     return clay->layoutDimensions.width;

--- a/engine/ui/nt_ui_clay_impl.c
+++ b/engine/ui/nt_ui_clay_impl.c
@@ -1597,8 +1597,9 @@ static cdv_layout_data_t cdv_render_layout_elements_list(nt_ui_context_t *ctx, i
 
     // #region highlight-emit
     if (highlightedElementId) {
-        /* Declared inside ntInsp_Root, so zIndex is relative to it: -1 lands just under the panel body
-         * it would otherwise cover, still above every game band. */
+        /* Declared inside ntInsp_Root (band 32765), so zIndex is relative to it: -1 lands just under the
+         * panel body it would otherwise cover, still above every game band. Nothing here may declare a
+         * delta above +2 — the band is that close to int16's ceiling. */
         CLAY({.id = CLAY_ID("ntInsp_ElementHighlight"),
               .layout = {.sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0)}},
               .userData = NT_UI_CLAY_DATA(NT_UI_LAYER_DEBUG_HIGHLIGHT),

--- a/engine/ui/nt_ui_clay_impl.c
+++ b/engine/ui/nt_ui_clay_impl.c
@@ -562,8 +562,8 @@ void nt_ui_internal_build_tree(nt_ui_context_t *ctx) {
 
         nt_ui_baked_xform_t seed;
         /* The document root (Clay__RootContainer) is the only tree root with parentId 0. Identify it by
-         * that, NOT by array index 0: Clay sorts tree roots by zIndex, so a negative-zIndex floating child
-         * (e.g. a tooltip drop-shadow) sorts ahead of the document root and shifts it off index 0. */
+         * that, NOT by array index 0: Clay sorts tree roots by zIndex, so any floating whose effective z
+         * is negative sorts ahead of the document root and shifts it off index 0. */
         if (root->parentId == 0U) {
             seed = identity;
         } else {
@@ -1588,11 +1588,12 @@ static cdv_layout_data_t cdv_render_layout_elements_list(nt_ui_context_t *ctx, i
 
     // #region highlight-emit
     if (highlightedElementId) {
-        /* zIndex 32764 keeps it above game UI but strictly under the panel root. */
+        /* Declared inside ntInsp_Root, so zIndex is relative to it: -1 keeps the highlight above game UI
+         * (the panel band is far above it) but strictly under the panel body it would otherwise cover. */
         CLAY({.id = CLAY_ID("ntInsp_ElementHighlight"),
               .layout = {.sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0)}},
               .userData = NT_UI_CLAY_DATA(NT_UI_LAYER_DEBUG_HIGHLIGHT),
-              .floating = {.parentId = highlightedElementId, .zIndex = 32764, .pointerCaptureMode = CLAY_POINTER_CAPTURE_MODE_PASSTHROUGH, .attachTo = CLAY_ATTACH_TO_ELEMENT_WITH_ID}}) {
+              .floating = {.parentId = highlightedElementId, .zIndex = -1, .pointerCaptureMode = CLAY_POINTER_CAPTURE_MODE_PASSTHROUGH, .attachTo = CLAY_ATTACH_TO_ELEMENT_WITH_ID}}) {
             CLAY({.id = CLAY_ID("ntInsp_ElementHighlightRectangle"),
                   .layout = {.sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0)}},
                   .userData = NT_UI_CLAY_DATA(NT_UI_LAYER_DEBUG_HIGHLIGHT),

--- a/engine/ui/nt_ui_clay_impl.c
+++ b/engine/ui/nt_ui_clay_impl.c
@@ -39,8 +39,8 @@ int32_t nt_ui_clay_priv_layout_elements_length(Clay_Context *clay) {
     return clay->layoutElements.length;
 }
 
-int32_t nt_ui_clay_priv_enclosing_floating_z(Clay_Context *clay) {
-    NT_ASSERT(clay != NULL && "nt_ui_clay_priv_enclosing_floating_z: clay must be non-NULL");
+int32_t nt_ui_clay_priv_open_floating_z(Clay_Context *clay) {
+    NT_ASSERT(clay != NULL && "nt_ui_clay_priv_open_floating_z: clay must be non-NULL");
     const int32_t len = clay->openFloatingZStack.length;
     return (len > 0) ? Clay__int32_tArray_GetValue(&clay->openFloatingZStack, len - 1) : 0;
 }
@@ -1597,10 +1597,8 @@ static cdv_layout_data_t cdv_render_layout_elements_list(nt_ui_context_t *ctx, i
 
     // #region highlight-emit
     if (highlightedElementId) {
-        /* Declared inside ntInsp_Root, so zIndex is relative to it: -1 lands on the inspector band minus
-         * one — above every game band, strictly under the panel body it would otherwise cover. Nothing
-         * inside ntInsp_Root may declare a POSITIVE delta: the band is one below int16's ceiling. */
-        NT_ASSERT(nt_ui_clay_priv_enclosing_floating_z(ctx->clay) == NT_UI_INSPECTOR_ROOT_Z && "inspector highlight must be declared inside ntInsp_Root");
+        /* Declared inside ntInsp_Root, so zIndex is relative to it: -1 lands just under the panel body
+         * it would otherwise cover, still above every game band. */
         CLAY({.id = CLAY_ID("ntInsp_ElementHighlight"),
               .layout = {.sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0)}},
               .userData = NT_UI_CLAY_DATA(NT_UI_LAYER_DEBUG_HIGHLIGHT),

--- a/engine/ui/nt_ui_clay_impl.c
+++ b/engine/ui/nt_ui_clay_impl.c
@@ -42,7 +42,7 @@ int32_t nt_ui_clay_priv_layout_elements_length(Clay_Context *clay) {
 int32_t nt_ui_clay_priv_enclosing_floating_z(Clay_Context *clay) {
     NT_ASSERT(clay != NULL && "nt_ui_clay_priv_enclosing_floating_z: clay must be non-NULL");
     const int32_t len = clay->openFloatingZStack.length;
-    return (len > 0) ? clay->openFloatingZStack.internalArray[len - 1] : 0;
+    return (len > 0) ? Clay__int32_tArray_GetValue(&clay->openFloatingZStack, len - 1) : 0;
 }
 
 float nt_ui_clay_priv_layout_width(Clay_Context *clay) {
@@ -679,6 +679,9 @@ static const Clay_Color CDV_COLOR_3 = {141, 133, 135, 255};
 static const Clay_Color CDV_COLOR_4 = {238, 226, 231, 255};
 static const Clay_Color CDV_COLOR_SELECTED_ROW = {102, 80, 78, 255};
 static const Clay_Color CDV_HIGHLIGHT_COLOR = {168, 66, 28, 100};
+/* Absolute band of the inspector root — two below int16's ceiling, above every game band. Floating
+ * zIndex is relative (NT patch 4), so anything declared inside it must use a NEGATIVE delta. */
+#define NT_UI_INSPECTOR_ROOT_Z 32765
 
 /* Filtered out of the viewport-hover scan to prevent self-feedback on the highlight rect. */
 enum { CDV_OWNED_ID_COUNT = 7 };
@@ -1594,8 +1597,10 @@ static cdv_layout_data_t cdv_render_layout_elements_list(nt_ui_context_t *ctx, i
 
     // #region highlight-emit
     if (highlightedElementId) {
-        /* Declared inside ntInsp_Root, so zIndex is relative to it: -1 keeps the highlight above game UI
-         * (the panel band is far above it) but strictly under the panel body it would otherwise cover. */
+        /* Declared inside ntInsp_Root, so zIndex is relative to it: -1 lands on the inspector band minus
+         * one — above every game band, strictly under the panel body it would otherwise cover. Nothing
+         * inside ntInsp_Root may declare a POSITIVE delta: the band is one below int16's ceiling. */
+        NT_ASSERT(nt_ui_clay_priv_enclosing_floating_z(ctx->clay) == NT_UI_INSPECTOR_ROOT_Z && "inspector highlight must be declared inside ntInsp_Root");
         CLAY({.id = CLAY_ID("ntInsp_ElementHighlight"),
               .layout = {.sizing = {CLAY_SIZING_GROW(0), CLAY_SIZING_GROW(0)}},
               .userData = NT_UI_CLAY_DATA(NT_UI_LAYER_DEBUG_HIGHLIGHT),
@@ -1671,7 +1676,7 @@ static void nt_ui_internal_emit_inspector_layout(nt_ui_context_t *ctx) {
     CLAY({.id = CLAY_ID("ntInsp_Root"),
           .layout = {.sizing = {CLAY_SIZING_FIXED(panel_w), CLAY_SIZING_FIXED(context->layoutDimensions.height)}, .layoutDirection = CLAY_TOP_TO_BOTTOM},
           .userData = NT_UI_CLAY_DATA(NT_UI_LAYER_DEBUG_PANEL_BG),
-          .floating = {.zIndex = 32765,
+          .floating = {.zIndex = NT_UI_INSPECTOR_ROOT_Z,
                        .attachPoints = {.element = CLAY_ATTACH_POINT_RIGHT_CENTER, .parent = CLAY_ATTACH_POINT_RIGHT_CENTER},
                        .attachTo = CLAY_ATTACH_TO_ROOT,
                        .clipTo = CLAY_CLIP_TO_ATTACHED_PARENT},

--- a/engine/ui/nt_ui_clay_impl.h
+++ b/engine/ui/nt_ui_clay_impl.h
@@ -30,6 +30,9 @@ void nt_ui_clay_priv_close_element(void);
 
 // #region clay_context primitive accessors
 int32_t nt_ui_clay_priv_layout_elements_length(Clay_Context *clay);
+/* Effective zIndex of the floating element currently open around the caller (0 at the root level) —
+ * the base Clay adds to the next floating's declared delta (NT patch 4). Valid only mid-layout. */
+int32_t nt_ui_clay_priv_enclosing_floating_z(Clay_Context *clay);
 float nt_ui_clay_priv_pointer_x(Clay_Context *clay);
 float nt_ui_clay_priv_pointer_y(Clay_Context *clay);
 /* 1 if state == PRESSED or PRESSED_THIS_FRAME. */

--- a/engine/ui/nt_ui_clay_impl.h
+++ b/engine/ui/nt_ui_clay_impl.h
@@ -30,9 +30,10 @@ void nt_ui_clay_priv_close_element(void);
 
 // #region clay_context primitive accessors
 int32_t nt_ui_clay_priv_layout_elements_length(Clay_Context *clay);
-/* Effective zIndex of the floating element currently open around the caller (0 at the root level) —
- * the base Clay adds to the next floating's declared delta (NT patch 4). Valid only mid-layout. */
-int32_t nt_ui_clay_priv_enclosing_floating_z(Clay_Context *clay);
+/* Effective zIndex of the innermost floating element open right now (0 at the root level): the base
+ * Clay adds to the next floating's declared delta, and — once that floating is configured — its own
+ * accumulated band (NT patch 4). Valid only mid-layout. */
+int32_t nt_ui_clay_priv_open_floating_z(Clay_Context *clay);
 float nt_ui_clay_priv_pointer_x(Clay_Context *clay);
 float nt_ui_clay_priv_pointer_y(Clay_Context *clay);
 /* 1 if state == PRESSED or PRESSED_THIS_FRAME. */

--- a/engine/ui/nt_ui_dropdown.c
+++ b/engine/ui/nt_ui_dropdown.c
@@ -75,9 +75,6 @@ static inline void combo_dup_key_check(nt_ui_context_t *ctx, uint32_t row_id) {
 #endif
 }
 
-#ifdef NT_TEST_ACCESS
-#endif
-
 nt_ui_dropdown_style_t nt_ui_dropdown_style_defaults(void) {
     /* Flat-color baseline: no atlas art (every bg.atlas.id stays 0), eased states, polished out of box.
      * The trigger reads as a button; rows highlight on hover; the selected row carries a distinct fill. */

--- a/engine/ui/nt_ui_dropdown.c
+++ b/engine/ui/nt_ui_dropdown.c
@@ -76,7 +76,6 @@ static inline void combo_dup_key_check(nt_ui_context_t *ctx, uint32_t row_id) {
 }
 
 #ifdef NT_TEST_ACCESS
-static uint8_t s_last_side; /* edge-flip probe (NT_TEST_ACCESS) */
 #endif
 
 nt_ui_dropdown_style_t nt_ui_dropdown_style_defaults(void) {
@@ -395,10 +394,6 @@ static bool combo_open_list(nt_ui_context_t *ctx, uint8_t fill_layer, uint8_t la
     if (!nt_ui_popup_visible(ctx, dropdown_popup_id(id), &pst, &anc, open)) {
         return false; /* popup self-balances when fully closed (no end needed) */
     }
-#ifdef NT_TEST_ACCESS
-    s_last_side = nt_ui_popup_test_last_side();
-#endif
-
     const bool scrolls = (style->max_visible_rows > 0U);
     combo_open_body(ctx, fill_layer, id, style, scrolls, panel_art);
 
@@ -562,7 +557,6 @@ void nt_ui_combo_end(nt_ui_context_t *ctx) {
 }
 
 #ifdef NT_TEST_ACCESS
-uint8_t nt_ui_dropdown_test_last_side(void) { return s_last_side; }
 uint32_t nt_ui_dropdown_test_scroll_id(uint32_t dropdown_id) { return dropdown_scroll_id(dropdown_id); }
 /* Combo rows key the label cell by (combo_id, row_idx); row_idx == idx for the in-order selectable feed. */
 nt_ui_bbox_t nt_ui_dropdown_test_row_label_bbox(const nt_ui_context_t *ctx, uint32_t dropdown_id, int idx) { return nt_ui_get_bbox(ctx, combo_row_label_id(dropdown_id, (uint32_t)idx)); }

--- a/engine/ui/nt_ui_dropdown.h
+++ b/engine/ui/nt_ui_dropdown.h
@@ -135,7 +135,6 @@ void nt_ui_combo_end(nt_ui_context_t *ctx);
 
 #ifdef NT_TEST_ACCESS
 /* The popup side chosen for the combo list on its last open (edge-flip probe). */
-uint8_t nt_ui_dropdown_test_last_side(void);
 /* The scroll id the list used for its long-list wrapper (0 if the list did not scroll). */
 uint32_t nt_ui_dropdown_test_scroll_id(uint32_t dropdown_id);
 /* The prev-frame bbox of a row's text label cell (icon-gutter alignment probe). */

--- a/engine/ui/nt_ui_input.c
+++ b/engine/ui/nt_ui_input.c
@@ -524,7 +524,8 @@ static uint32_t caret_from_x(const nt_ui_input_style_t *style, bool password, nt
 // #region render
 
 /* A filled rect floated at (x,y) inside the field; used for both the caret and the selection
- * highlight (the highlight sits BEHIND the text by emitting before the label). */
+ * highlight (the highlight sits BEHIND the text by emitting before the label). Every floating part of
+ * the field omits zIndex on purpose: delta 0 keeps it in the field's own band (NT patch 4). */
 static void emit_rect(nt_ui_context_t *ctx, uint8_t layer, float x, float y, float w, float h, uint32_t color) {
     nt_ui_transform_t tt = nt_ui_transform_defaults();
     tt.offset_x = x;

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -230,9 +230,10 @@ struct nt_ui_context {
      * the inner begin's return, so we use last frame's resolved top). */
     uint32_t modal_top_id_prev;
     uint32_t modal_top_id_cur;
-    /* Highest effective floating band claimed this frame — the same key Clay sorts roots by, so the
-     * overlay that eats Esc is the one actually painted on top. INT32_MIN until the first claim. */
+    /* Highest (band, layer) claimed this frame — the walker's own paint key, so the overlay that eats
+     * Esc is the one actually painted on top. Band is INT32_MIN until the first claim. */
     int32_t modal_top_z_cur;
+    uint8_t modal_top_layer_cur;
     /* Keyboard-focus arbiter: the input field that eats typed chars + editing keys.
      * 0 = none. A press inside a field sets it; Esc clears it; Tab moves it to the next
      * field declared this frame. Survives across frames (not reset by begin). */

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -253,7 +253,6 @@ struct nt_ui_context {
     int16_t modal_zband_stride;
     uint16_t wheel_depth;
     uint8_t active_modal_depth;
-    uint8_t modal_top_layer_cur; /* layer of the current top claim; ties on band are broken by it */
     uint8_t capture_seen[NT_INPUT_MAX_POINTERS];
     bool pointer_over_any;
     bool hot_resolved; /* gates the once-per-frame lazy hot resolve */

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -154,8 +154,8 @@ typedef struct {
 #define NT_UI_WHEEL_CANDIDATES 24
 #endif
 
-/* Nested-modal cap (fail-early assert on overflow; depth is a counter, no heap).
- * Depth drives the z-band stride*(depth+1) and close-signal top-targeting.
+/* Nested-modal cap (fail-early assert on overflow; depth is a counter, no heap). Depth is the
+ * overflow guard only — bands come from Clay's relative zIndex, top-targeting from modal_top_z_cur.
  * Build-overridable; raising it requires stride*depth to still fit int16 (see _Static_assert). */
 #ifndef NT_UI_MODAL_MAX_DEPTH
 #define NT_UI_MODAL_MAX_DEPTH 16
@@ -233,7 +233,6 @@ struct nt_ui_context {
     /* Highest (band, layer) claimed this frame — the walker's own paint key, so the overlay that eats
      * Esc is the one actually painted on top. Band is INT32_MIN until the first claim. */
     int32_t modal_top_z_cur;
-    uint8_t modal_top_layer_cur;
     /* Keyboard-focus arbiter: the input field that eats typed chars + editing keys.
      * 0 = none. A press inside a field sets it; Esc clears it; Tab moves it to the next
      * field declared this frame. Survives across frames (not reset by begin). */
@@ -254,6 +253,7 @@ struct nt_ui_context {
     int16_t modal_zband_stride;
     uint16_t wheel_depth;
     uint8_t active_modal_depth;
+    uint8_t modal_top_layer_cur; /* layer of the current top claim; ties on band are broken by it */
     uint8_t capture_seen[NT_INPUT_MAX_POINTERS];
     bool pointer_over_any;
     bool hot_resolved; /* gates the once-per-frame lazy hot resolve */

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -230,6 +230,9 @@ struct nt_ui_context {
      * the inner begin's return, so we use last frame's resolved top). */
     uint32_t modal_top_id_prev;
     uint32_t modal_top_id_cur;
+    /* Highest effective floating band claimed this frame — the same key Clay sorts roots by, so the
+     * overlay that eats Esc is the one actually painted on top. INT32_MIN until the first claim. */
+    int32_t modal_top_z_cur;
     /* Keyboard-focus arbiter: the input field that eats typed chars + editing keys.
      * 0 = none. A press inside a field sets it; Esc clears it; Tab moves it to the next
      * field declared this frame. Survives across frames (not reset by begin). */
@@ -250,7 +253,6 @@ struct nt_ui_context {
     int16_t modal_zband_stride;
     uint16_t wheel_depth;
     uint8_t active_modal_depth;
-    uint8_t modal_max_depth_cur; /* deepest active_modal_depth reached this frame (drives modal_top_id_cur) */
     uint8_t capture_seen[NT_INPUT_MAX_POINTERS];
     bool pointer_over_any;
     bool hot_resolved; /* gates the once-per-frame lazy hot resolve */

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -230,8 +230,8 @@ struct nt_ui_context {
      * the inner begin's return, so we use last frame's resolved top). */
     uint32_t modal_top_id_prev;
     uint32_t modal_top_id_cur;
-    /* Highest (band, layer) claimed this frame — the walker's own paint key, so the overlay that eats
-     * Esc is the one actually painted on top. Band is INT32_MIN until the first claim. */
+    /* Highest band claimed this frame; ties go to the last declared, matching the pointer arbiter that
+     * delivers the dismiss click. INT32_MIN until the first claim. */
     int32_t modal_top_z_cur;
     /* Keyboard-focus arbiter: the input field that eats typed chars + editing keys.
      * 0 = none. A press inside a field sets it; Esc clears it; Tab moves it to the next

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -249,7 +249,7 @@ struct nt_ui_context {
     uint32_t rich_max_runs;
     uint32_t rich_max_styles;
     uint32_t rich_max_text_bytes;
-    /* Per-depth modal z-band stride; resolved + validated in create_context (> 0). */
+    /* Band each overlay level declares above the floating enclosing it; validated in create_context (> 1). */
     int16_t modal_zband_stride;
     uint16_t wheel_depth;
     uint8_t active_modal_depth;

--- a/engine/ui/nt_ui_menu.c
+++ b/engine/ui/nt_ui_menu.c
@@ -421,7 +421,7 @@ static bool menu_cursor_over_any_panel(const nt_ui_context_t *ctx, uint32_t menu
  * level's panel + rows stay hittable above it. */
 static void menu_declare_occluder(nt_ui_context_t *ctx, uint8_t fill_layer, uint32_t menu_id) {
     const uint32_t occ_id = menu_occluder_id(menu_id);
-    const int16_t occ_z = (int16_t)(ctx->modal_zband_stride - 1); /* just below the root panel band (stride*1) */
+    const int16_t occ_z = (int16_t)(ctx->modal_zband_stride - 1); /* one below the menu's own panel band, relative to whatever encloses the menu */
     const nt_ui_transform_t id_xf = nt_ui_transform_defaults();
     const nt_ui_element_data_t *occ_data = nt_ui_make_element_data_xform(fill_layer, NULL, &id_xf, 1.0F);
     CLAY({.id = (Clay_ElementId){.id = occ_id},

--- a/engine/ui/nt_ui_modal.c
+++ b/engine/ui/nt_ui_modal.c
@@ -23,7 +23,8 @@ const nt_ui_widget_def_t NT_UI_MODAL_DEF = {
 };
 
 /* Build-time sanity net on the DEFAULT stride; the configured per-ctx value is validated at runtime
- * in nt_ui_create_context. Per-depth z-band: panel_z = stride*(depth+1), backdrop one below. */
+ * in nt_ui_create_context. Each level declares one stride above its enclosing floating (backdrop one
+ * below the panel), so lexically nested overlays still reach stride*(depth+1). */
 _Static_assert(NT_UI_MODAL_ZBAND_STRIDE *(NT_UI_MODAL_MAX_DEPTH) <= INT16_MAX, "modal z-band exceeds int16 zIndex");
 
 #ifdef NT_TEST_ACCESS

--- a/engine/ui/nt_ui_modal.c
+++ b/engine/ui/nt_ui_modal.c
@@ -133,7 +133,9 @@ nt_ui_modal_result_t nt_ui_modal_begin(nt_ui_context_t *ctx, uint32_t id, const 
     const nt_ui_modal_close_reason_t reason = modal_reason_from_src(src);
 
 #ifdef NT_TEST_ACCESS
-    s_last_panel_zband = (uint16_t)(ctx->modal_zband_stride * ctx->active_modal_depth); /* depth already pushed */
+    /* Effective band ASSUMING every enclosing floating is an engine overlay (see nt_ui_popup.c); depth
+     * is already pushed here. */
+    s_last_panel_zband = (uint16_t)(ctx->modal_zband_stride * ctx->active_modal_depth);
     s_last_backdrop_zband = (uint16_t)(s_last_panel_zband - 1U);
     s_last_close_reason = reason;
     /* Panel offset = start offset eased by (1-t); matches popup-core's panel transform exactly. */

--- a/engine/ui/nt_ui_modal.c
+++ b/engine/ui/nt_ui_modal.c
@@ -24,7 +24,7 @@ const nt_ui_widget_def_t NT_UI_MODAL_DEF = {
 
 /* Build-time sanity net on the DEFAULT stride; the configured per-ctx value is validated at runtime
  * in nt_ui_create_context. Each level declares one stride above its enclosing floating (backdrop one
- * below the panel), so lexically nested overlays still reach stride*(depth+1). */
+ * below the panel), so lexically nested overlays accumulate one stride per level, themselves included. */
 _Static_assert(NT_UI_MODAL_ZBAND_STRIDE *(NT_UI_MODAL_MAX_DEPTH) <= INT16_MAX, "modal z-band exceeds int16 zIndex");
 
 #ifdef NT_TEST_ACCESS

--- a/engine/ui/nt_ui_modal.c
+++ b/engine/ui/nt_ui_modal.c
@@ -28,8 +28,6 @@ const nt_ui_widget_def_t NT_UI_MODAL_DEF = {
 _Static_assert(NT_UI_MODAL_ZBAND_STRIDE *(NT_UI_MODAL_MAX_DEPTH) <= INT16_MAX, "modal z-band exceeds int16 zIndex");
 
 #ifdef NT_TEST_ACCESS
-static uint16_t s_last_panel_zband;
-static uint16_t s_last_backdrop_zband;
 static nt_ui_modal_close_reason_t s_last_close_reason;
 static float s_last_panel_off_x;
 static float s_last_panel_off_y;
@@ -133,8 +131,6 @@ nt_ui_modal_result_t nt_ui_modal_begin(nt_ui_context_t *ctx, uint32_t id, const 
     const nt_ui_modal_close_reason_t reason = modal_reason_from_src(src);
 
 #ifdef NT_TEST_ACCESS
-    s_last_panel_zband = nt_ui_popup_test_last_zband(); /* whatever popup-core just declared */
-    s_last_backdrop_zband = (uint16_t)(s_last_panel_zband - 1U);
     s_last_close_reason = reason;
     /* Panel offset = start offset eased by (1-t); matches popup-core's panel transform exactly. */
     s_last_panel_off_x = start.offset_x * (1.0F - pr.t);
@@ -175,8 +171,6 @@ bool nt_ui_modal_active(const nt_ui_context_t *ctx) {
 void nt_ui_modal_clear_state(nt_ui_context_t *ctx, uint32_t id) { nt_ui_popup_clear_state(ctx, id); }
 
 #ifdef NT_TEST_ACCESS
-uint16_t nt_ui_modal_test_last_zband(void) { return s_last_panel_zband; }
-uint16_t nt_ui_modal_test_last_backdrop_zband(void) { return s_last_backdrop_zband; }
 uint8_t nt_ui_modal_test_stack_depth(const nt_ui_context_t *ctx) {
     NT_ASSERT(ctx != NULL && "nt_ui_modal_test_stack_depth: ctx must be non-NULL");
     return ctx->active_modal_depth;

--- a/engine/ui/nt_ui_modal.c
+++ b/engine/ui/nt_ui_modal.c
@@ -28,7 +28,6 @@ const nt_ui_widget_def_t NT_UI_MODAL_DEF = {
 _Static_assert(NT_UI_MODAL_ZBAND_STRIDE *(NT_UI_MODAL_MAX_DEPTH) <= INT16_MAX, "modal z-band exceeds int16 zIndex");
 
 #ifdef NT_TEST_ACCESS
-static nt_ui_modal_close_reason_t s_last_close_reason;
 static float s_last_panel_off_x;
 static float s_last_panel_off_y;
 #endif
@@ -131,7 +130,6 @@ nt_ui_modal_result_t nt_ui_modal_begin(nt_ui_context_t *ctx, uint32_t id, const 
     const nt_ui_modal_close_reason_t reason = modal_reason_from_src(src);
 
 #ifdef NT_TEST_ACCESS
-    s_last_close_reason = reason;
     /* Panel offset = start offset eased by (1-t); matches popup-core's panel transform exactly. */
     s_last_panel_off_x = start.offset_x * (1.0F - pr.t);
     s_last_panel_off_y = start.offset_y * (1.0F - pr.t);
@@ -171,17 +169,6 @@ bool nt_ui_modal_active(const nt_ui_context_t *ctx) {
 void nt_ui_modal_clear_state(nt_ui_context_t *ctx, uint32_t id) { nt_ui_popup_clear_state(ctx, id); }
 
 #ifdef NT_TEST_ACCESS
-uint8_t nt_ui_modal_test_stack_depth(const nt_ui_context_t *ctx) {
-    NT_ASSERT(ctx != NULL && "nt_ui_modal_test_stack_depth: ctx must be non-NULL");
-    return ctx->active_modal_depth;
-}
-nt_ui_modal_close_reason_t nt_ui_modal_test_last_close_reason(void) { return s_last_close_reason; }
-float nt_ui_modal_test_tween(const nt_ui_context_t *ctx, uint32_t id) {
-    NT_ASSERT(ctx != NULL && "nt_ui_modal_test_tween: ctx must be non-NULL");
-    NT_ASSERT(id != 0U && "nt_ui_modal_test_tween: id must be non-zero");
-    /* Delegate to the popup-core tween probe (the modal eases through popup-core's anim slot). */
-    return nt_ui_popup_test_tween(ctx, id);
-}
 void nt_ui_modal_test_last_panel_offset(float *ox, float *oy) {
     if (ox != NULL) {
         *ox = s_last_panel_off_x;

--- a/engine/ui/nt_ui_modal.c
+++ b/engine/ui/nt_ui_modal.c
@@ -133,9 +133,7 @@ nt_ui_modal_result_t nt_ui_modal_begin(nt_ui_context_t *ctx, uint32_t id, const 
     const nt_ui_modal_close_reason_t reason = modal_reason_from_src(src);
 
 #ifdef NT_TEST_ACCESS
-    /* Effective band ASSUMING every enclosing floating is an engine overlay (see nt_ui_popup.c); depth
-     * is already pushed here. */
-    s_last_panel_zband = (uint16_t)(ctx->modal_zband_stride * ctx->active_modal_depth);
+    s_last_panel_zband = nt_ui_popup_test_last_zband(); /* whatever popup-core just declared */
     s_last_backdrop_zband = (uint16_t)(s_last_panel_zband - 1U);
     s_last_close_reason = reason;
     /* Panel offset = start offset eased by (1-t); matches popup-core's panel transform exactly. */

--- a/engine/ui/nt_ui_modal.h
+++ b/engine/ui/nt_ui_modal.h
@@ -78,7 +78,8 @@ _Static_assert(sizeof(nt_ui_modal_style_t) == 40, "nt_ui_modal_style_t stable AB
 nt_ui_modal_style_t nt_ui_modal_style_defaults(void);
 
 /* Low-level, UNCONDITIONAL begin/end (like nt_ui_scroll_begin): always begin -> ... -> end. Opens the
- * backdrop + panel floating elements (z-band ctx->modal_zband_stride*(depth+1)) and eases t toward
+ * backdrop + panel floating elements (declared one ctx->modal_zband_stride above the enclosing
+ * floating; Clay accumulates the nesting) and eases t toward
  * open?1:0; returns the full result (t / close reason / visible). Panel stays OPEN until nt_ui_modal_end.
  * id non-zero, style non-NULL. Asserts depth < NT_UI_MODAL_MAX_DEPTH BEFORE push (overflow, no fallback).
  * Prefer the scoped nt_ui_modal_visible() unless you need the close reason. */

--- a/engine/ui/nt_ui_modal.h
+++ b/engine/ui/nt_ui_modal.h
@@ -112,10 +112,7 @@ void nt_ui_modal_clear_state(nt_ui_context_t *ctx, uint32_t id);
 bool nt_ui_modal_active(const nt_ui_context_t *ctx);
 
 #ifdef NT_TEST_ACCESS
-uint8_t nt_ui_modal_test_stack_depth(const nt_ui_context_t *ctx);      /* live active_modal_depth */
-nt_ui_modal_close_reason_t nt_ui_modal_test_last_close_reason(void);   /* reason of the last begin */
-float nt_ui_modal_test_tween(const nt_ui_context_t *ctx, uint32_t id); /* eased t in the anim slot */
-void nt_ui_modal_test_last_panel_offset(float *ox, float *oy);         /* panel transform offset of the last begin */
+void nt_ui_modal_test_last_panel_offset(float *ox, float *oy); /* panel transform offset of the last begin */
 #endif
 
 #endif /* NT_UI_MODAL_H */

--- a/engine/ui/nt_ui_modal.h
+++ b/engine/ui/nt_ui_modal.h
@@ -112,8 +112,6 @@ void nt_ui_modal_clear_state(nt_ui_context_t *ctx, uint32_t id);
 bool nt_ui_modal_active(const nt_ui_context_t *ctx);
 
 #ifdef NT_TEST_ACCESS
-uint16_t nt_ui_modal_test_last_zband(void);                            /* panel z of the last begin */
-uint16_t nt_ui_modal_test_last_backdrop_zband(void);                   /* backdrop z of the last begin */
 uint8_t nt_ui_modal_test_stack_depth(const nt_ui_context_t *ctx);      /* live active_modal_depth */
 nt_ui_modal_close_reason_t nt_ui_modal_test_last_close_reason(void);   /* reason of the last begin */
 float nt_ui_modal_test_tween(const nt_ui_context_t *ctx, uint32_t id); /* eased t in the anim slot */

--- a/engine/ui/nt_ui_popup.c
+++ b/engine/ui/nt_ui_popup.c
@@ -299,12 +299,13 @@ nt_ui_popup_result_t nt_ui_popup_begin_internal(nt_ui_context_t *ctx, uint32_t i
     nt_ui_clay_priv_configure_open_element(panel_decl);
     nt_ui_widget_register(ctx, id, reg_def, NULL, true);
     /* The panel is the innermost open floating here, so this IS the band Clay stamped. The claim below
-     * must use the pointer arbiter's key (band, ties to the last declared): the winner runs the
-     * close-scan through its own catcher, so a differently-ranked slot dismisses nothing. */
+     * must use the 2D pointer arbiter's key (band, ties to the last declared): the winner runs the
+     * close-scan through its own catcher, so a differently-ranked slot dismisses nothing. A 3D ctx
+     * arbitrates by ray distance and does not rank overlays by band at all. */
     const int32_t panel_band = nt_ui_clay_priv_open_floating_z(ctx->clay);
     /* A catcher gates base UI from one band below its panel; at or under the base band it loses the hit
      * arbitration and silently stops gating while nt_ui_modal_active() still reports the overlay up. */
-    NT_ASSERT((!want_catcher || panel_band > 1) && "nt_ui_popup: a gating overlay needs a band above base content");
+    NT_ASSERT((!want_catcher || panel_band > 1) && "nt_ui_popup: the catcher must sit above the base band (0)");
     if (want_catcher && panel_band >= ctx->modal_top_z_cur) {
         ctx->modal_top_z_cur = panel_band;
         ctx->modal_top_id_cur = id;

--- a/engine/ui/nt_ui_popup.c
+++ b/engine/ui/nt_ui_popup.c
@@ -173,8 +173,8 @@ nt_ui_popup_result_t nt_ui_popup_begin_internal(nt_ui_context_t *ctx, uint32_t i
 
     // #region stack push + z-band (shared depth counter with modal)
     ++ctx->active_modal_depth;
-    /* One band ABOVE whatever floating encloses this call — Clay accumulates the nesting for us, so a
-     * popup opened from inside another popup lands on stride*depth without the depth arithmetic. */
+    /* One band ABOVE whatever floating encloses this call; Clay accumulates the nesting, so a popup
+     * opened inside another needs no depth arithmetic here. */
     const int16_t panel_z = ctx->modal_zband_stride;
     const int16_t catcher_z = (int16_t)(panel_z - 1);
     const uint32_t catcher_id = popup_catcher_id(id);
@@ -298,11 +298,9 @@ nt_ui_popup_result_t nt_ui_popup_begin_internal(nt_ui_context_t *ctx, uint32_t i
     nt_ui_clay_priv_open_element();
     nt_ui_clay_priv_configure_open_element(panel_decl);
     nt_ui_widget_register(ctx, id, reg_def, NULL, true);
-    /* The panel is now the innermost open floating, so this IS the band Clay stamped on it — read it
-     * back rather than re-deriving the sum and Clay's clamp. The key must MATCH the pointer arbiter
-     * (nt_ui.c resolve_hot: band, ties to the last registered), because the winner runs the close-scan
-     * through its catcher's interaction — ranking Esc by draw layer instead would hand the scan to a
-     * popup whose catcher never wins the click, and neither overlay would dismiss. */
+    /* The panel is the innermost open floating here, so this IS the band Clay stamped. The claim below
+     * must use the pointer arbiter's key (band, ties to the last declared): the winner runs the
+     * close-scan through its own catcher, so a differently-ranked slot dismisses nothing. */
     const int32_t panel_band = nt_ui_clay_priv_open_floating_z(ctx->clay);
     /* A catcher gates base UI from one band below its panel; at or under the base band it loses the hit
      * arbitration and silently stops gating while nt_ui_modal_active() still reports the overlay up. */

--- a/engine/ui/nt_ui_popup.c
+++ b/engine/ui/nt_ui_popup.c
@@ -52,8 +52,6 @@ static bool popup_anim_slot_absent(const nt_ui_context_t *ctx, uint32_t id) {
 }
 
 #ifdef NT_TEST_ACCESS
-static uint16_t s_last_panel_zband;
-static uint16_t s_last_catcher_zband;
 static uint8_t s_last_side;
 static bool s_last_catcher_present;
 static uint32_t s_entrance_seed_count; /* # of entrance t=0 re-seeds; must fire once per open-edge, not per frame */
@@ -317,8 +315,6 @@ nt_ui_popup_result_t nt_ui_popup_begin_internal(nt_ui_context_t *ctx, uint32_t i
     }
 
 #ifdef NT_TEST_ACCESS
-    s_last_panel_zband = (uint16_t)panel_band; /* the band Clay stamped, not a recomputation */
-    s_last_catcher_zband = (uint16_t)(s_last_panel_zband - 1U);
     s_last_side = (uint8_t)side;
     s_last_catcher_present = want_catcher;
 #endif
@@ -366,8 +362,6 @@ void nt_ui_popup_clear_state(nt_ui_context_t *ctx, uint32_t id) {
 }
 
 #ifdef NT_TEST_ACCESS
-uint16_t nt_ui_popup_test_last_zband(void) { return s_last_panel_zband; }
-uint16_t nt_ui_popup_test_last_catcher_zband(void) { return s_last_catcher_zband; }
 uint8_t nt_ui_popup_test_stack_depth(const nt_ui_context_t *ctx) {
     NT_ASSERT(ctx != NULL && "nt_ui_popup_test_stack_depth: ctx must be non-NULL");
     return ctx->active_modal_depth;

--- a/engine/ui/nt_ui_popup.c
+++ b/engine/ui/nt_ui_popup.c
@@ -248,8 +248,11 @@ nt_ui_popup_result_t nt_ui_popup_begin_internal(nt_ui_context_t *ctx, uint32_t i
      * top-id dismiss slot from a coexisting dropdown. */
     if (want_catcher) {
         ctx->modal_present_cur = true;
-        if (ctx->active_modal_depth >= ctx->modal_max_depth_cur) {
-            ctx->modal_max_depth_cur = ctx->active_modal_depth;
+        /* Topmost = highest effective band, ties to the last declared — Clay's own root-sort key, so the
+         * popup that eats Esc is the one painted on top even when a game floating shifts the band. */
+        const int32_t panel_z_eff = nt_ui_clay_priv_enclosing_floating_z(ctx->clay) + (int32_t)panel_z;
+        if (panel_z_eff >= ctx->modal_top_z_cur) {
+            ctx->modal_top_z_cur = panel_z_eff;
             ctx->modal_top_id_cur = id;
         }
     }

--- a/engine/ui/nt_ui_popup.c
+++ b/engine/ui/nt_ui_popup.c
@@ -248,21 +248,6 @@ nt_ui_popup_result_t nt_ui_popup_begin_internal(nt_ui_context_t *ctx, uint32_t i
      * top-id dismiss slot from a coexisting dropdown. */
     if (want_catcher) {
         ctx->modal_present_cur = true;
-        /* Topmost = the walker's own paint key (nt_ui_walk: zIndex asc, then layer asc, then
-         * declaration), so the popup that eats Esc is the one painted on top even when a game floating
-         * shifts the band. Clamped exactly like Clay clamps the stored band, or the key would drift from
-         * the shipped one in OFF builds, where the saturation error no longer aborts. */
-        int32_t panel_z_eff = nt_ui_clay_priv_enclosing_floating_z(ctx->clay) + (int32_t)panel_z;
-        panel_z_eff = (panel_z_eff < INT16_MIN) ? INT16_MIN : panel_z_eff;
-        panel_z_eff = (panel_z_eff > INT16_MAX) ? INT16_MAX : panel_z_eff;
-        /* A modal gates base UI with a catcher one band below its panel; at or under the base band it
-         * loses that arbitration and silently stops gating while nt_ui_modal_active() still reports it. */
-        NT_ASSERT((!force_catcher || panel_z_eff > 1) && "nt_ui_popup: a modal needs a band above base content to gate it");
-        if ((panel_z_eff > ctx->modal_top_z_cur) || (panel_z_eff == ctx->modal_top_z_cur && style->layer >= ctx->modal_top_layer_cur)) {
-            ctx->modal_top_z_cur = panel_z_eff;
-            ctx->modal_top_layer_cur = style->layer;
-            ctx->modal_top_id_cur = id;
-        }
     }
     if (want_catcher) {
         /* Full-viewport catcher at catcher_z. Transparent for a plain popup; a visible dim rect when a
@@ -316,6 +301,15 @@ nt_ui_popup_result_t nt_ui_popup_begin_internal(nt_ui_context_t *ctx, uint32_t i
     nt_ui_clay_priv_open_element();
     nt_ui_clay_priv_configure_open_element(panel_decl);
     nt_ui_widget_register(ctx, id, reg_def, NULL, true);
+    /* The panel is now the innermost open floating, so this IS the band Clay stamped on it — read it
+     * back rather than re-deriving the sum and Clay's clamp. Topmost = the walker's paint key
+     * (nt_ui_walk: zIndex asc, then layer asc, then declaration); only a catcher-bearing popup claims. */
+    const int32_t panel_band = nt_ui_clay_priv_open_floating_z(ctx->clay);
+    if (want_catcher && ((panel_band > ctx->modal_top_z_cur) || (panel_band == ctx->modal_top_z_cur && style->layer >= ctx->modal_top_layer_cur))) {
+        ctx->modal_top_z_cur = panel_band;
+        ctx->modal_top_layer_cur = style->layer;
+        ctx->modal_top_id_cur = id;
+    }
     // #endregion
 
     if (out_src != NULL) {
@@ -323,10 +317,7 @@ nt_ui_popup_result_t nt_ui_popup_begin_internal(nt_ui_context_t *ctx, uint32_t i
     }
 
 #ifdef NT_TEST_ACCESS
-    /* Effective band ASSUMING every enclosing floating is an engine overlay (each contributes one
-     * stride). A game floating with its own zIndex shifts the real band — tests that need the shipped
-     * value read Clay_RenderCommand::zIndex instead. */
-    s_last_panel_zband = (uint16_t)(ctx->modal_zband_stride * ctx->active_modal_depth);
+    s_last_panel_zband = (uint16_t)panel_band; /* the band Clay stamped, not a recomputation */
     s_last_catcher_zband = (uint16_t)(s_last_panel_zband - 1U);
     s_last_side = (uint8_t)side;
     s_last_catcher_present = want_catcher;

--- a/engine/ui/nt_ui_popup.c
+++ b/engine/ui/nt_ui_popup.c
@@ -299,12 +299,16 @@ nt_ui_popup_result_t nt_ui_popup_begin_internal(nt_ui_context_t *ctx, uint32_t i
     nt_ui_clay_priv_configure_open_element(panel_decl);
     nt_ui_widget_register(ctx, id, reg_def, NULL, true);
     /* The panel is now the innermost open floating, so this IS the band Clay stamped on it — read it
-     * back rather than re-deriving the sum and Clay's clamp. Topmost = the walker's paint key
-     * (nt_ui_walk: zIndex asc, then layer asc, then declaration); only a catcher-bearing popup claims. */
+     * back rather than re-deriving the sum and Clay's clamp. The key must MATCH the pointer arbiter
+     * (nt_ui.c resolve_hot: band, ties to the last registered), because the winner runs the close-scan
+     * through its catcher's interaction — ranking Esc by draw layer instead would hand the scan to a
+     * popup whose catcher never wins the click, and neither overlay would dismiss. */
     const int32_t panel_band = nt_ui_clay_priv_open_floating_z(ctx->clay);
-    if (want_catcher && ((panel_band > ctx->modal_top_z_cur) || (panel_band == ctx->modal_top_z_cur && style->layer >= ctx->modal_top_layer_cur))) {
+    /* A catcher gates base UI from one band below its panel; at or under the base band it loses the hit
+     * arbitration and silently stops gating while nt_ui_modal_active() still reports the overlay up. */
+    NT_ASSERT((!want_catcher || panel_band > 1) && "nt_ui_popup: a gating overlay needs a band above base content");
+    if (want_catcher && panel_band >= ctx->modal_top_z_cur) {
         ctx->modal_top_z_cur = panel_band;
-        ctx->modal_top_layer_cur = style->layer;
         ctx->modal_top_id_cur = id;
     }
     // #endregion

--- a/engine/ui/nt_ui_popup.c
+++ b/engine/ui/nt_ui_popup.c
@@ -248,11 +248,19 @@ nt_ui_popup_result_t nt_ui_popup_begin_internal(nt_ui_context_t *ctx, uint32_t i
      * top-id dismiss slot from a coexisting dropdown. */
     if (want_catcher) {
         ctx->modal_present_cur = true;
-        /* Topmost = highest effective band, ties to the last declared — Clay's own root-sort key, so the
-         * popup that eats Esc is the one painted on top even when a game floating shifts the band. */
-        const int32_t panel_z_eff = nt_ui_clay_priv_enclosing_floating_z(ctx->clay) + (int32_t)panel_z;
-        if (panel_z_eff >= ctx->modal_top_z_cur) {
+        /* Topmost = the walker's own paint key (nt_ui_walk: zIndex asc, then layer asc, then
+         * declaration), so the popup that eats Esc is the one painted on top even when a game floating
+         * shifts the band. Clamped exactly like Clay clamps the stored band, or the key would drift from
+         * the shipped one in OFF builds, where the saturation error no longer aborts. */
+        int32_t panel_z_eff = nt_ui_clay_priv_enclosing_floating_z(ctx->clay) + (int32_t)panel_z;
+        panel_z_eff = (panel_z_eff < INT16_MIN) ? INT16_MIN : panel_z_eff;
+        panel_z_eff = (panel_z_eff > INT16_MAX) ? INT16_MAX : panel_z_eff;
+        /* A modal gates base UI with a catcher one band below its panel; at or under the base band it
+         * loses that arbitration and silently stops gating while nt_ui_modal_active() still reports it. */
+        NT_ASSERT((!force_catcher || panel_z_eff > 1) && "nt_ui_popup: a modal needs a band above base content to gate it");
+        if ((panel_z_eff > ctx->modal_top_z_cur) || (panel_z_eff == ctx->modal_top_z_cur && style->layer >= ctx->modal_top_layer_cur)) {
             ctx->modal_top_z_cur = panel_z_eff;
+            ctx->modal_top_layer_cur = style->layer;
             ctx->modal_top_id_cur = id;
         }
     }

--- a/engine/ui/nt_ui_popup.c
+++ b/engine/ui/nt_ui_popup.c
@@ -175,9 +175,10 @@ nt_ui_popup_result_t nt_ui_popup_begin_internal(nt_ui_context_t *ctx, uint32_t i
     NT_ASSERT(ctx->active_modal_depth < NT_UI_MODAL_MAX_DEPTH && "nt_ui_popup_begin: nesting exceeds NT_UI_MODAL_MAX_DEPTH");
 
     // #region stack push + z-band (shared depth counter with modal)
-    const uint8_t depth = ctx->active_modal_depth;
     ++ctx->active_modal_depth;
-    const int16_t panel_z = (int16_t)(ctx->modal_zband_stride * (depth + 1));
+    /* One band ABOVE whatever floating encloses this call — Clay accumulates the nesting for us, so a
+     * popup opened from inside another popup lands on stride*depth without the depth arithmetic. */
+    const int16_t panel_z = ctx->modal_zband_stride;
     const int16_t catcher_z = (int16_t)(panel_z - 1);
     const uint32_t catcher_id = popup_catcher_id(id);
     // #endregion
@@ -311,8 +312,10 @@ nt_ui_popup_result_t nt_ui_popup_begin_internal(nt_ui_context_t *ctx, uint32_t i
     }
 
 #ifdef NT_TEST_ACCESS
-    s_last_panel_zband = (uint16_t)panel_z;
-    s_last_catcher_zband = (uint16_t)catcher_z;
+    /* Effective band, not the declared delta: Clay adds the enclosing floating's z, and every popup
+     * level contributes exactly one stride. */
+    s_last_panel_zband = (uint16_t)(ctx->modal_zband_stride * ctx->active_modal_depth);
+    s_last_catcher_zband = (uint16_t)(s_last_panel_zband - 1U);
     s_last_side = (uint8_t)side;
     s_last_catcher_present = want_catcher;
 #endif

--- a/engine/ui/nt_ui_popup.c
+++ b/engine/ui/nt_ui_popup.c
@@ -312,8 +312,9 @@ nt_ui_popup_result_t nt_ui_popup_begin_internal(nt_ui_context_t *ctx, uint32_t i
     }
 
 #ifdef NT_TEST_ACCESS
-    /* Effective band, not the declared delta: Clay adds the enclosing floating's z, and every popup
-     * level contributes exactly one stride. */
+    /* Effective band ASSUMING every enclosing floating is an engine overlay (each contributes one
+     * stride). A game floating with its own zIndex shifts the real band — tests that need the shipped
+     * value read Clay_RenderCommand::zIndex instead. */
     s_last_panel_zband = (uint16_t)(ctx->modal_zband_stride * ctx->active_modal_depth);
     s_last_catcher_zband = (uint16_t)(s_last_panel_zband - 1U);
     s_last_side = (uint8_t)side;

--- a/engine/ui/nt_ui_popup.c
+++ b/engine/ui/nt_ui_popup.c
@@ -52,7 +52,6 @@ static bool popup_anim_slot_absent(const nt_ui_context_t *ctx, uint32_t id) {
 }
 
 #ifdef NT_TEST_ACCESS
-static uint8_t s_last_side;
 static bool s_last_catcher_present;
 static uint32_t s_entrance_seed_count; /* # of entrance t=0 re-seeds; must fire once per open-edge, not per frame */
 #endif
@@ -315,7 +314,6 @@ nt_ui_popup_result_t nt_ui_popup_begin_internal(nt_ui_context_t *ctx, uint32_t i
     }
 
 #ifdef NT_TEST_ACCESS
-    s_last_side = (uint8_t)side;
     s_last_catcher_present = want_catcher;
 #endif
 
@@ -362,24 +360,7 @@ void nt_ui_popup_clear_state(nt_ui_context_t *ctx, uint32_t id) {
 }
 
 #ifdef NT_TEST_ACCESS
-uint8_t nt_ui_popup_test_stack_depth(const nt_ui_context_t *ctx) {
-    NT_ASSERT(ctx != NULL && "nt_ui_popup_test_stack_depth: ctx must be non-NULL");
-    return ctx->active_modal_depth;
-}
-uint8_t nt_ui_popup_test_last_side(void) { return s_last_side; }
 bool nt_ui_popup_test_last_catcher_present(void) { return s_last_catcher_present; }
 uint32_t nt_ui_popup_test_entrance_seed_count(void) { return s_entrance_seed_count; }
 void nt_ui_popup_test_entrance_seed_reset(void) { s_entrance_seed_count = 0U; }
-float nt_ui_popup_test_tween(const nt_ui_context_t *ctx, uint32_t id) {
-    NT_ASSERT(ctx != NULL && "nt_ui_popup_test_tween: ctx must be non-NULL");
-    NT_ASSERT(id != 0U && "nt_ui_popup_test_tween: id must be non-zero");
-    const uint32_t base = id & (uint32_t)(NT_UI_ANIM_SLOTS - 1);
-    for (uint32_t k = 0; k < NT_UI_ANIM_PROBE_MAX; ++k) {
-        const nt_ui_anim_interaction_t *cand = &ctx->anim[(base + k) & (uint32_t)(NT_UI_ANIM_SLOTS - 1)];
-        if (cand->valid && cand->id == id) {
-            return cand->value_t;
-        }
-    }
-    return 0.0F;
-}
 #endif

--- a/engine/ui/nt_ui_popup.h
+++ b/engine/ui/nt_ui_popup.h
@@ -3,7 +3,7 @@
 
 /* Popup-core: the shared floating-overlay primitive. One panel floating element + a
  * transparent light-dismiss catcher (block_pointer occluder) + an open/close value_t tween + a
- * per-depth z-band stack + trigger-anchoring with per-side edge-flip. The game owns the `bool open`;
+ * one-stride-per-level z-band + trigger-anchoring with per-side edge-flip. The game owns the `bool open`;
  * the core only RAISES close_requested (outside-click on the catcher) and never closes itself.
  * begin/end are balanced (mirror nt_ui_modal_begin/end). The modal is re-expressed on top of this
  * core (modal = popup-core centered + dim backdrop). Dropdown / tooltip / context-menu reuse it. */

--- a/engine/ui/nt_ui_popup.h
+++ b/engine/ui/nt_ui_popup.h
@@ -93,8 +93,6 @@ bool nt_ui_popup_visible(nt_ui_context_t *ctx, uint32_t id, const nt_ui_popup_st
 void nt_ui_popup_clear_state(nt_ui_context_t *ctx, uint32_t id);
 
 #ifdef NT_TEST_ACCESS
-uint16_t nt_ui_popup_test_last_zband(void);                            /* panel z of the last begin */
-uint16_t nt_ui_popup_test_last_catcher_zband(void);                    /* catcher z of the last begin */
 uint8_t nt_ui_popup_test_stack_depth(const nt_ui_context_t *ctx);      /* live active depth (shared modal counter) */
 uint8_t nt_ui_popup_test_last_side(void);                              /* nt_ui_popup_side_t chosen last begin */
 bool nt_ui_popup_test_last_catcher_present(void);                      /* did the last begin declare a catcher? */

--- a/engine/ui/nt_ui_popup.h
+++ b/engine/ui/nt_ui_popup.h
@@ -68,7 +68,8 @@ _Static_assert(sizeof(nt_ui_popup_style_t) == 80, "nt_ui_popup_style_t stable AB
 nt_ui_popup_style_t nt_ui_popup_style_defaults(void);
 
 /* Low-level, UNCONDITIONAL begin/end (like nt_ui_scroll_begin): always begin -> ... -> end. Opens the
- * catcher (light-dismiss) + panel floating elements (z-band stride*(depth+1)) eased toward open?1:0,
+ * catcher (light-dismiss) + panel floating elements (declared one stride above the enclosing floating;
+ * Clay accumulates the nesting) eased toward open?1:0,
  * placed at the anchor with edge-flip (or centered for a CENTER anchor). Panel stays OPEN until
  * nt_ui_popup_end. id non-zero, style non-NULL, anchor non-NULL. Asserts depth < NT_UI_MODAL_MAX_DEPTH
  * BEFORE push (overflow, no fallback). Prefer the scoped nt_ui_popup_visible unless you need the side. */

--- a/engine/ui/nt_ui_popup.h
+++ b/engine/ui/nt_ui_popup.h
@@ -93,12 +93,9 @@ bool nt_ui_popup_visible(nt_ui_context_t *ctx, uint32_t id, const nt_ui_popup_st
 void nt_ui_popup_clear_state(nt_ui_context_t *ctx, uint32_t id);
 
 #ifdef NT_TEST_ACCESS
-uint8_t nt_ui_popup_test_stack_depth(const nt_ui_context_t *ctx);      /* live active depth (shared modal counter) */
-uint8_t nt_ui_popup_test_last_side(void);                              /* nt_ui_popup_side_t chosen last begin */
-bool nt_ui_popup_test_last_catcher_present(void);                      /* did the last begin declare a catcher? */
-float nt_ui_popup_test_tween(const nt_ui_context_t *ctx, uint32_t id); /* eased t in the anim slot */
-uint32_t nt_ui_popup_test_entrance_seed_count(void);                   /* cumulative entrance t=0 re-seeds (once per open-edge) */
-void nt_ui_popup_test_entrance_seed_reset(void);                       /* zero the entrance-seed counter */
+bool nt_ui_popup_test_last_catcher_present(void);    /* did the last begin declare a catcher? */
+uint32_t nt_ui_popup_test_entrance_seed_count(void); /* cumulative entrance t=0 re-seeds (once per open-edge) */
+void nt_ui_popup_test_entrance_seed_reset(void);     /* zero the entrance-seed counter */
 #endif
 
 #endif /* NT_UI_POPUP_H */

--- a/engine/ui/nt_ui_scroll.c
+++ b/engine/ui/nt_ui_scroll.c
@@ -242,7 +242,6 @@ static float s_last_bar_thumb_off[2] = {0.0F};     /* per-axis thumb offset alon
 static float s_last_bar_track_len[2] = {0.0F};     /* per-axis track length */
 static float s_last_bar_opacity[2] = {0.0F, 0.0F}; /* per-axis eased fade opacity */
 static uint8_t s_last_bar_layer[2] = {0U, 0U};     /* per-axis draw layer of the emitted bar */
-static int16_t s_last_bar_zindex[2] = {0, 0};      /* per-axis Clay floating zIndex of the emitted bar */
 static uint32_t s_wheel_recipients = 0U;           /* # of scroll_begin gathers that consumed a wheel since reset (broadcast pin) */
 #endif
 // #endregion
@@ -773,15 +772,6 @@ static void scrollbar_emit_axis(nt_ui_context_t *ctx, uint32_t scroll_id, int ax
         const nt_ui_anim_interaction_t *a = nt_ui_anim(ctx, bar_id, &tgt, 0.0F, style->bar_fade_speed);
         opacity = nt_ui_clampf(a->value_t, 0.0F, 1.0F);
     }
-    /* Clay sorts ALL floating roots by zIndex GLOBALLY: inside a popup/modal the panel floats at
-     * stride*active_modal_depth, so a zIndex-0 bar draws UNDER the (settled-opaque) panel and is only
-     * seen through the translucent open/close tween. Float the bar one band above ITS popup panel (still
-     * below any deeper-nested popup). Standalone scroll (depth 0) keeps zIndex 0 — nothing floats over it. */
-    int16_t bar_zindex = 0;
-    if (ctx->active_modal_depth > 0U) {
-        const int32_t z = ((int32_t)ctx->modal_zband_stride * (int32_t)ctx->active_modal_depth) + 1;
-        bar_zindex = (int16_t)((z > INT16_MAX) ? INT16_MAX : z); /* clamp — int16 ceiling for deep nests */
-    }
 #ifdef NT_TEST_ACCESS
     /* Single write site — geometry + opacity are final by here (incl. the faded case). */
     s_last_bar_thumb_len[axis] = thumb_len;
@@ -789,7 +779,6 @@ static void scrollbar_emit_axis(nt_ui_context_t *ctx, uint32_t scroll_id, int ax
     s_last_bar_track_len[axis] = track_len;
     s_last_bar_opacity[axis] = opacity;
     s_last_bar_layer[axis] = bar_layer;
-    s_last_bar_zindex[axis] = bar_zindex;
 #endif
     if (opacity < NT_UI_SCROLLBAR_FADE_EPS) {
         return; /* fully faded — nothing to draw (the id stays registered for next-frame hover) */
@@ -810,16 +799,12 @@ static void scrollbar_emit_axis(nt_ui_context_t *ctx, uint32_t scroll_id, int ax
     if (axis == 1) { /* vertical bar on the right edge */
         track_decl = (Clay_ElementDeclaration){
             .layout = {.sizing = {CLAY_SIZING_FIXED(thickness), CLAY_SIZING_FIXED(track_len)}},
-            .floating = {.attachTo = CLAY_ATTACH_TO_PARENT,
-                         .clipTo = CLAY_CLIP_TO_ATTACHED_PARENT,
-                         .zIndex = bar_zindex,
-                         .attachPoints = {.element = CLAY_ATTACH_POINT_RIGHT_TOP, .parent = CLAY_ATTACH_POINT_RIGHT_TOP}},
+            .floating = {.attachTo = CLAY_ATTACH_TO_PARENT, .clipTo = CLAY_CLIP_TO_ATTACHED_PARENT, .attachPoints = {.element = CLAY_ATTACH_POINT_RIGHT_TOP, .parent = CLAY_ATTACH_POINT_RIGHT_TOP}},
         };
         thumb_decl = (Clay_ElementDeclaration){
             .layout = {.sizing = {CLAY_SIZING_FIXED(thickness), CLAY_SIZING_FIXED(thumb_len)}},
             .floating = {.attachTo = CLAY_ATTACH_TO_PARENT,
                          .clipTo = CLAY_CLIP_TO_ATTACHED_PARENT,
-                         .zIndex = bar_zindex,
                          .offset = {.x = 0.0F, .y = thumb_off},
                          .attachPoints = {.element = CLAY_ATTACH_POINT_RIGHT_TOP, .parent = CLAY_ATTACH_POINT_RIGHT_TOP}},
         };
@@ -828,14 +813,12 @@ static void scrollbar_emit_axis(nt_ui_context_t *ctx, uint32_t scroll_id, int ax
             .layout = {.sizing = {CLAY_SIZING_FIXED(track_len), CLAY_SIZING_FIXED(thickness)}},
             .floating = {.attachTo = CLAY_ATTACH_TO_PARENT,
                          .clipTo = CLAY_CLIP_TO_ATTACHED_PARENT,
-                         .zIndex = bar_zindex,
                          .attachPoints = {.element = CLAY_ATTACH_POINT_LEFT_BOTTOM, .parent = CLAY_ATTACH_POINT_LEFT_BOTTOM}},
         };
         thumb_decl = (Clay_ElementDeclaration){
             .layout = {.sizing = {CLAY_SIZING_FIXED(thumb_len), CLAY_SIZING_FIXED(thickness)}},
             .floating = {.attachTo = CLAY_ATTACH_TO_PARENT,
                          .clipTo = CLAY_CLIP_TO_ATTACHED_PARENT,
-                         .zIndex = bar_zindex,
                          .offset = {.x = thumb_off, .y = 0.0F},
                          .attachPoints = {.element = CLAY_ATTACH_POINT_LEFT_BOTTOM, .parent = CLAY_ATTACH_POINT_LEFT_BOTTOM}},
         };
@@ -1072,10 +1055,6 @@ uint32_t nt_ui_scroll_test_bar_id(uint32_t scroll_id, int axis) { return scrollb
 uint8_t nt_ui_scroll_test_last_bar_layer(int axis) {
     NT_ASSERT(axis == 0 || axis == 1);
     return s_last_bar_layer[axis];
-}
-int16_t nt_ui_scroll_test_last_bar_zindex(int axis) {
-    NT_ASSERT(axis == 0 || axis == 1);
-    return s_last_bar_zindex[axis];
 }
 uint32_t nt_ui_scroll_test_wheel_recipients(void) { return s_wheel_recipients; }
 void nt_ui_scroll_test_wheel_recipients_reset(void) { s_wheel_recipients = 0U; }

--- a/engine/ui/nt_ui_scroll.h
+++ b/engine/ui/nt_ui_scroll.h
@@ -110,7 +110,10 @@ uint32_t nt_ui_scroll_test_last_scroll_id(void);
 uint8_t nt_ui_scroll_test_last_bar_emitted_axes(void);
 void nt_ui_scroll_test_last_bar_geometry(int axis, float *thumb_len, float *thumb_off, float *track_len, float *opacity);
 uint32_t nt_ui_scroll_test_bar_id(uint32_t scroll_id, int axis);
-/* The draw layer the last-emitted bar used (per axis); must match the container's content layer so the
+/* The bar floats at its container's own band (delta 0) and is declared last, so it paints over the
+ * container's content — but a floating declared after it in the same band paints over the bar.
+ *
+ * The draw layer the last-emitted bar used (per axis); must match the container's content layer so the
  * bar isn't buried under higher-layer content. */
 uint8_t nt_ui_scroll_test_last_bar_layer(int axis);
 /* Count of scroll_begin gathers that consumed a wheel since the last reset; lets a multi-container

--- a/engine/ui/nt_ui_scroll.h
+++ b/engine/ui/nt_ui_scroll.h
@@ -90,6 +90,9 @@ nt_ui_scroll_style_t nt_ui_scroll_style_defaults(void);
  * padding only. Scroll state rides the nt_ui_state pool keyed by id. Must be balanced
  * with nt_ui_scroll_end. */
 void nt_ui_scroll_begin(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint32_t id, const nt_ui_scroll_style_t *style, const Clay_ElementDeclaration *decl);
+/* Emits the scrollbars (both axes) as floating children at the container's own band (delta 0), declared
+ * last so they paint over the container's content — a floating declared after them in the same band
+ * paints over the bar. */
 void nt_ui_scroll_end(nt_ui_context_t *ctx);
 
 /* Set the target offset (Clay sign: negative = down/right) and ease there.
@@ -110,10 +113,7 @@ uint32_t nt_ui_scroll_test_last_scroll_id(void);
 uint8_t nt_ui_scroll_test_last_bar_emitted_axes(void);
 void nt_ui_scroll_test_last_bar_geometry(int axis, float *thumb_len, float *thumb_off, float *track_len, float *opacity);
 uint32_t nt_ui_scroll_test_bar_id(uint32_t scroll_id, int axis);
-/* The bar floats at its container's own band (delta 0) and is declared last, so it paints over the
- * container's content — but a floating declared after it in the same band paints over the bar.
- *
- * The draw layer the last-emitted bar used (per axis); must match the container's content layer so the
+/* The draw layer the last-emitted bar used (per axis); must match the container's content layer so the
  * bar isn't buried under higher-layer content. */
 uint8_t nt_ui_scroll_test_last_bar_layer(int axis);
 /* Count of scroll_begin gathers that consumed a wheel since the last reset; lets a multi-container

--- a/engine/ui/nt_ui_scroll.h
+++ b/engine/ui/nt_ui_scroll.h
@@ -113,9 +113,6 @@ uint32_t nt_ui_scroll_test_bar_id(uint32_t scroll_id, int axis);
 /* The draw layer the last-emitted bar used (per axis); must match the container's content layer so the
  * bar isn't buried under higher-layer content. */
 uint8_t nt_ui_scroll_test_last_bar_layer(int axis);
-/* The Clay floating zIndex the last-emitted bar used (per axis). Inside a popup/modal it must sit ABOVE
- * the popup panel band (stride*depth) so the bar isn't occluded by the panel; 0 for standalone scroll. */
-int16_t nt_ui_scroll_test_last_bar_zindex(int axis);
 /* Count of scroll_begin gathers that consumed a wheel since the last reset; lets a multi-container
  * test detect a wheel reaching more than one container in a single frame (the broadcast bug). */
 uint32_t nt_ui_scroll_test_wheel_recipients(void);

--- a/engine/ui/nt_ui_slider.c
+++ b/engine/ui/nt_ui_slider.c
@@ -206,7 +206,8 @@ static void slider_compose(nt_ui_context_t *ctx, const nt_ui_element_data_t *dat
         nt_ui_image_style_t thumb_style = nt_ui_image_style_defaults();
         thumb_style.color_packed = cell->thumb_tint;
         /* Floating so the thumb offset overlays the track without consuming layout. clipTo the
-         * attached parent so a slider inside a scroll container can't leak its thumb past the clip. */
+         * attached parent so a slider inside a scroll container can't leak its thumb past the clip.
+         * No zIndex: delta 0 keeps the thumb in the track's own band, painted after it (NT patch 4). */
         const Clay_ElementDeclaration thumb_decl = {
             .layout = {.sizing = {CLAY_SIZING_FIXED(style->thumb_w), CLAY_SIZING_FIXED(style->thumb_h)}},
             .floating = {.attachTo = CLAY_ATTACH_TO_PARENT, .clipTo = CLAY_CLIP_TO_ATTACHED_PARENT, .attachPoints = {.element = attach, .parent = attach}},

--- a/engine/ui/nt_ui_tooltip.c
+++ b/engine/ui/nt_ui_tooltip.c
@@ -36,11 +36,6 @@ typedef struct {
 } nt_ui_tooltip_cell_t;
 
 #ifdef NT_TEST_ACCESS
-static uint8_t s_last_side;              /* popup side chosen this frame (edge-flip + caret-flip probe) */
-static bool s_last_caret_present;        /* did the last shown tooltip declare a caret? */
-static uint8_t s_last_caret_flip;        /* caret flip_bits the last shown tooltip used */
-static bool s_last_panel_art;            /* did the last shown panel use slice9 art? */
-static float s_last_panel_corner_radius; /* the cornerRadius the last shown panel applied (0 under art) */
 #endif
 
 nt_ui_tooltip_style_t nt_ui_tooltip_style_defaults(void) {
@@ -122,10 +117,6 @@ static void tooltip_declare_caret(nt_ui_context_t *ctx, uint8_t fill_layer, uint
           .image = (Clay_ImageElementConfig){.imageData = p},
           .backgroundColor = nt_ui_unpack_tint(style->caret_tint),
           .userData = (void *)nt_ui_make_element_data(fill_layer, NULL)}) {}
-#ifdef NT_TEST_ACCESS
-    s_last_caret_present = true;
-    s_last_caret_flip = flip;
-#endif
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity) — complexity is the validation assert chain, not control flow
@@ -135,13 +126,6 @@ bool nt_ui_tooltip(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint8
     NT_ASSERT(isfinite(style->delay_secs) && style->delay_secs >= 0.0F && "nt_ui_tooltip: delay_secs finite && >= 0");
     NT_ASSERT(style->font_size > 0.0F && "nt_ui_tooltip: font_size > 0");
     NT_ASSERT(isfinite(style->slice9_scale) && style->slice9_scale > 0.0F && "nt_ui_tooltip: slice9_scale must be finite > 0");
-
-#ifdef NT_TEST_ACCESS
-    s_last_caret_present = false;
-    s_last_caret_flip = 0U;
-    s_last_panel_art = false;
-    s_last_panel_corner_radius = 0.0F;
-#endif
 
     const uint8_t fill_layer = (data != NULL) ? data->layer : 0U; /* panel fill on data->layer, label on label_layer */
 
@@ -184,9 +168,6 @@ bool nt_ui_tooltip(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint8
     /* Low-level begin/end (no one-bool wrapper): the open state is engine-derived from the hover timer,
      * not a game bool, and there is no close_requested path to harvest. */
     const nt_ui_popup_result_t r = nt_ui_popup_begin(ctx, tooltip_popup_id(target_id), &pst, &anc, open);
-#ifdef NT_TEST_ACCESS
-    s_last_side = r.side; /* the side popup-core chose this frame (drives the caret flip) */
-#endif
     if (r.visible) {
         const uint32_t panel_id = tooltip_panel_id(target_id);
         const nt_ui_label_style_t lbl = {.font_id = style->font_id, .font_size = style->font_size, .color = nt_ui_unpack_abgr(style->text_color)};
@@ -207,10 +188,6 @@ bool nt_ui_tooltip(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint8
             panel.backgroundColor = nt_ui_unpack_abgr(style->panel_bg);
             panel.cornerRadius = CLAY_CORNER_RADIUS((float)style->corner_radius);
         }
-#ifdef NT_TEST_ACCESS
-        s_last_panel_art = panel_art;
-        s_last_panel_corner_radius = panel.cornerRadius.topLeft; /* 0 under art (cornerRadius never set) */
-#endif
         if (style->border_px > 0U && style->border_color != 0U) {
             const uint16_t bw = style->border_px;
             panel.border = (Clay_BorderElementConfig){.color = nt_ui_unpack_abgr(style->border_color), .width = {.left = bw, .right = bw, .top = bw, .bottom = bw}};
@@ -234,9 +211,4 @@ float nt_ui_tooltip_test_hover_secs(nt_ui_context_t *ctx, uint32_t target_id) {
     const nt_ui_tooltip_cell_t *c = (const nt_ui_tooltip_cell_t *)nt_ui_state_find(ctx, tooltip_timer_id(target_id));
     return (c != NULL) ? c->hover : 0.0F;
 }
-uint8_t nt_ui_tooltip_test_last_side(void) { return s_last_side; }
-bool nt_ui_tooltip_test_last_caret_present(void) { return s_last_caret_present; }
-uint8_t nt_ui_tooltip_test_last_caret_flip(void) { return s_last_caret_flip; }
-bool nt_ui_tooltip_test_last_panel_art(void) { return s_last_panel_art; }
-float nt_ui_tooltip_test_last_panel_corner_radius(void) { return s_last_panel_corner_radius; }
 #endif

--- a/engine/ui/nt_ui_tooltip.c
+++ b/engine/ui/nt_ui_tooltip.c
@@ -35,9 +35,6 @@ typedef struct {
     float hover; /* accumulated seconds the cursor has been over the target */
 } nt_ui_tooltip_cell_t;
 
-#ifdef NT_TEST_ACCESS
-#endif
-
 nt_ui_tooltip_style_t nt_ui_tooltip_style_defaults(void) {
     /* Polished flat baseline: no atlas art (panel_art / caret atlas.id stay 0), no border/shadow. Wire
      * panel_art + caret + border/shadow to opt into the sprite look (parity with dropdown/menu). */
@@ -113,7 +110,9 @@ static void tooltip_declare_caret(nt_ui_context_t *ctx, uint8_t fill_layer, uint
     const Clay_FloatingAttachPoints ap = above ? (Clay_FloatingAttachPoints){.element = CLAY_ATTACH_POINT_CENTER_TOP, .parent = CLAY_ATTACH_POINT_CENTER_BOTTOM}
                                                : (Clay_FloatingAttachPoints){.element = CLAY_ATTACH_POINT_CENTER_BOTTOM, .parent = CLAY_ATTACH_POINT_CENTER_TOP};
     CLAY({.layout = {.sizing = {CLAY_SIZING_FIXED(sz), CLAY_SIZING_FIXED(sz)}},
-          .floating = {.attachTo = CLAY_ATTACH_TO_PARENT, .zIndex = 1, .attachPoints = ap},
+          /* Delta 0 like every other widget part: declared after the panel body, so it paints over the
+           * panel without escaping the tooltip's own band (a +1 would top later overlays too). */
+          .floating = {.attachTo = CLAY_ATTACH_TO_PARENT, .attachPoints = ap},
           .image = (Clay_ImageElementConfig){.imageData = p},
           .backgroundColor = nt_ui_unpack_tint(style->caret_tint),
           .userData = (void *)nt_ui_make_element_data(fill_layer, NULL)}) {}

--- a/engine/ui/nt_ui_tooltip.h
+++ b/engine/ui/nt_ui_tooltip.h
@@ -67,14 +67,6 @@ bool nt_ui_tooltip(nt_ui_context_t *ctx, const nt_ui_element_data_t *data, uint8
 uint32_t nt_ui_tooltip_test_timer_id(uint32_t target_id);
 /* The accumulated hover seconds in the timer cell for target_id (0 if no cell). */
 float nt_ui_tooltip_test_hover_secs(nt_ui_context_t *ctx, uint32_t target_id);
-/* The popup side chosen on the last nt_ui_tooltip call (nt_ui_popup_side_t; edge-flip + caret-flip probe). */
-uint8_t nt_ui_tooltip_test_last_side(void);
-/* Whether the last shown tooltip declared a caret (ref + caret_size both present) and its flip_bits. */
-bool nt_ui_tooltip_test_last_caret_present(void);
-uint8_t nt_ui_tooltip_test_last_caret_flip(void);
-/* Whether the last shown panel used slice9 art, and the cornerRadius it applied (0 under art). */
-bool nt_ui_tooltip_test_last_panel_art(void);
-float nt_ui_tooltip_test_last_panel_corner_radius(void);
 #endif
 
 #endif /* NT_UI_TOOLTIP_H */

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -252,8 +252,20 @@ if [ "$MODE" = "push" ]; then
     # and -O2: a test registered behind an assert-mode guard, or a variable only an assert reads, is
     # -Wunused under -Werror here and nowhere in the debug builds. Mirrors ci.yml's native-release job.
     step "build (native-release)"
-    if [ ! -f "build/_cmake/native-release/CMakeCache.txt" ]; then
-        cmake --preset native-release
+    NR_CACHE="build/_cmake/native-release/CMakeCache.txt"
+    if [ ! -f "$NR_CACHE" ]; then
+        # Configure explicitly (like the wasm steps): a fresh cache here would miss the developer's own
+        # -DNT_SKIP_EXAMPLE_PACKS and walk into the multi-hour cold sponza encode.
+        echo "ERROR: build/_cmake/native-release missing — configure the preset first:"
+        echo "  cmake --preset native-release"
+        exit 1
+    fi
+    # An overridden assert mode turns this step green and empty: NT_ASSERT_FULL-only code compiles again
+    # and the -Wunused class this step exists for disappears.
+    if ! grep -q '^NT_ASSERT_MODE:STRING=$' "$NR_CACHE"; then
+        echo "ERROR: native-release cache overrides NT_ASSERT_MODE — it must stay empty (auto -> TRAP)."
+        echo "  cmake --preset native-release -DNT_ASSERT_MODE="
+        exit 1
     fi
     cmake --build build/_cmake/native-release
     ok

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -252,19 +252,9 @@ if [ "$MODE" = "push" ]; then
     # and -O2: a test registered behind an assert-mode guard, or a variable only an assert reads, is
     # -Wunused under -Werror here and nowhere in the debug builds. Mirrors ci.yml's native-release job.
     step "build (native-release)"
-    NR_CACHE="build/_cmake/native-release/CMakeCache.txt"
-    if [ ! -f "$NR_CACHE" ]; then
-        # Configure explicitly (like the wasm steps): a fresh cache here would miss the developer's own
-        # -DNT_SKIP_EXAMPLE_PACKS and walk into the multi-hour cold sponza encode.
+    if [ ! -d "build/_cmake/native-release" ]; then
         echo "ERROR: build/_cmake/native-release missing — configure the preset first:"
         echo "  cmake --preset native-release"
-        exit 1
-    fi
-    # An overridden assert mode turns this step green and empty: NT_ASSERT_FULL-only code compiles again
-    # and the -Wunused class this step exists for disappears.
-    if ! grep -q '^NT_ASSERT_MODE:STRING=$' "$NR_CACHE"; then
-        echo "ERROR: native-release cache overrides NT_ASSERT_MODE — it must stay empty (auto -> TRAP)."
-        echo "  cmake --preset native-release -DNT_ASSERT_MODE="
         exit 1
     fi
     cmake --build build/_cmake/native-release

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -3,7 +3,7 @@
 # opts into running the formatter under the same lock first. Modes:
 #   scripts/check.sh                    gates + build + ctest + format/tidy on changed files
 #   scripts/check.sh --full             default + whole-tree format + full tidy
-#   scripts/check.sh --push             default + wasm-debug + wasm-release + submodule test
+#   scripts/check.sh --push             default + native-release + wasm-debug + wasm-release + submodule test
 #   scripts/check.sh --format [--full|--push]  format changed files under the same run lock first
 # The cheap gates (module composition, EM_JS_DEPS, doc links, CRT pins) run in EVERY mode —
 # they cost seconds and previously CI-only failures came exactly from skipping them.
@@ -248,6 +248,16 @@ fi
 collect_ctest
 
 if [ "$MODE" = "push" ]; then
+    # Release compiles the same TUs with NDEBUG (asserts -> TRAP, so NT_ASSERT_FULL-only code drops out)
+    # and -O2: a test registered behind an assert-mode guard, or a variable only an assert reads, is
+    # -Wunused under -Werror here and nowhere in the debug builds. Mirrors ci.yml's native-release job.
+    step "build (native-release)"
+    if [ ! -f "build/_cmake/native-release/CMakeCache.txt" ]; then
+        cmake --preset native-release
+    fi
+    cmake --build build/_cmake/native-release
+    ok
+
     step "build (wasm-debug)"
     if ! command -v emcc > /dev/null 2>&1; then
         echo "ERROR: emcc not found in PATH — the wasm-debug build is required before push."

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -252,9 +252,16 @@ if [ "$MODE" = "push" ]; then
     # and -O2: a test registered behind an assert-mode guard, or a variable only an assert reads, is
     # -Wunused under -Werror here and nowhere in the debug builds. Mirrors ci.yml's native-release job.
     step "build (native-release)"
-    if [ ! -d "build/_cmake/native-release" ]; then
-        echo "ERROR: build/_cmake/native-release missing — configure the preset first:"
-        echo "  cmake --preset native-release"
+    NR_CACHE="build/_cmake/native-release/CMakeCache.txt"
+    if [ ! -f "$NR_CACHE" ]; then
+        echo "ERROR: build/_cmake/native-release not configured — run it yourself, so your own"
+        echo "       -DNT_SKIP_EXAMPLE_PACKS carries over:  cmake --preset native-release"
+        exit 1
+    fi
+    # A hand-passed -DNT_ASSERT_MODE=2 here makes this step green and empty: NT_ASSERT_FULL-only code
+    # compiles again and the -Wunused class the step exists for disappears.
+    if ! grep -q '^NT_ASSERT_MODE:STRING=$' "$NR_CACHE"; then
+        echo "ERROR: native-release cache overrides NT_ASSERT_MODE — it must stay empty (auto -> TRAP)."
         exit 1
     fi
     cmake --build build/_cmake/native-release

--- a/tests/unit/test_nt_ui_modal.c
+++ b/tests/unit/test_nt_ui_modal.c
@@ -58,6 +58,29 @@ static void test_modal_defaults_valid(void) {
     TEST_ASSERT_TRUE((st.flags & NT_UI_MODAL_CLOSE_ON_BACKDROP) != 0U);
 }
 
+/* Bands are read off what the frame actually ships: Clay stamps the owning floating root's zIndex on
+ * RECTANGLE and TEXT commands. INT32_MIN = the id emitted no rectangle this frame. */
+static int32_t band_of_rect(const nt_ui_context_t *ctx, uint32_t id) {
+    for (int32_t i = 0; i < ctx->frozen_cmds.length; ++i) {
+        const Clay_RenderCommand *c = &ctx->frozen_cmds.internalArray[i];
+        if (c->id == id && c->commandType == CLAY_RENDER_COMMAND_TYPE_RECTANGLE) {
+            return c->zIndex;
+        }
+    }
+    return INT32_MIN;
+}
+
+/* The backdrop's id is engine-derived and deliberately unpublished, so assert its band by presence. */
+static bool band_has_rect(const nt_ui_context_t *ctx, int32_t band) {
+    for (int32_t i = 0; i < ctx->frozen_cmds.length; ++i) {
+        const Clay_RenderCommand *c = &ctx->frozen_cmds.internalArray[i];
+        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_RECTANGLE && c->zIndex == band) {
+            return true;
+        }
+    }
+    return false;
+}
+
 /* ---- Floating-modal smoke: a floating modal (z=1000, transform + opacity) declared over base content;
  *      the walker exits with a balanced scissor stack and composes the panel transform. ---- */
 static void test_modal_floating_smoke(void) {
@@ -68,11 +91,11 @@ static void test_modal_floating_smoke(void) {
     CLAY({.id = CLAY_ID("base"), .layout = {.sizing = {CLAY_SIZING_FIXED(800), CLAY_SIZING_FIXED(600)}}}) {}
     nt_ui_modal_result_t r = nt_ui_modal_begin(s_fx.ctx, MODAL_A, &st, true);
     {
-        CLAY({.id = CLAY_ID("modal_body"), .layout = {.sizing = {CLAY_SIZING_FIXED(300), CLAY_SIZING_FIXED(200)}}}) {}
+        CLAY({.id = CLAY_ID("modal_body"), .layout = {.sizing = {CLAY_SIZING_FIXED(300), CLAY_SIZING_FIXED(200)}}, .backgroundColor = {8, 8, 8, 255}}) {}
     }
     nt_ui_modal_end(s_fx.ctx);
     nt_ui_end(s_fx.ctx); /* walks: balanced scissor assert + transform compose must not trip */
-    TEST_ASSERT_EQUAL_UINT16((uint16_t)1000U, nt_ui_modal_test_last_zband());
+    TEST_ASSERT_EQUAL_INT32((int32_t)1000, band_of_rect(s_fx.ctx, CLAY_ID("modal_body").id));
     TEST_ASSERT_TRUE(r.visible);
     TEST_ASSERT_EQUAL_UINT8(0U, nt_ui_modal_test_stack_depth(s_fx.ctx)); /* balanced */
 }
@@ -84,16 +107,20 @@ static void test_modal_zband_and_nesting(void) {
     nt_pointer_t p = {.active = true};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 1.0F / 60.0F, &p, 1);
     nt_ui_modal_begin(s_fx.ctx, MODAL_A, &st, true);
-    TEST_ASSERT_EQUAL_UINT16((uint16_t)1000U, nt_ui_modal_test_last_zband());
-    TEST_ASSERT_EQUAL_UINT16((uint16_t)999U, nt_ui_modal_test_last_backdrop_zband());
+    /* Opaque bodies so each panel subtree emits a rectangle carrying its root's band. */
+    CLAY({.id = CLAY_ID("body_a"), .layout = {.sizing = {CLAY_SIZING_FIXED(40), CLAY_SIZING_FIXED(20)}}, .backgroundColor = {8, 8, 8, 255}}) {}
     nt_ui_modal_begin(s_fx.ctx, MODAL_B, &st, true); /* modal-over-modal */
-    TEST_ASSERT_EQUAL_UINT16((uint16_t)2000U, nt_ui_modal_test_last_zband());
-    TEST_ASSERT_EQUAL_UINT16((uint16_t)1999U, nt_ui_modal_test_last_backdrop_zband());
+    CLAY({.id = CLAY_ID("body_b"), .layout = {.sizing = {CLAY_SIZING_FIXED(40), CLAY_SIZING_FIXED(20)}}, .backgroundColor = {8, 8, 8, 255}}) {}
     TEST_ASSERT_EQUAL_UINT8(2U, nt_ui_modal_test_stack_depth(s_fx.ctx));
     nt_ui_modal_end(s_fx.ctx);
     nt_ui_modal_end(s_fx.ctx);
     TEST_ASSERT_EQUAL_UINT8(0U, nt_ui_modal_test_stack_depth(s_fx.ctx));
     nt_ui_end(s_fx.ctx);
+
+    TEST_ASSERT_EQUAL_INT32((int32_t)1000, band_of_rect(s_fx.ctx, CLAY_ID("body_a").id));
+    TEST_ASSERT_EQUAL_INT32((int32_t)2000, band_of_rect(s_fx.ctx, CLAY_ID("body_b").id));
+    TEST_ASSERT_TRUE_MESSAGE(band_has_rect(s_fx.ctx, 999), "the outer backdrop must paint one band under its panel");
+    TEST_ASSERT_TRUE_MESSAGE(band_has_rect(s_fx.ctx, 1999), "the nested backdrop must paint one band under its panel");
 }
 
 /* ---- Stack depth is zero at frame start and after balanced begin/end. ---- */
@@ -592,14 +619,17 @@ static void test_modal_custom_zband_stride(void) {
     nt_pointer_t p = {.active = true};
     nt_ui_begin(ctx, 800.0F, 600.0F, 1.0F / 60.0F, &p, 1);
     nt_ui_modal_begin(ctx, MODAL_A, &st, true); /* depth 0 -> stride*1 */
-    TEST_ASSERT_EQUAL_UINT16((uint16_t)(custom_stride * 1), nt_ui_modal_test_last_zband());
-    TEST_ASSERT_EQUAL_UINT16((uint16_t)((custom_stride * 1) - 1), nt_ui_modal_test_last_backdrop_zband());
+    CLAY({.id = CLAY_ID("cs_a"), .layout = {.sizing = {CLAY_SIZING_FIXED(40), CLAY_SIZING_FIXED(20)}}, .backgroundColor = {8, 8, 8, 255}}) {}
     nt_ui_modal_begin(ctx, MODAL_B, &st, true); /* depth 1 -> stride*2 */
-    TEST_ASSERT_EQUAL_UINT16((uint16_t)(custom_stride * 2), nt_ui_modal_test_last_zband());
-    TEST_ASSERT_EQUAL_UINT16((uint16_t)((custom_stride * 2) - 1), nt_ui_modal_test_last_backdrop_zband());
+    CLAY({.id = CLAY_ID("cs_b"), .layout = {.sizing = {CLAY_SIZING_FIXED(40), CLAY_SIZING_FIXED(20)}}, .backgroundColor = {8, 8, 8, 255}}) {}
     nt_ui_modal_end(ctx);
     nt_ui_modal_end(ctx);
     nt_ui_end(ctx);
+
+    TEST_ASSERT_EQUAL_INT32((int32_t)(custom_stride * 1), band_of_rect(ctx, CLAY_ID("cs_a").id));
+    TEST_ASSERT_EQUAL_INT32((int32_t)(custom_stride * 2), band_of_rect(ctx, CLAY_ID("cs_b").id));
+    TEST_ASSERT_TRUE(band_has_rect(ctx, (custom_stride * 1) - 1));
+    TEST_ASSERT_TRUE(band_has_rect(ctx, (custom_stride * 2) - 1));
 
     nt_ui_destroy_context(ctx);
 }
@@ -735,8 +765,9 @@ static void test_modal_close_uses_close_recipe(void) {
     TEST_ASSERT_TRUE(ox > 0.0F); /* close recipe = RIGHT (from style.close) */
 }
 
-/* ---- Delegation proof: the modal's z-band equals what popup-core computes for the same depth, i.e.
- *      the modal is re-expressed ON popup-core, not a divergent parallel copy of the z-band math. ---- */
+/* ---- Delegation proof: the modal's shipped band equals the popup's for the same depth, i.e. the modal
+ *      is re-expressed ON popup-core, not a divergent parallel copy of the z-band math. The catcher half
+ *      is unmeasurable here on purpose: a plain popup's catcher is transparent and emits no command. ---- */
 static void test_modal_zband_matches_popup_core(void) {
     nt_ui_modal_style_t mst = nt_ui_modal_style_defaults();
     mst.ease_speed = 0.0F;
@@ -748,21 +779,22 @@ static void test_modal_zband_matches_popup_core(void) {
     /* Modal at depth 0 -> panel z. */
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 1.0F / 60.0F, &p, 1);
     nt_ui_modal_begin(s_fx.ctx, MODAL_A, &mst, true);
-    const uint16_t modal_z = nt_ui_modal_test_last_zband();
-    const uint16_t modal_bz = nt_ui_modal_test_last_backdrop_zband();
+    CLAY({.id = CLAY_ID("dele_body"), .layout = {.sizing = {CLAY_SIZING_FIXED(40), CLAY_SIZING_FIXED(20)}}, .backgroundColor = {8, 8, 8, 255}}) {}
     nt_ui_modal_end(s_fx.ctx);
     nt_ui_end(s_fx.ctx);
+    const int32_t modal_z = band_of_rect(s_fx.ctx, CLAY_ID("dele_body").id);
+    const bool modal_backdrop = band_has_rect(s_fx.ctx, modal_z - 1);
 
-    /* Popup at depth 0 -> same panel/backdrop z (same shared depth counter + stride). */
+    /* Popup at depth 0 -> the same panel band (one shared depth counter + stride). */
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 1.0F / 60.0F, &p, 1);
     nt_ui_popup_begin(s_fx.ctx, MODAL_A, &pst, &panc, true);
-    const uint16_t popup_z = nt_ui_popup_test_last_zband();
-    const uint16_t popup_cz = nt_ui_popup_test_last_catcher_zband();
+    CLAY({.id = CLAY_ID("dele_body"), .layout = {.sizing = {CLAY_SIZING_FIXED(40), CLAY_SIZING_FIXED(20)}}, .backgroundColor = {8, 8, 8, 255}}) {}
     nt_ui_popup_end(s_fx.ctx);
     nt_ui_end(s_fx.ctx);
+    const int32_t popup_z = band_of_rect(s_fx.ctx, CLAY_ID("dele_body").id);
 
-    TEST_ASSERT_EQUAL_UINT16(popup_z, modal_z);
-    TEST_ASSERT_EQUAL_UINT16(popup_cz, modal_bz); /* modal backdrop == popup catcher z-band */
+    TEST_ASSERT_EQUAL_INT32(popup_z, modal_z);
+    TEST_ASSERT_TRUE_MESSAGE(modal_backdrop, "the modal backdrop paints one band under its panel");
 }
 
 int main(void) {

--- a/tests/unit/test_nt_ui_modal.c
+++ b/tests/unit/test_nt_ui_modal.c
@@ -539,7 +539,8 @@ static void test_modal_active_prev_frame(void) {
 }
 
 /* ---- Sequential SAME-DEPTH modals in one frame: a FULLY-CLOSED first must not steal top from an
- *      OPEN second at the same level. The latest PRESENT modal at the max depth wins top, so next
+ *      OPEN second at the same level. Top goes to the highest effective band, ties to the last PRESENT
+ *      declaration, so next
  *      frame the second (open) modal's Esc fires and the first (closed) stays silent. ---- */
 static void test_modal_closed_same_depth_does_not_steal_top(void) {
     nt_ui_modal_style_t st = nt_ui_modal_style_defaults();

--- a/tests/unit/test_nt_ui_modal.c
+++ b/tests/unit/test_nt_ui_modal.c
@@ -648,6 +648,14 @@ static void test_modal_zero_stride_asserts(void) {
     NT_TEST_EXPECT_ASSERT((void)nt_ui_create_context(s_custom_arena, sizeof s_custom_arena, &desc));
 }
 
+/* ---- A stride of 1 leaves no band for the catcher (it sits at panel-1 = the base band, where it stops
+ *      gating base UI), so it is rejected at create rather than asserting later inside popup-core. ---- */
+static void test_modal_stride_one_asserts(void) {
+    nt_ui_create_desc_t desc = nt_ui_create_desc_defaults();
+    desc.modal_zband_stride = 1;
+    NT_TEST_EXPECT_ASSERT((void)nt_ui_create_context(s_custom_arena, sizeof s_custom_arena, &desc));
+}
+
 /* ---- An over-large stride (stride*MAX_DEPTH > INT16_MAX) trips the create-time NT_ASSERT
  *      (fail-early, no silent clamp). ---- */
 static void test_modal_oversize_stride_asserts(void) {
@@ -834,6 +842,7 @@ int main(void) {
     RUN_TEST(test_modal_anim_asserts);
     RUN_TEST(test_modal_custom_zband_stride);
     RUN_TEST(test_modal_zero_stride_asserts);
+    RUN_TEST(test_modal_stride_one_asserts);
     RUN_TEST(test_modal_oversize_stride_asserts);
     return UNITY_END();
 }

--- a/tests/unit/test_nt_ui_modal.c
+++ b/tests/unit/test_nt_ui_modal.c
@@ -97,7 +97,7 @@ static void test_modal_floating_smoke(void) {
     nt_ui_end(s_fx.ctx); /* walks: balanced scissor assert + transform compose must not trip */
     TEST_ASSERT_EQUAL_INT32((int32_t)1000, band_of_rect(s_fx.ctx, CLAY_ID("modal_body").id));
     TEST_ASSERT_TRUE(r.visible);
-    TEST_ASSERT_EQUAL_UINT8(0U, nt_ui_modal_test_stack_depth(s_fx.ctx)); /* balanced */
+    TEST_ASSERT_EQUAL_UINT8(0U, s_fx.ctx->active_modal_depth); /* balanced */
 }
 
 /* ---- z-band: panel = 1000*(depth+1), backdrop = panel-1. Nested = 2000/1999, depth 2. ---- */
@@ -111,10 +111,10 @@ static void test_modal_zband_and_nesting(void) {
     CLAY({.id = CLAY_ID("body_a"), .layout = {.sizing = {CLAY_SIZING_FIXED(40), CLAY_SIZING_FIXED(20)}}, .backgroundColor = {8, 8, 8, 255}}) {}
     nt_ui_modal_begin(s_fx.ctx, MODAL_B, &st, true); /* modal-over-modal */
     CLAY({.id = CLAY_ID("body_b"), .layout = {.sizing = {CLAY_SIZING_FIXED(40), CLAY_SIZING_FIXED(20)}}, .backgroundColor = {8, 8, 8, 255}}) {}
-    TEST_ASSERT_EQUAL_UINT8(2U, nt_ui_modal_test_stack_depth(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT8(2U, s_fx.ctx->active_modal_depth);
     nt_ui_modal_end(s_fx.ctx);
     nt_ui_modal_end(s_fx.ctx);
-    TEST_ASSERT_EQUAL_UINT8(0U, nt_ui_modal_test_stack_depth(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT8(0U, s_fx.ctx->active_modal_depth);
     nt_ui_end(s_fx.ctx);
 
     TEST_ASSERT_EQUAL_INT32((int32_t)1000, band_of_rect(s_fx.ctx, CLAY_ID("body_a").id));
@@ -126,12 +126,12 @@ static void test_modal_zband_and_nesting(void) {
 /* ---- Stack depth is zero at frame start and after balanced begin/end. ---- */
 static void test_modal_stack_depth_zero_balanced(void) {
     nt_ui_modal_style_t st = nt_ui_modal_style_defaults();
-    TEST_ASSERT_EQUAL_UINT8(0U, nt_ui_modal_test_stack_depth(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT8(0U, s_fx.ctx->active_modal_depth);
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 1.0F / 60.0F, &(nt_pointer_t){.active = true}, 1);
     nt_ui_modal_begin(s_fx.ctx, MODAL_A, &st, true);
-    TEST_ASSERT_EQUAL_UINT8(1U, nt_ui_modal_test_stack_depth(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT8(1U, s_fx.ctx->active_modal_depth);
     nt_ui_modal_end(s_fx.ctx);
-    TEST_ASSERT_EQUAL_UINT8(0U, nt_ui_modal_test_stack_depth(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT8(0U, s_fx.ctx->active_modal_depth);
     nt_ui_end(s_fx.ctx);
 }
 
@@ -143,7 +143,7 @@ static void test_modal_depth_overflow_asserts(void) {
     for (uint32_t i = 0; i < NT_UI_MODAL_MAX_DEPTH; ++i) {
         nt_ui_modal_begin(s_fx.ctx, 0x4D1000U + i, &st, true);
     }
-    TEST_ASSERT_EQUAL_UINT8((uint8_t)NT_UI_MODAL_MAX_DEPTH, nt_ui_modal_test_stack_depth(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT8((uint8_t)NT_UI_MODAL_MAX_DEPTH, s_fx.ctx->active_modal_depth);
     NT_TEST_EXPECT_ASSERT(nt_ui_modal_begin(s_fx.ctx, 0x4D1FFFU, &st, true));
     for (uint32_t i = 0; i < NT_UI_MODAL_MAX_DEPTH; ++i) {
         nt_ui_modal_end(s_fx.ctx);
@@ -417,9 +417,11 @@ static void test_modal_no_backdrop_close_still_gates(void) {
 
 /* One modal frame with a stepped button child. The button id is stepped INSIDE the body — mirrors the
  * showcase's action-button pattern. */
+static nt_ui_modal_close_reason_t s_frame_close_reason; /* reason from the last modal_button_frame */
+
 static nt_ui_interaction_t modal_button_frame(const nt_ui_modal_style_t *st, const nt_pointer_t *p) {
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 1.0F / 60.0F, p, 1);
-    nt_ui_modal_begin(s_fx.ctx, MODAL_A, st, true);
+    s_frame_close_reason = nt_ui_modal_begin(s_fx.ctx, MODAL_A, st, true).reason;
     nt_ui_interaction_t in;
     CLAY({.id = (Clay_ElementId){.id = nt_ui_id("modal_btn")}, .layout = {.sizing = {CLAY_SIZING_FIXED(MODAL_BTN_W), CLAY_SIZING_FIXED(MODAL_BTN_H)}}}) {
         in = nt_ui_step_interaction(s_fx.ctx, nt_ui_id("modal_btn"));
@@ -460,7 +462,7 @@ static nt_ui_modal_close_reason_t modal_backdrop_click_reason(const nt_ui_modal_
     nt_pointer_t f2 = modal_pointer_at(cx, cy, false, false, true);
     f2.buttons[NT_BUTTON_LEFT].is_pressed = true;
     modal_button_frame(st, &f2);
-    return nt_ui_modal_test_last_close_reason();
+    return s_frame_close_reason;
 }
 
 static void test_modal_backdrop_close_pad(void) {
@@ -545,8 +547,8 @@ static void test_modal_active_prev_frame(void) {
     nt_ui_modal_begin(s_fx.ctx, MODAL_A, &st, true);
     nt_ui_modal_end(s_fx.ctx);
     nt_ui_end(s_fx.ctx);
-    TEST_ASSERT_EQUAL_UINT8(0U, nt_ui_modal_test_stack_depth(s_fx.ctx)); /* live depth IS 0 ... */
-    TEST_ASSERT_TRUE(nt_ui_modal_active(s_fx.ctx));                      /* ... yet prev-frame presence is true */
+    TEST_ASSERT_EQUAL_UINT8(0U, s_fx.ctx->active_modal_depth); /* live depth IS 0 ... */
+    TEST_ASSERT_TRUE(nt_ui_modal_active(s_fx.ctx));            /* ... yet prev-frame presence is true */
 
     /* Frame 2: no modal declared at all -> presence falls back to inactive. */
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 1.0F / 60.0F, &(nt_pointer_t){.active = true}, 1);

--- a/tests/unit/test_nt_ui_modal.c
+++ b/tests/unit/test_nt_ui_modal.c
@@ -25,7 +25,10 @@
 alignas(NT_UI_ARENA_ALIGN) static uint8_t s_arena[NT_UI_TEST_ARENA_SIZE];
 static ui_walker_fixture_t s_fx;
 
+static nt_ui_modal_close_reason_t s_frame_close_reason; /* reason from the last modal_button_frame; reset in setUp */
+
 void setUp(void) {
+    s_frame_close_reason = NT_UI_MODAL_CLOSE_NONE;
     nt_test_assert_install();
     nt_input_clear_all_keys();
     ui_walker_fixture_init(&s_fx, s_arena, sizeof s_arena, UI_WALKER_FX_BIND_ALL);
@@ -70,11 +73,13 @@ static int32_t band_of_rect(const nt_ui_context_t *ctx, uint32_t id) {
     return INT32_MIN;
 }
 
-/* The backdrop's id is engine-derived and deliberately unpublished, so assert its band by presence. */
-static bool band_has_rect(const nt_ui_context_t *ctx, int32_t band) {
+/* The backdrop's id is engine-derived and deliberately unpublished, so identify it by shape: the only
+ * full-viewport rectangle in the frame. Band alone would also match a game rect that happens to land
+ * there. */
+static bool band_has_backdrop(const nt_ui_context_t *ctx, int32_t band) {
     for (int32_t i = 0; i < ctx->frozen_cmds.length; ++i) {
         const Clay_RenderCommand *c = &ctx->frozen_cmds.internalArray[i];
-        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_RECTANGLE && c->zIndex == band) {
+        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_RECTANGLE && c->zIndex == band && c->boundingBox.width >= 800.0F && c->boundingBox.height >= 600.0F) {
             return true;
         }
     }
@@ -119,8 +124,8 @@ static void test_modal_zband_and_nesting(void) {
 
     TEST_ASSERT_EQUAL_INT32((int32_t)1000, band_of_rect(s_fx.ctx, CLAY_ID("body_a").id));
     TEST_ASSERT_EQUAL_INT32((int32_t)2000, band_of_rect(s_fx.ctx, CLAY_ID("body_b").id));
-    TEST_ASSERT_TRUE_MESSAGE(band_has_rect(s_fx.ctx, 999), "the outer backdrop must paint one band under its panel");
-    TEST_ASSERT_TRUE_MESSAGE(band_has_rect(s_fx.ctx, 1999), "the nested backdrop must paint one band under its panel");
+    TEST_ASSERT_TRUE_MESSAGE(band_has_backdrop(s_fx.ctx, 999), "the outer backdrop must paint one band under its panel");
+    TEST_ASSERT_TRUE_MESSAGE(band_has_backdrop(s_fx.ctx, 1999), "the nested backdrop must paint one band under its panel");
 }
 
 /* ---- Stack depth is zero at frame start and after balanced begin/end. ---- */
@@ -417,7 +422,6 @@ static void test_modal_no_backdrop_close_still_gates(void) {
 
 /* One modal frame with a stepped button child. The button id is stepped INSIDE the body — mirrors the
  * showcase's action-button pattern. */
-static nt_ui_modal_close_reason_t s_frame_close_reason; /* reason from the last modal_button_frame */
 
 static nt_ui_interaction_t modal_button_frame(const nt_ui_modal_style_t *st, const nt_pointer_t *p) {
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 1.0F / 60.0F, p, 1);
@@ -630,8 +634,8 @@ static void test_modal_custom_zband_stride(void) {
 
     TEST_ASSERT_EQUAL_INT32((int32_t)(custom_stride * 1), band_of_rect(ctx, CLAY_ID("cs_a").id));
     TEST_ASSERT_EQUAL_INT32((int32_t)(custom_stride * 2), band_of_rect(ctx, CLAY_ID("cs_b").id));
-    TEST_ASSERT_TRUE(band_has_rect(ctx, (custom_stride * 1) - 1));
-    TEST_ASSERT_TRUE(band_has_rect(ctx, (custom_stride * 2) - 1));
+    TEST_ASSERT_TRUE(band_has_backdrop(ctx, (custom_stride * 1) - 1));
+    TEST_ASSERT_TRUE(band_has_backdrop(ctx, (custom_stride * 2) - 1));
 
     nt_ui_destroy_context(ctx);
 }
@@ -785,7 +789,8 @@ static void test_modal_zband_matches_popup_core(void) {
     nt_ui_modal_end(s_fx.ctx);
     nt_ui_end(s_fx.ctx);
     const int32_t modal_z = band_of_rect(s_fx.ctx, CLAY_ID("dele_body").id);
-    const bool modal_backdrop = band_has_rect(s_fx.ctx, modal_z - 1);
+    TEST_ASSERT_TRUE_MESSAGE(modal_z != INT32_MIN, "the modal body must emit a rectangle to measure");
+    const bool modal_backdrop = band_has_backdrop(s_fx.ctx, modal_z - 1);
 
     /* Popup at depth 0 -> the same panel band (one shared depth counter + stride). */
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 1.0F / 60.0F, &p, 1);
@@ -794,6 +799,7 @@ static void test_modal_zband_matches_popup_core(void) {
     nt_ui_popup_end(s_fx.ctx);
     nt_ui_end(s_fx.ctx);
     const int32_t popup_z = band_of_rect(s_fx.ctx, CLAY_ID("dele_body").id);
+    TEST_ASSERT_TRUE_MESSAGE(popup_z != INT32_MIN, "the popup body must emit a rectangle to measure");
 
     TEST_ASSERT_EQUAL_INT32(popup_z, modal_z);
     TEST_ASSERT_TRUE_MESSAGE(modal_backdrop, "the modal backdrop paints one band under its panel");

--- a/tests/unit/test_nt_ui_scroll.c
+++ b/tests/unit/test_nt_ui_scroll.c
@@ -411,16 +411,24 @@ static void test_scrollbar_standalone_no_z_lift(void) {
     scrollbar_frame(&p, &style, 1000.0F); /* overflow */
     scrollbar_frame(&p, &style, 1000.0F);
     TEST_ASSERT_TRUE((nt_ui_scroll_test_last_bar_emitted_axes() & 2U) != 0U);
+    /* The bar's own band: Clay stamps root->zIndex on the clipTo SCISSOR that opens the bar's floating
+     * root, which is the command immediately preceding the bar's art (image commands are stamped 0). */
     const Clay_RenderCommandArray *arr = &s_fx.ctx->frozen_cmds;
-    bool bar_emitted = false;
-    int32_t max_z = 0;
     const uint32_t bar_id = nt_ui_scroll_test_bar_id(SCROLL_ID, 1);
+    int32_t last_scissor_z = INT32_MIN;
+    int32_t bar_band = INT32_MIN;
     for (int32_t i = 0; i < arr->length; ++i) {
-        bar_emitted = bar_emitted || (arr->internalArray[i].id == bar_id);
-        max_z = (arr->internalArray[i].zIndex > max_z) ? arr->internalArray[i].zIndex : max_z;
+        const Clay_RenderCommand *c = &arr->internalArray[i];
+        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_SCISSOR_START) {
+            last_scissor_z = c->zIndex;
+        }
+        if (c->id == bar_id) {
+            bar_band = last_scissor_z;
+            break;
+        }
     }
-    TEST_ASSERT_TRUE_MESSAGE(bar_emitted, "standalone scrollbar must reach the render commands");
-    TEST_ASSERT_EQUAL_INT32_MESSAGE(0, max_z, "standalone scroll must stay in z band 0");
+    TEST_ASSERT_TRUE_MESSAGE(bar_band != INT32_MIN, "standalone scrollbar must reach the render commands");
+    TEST_ASSERT_EQUAL_INT32_MESSAGE(0, bar_band, "standalone scroll bar must stay in z band 0");
 }
 
 /* ---- Test 12: thumb length is proportional to container/content (clamped to min). ---- */

--- a/tests/unit/test_nt_ui_scroll.c
+++ b/tests/unit/test_nt_ui_scroll.c
@@ -417,17 +417,20 @@ static void test_scrollbar_standalone_no_z_lift(void) {
     const uint32_t bar_id = nt_ui_scroll_test_bar_id(SCROLL_ID, 1);
     int32_t last_scissor_z = INT32_MIN;
     int32_t bar_band = INT32_MIN;
+    bool bar_found = false;
     for (int32_t i = 0; i < arr->length; ++i) {
         const Clay_RenderCommand *c = &arr->internalArray[i];
         if (c->commandType == CLAY_RENDER_COMMAND_TYPE_SCISSOR_START) {
             last_scissor_z = c->zIndex;
         }
         if (c->id == bar_id) {
+            bar_found = true;
             bar_band = last_scissor_z;
             break;
         }
     }
-    TEST_ASSERT_TRUE_MESSAGE(bar_band != INT32_MIN, "standalone scrollbar must reach the render commands");
+    TEST_ASSERT_TRUE_MESSAGE(bar_found, "standalone scrollbar must reach the render commands");
+    TEST_ASSERT_TRUE_MESSAGE(bar_band != INT32_MIN, "the bar's clipTo SCISSOR must precede its art");
     TEST_ASSERT_EQUAL_INT32_MESSAGE(0, bar_band, "standalone scroll bar must stay in z band 0");
 }
 

--- a/tests/unit/test_nt_ui_scroll.c
+++ b/tests/unit/test_nt_ui_scroll.c
@@ -402,16 +402,25 @@ static void test_scrollbar_always_shows(void) {
     TEST_ASSERT_TRUE((nt_ui_scroll_test_last_bar_emitted_axes() & 2U) != 0U);
 }
 
-/* ---- A standalone scroll (NOT inside a popup) floats its bar at zIndex 0: nothing floats above it,
- *      so the popup-band lift must NOT kick in (active_modal_depth == 0). ---- */
-static void test_scrollbar_standalone_zindex_zero(void) {
+/* ---- A standalone scroll (no floating encloses it) must not lift anything: with zIndex inherited from
+ *      the enclosing floating, "no enclosing floating" means every command stays in band 0. ---- */
+static void test_scrollbar_standalone_no_z_lift(void) {
     nt_ui_scroll_style_t style = bar_style(NT_UI_SCROLLBAR_ALWAYS);
     nt_pointer_t p = {0};
     p.active = true;
     scrollbar_frame(&p, &style, 1000.0F); /* overflow */
     scrollbar_frame(&p, &style, 1000.0F);
     TEST_ASSERT_TRUE((nt_ui_scroll_test_last_bar_emitted_axes() & 2U) != 0U);
-    TEST_ASSERT_EQUAL_INT16_MESSAGE(0, nt_ui_scroll_test_last_bar_zindex(1), "standalone scroll bar must float at zIndex 0");
+    const Clay_RenderCommandArray *arr = &s_fx.ctx->frozen_cmds;
+    bool bar_emitted = false;
+    int32_t max_z = 0;
+    const uint32_t bar_id = nt_ui_scroll_test_bar_id(SCROLL_ID, 1);
+    for (int32_t i = 0; i < arr->length; ++i) {
+        bar_emitted = bar_emitted || (arr->internalArray[i].id == bar_id);
+        max_z = (arr->internalArray[i].zIndex > max_z) ? arr->internalArray[i].zIndex : max_z;
+    }
+    TEST_ASSERT_TRUE_MESSAGE(bar_emitted, "standalone scrollbar must reach the render commands");
+    TEST_ASSERT_EQUAL_INT32_MESSAGE(0, max_z, "standalone scroll must stay in z band 0");
 }
 
 /* ---- Test 12: thumb length is proportional to container/content (clamped to min). ---- */
@@ -2058,7 +2067,7 @@ int main(void) {
     RUN_TEST(test_scroll_capture_tap_no_steal);
     RUN_TEST(test_scrollbar_auto_only_on_overflow);
     RUN_TEST(test_scrollbar_always_shows);
-    RUN_TEST(test_scrollbar_standalone_zindex_zero);
+    RUN_TEST(test_scrollbar_standalone_no_z_lift);
     RUN_TEST(test_scrollbar_thumb_size_ratio);
     RUN_TEST(test_scrollbar_thumb_pos_clay_sign);
     RUN_TEST(test_scrollbar_track_click_scroll_to);

--- a/tests/unit/test_nt_ui_slider.c
+++ b/tests/unit/test_nt_ui_slider.c
@@ -19,6 +19,7 @@
 #include "test_helpers/ui_walker_fixture.h"
 #include "ui/nt_ui.h"
 #include "ui/nt_ui_internal.h"
+#include "ui/nt_ui_modal.h"
 #include "ui/nt_ui_scroll.h"
 #include "ui/nt_ui_slider.h"
 #include "unity.h"
@@ -838,6 +839,61 @@ static void test_assert_orientation_invalid(void) {
 
 #endif /* NT_ASSERT_MODE == NT_ASSERT_FULL */
 
+/* ---- A slider declared inside a modal (a floating z-band) draws its thumb ABOVE the panel and in the
+ *      right place on the FIRST frame. The thumb is a floating child: while Clay sorted every floating
+ *      root by its own zIndex, the thumb root (z 0) sorted UNDER the panel band AND was positioned from
+ *      the track's previous-frame bbox — invisible, one frame stale, and the clip parent's empty bbox
+ *      tripped the walker's SCISSOR assert. Panel .clip keeps that scissor path in the test. ---- */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+static void test_thumb_above_modal_band_first_frame(void) {
+    float value = 0.5F;
+    nt_pointer_t idle = make_pointer(0.0F, 0.0F, false, false, false);
+    nt_ui_modal_style_t mst = nt_ui_modal_style_defaults();
+    mst.ease_speed = 0.0F; /* snap open: the panel is at full size on frame 1 */
+
+    nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &idle, 1);
+    (void)nt_ui_modal_begin(s_fx.ctx, 0x5D0001U, &mst, true);
+    CLAY({.id = CLAY_ID("modal_panel"),
+          .layout = {.sizing = {CLAY_SIZING_FIXED(400.0F), CLAY_SIZING_FIXED(200.0F)}},
+          .backgroundColor = {10, 10, 10, 255},
+          .clip = {.horizontal = true, .vertical = true}}) {
+        (void)nt_ui_slider_float(s_fx.ctx, NULL, 0, nt_ui_id("modal_sl"), NULL, &value, 0.0F, 1.0F, 0.0F, &s_style, &s_track_decl, true);
+    }
+    nt_ui_modal_end(s_fx.ctx);
+    nt_ui_end(s_fx.ctx);
+    /* Walks the SCISSOR the thumb's clipTo emits — an empty clip bbox aborts here. */
+    nt_ui_target_t target = {.viewport = {0.0F, 0.0F, 800.0F, 600.0F}};
+    nt_ui_walk(s_fx.ctx, &target);
+
+    int32_t thumb_at = -1;
+    const Clay_RenderCommand *thumb = find_thumb_image(&thumb_at);
+    TEST_ASSERT_NOT_NULL_MESSAGE(thumb, "slider inside a modal must emit its thumb");
+
+    /* The panel rect carries the modal's effective band; the thumb must paint after it. */
+    int32_t panel_at = -1;
+    const Clay_RenderCommand *track = NULL;
+    for (int32_t i = 0; i < s_fx.ctx->frozen_cmds.length; ++i) {
+        const Clay_RenderCommand *c = &s_fx.ctx->frozen_cmds.internalArray[i];
+        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_RECTANGLE && c->zIndex > 0) {
+            panel_at = i;
+        }
+        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_IMAGE && float_near(c->boundingBox.width, SL_W, 0.5F)) {
+            track = c;
+        }
+    }
+    TEST_ASSERT_TRUE_MESSAGE(panel_at >= 0, "the modal panel must paint in a lifted z band");
+    TEST_ASSERT_TRUE_MESSAGE(thumb_at > panel_at, "thumb must paint AFTER the modal panel, not under it");
+
+    /* Frame-1 placement is measured against the track in the SAME frame, so a stale parent bbox shows up
+     * as an offset instead of a coordinate the test has to predict. The value travel rides the walker
+     * transform, not the Clay box, so the attached box sits exactly on the track's left edge. */
+    TEST_ASSERT_NOT_NULL(track);
+    TEST_ASSERT_TRUE_MESSAGE(float_near(thumb->boundingBox.x, track->boundingBox.x, 0.5F), "thumb box must attach to the track left edge, not a stale-bbox origin");
+    const float thumb_cy = thumb->boundingBox.y + (thumb->boundingBox.height * 0.5F);
+    const float track_cy = track->boundingBox.y + (track->boundingBox.height * 0.5F);
+    TEST_ASSERT_TRUE_MESSAGE(float_near(thumb_cy, track_cy, 0.5F), "thumb must stay centered on the track cross axis");
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_track_jump_value_map);
@@ -857,6 +913,7 @@ int main(void) {
     RUN_TEST(test_step_thumb_visual_snap);
     RUN_TEST(test_out_of_range_writeback);
     RUN_TEST(test_thumb_clipped_in_scroll);
+    RUN_TEST(test_thumb_above_modal_band_first_frame);
     RUN_TEST(test_vertical_track_jump_bottom_up);
     RUN_TEST(test_vertical_track_jump_top_down);
     RUN_TEST(test_vertical_thumb_grab_bottom_up);

--- a/tests/unit/test_nt_ui_slider.c
+++ b/tests/unit/test_nt_ui_slider.c
@@ -877,13 +877,13 @@ static void test_thumb_above_modal_band_first_frame(void) {
         if (c->commandType == CLAY_RENDER_COMMAND_TYPE_RECTANGLE && c->id == CLAY_ID("modal_panel").id) {
             panel_at = i;
         }
-        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_IMAGE && float_near(c->boundingBox.width, SL_W, 0.5F)) {
-            track = c;
+        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_IMAGE && c->id == nt_ui_id("modal_sl")) {
+            track = c; /* by id: at value 1 the fill image is SL_W wide too */
         }
     }
     TEST_ASSERT_TRUE_MESSAGE(panel_at >= 0, "the modal panel must emit its background");
-    /* Command index is paint order here because both carry layer 0 — the walker only reorders within a
-     * same-zIndex run, and then by layer. */
+    /* Command index is paint order here because the two commands sit in different zIndex runs (the panel
+     * rect carries the modal band, the thumb image carries 0), and the walker never reorders across runs. */
     TEST_ASSERT_TRUE_MESSAGE(thumb_at > panel_at, "thumb must paint AFTER the modal panel, not under it");
 
     /* Frame-1 placement is measured against the track in the SAME frame, so a stale parent bbox shows up

--- a/tests/unit/test_nt_ui_slider.c
+++ b/tests/unit/test_nt_ui_slider.c
@@ -874,14 +874,16 @@ static void test_thumb_above_modal_band_first_frame(void) {
     const Clay_RenderCommand *track = NULL;
     for (int32_t i = 0; i < s_fx.ctx->frozen_cmds.length; ++i) {
         const Clay_RenderCommand *c = &s_fx.ctx->frozen_cmds.internalArray[i];
-        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_RECTANGLE && c->zIndex > 0) {
+        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_RECTANGLE && c->id == CLAY_ID("modal_panel").id) {
             panel_at = i;
         }
         if (c->commandType == CLAY_RENDER_COMMAND_TYPE_IMAGE && float_near(c->boundingBox.width, SL_W, 0.5F)) {
             track = c;
         }
     }
-    TEST_ASSERT_TRUE_MESSAGE(panel_at >= 0, "the modal panel must paint in a lifted z band");
+    TEST_ASSERT_TRUE_MESSAGE(panel_at >= 0, "the modal panel must emit its background");
+    /* Command index is paint order here because both carry layer 0 — the walker only reorders within a
+     * same-zIndex run, and then by layer. */
     TEST_ASSERT_TRUE_MESSAGE(thumb_at > panel_at, "thumb must paint AFTER the modal panel, not under it");
 
     /* Frame-1 placement is measured against the track in the SAME frame, so a stale parent bbox shows up

--- a/tests/unit/test_ui_dropdown.c
+++ b/tests/unit/test_ui_dropdown.c
@@ -499,7 +499,12 @@ static void test_dropdown_edge_flip_up_near_bottom(void) {
     nt_pointer_t idle = pointer_at(400.0F, 300.0F, false, false, false);
     combo_im_frame(&idle, 30.0F, 540.0F, s_short, 3, &selected, &open, &st, NULL);
     combo_im_frame(&idle, 30.0F, 540.0F, s_short, 3, &selected, &open, &st, NULL);
-    TEST_ASSERT_EQUAL_UINT8(NT_UI_POPUP_ABOVE, nt_ui_dropdown_test_last_side());
+    /* The flip's visible consequence: the list sits wholly above the trigger it belongs to. */
+    const nt_ui_bbox_t trigger = nt_ui_get_bbox(s_fx.ctx, DD_A);
+    const nt_ui_bbox_t row0 = nt_ui_get_bbox(s_fx.ctx, nt_ui_dropdown_test_combo_row_id(DD_A, ROW_KEY(0)));
+    TEST_ASSERT_TRUE(trigger.found);
+    TEST_ASSERT_TRUE(row0.found);
+    TEST_ASSERT_TRUE_MESSAGE(row0.y + row0.height <= trigger.y + 0.5F, "a trigger near the bottom must open its list ABOVE itself");
 }
 
 /* The row's label x after two warm frames (1-frame IM lag bakes the bbox). The same `icons` array is fed

--- a/tests/unit/test_ui_dropdown.c
+++ b/tests/unit/test_ui_dropdown.c
@@ -341,8 +341,11 @@ static void test_dropdown_long_list_scrollbar_showcase_fidelity(void) {
 static void test_dropdown_long_list_scrollbar_above_popup_band(void) {
     nt_ui_dropdown_style_t st = nt_ui_dropdown_style_defaults();
     st.max_visible_rows = 4; /* 12 rows > 4 -> the list scrolls */
-    st.list_scroll.track_ref = nt_atlas_ref((nt_resource_t){.id = 1U}, 0x100U);
-    st.list_scroll.thumb_ref = nt_atlas_ref((nt_resource_t){.id = 1U}, 0x101U);
+    /* Real fixture art, not the placeholder refs the other cases use: an unresolvable ref draws nothing,
+     * and this case reads the zIndex Clay stamped on the bar's own render command. */
+    const nt_atlas_region_ref_t bar_art = nt_atlas_ref_idx(s_fx.atlas.handle, 0, s_fx.atlas.white_region_idx);
+    st.list_scroll.track_ref = bar_art;
+    st.list_scroll.thumb_ref = bar_art;
 
     int selected = 0;
     bool open = true;
@@ -351,11 +354,28 @@ static void test_dropdown_long_list_scrollbar_above_popup_band(void) {
     combo_im_frame(&idle, 30.0F, 30.0F, s_long, 12, &selected, &open, &st, NULL);
 
     TEST_ASSERT_TRUE_MESSAGE((nt_ui_scroll_test_last_bar_emitted_axes() & 2U) != 0U, "popup-nested long list must emit a vertical scrollbar");
-    /* The single combo popup floats at depth 1: panel_z == stride*1. The bar must sit strictly above it. */
-    const int16_t stride = s_fx.ctx->modal_zband_stride;
-    const int16_t bar_z = nt_ui_scroll_test_last_bar_zindex(1);
-    TEST_ASSERT_GREATER_THAN_INT16_MESSAGE(0, bar_z, "popup-nested bar zIndex must be > 0");
-    TEST_ASSERT_GREATER_THAN_INT16_MESSAGE(stride, bar_z, "popup-nested bar zIndex must sit ABOVE the popup panel band (stride*depth)");
+    /* The combo popup panel floats one band up (stride*1 here). The bar is declared INSIDE that panel, so
+     * it must inherit the panel's band instead of sinking to the base 0 and drawing under the panel. */
+    const int32_t stride = (int32_t)s_fx.ctx->modal_zband_stride;
+    const uint32_t bar_id = nt_ui_scroll_test_bar_id(nt_ui_dropdown_test_scroll_id(DD_A), 1);
+    const Clay_RenderCommandArray *arr = &s_fx.ctx->frozen_cmds;
+    int32_t bar_at = -1;
+    int32_t last_panel_at = -1;
+    for (int32_t i = 0; i < arr->length; ++i) {
+        const Clay_RenderCommand *c = &arr->internalArray[i];
+        if (c->id == bar_id && bar_at < 0) {
+            bar_at = i;
+        }
+        /* Panel-band CONTENT only: RECTANGLE/TEXT carry their floating root's effective band, while the
+         * bar's own clipTo SCISSOR markers also carry it (they clip to the panel-side parent). */
+        const bool content = (c->commandType == CLAY_RENDER_COMMAND_TYPE_RECTANGLE || c->commandType == CLAY_RENDER_COMMAND_TYPE_TEXT);
+        if (content && c->zIndex == stride) {
+            last_panel_at = i;
+        }
+    }
+    TEST_ASSERT_TRUE_MESSAGE(bar_at >= 0, "popup-nested bar must reach the render commands");
+    TEST_ASSERT_TRUE_MESSAGE(last_panel_at >= 0, "the popup panel band must be present in the frame");
+    TEST_ASSERT_TRUE_MESSAGE(bar_at > last_panel_at, "popup-nested bar must paint AFTER the popup panel, not sink under it");
 }
 
 /* ---- Eased open is STABLE: with open_ease_speed > 0, opening the list then running idle frames with NO

--- a/tests/unit/test_ui_dropdown.c
+++ b/tests/unit/test_ui_dropdown.c
@@ -499,12 +499,15 @@ static void test_dropdown_edge_flip_up_near_bottom(void) {
     nt_pointer_t idle = pointer_at(400.0F, 300.0F, false, false, false);
     combo_im_frame(&idle, 30.0F, 540.0F, s_short, 3, &selected, &open, &st, NULL);
     combo_im_frame(&idle, 30.0F, 540.0F, s_short, 3, &selected, &open, &st, NULL);
-    /* The flip's visible consequence: the list sits wholly above the trigger it belongs to. */
+    /* The flip's visible consequence: the list is ADJACENT above the trigger. Bare "somewhere higher"
+     * would also accept a CENTER-placed list or a list collapsed to y=0. */
     const nt_ui_bbox_t trigger = nt_ui_get_bbox(s_fx.ctx, DD_A);
-    const nt_ui_bbox_t row0 = nt_ui_get_bbox(s_fx.ctx, nt_ui_dropdown_test_combo_row_id(DD_A, ROW_KEY(0)));
+    const nt_ui_bbox_t last_row = nt_ui_get_bbox(s_fx.ctx, nt_ui_dropdown_test_combo_row_id(DD_A, ROW_KEY(2)));
     TEST_ASSERT_TRUE(trigger.found);
-    TEST_ASSERT_TRUE(row0.found);
-    TEST_ASSERT_TRUE_MESSAGE(row0.y + row0.height <= trigger.y + 0.5F, "a trigger near the bottom must open its list ABOVE itself");
+    TEST_ASSERT_TRUE(last_row.found);
+    TEST_ASSERT_TRUE_MESSAGE(last_row.height > 0.0F, "the list must have measured a size");
+    TEST_ASSERT_TRUE_MESSAGE(last_row.y + last_row.height <= trigger.y + 0.5F, "a trigger near the bottom must open its list ABOVE itself");
+    TEST_ASSERT_TRUE_MESSAGE(trigger.y - (last_row.y + last_row.height) <= (float)st.pad + 8.0F, "the list must sit ADJACENT above the trigger, not float off elsewhere");
 }
 
 /* The row's label x after two warm frames (1-frame IM lag bakes the bbox). The same `icons` array is fed

--- a/tests/unit/test_ui_dropdown.c
+++ b/tests/unit/test_ui_dropdown.c
@@ -335,10 +335,10 @@ static void test_dropdown_long_list_scrollbar_showcase_fidelity(void) {
     TEST_ASSERT_EQUAL_UINT8_MESSAGE(1U, nt_ui_scroll_test_last_bar_layer(1), "scrollbar must draw on the container content layer, not buried under the panel");
 }
 
-/* ---- The combo list is a popup-nested scroll, so its bar must float at a Clay zIndex ABOVE the popup
- *      panel band (stride*depth). ---- */
+/* ---- The combo list is a popup-nested scroll: its bar INHERITS the popup panel's band (it no longer
+ *      lifts itself one band above) and paints after the panel because its root is declared later. ---- */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-static void test_dropdown_long_list_scrollbar_above_popup_band(void) {
+static void test_dropdown_long_list_scrollbar_inherits_popup_band(void) {
     nt_ui_dropdown_style_t st = nt_ui_dropdown_style_defaults();
     st.max_visible_rows = 4; /* 12 rows > 4 -> the list scrolls */
     /* Real fixture art, not the placeholder refs the other cases use: an unresolvable ref draws nothing,
@@ -360,11 +360,17 @@ static void test_dropdown_long_list_scrollbar_above_popup_band(void) {
     const uint32_t bar_id = nt_ui_scroll_test_bar_id(nt_ui_dropdown_test_scroll_id(DD_A), 1);
     const Clay_RenderCommandArray *arr = &s_fx.ctx->frozen_cmds;
     int32_t bar_at = -1;
+    int32_t bar_band = INT32_MIN;
+    int32_t last_scissor_z = INT32_MIN;
     int32_t last_panel_at = -1;
     for (int32_t i = 0; i < arr->length; ++i) {
         const Clay_RenderCommand *c = &arr->internalArray[i];
+        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_SCISSOR_START) {
+            last_scissor_z = c->zIndex; /* the bar root's clipTo marker carries its band */
+        }
         if (c->id == bar_id && bar_at < 0) {
             bar_at = i;
+            bar_band = last_scissor_z;
         }
         /* Panel-band CONTENT only: RECTANGLE/TEXT carry their floating root's effective band, while the
          * bar's own clipTo SCISSOR markers also carry it (they clip to the panel-side parent). */
@@ -376,6 +382,7 @@ static void test_dropdown_long_list_scrollbar_above_popup_band(void) {
     TEST_ASSERT_TRUE_MESSAGE(bar_at >= 0, "popup-nested bar must reach the render commands");
     TEST_ASSERT_TRUE_MESSAGE(last_panel_at >= 0, "the popup panel band must be present in the frame");
     TEST_ASSERT_TRUE_MESSAGE(bar_at > last_panel_at, "popup-nested bar must paint AFTER the popup panel, not sink under it");
+    TEST_ASSERT_EQUAL_INT32_MESSAGE(stride, bar_band, "popup-nested bar must sit IN the panel band, neither sunk to 0 nor lifted above it");
 }
 
 /* ---- Eased open is STABLE: with open_ease_speed > 0, opening the list then running idle frames with NO
@@ -761,7 +768,7 @@ int main(void) {
     RUN_TEST(test_dropdown_long_list_scroll_no_leak);
     RUN_TEST(test_dropdown_long_list_shows_scrollbar);
     RUN_TEST(test_dropdown_long_list_scrollbar_showcase_fidelity);
-    RUN_TEST(test_dropdown_long_list_scrollbar_above_popup_band);
+    RUN_TEST(test_dropdown_long_list_scrollbar_inherits_popup_band);
     RUN_TEST(test_dropdown_eased_open_no_flicker);
     RUN_TEST(test_dropdown_eased_open_no_reseed_under_churn);
     RUN_TEST(test_dropdown_eased_reclick_closes_once);

--- a/tests/unit/test_ui_input.c
+++ b/tests/unit/test_ui_input.c
@@ -1452,12 +1452,12 @@ static void test_field_text_above_modal_band(void) {
         if (c->commandType == CLAY_RENDER_COMMAND_TYPE_TEXT && text_at < 0) {
             text_at = i;
         }
-        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_RECTANGLE && c->zIndex > 0) {
-            panel_at = i; /* backdrop and panel both carry the modal band */
+        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_RECTANGLE && c->id == CLAY_ID("modal_panel").id) {
+            panel_at = i; /* by id: the field's caret is a floating RECTANGLE in the same band */
         }
     }
     TEST_ASSERT_TRUE_MESSAGE(text_at >= 0, "the field must emit its text");
-    TEST_ASSERT_TRUE_MESSAGE(panel_at >= 0, "the modal panel must paint in a lifted z band");
+    TEST_ASSERT_TRUE_MESSAGE(panel_at >= 0, "the modal panel must emit its background");
     TEST_ASSERT_TRUE_MESSAGE(text_at > panel_at, "field text must paint AFTER the modal panel, not under it");
 }
 
@@ -1514,9 +1514,9 @@ int main(void) {
     RUN_TEST(test_edit_step_insert_caret_on_codepoint_boundary);
     RUN_TEST(test_edit_step_backspace_across_multibyte_caret_boundary);
     RUN_TEST(test_scroll_step_caret_follow_fixed_width);
+    RUN_TEST(test_field_text_above_modal_band);
 #if NT_ASSERT_MODE == NT_ASSERT_FULL
     RUN_TEST(test_assert_null_buffer);
-    RUN_TEST(test_field_text_above_modal_band);
     RUN_TEST(test_assert_zero_cap);
     RUN_TEST(test_assert_null_props);
     RUN_TEST(test_assert_null_style);

--- a/tests/unit/test_ui_input.c
+++ b/tests/unit/test_ui_input.c
@@ -28,6 +28,7 @@
 #include "ui/nt_ui.h"
 #include "ui/nt_ui_input.h"
 #include "ui/nt_ui_internal.h"
+#include "ui/nt_ui_modal.h"
 #include "ui/nt_ui_state.h"
 #include "unity.h"
 #include "utf8/nt_utf8.h"
@@ -1428,6 +1429,38 @@ static void test_assert_null_style(void) {
 
 #endif /* NT_ASSERT_MODE == NT_ASSERT_FULL */
 
+/* ---- A field declared inside a modal paints its text ABOVE the panel. Caret, selection and the text
+ *      wrapper are floating children; while floating zIndex was global they sorted into band 0 and the
+ *      whole line drew under the modal backdrop. ---- */
+static void test_field_text_above_modal_band(void) {
+    char buf[32] = "abc";
+    nt_ui_modal_style_t mst = nt_ui_modal_style_defaults();
+    mst.ease_speed = 0.0F;
+
+    nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 1.0F / 60.0F, &(nt_pointer_t){.active = true}, 1);
+    (void)nt_ui_modal_begin(s_fx.ctx, 0x1F0001U, &mst, true);
+    CLAY({.id = CLAY_ID("modal_panel"), .layout = {.sizing = {CLAY_SIZING_FIXED(400.0F), CLAY_SIZING_FIXED(200.0F)}}, .backgroundColor = {10, 10, 10, 255}}) {
+        (void)nt_ui_input_text(s_fx.ctx, NULL, 0, nt_ui_id("modal_field"), buf, sizeof buf, &s_props, &s_style, &s_field_decl, true, NULL);
+    }
+    nt_ui_modal_end(s_fx.ctx);
+    nt_ui_end(s_fx.ctx);
+
+    int32_t text_at = -1;
+    int32_t panel_at = -1;
+    for (int32_t i = 0; i < s_fx.ctx->frozen_cmds.length; ++i) {
+        const Clay_RenderCommand *c = &s_fx.ctx->frozen_cmds.internalArray[i];
+        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_TEXT && text_at < 0) {
+            text_at = i;
+        }
+        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_RECTANGLE && c->zIndex > 0) {
+            panel_at = i; /* backdrop and panel both carry the modal band */
+        }
+    }
+    TEST_ASSERT_TRUE_MESSAGE(text_at >= 0, "the field must emit its text");
+    TEST_ASSERT_TRUE_MESSAGE(panel_at >= 0, "the modal panel must paint in a lifted z band");
+    TEST_ASSERT_TRUE_MESSAGE(text_at > panel_at, "field text must paint AFTER the modal panel, not under it");
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_insert_cyrillic_codepoints);
@@ -1483,6 +1516,7 @@ int main(void) {
     RUN_TEST(test_scroll_step_caret_follow_fixed_width);
 #if NT_ASSERT_MODE == NT_ASSERT_FULL
     RUN_TEST(test_assert_null_buffer);
+    RUN_TEST(test_field_text_above_modal_band);
     RUN_TEST(test_assert_zero_cap);
     RUN_TEST(test_assert_null_props);
     RUN_TEST(test_assert_null_style);

--- a/tests/unit/test_ui_menu.c
+++ b/tests/unit/test_ui_menu.c
@@ -1498,13 +1498,15 @@ static void test_menu_right_edge_root_clamp_and_submenu_flip(void) {
     TEST_ASSERT_TRUE_MESSAGE(root.x + root.width <= VIEW_W + 0.5F, "root menu near the right edge must clamp on-screen (no right clip)");
     TEST_ASSERT_TRUE_MESSAGE(root.x >= -0.5F, "clamped root must not push off the left edge");
 
-    /* (b) Submenu flipped LEFT and stays on-screen: a LEFT flip lands it wholly left of the root panel,
-     *      which is the visible consequence the side enum stands for. */
+    /* (b) Submenu flipped LEFT: popup-core attaches a LEFT-side panel's RIGHT edge to the anchor's left
+     *      edge, and the anchor is the parent row — so the flip is an exact geometric identity, not a
+     *      "somewhere to the left" (CENTER or a vertical side would also land left of the panel). */
     const nt_ui_bbox_t sub = nt_ui_get_bbox(s_fx.ctx, nt_ui_menu_test_panel_id(MENU_A, 1U));
     TEST_ASSERT_TRUE(sub.found);
-    /* A RIGHT-side submenu starts at the parent panel's right edge, so its own right edge would land a
-     * full width past it. Staying within the parent's right edge is the LEFT flip. */
-    TEST_ASSERT_TRUE_MESSAGE(sub.x + sub.width <= root.x + root.width + 0.5F, "submenu near the right edge must flip LEFT, not hang off the panel's right side");
+    const nt_ui_bbox_t file_row = nt_ui_get_bbox(s_fx.ctx, nt_ui_menu_test_item_id(MENU_A, KEY_FILE));
+    TEST_ASSERT_TRUE(file_row.found);
+    TEST_ASSERT_TRUE_MESSAGE(sub.width > 0.0F, "the submenu panel must have measured a size");
+    TEST_ASSERT_TRUE_MESSAGE(fabsf((sub.x + sub.width) - file_row.x) <= 0.5F, "a LEFT flip puts the submenu's right edge exactly on its anchor row's left edge");
     TEST_ASSERT_TRUE_MESSAGE(sub.x + sub.width <= VIEW_W + 0.5F, "left-flipped submenu must stay on-screen (right edge within the viewport)");
     TEST_ASSERT_TRUE_MESSAGE(sub.x >= -0.5F, "left-flipped submenu must not clip off the left edge");
 }

--- a/tests/unit/test_ui_menu.c
+++ b/tests/unit/test_ui_menu.c
@@ -292,10 +292,10 @@ static void test_menu_smoke_open_and_closed(void) {
     nt_ui_menu_state_t st = {0};
     menu_im_open(&st, 120.0F, 80.0F);
     menu_im_frame(&st, &style, 0.0F, 0.0F);
-    TEST_ASSERT_EQUAL_UINT8(0U, nt_ui_popup_test_stack_depth(s_fx.ctx)); /* balanced */
+    TEST_ASSERT_EQUAL_UINT8(0U, s_fx.ctx->active_modal_depth); /* balanced */
     st.open = false;
     menu_im_frame(&st, &style, 0.0F, 0.0F);
-    TEST_ASSERT_EQUAL_UINT8(0U, nt_ui_popup_test_stack_depth(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT8(0U, s_fx.ctx->active_modal_depth);
 }
 
 /* ---- Keyboard-nav reaches a nested leaf: Down focuses File, Right opens its submenu, Down to Open,
@@ -1498,10 +1498,13 @@ static void test_menu_right_edge_root_clamp_and_submenu_flip(void) {
     TEST_ASSERT_TRUE_MESSAGE(root.x + root.width <= VIEW_W + 0.5F, "root menu near the right edge must clamp on-screen (no right clip)");
     TEST_ASSERT_TRUE_MESSAGE(root.x >= -0.5F, "clamped root must not push off the left edge");
 
-    /* (b) Submenu flipped LEFT and stays on-screen. */
-    TEST_ASSERT_EQUAL_UINT8_MESSAGE(NT_UI_POPUP_LEFT, nt_ui_popup_test_last_side(), "submenu near the right edge must flip LEFT");
+    /* (b) Submenu flipped LEFT and stays on-screen: a LEFT flip lands it wholly left of the root panel,
+     *      which is the visible consequence the side enum stands for. */
     const nt_ui_bbox_t sub = nt_ui_get_bbox(s_fx.ctx, nt_ui_menu_test_panel_id(MENU_A, 1U));
     TEST_ASSERT_TRUE(sub.found);
+    /* A RIGHT-side submenu starts at the parent panel's right edge, so its own right edge would land a
+     * full width past it. Staying within the parent's right edge is the LEFT flip. */
+    TEST_ASSERT_TRUE_MESSAGE(sub.x + sub.width <= root.x + root.width + 0.5F, "submenu near the right edge must flip LEFT, not hang off the panel's right side");
     TEST_ASSERT_TRUE_MESSAGE(sub.x + sub.width <= VIEW_W + 0.5F, "left-flipped submenu must stay on-screen (right edge within the viewport)");
     TEST_ASSERT_TRUE_MESSAGE(sub.x >= -0.5F, "left-flipped submenu must not clip off the left edge");
 }

--- a/tests/unit/test_ui_popup.c
+++ b/tests/unit/test_ui_popup.c
@@ -488,26 +488,33 @@ static void test_popup_top_id_follows_paint_order(void) {
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(POP_B, s_fx.ctx->modal_top_id_prev, "the top-band claim must reset per frame, not stick to the highest band ever seen");
 }
 
-/* ---- Same band, different draw layers: the walker sorts a same-band run by layer, so the HIGHER layer
- *      is the one on screen even when it was declared first. The Esc/close-scan slot must follow it. ---- */
-static void test_popup_top_id_breaks_band_ties_by_layer(void) {
+/* ---- Two catcher-bearing popups on ONE band: whoever owns the close-scan slot must also be the one
+ *      the pointer hands the click to. The slot is picked by band with ties to the last declared, which
+ *      is the pointer arbiter's own key — ranking the slot by draw layer instead left the scan with a
+ *      popup whose catcher never won the click, and NEITHER overlay dismissed. ---- */
+static void test_popup_dismiss_survives_a_band_tie(void) {
     nt_ui_popup_style_t hi = nt_ui_popup_style_defaults();
     hi.ease_speed = 0.0F;
-    hi.layer = 2U;
+    hi.layer = 2U; /* a draw layer that does NOT move the close-scan slot */
     nt_ui_popup_style_t lo = nt_ui_popup_style_defaults();
     lo.ease_speed = 0.0F;
-    lo.layer = 0U;
     nt_ui_popup_anchor_t anc = {.x = 100.0F, .y = 100.0F, .w = 80.0F, .h = 30.0F, .prefer_side = NT_UI_POPUP_BELOW};
-    for (int frame = 0; frame < 2; ++frame) {
-        nt_pointer_t p = pointer_at(700.0F, 500.0F, false, false, false);
+
+    nt_ui_popup_result_t ra = {0};
+    nt_ui_popup_result_t rb = {0};
+    for (int frame = 0; frame < 3; ++frame) {
+        const bool pressing = (frame == 1);
+        const bool releasing = (frame == 2);
+        nt_pointer_t p = pointer_at(700.0F, 500.0F, pressing, pressing, releasing);
         nt_ui_begin(s_fx.ctx, VIEW_W, VIEW_H, 1.0F / 60.0F, &p, 1);
-        nt_ui_popup_begin(s_fx.ctx, POP_A, &hi, &anc, true); /* higher layer, declared FIRST */
+        ra = nt_ui_popup_begin(s_fx.ctx, POP_A, &hi, &anc, true);
         nt_ui_popup_end(s_fx.ctx);
-        nt_ui_popup_begin(s_fx.ctx, POP_B, &lo, &anc, true); /* same band, lower layer, declared last */
+        rb = nt_ui_popup_begin(s_fx.ctx, POP_B, &lo, &anc, true); /* same band, declared last -> owns the slot */
         nt_ui_popup_end(s_fx.ctx);
         nt_ui_end(s_fx.ctx);
     }
-    TEST_ASSERT_EQUAL_UINT32_MESSAGE(POP_A, s_fx.ctx->modal_top_id_prev, "a band tie must go to the higher draw layer, not the later declaration");
+    TEST_ASSERT_TRUE_MESSAGE(rb.close_requested, "the popup holding the close-scan slot must receive the outside click");
+    TEST_ASSERT_FALSE_MESSAGE(ra.close_requested, "the other popup stays an inert gate");
 }
 
 int main(void) {
@@ -517,7 +524,7 @@ int main(void) {
     RUN_TEST(test_popup_floating_smoke);
     RUN_TEST(test_popup_zband_and_nesting);
     RUN_TEST(test_popup_top_id_follows_paint_order);
-    RUN_TEST(test_popup_top_id_breaks_band_ties_by_layer);
+    RUN_TEST(test_popup_dismiss_survives_a_band_tie);
     RUN_TEST(test_popup_depth_overflow_asserts);
     RUN_TEST(test_popup_present_only_catcher);
     RUN_TEST(test_popup_closed_does_not_block_base);

--- a/tests/unit/test_ui_popup.c
+++ b/tests/unit/test_ui_popup.c
@@ -88,7 +88,10 @@ static void test_popup_floating_smoke(void) {
     TEST_ASSERT_EQUAL_UINT8(0U, nt_ui_popup_test_stack_depth(s_fx.ctx));
 }
 
-/* ---- z-band: panel = stride*(depth+1), catcher = panel-1. Nested = 2000/1999, depth 2. ---- */
+/* ---- z-band: each popup declares ONE stride above its enclosing floating, catcher one below its own
+ *      panel. A popup nested inside another must therefore reach 2*stride — asserted on the band Clay
+ *      stamped on the bodies' render commands, not on the engine's own arithmetic. ---- */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void test_popup_zband_and_nesting(void) {
     nt_ui_popup_style_t st = nt_ui_popup_style_defaults();
     st.ease_speed = 0.0F;
@@ -98,14 +101,34 @@ static void test_popup_zband_and_nesting(void) {
     nt_ui_popup_begin(s_fx.ctx, POP_A, &st, &anc, true);
     TEST_ASSERT_EQUAL_UINT16((uint16_t)1000U, nt_ui_popup_test_last_zband());
     TEST_ASSERT_EQUAL_UINT16((uint16_t)999U, nt_ui_popup_test_last_catcher_zband());
+    /* Opaque bodies so each panel subtree emits a RECTANGLE, which Clay stamps with its root's band. */
+    CLAY({.id = CLAY_ID("body_a"), .layout = {.sizing = {CLAY_SIZING_FIXED(40), CLAY_SIZING_FIXED(20)}}, .backgroundColor = {8, 8, 8, 255}}) {}
     nt_ui_popup_begin(s_fx.ctx, POP_B, &st, &anc, true);
     TEST_ASSERT_EQUAL_UINT16((uint16_t)2000U, nt_ui_popup_test_last_zband());
     TEST_ASSERT_EQUAL_UINT16((uint16_t)1999U, nt_ui_popup_test_last_catcher_zband());
     TEST_ASSERT_EQUAL_UINT8(2U, nt_ui_popup_test_stack_depth(s_fx.ctx));
+    CLAY({.id = CLAY_ID("body_b"), .layout = {.sizing = {CLAY_SIZING_FIXED(40), CLAY_SIZING_FIXED(20)}}, .backgroundColor = {8, 8, 8, 255}}) {}
     nt_ui_popup_end(s_fx.ctx);
     nt_ui_popup_end(s_fx.ctx);
     TEST_ASSERT_EQUAL_UINT8(0U, nt_ui_popup_test_stack_depth(s_fx.ctx));
     nt_ui_end(s_fx.ctx);
+
+    const int32_t stride = (int32_t)s_fx.ctx->modal_zband_stride;
+    int32_t z_a = INT32_MIN;
+    int32_t z_b = INT32_MIN;
+    for (int32_t i = 0; i < s_fx.ctx->frozen_cmds.length; ++i) {
+        const Clay_RenderCommand *c = &s_fx.ctx->frozen_cmds.internalArray[i];
+        if (c->commandType != CLAY_RENDER_COMMAND_TYPE_RECTANGLE) {
+            continue;
+        }
+        if (c->id == CLAY_ID("body_a").id) {
+            z_a = c->zIndex;
+        } else if (c->id == CLAY_ID("body_b").id) {
+            z_b = c->zIndex;
+        }
+    }
+    TEST_ASSERT_EQUAL_INT32_MESSAGE(stride, z_a, "outer popup must land one stride above the base band");
+    TEST_ASSERT_EQUAL_INT32_MESSAGE(2 * stride, z_b, "a popup nested inside another must accumulate a second stride");
 }
 
 /* ---- Depth overflow fires NT_ASSERT before the push (no silent fallback). ---- */

--- a/tests/unit/test_ui_popup.c
+++ b/tests/unit/test_ui_popup.c
@@ -491,6 +491,28 @@ static void test_popup_top_id_follows_paint_order(void) {
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(POP_B, s_fx.ctx->modal_top_id_prev, "the top-band claim must reset per frame, not stick to the highest band ever seen");
 }
 
+/* ---- Same band, different draw layers: the walker sorts a same-band run by layer, so the HIGHER layer
+ *      is the one on screen even when it was declared first. The Esc/close-scan slot must follow it. ---- */
+static void test_popup_top_id_breaks_band_ties_by_layer(void) {
+    nt_ui_popup_style_t hi = nt_ui_popup_style_defaults();
+    hi.ease_speed = 0.0F;
+    hi.layer = 2U;
+    nt_ui_popup_style_t lo = nt_ui_popup_style_defaults();
+    lo.ease_speed = 0.0F;
+    lo.layer = 0U;
+    nt_ui_popup_anchor_t anc = {.x = 100.0F, .y = 100.0F, .w = 80.0F, .h = 30.0F, .prefer_side = NT_UI_POPUP_BELOW};
+    for (int frame = 0; frame < 2; ++frame) {
+        nt_pointer_t p = pointer_at(700.0F, 500.0F, false, false, false);
+        nt_ui_begin(s_fx.ctx, VIEW_W, VIEW_H, 1.0F / 60.0F, &p, 1);
+        nt_ui_popup_begin(s_fx.ctx, POP_A, &hi, &anc, true); /* higher layer, declared FIRST */
+        nt_ui_popup_end(s_fx.ctx);
+        nt_ui_popup_begin(s_fx.ctx, POP_B, &lo, &anc, true); /* same band, lower layer, declared last */
+        nt_ui_popup_end(s_fx.ctx);
+        nt_ui_end(s_fx.ctx);
+    }
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(POP_A, s_fx.ctx->modal_top_id_prev, "a band tie must go to the higher draw layer, not the later declaration");
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_popup_abi_sizes);
@@ -498,6 +520,7 @@ int main(void) {
     RUN_TEST(test_popup_floating_smoke);
     RUN_TEST(test_popup_zband_and_nesting);
     RUN_TEST(test_popup_top_id_follows_paint_order);
+    RUN_TEST(test_popup_top_id_breaks_band_ties_by_layer);
     RUN_TEST(test_popup_depth_overflow_asserts);
     RUN_TEST(test_popup_present_only_catcher);
     RUN_TEST(test_popup_closed_does_not_block_base);

--- a/tests/unit/test_ui_popup.c
+++ b/tests/unit/test_ui_popup.c
@@ -99,13 +99,9 @@ static void test_popup_zband_and_nesting(void) {
     nt_pointer_t p = {.active = true};
     nt_ui_begin(s_fx.ctx, VIEW_W, VIEW_H, 1.0F / 60.0F, &p, 1);
     nt_ui_popup_begin(s_fx.ctx, POP_A, &st, &anc, true);
-    TEST_ASSERT_EQUAL_UINT16((uint16_t)1000U, nt_ui_popup_test_last_zband());
-    TEST_ASSERT_EQUAL_UINT16((uint16_t)999U, nt_ui_popup_test_last_catcher_zband());
     /* Opaque bodies so each panel subtree emits a RECTANGLE, which Clay stamps with its root's band. */
     CLAY({.id = CLAY_ID("body_a"), .layout = {.sizing = {CLAY_SIZING_FIXED(40), CLAY_SIZING_FIXED(20)}}, .backgroundColor = {8, 8, 8, 255}}) {}
     nt_ui_popup_begin(s_fx.ctx, POP_B, &st, &anc, true);
-    TEST_ASSERT_EQUAL_UINT16((uint16_t)2000U, nt_ui_popup_test_last_zband());
-    TEST_ASSERT_EQUAL_UINT16((uint16_t)1999U, nt_ui_popup_test_last_catcher_zband());
     TEST_ASSERT_EQUAL_UINT8(2U, nt_ui_popup_test_stack_depth(s_fx.ctx));
     CLAY({.id = CLAY_ID("body_b"), .layout = {.sizing = {CLAY_SIZING_FIXED(40), CLAY_SIZING_FIXED(20)}}, .backgroundColor = {8, 8, 8, 255}}) {}
     nt_ui_popup_end(s_fx.ctx);

--- a/tests/unit/test_ui_popup.c
+++ b/tests/unit/test_ui_popup.c
@@ -85,7 +85,7 @@ static void test_popup_floating_smoke(void) {
     nt_ui_popup_end(s_fx.ctx);
     nt_ui_end(s_fx.ctx);
     TEST_ASSERT_TRUE(r.visible);
-    TEST_ASSERT_EQUAL_UINT8(0U, nt_ui_popup_test_stack_depth(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT8(0U, s_fx.ctx->active_modal_depth);
 }
 
 /* ---- z-band: each popup declares ONE stride above its enclosing floating, catcher one below its own
@@ -102,11 +102,11 @@ static void test_popup_zband_and_nesting(void) {
     /* Opaque bodies so each panel subtree emits a RECTANGLE, which Clay stamps with its root's band. */
     CLAY({.id = CLAY_ID("body_a"), .layout = {.sizing = {CLAY_SIZING_FIXED(40), CLAY_SIZING_FIXED(20)}}, .backgroundColor = {8, 8, 8, 255}}) {}
     nt_ui_popup_begin(s_fx.ctx, POP_B, &st, &anc, true);
-    TEST_ASSERT_EQUAL_UINT8(2U, nt_ui_popup_test_stack_depth(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT8(2U, s_fx.ctx->active_modal_depth);
     CLAY({.id = CLAY_ID("body_b"), .layout = {.sizing = {CLAY_SIZING_FIXED(40), CLAY_SIZING_FIXED(20)}}, .backgroundColor = {8, 8, 8, 255}}) {}
     nt_ui_popup_end(s_fx.ctx);
     nt_ui_popup_end(s_fx.ctx);
-    TEST_ASSERT_EQUAL_UINT8(0U, nt_ui_popup_test_stack_depth(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT8(0U, s_fx.ctx->active_modal_depth);
     nt_ui_end(s_fx.ctx);
 
     const int32_t stride = (int32_t)s_fx.ctx->modal_zband_stride;
@@ -211,16 +211,17 @@ static uint8_t edge_flip_side(uint32_t id, float ax, float ay, uint8_t prefer) {
     st.ease_speed = 0.0F;
     nt_ui_popup_anchor_t anc = {.x = ax, .y = ay, .w = 40.0F, .h = 24.0F, .prefer_side = prefer};
 
+    uint8_t side = (uint8_t)NT_UI_POPUP_CENTER;
     for (int f = 0; f < 2; ++f) {
         nt_ui_begin(s_fx.ctx, VIEW_W, VIEW_H, 1.0F / 60.0F, &(nt_pointer_t){.active = true}, 1);
-        nt_ui_popup_begin(s_fx.ctx, id, &st, &anc, true);
+        side = nt_ui_popup_begin(s_fx.ctx, id, &st, &anc, true).side;
         {
             CLAY({.id = (Clay_ElementId){.id = id ^ 0xB0D70U}, .layout = {.sizing = {CLAY_SIZING_FIXED(POP_W), CLAY_SIZING_FIXED(POP_H)}}}) {}
         }
         nt_ui_popup_end(s_fx.ctx);
         nt_ui_end(s_fx.ctx);
     }
-    return nt_ui_popup_test_last_side();
+    return side;
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)

--- a/tests/unit/test_ui_popup.c
+++ b/tests/unit/test_ui_popup.c
@@ -415,12 +415,60 @@ static void test_popup_tween_clamp(void) {
     TEST_ASSERT_TRUE(saw_closed);
 }
 
+/* ---- The overlay that eats Esc / runs the close-scan is the one PAINTED on top, not the one deepest in
+ *      the begin/end counter. A game floating with its own zIndex shifts the band of the popup declared
+ *      inside it, so the two answers can disagree; the arbitration key must be the band Clay sorts by. ---- */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity)
+static void test_popup_top_id_follows_paint_order(void) {
+    nt_ui_popup_style_t st = nt_ui_popup_style_defaults();
+    st.ease_speed = 0.0F;
+    nt_ui_popup_anchor_t anc = {.x = 100.0F, .y = 100.0F, .w = 80.0F, .h = 30.0F, .prefer_side = NT_UI_POPUP_BELOW};
+    nt_pointer_t p = {.active = true};
+    /* Two frames: the close-scan target is committed at the next nt_ui_begin (1-frame IM lag). */
+    for (int frame = 0; frame < 2; ++frame) {
+        nt_ui_begin(s_fx.ctx, VIEW_W, VIEW_H, 1.0F / 60.0F, &p, 1);
+        CLAY({.id = CLAY_ID("game_hud"), .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .zIndex = 500}}) {
+            nt_ui_popup_begin(s_fx.ctx, POP_A, &st, &anc, true);
+            CLAY({.id = CLAY_ID("body_a"), .layout = {.sizing = {CLAY_SIZING_FIXED(40), CLAY_SIZING_FIXED(20)}}, .backgroundColor = {8, 8, 8, 255}}) {}
+            nt_ui_popup_end(s_fx.ctx);
+        }
+        /* Same nesting depth as A, but no enclosing band -> lands lower even though it is declared later. */
+        nt_ui_popup_begin(s_fx.ctx, POP_B, &st, &anc, true);
+        CLAY({.id = CLAY_ID("body_b"), .layout = {.sizing = {CLAY_SIZING_FIXED(40), CLAY_SIZING_FIXED(20)}}, .backgroundColor = {8, 8, 8, 255}}) {}
+        nt_ui_popup_end(s_fx.ctx);
+        nt_ui_end(s_fx.ctx);
+    }
+
+    int32_t z_a = INT32_MIN;
+    int32_t z_b = INT32_MIN;
+    int32_t at_a = -1;
+    int32_t at_b = -1;
+    for (int32_t i = 0; i < s_fx.ctx->frozen_cmds.length; ++i) {
+        const Clay_RenderCommand *c = &s_fx.ctx->frozen_cmds.internalArray[i];
+        if (c->commandType != CLAY_RENDER_COMMAND_TYPE_RECTANGLE) {
+            continue;
+        }
+        if (c->id == CLAY_ID("body_a").id) {
+            z_a = c->zIndex;
+            at_a = i;
+        } else if (c->id == CLAY_ID("body_b").id) {
+            z_b = c->zIndex;
+            at_b = i;
+        }
+    }
+    TEST_ASSERT_TRUE_MESSAGE(at_a >= 0 && at_b >= 0, "both popups must reach the render commands");
+    TEST_ASSERT_TRUE_MESSAGE(z_a > z_b, "the popup inside the lifted game floating must land in a higher band");
+    TEST_ASSERT_TRUE_MESSAGE(at_a > at_b, "and must therefore paint after the root-level popup");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(POP_A, s_fx.ctx->modal_top_id_prev, "the painted-on-top popup must own Esc and the close-scan");
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_popup_abi_sizes);
     RUN_TEST(test_popup_defaults_valid);
     RUN_TEST(test_popup_floating_smoke);
     RUN_TEST(test_popup_zband_and_nesting);
+    RUN_TEST(test_popup_top_id_follows_paint_order);
     RUN_TEST(test_popup_depth_overflow_asserts);
     RUN_TEST(test_popup_present_only_catcher);
     RUN_TEST(test_popup_closed_does_not_block_base);

--- a/tests/unit/test_ui_popup.c
+++ b/tests/unit/test_ui_popup.c
@@ -416,7 +416,7 @@ static void test_popup_tween_clamp(void) {
  *      the begin/end counter. A game floating with its own zIndex shifts the band of the popup declared
  *      inside it, so the two answers can disagree; the arbitration key must be the band Clay sorts by. ---- */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-static void test_popup_top_id_follows_paint_order(void) {
+static void test_popup_top_id_follows_band(void) {
     nt_ui_popup_style_t st = nt_ui_popup_style_defaults();
     st.ease_speed = 0.0F;
     nt_ui_popup_anchor_t anc = {.x = 100.0F, .y = 100.0F, .w = 80.0F, .h = 30.0F, .prefer_side = NT_UI_POPUP_BELOW};
@@ -456,10 +456,10 @@ static void test_popup_top_id_follows_paint_order(void) {
     TEST_ASSERT_TRUE_MESSAGE(at_a >= 0 && at_b >= 0, "both popups must reach the render commands");
     TEST_ASSERT_TRUE_MESSAGE(z_a > z_b, "the popup inside the lifted game floating must land in a higher band");
     TEST_ASSERT_TRUE_MESSAGE(at_a > at_b, "and must therefore paint after the root-level popup");
-    TEST_ASSERT_EQUAL_UINT32_MESSAGE(POP_A, s_fx.ctx->modal_top_id_prev, "the painted-on-top popup must own Esc and the close-scan");
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(POP_A, s_fx.ctx->modal_top_id_prev, "the higher-band popup must own Esc and the close-scan");
 
-    /* And the consequence, not just the gate: an outside click must dismiss the painted-on-top popup and
-     * leave the one under it alone (a non-top catcher is an inert pointer gate). */
+    /* And the consequence, not just the gate: an outside click must dismiss the popup that owns the slot
+     * and leave the other alone (a non-top catcher is an inert pointer gate). */
     nt_ui_popup_result_t ra = {0};
     nt_ui_popup_result_t rb = {0};
     for (int frame = 0; frame < 2; ++frame) {
@@ -508,8 +508,12 @@ static void test_popup_dismiss_survives_a_band_tie(void) {
         nt_pointer_t p = pointer_at(700.0F, 500.0F, pressing, pressing, releasing);
         nt_ui_begin(s_fx.ctx, VIEW_W, VIEW_H, 1.0F / 60.0F, &p, 1);
         ra = nt_ui_popup_begin(s_fx.ctx, POP_A, &hi, &anc, true);
+        /* Sized bodies: with 0x0 panels "the click landed outside" would be true even if the panel
+         * vanished, and the test could not tell the two apart. */
+        CLAY({.id = CLAY_ID("tie_a"), .layout = {.sizing = {CLAY_SIZING_FIXED(POP_W), CLAY_SIZING_FIXED(POP_H)}}}) {}
         nt_ui_popup_end(s_fx.ctx);
         rb = nt_ui_popup_begin(s_fx.ctx, POP_B, &lo, &anc, true); /* same band, declared last -> owns the slot */
+        CLAY({.id = CLAY_ID("tie_b"), .layout = {.sizing = {CLAY_SIZING_FIXED(POP_W), CLAY_SIZING_FIXED(POP_H)}}}) {}
         nt_ui_popup_end(s_fx.ctx);
         nt_ui_end(s_fx.ctx);
     }
@@ -523,7 +527,7 @@ int main(void) {
     RUN_TEST(test_popup_defaults_valid);
     RUN_TEST(test_popup_floating_smoke);
     RUN_TEST(test_popup_zband_and_nesting);
-    RUN_TEST(test_popup_top_id_follows_paint_order);
+    RUN_TEST(test_popup_top_id_follows_band);
     RUN_TEST(test_popup_dismiss_survives_a_band_tie);
     RUN_TEST(test_popup_depth_overflow_asserts);
     RUN_TEST(test_popup_present_only_catcher);

--- a/tests/unit/test_ui_popup.c
+++ b/tests/unit/test_ui_popup.c
@@ -460,6 +460,35 @@ static void test_popup_top_id_follows_paint_order(void) {
     TEST_ASSERT_TRUE_MESSAGE(z_a > z_b, "the popup inside the lifted game floating must land in a higher band");
     TEST_ASSERT_TRUE_MESSAGE(at_a > at_b, "and must therefore paint after the root-level popup");
     TEST_ASSERT_EQUAL_UINT32_MESSAGE(POP_A, s_fx.ctx->modal_top_id_prev, "the painted-on-top popup must own Esc and the close-scan");
+
+    /* And the consequence, not just the gate: an outside click must dismiss the painted-on-top popup and
+     * leave the one under it alone (a non-top catcher is an inert pointer gate). */
+    nt_ui_popup_result_t ra = {0};
+    nt_ui_popup_result_t rb = {0};
+    for (int frame = 0; frame < 2; ++frame) {
+        const bool pressing = (frame == 0);
+        nt_pointer_t click = pointer_at(700.0F, 500.0F, pressing, pressing, !pressing);
+        nt_ui_begin(s_fx.ctx, VIEW_W, VIEW_H, 1.0F / 60.0F, &click, 1);
+        CLAY({.id = CLAY_ID("game_hud"), .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .zIndex = 500}}) {
+            ra = nt_ui_popup_begin(s_fx.ctx, POP_A, &st, &anc, true);
+            nt_ui_popup_end(s_fx.ctx);
+        }
+        rb = nt_ui_popup_begin(s_fx.ctx, POP_B, &st, &anc, true);
+        nt_ui_popup_end(s_fx.ctx);
+        nt_ui_end(s_fx.ctx);
+    }
+    TEST_ASSERT_TRUE_MESSAGE(ra.close_requested, "the outside click must dismiss the popup painted on top");
+    TEST_ASSERT_FALSE_MESSAGE(rb.close_requested, "the popup underneath must stay an inert gate");
+
+    /* The band claim resets each frame: with the lifted wrapper gone, the root-level popup takes top. */
+    for (int frame = 0; frame < 2; ++frame) {
+        nt_pointer_t idle = pointer_at(700.0F, 500.0F, false, false, false);
+        nt_ui_begin(s_fx.ctx, VIEW_W, VIEW_H, 1.0F / 60.0F, &idle, 1);
+        nt_ui_popup_begin(s_fx.ctx, POP_B, &st, &anc, true);
+        nt_ui_popup_end(s_fx.ctx);
+        nt_ui_end(s_fx.ctx);
+    }
+    TEST_ASSERT_EQUAL_UINT32_MESSAGE(POP_B, s_fx.ctx->modal_top_id_prev, "the top-band claim must reset per frame, not stick to the highest band ever seen");
 }
 
 int main(void) {

--- a/tests/unit/test_ui_tooltip.c
+++ b/tests/unit/test_ui_tooltip.c
@@ -244,6 +244,36 @@ static void reveal_at(nt_pointer_t *over, nt_ui_tooltip_style_t *st, bool at_bot
     }
 }
 
+/* The tooltip panel is the frame's only lifted-band RECTANGLE — the target and its label live in the
+ * base band, and the tooltip is the only overlay these tests declare. Returns false under panel art,
+ * where the panel emits an IMAGE and no rectangle exists to carry a cornerRadius. */
+static bool tooltip_panel_rect(Clay_BoundingBox *out_box, float *out_radius) {
+    for (int32_t i = 0; i < s_fx.ctx->frozen_cmds.length; ++i) {
+        const Clay_RenderCommand *c = &s_fx.ctx->frozen_cmds.internalArray[i];
+        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_RECTANGLE && c->zIndex > 0) {
+            *out_box = c->boundingBox;
+            *out_radius = c->renderData.rectangle.cornerRadius.topLeft;
+            return true;
+        }
+    }
+    return false;
+}
+
+/* The caret is the only square image of caret_size in these frames; its flip bits ride the payload. */
+static bool tooltip_caret(float caret_size, Clay_BoundingBox *out_box, uint8_t *out_flip) {
+    for (int32_t i = 0; i < s_fx.ctx->frozen_cmds.length; ++i) {
+        const Clay_RenderCommand *c = &s_fx.ctx->frozen_cmds.internalArray[i];
+        if (c->commandType != CLAY_RENDER_COMMAND_TYPE_IMAGE || !float_near(c->boundingBox.width, caret_size, 0.5F) || !float_near(c->boundingBox.height, caret_size, 0.5F)) {
+            continue;
+        }
+        const nt_ui_image_payload_t *p = (const nt_ui_image_payload_t *)c->renderData.image.imageData;
+        *out_box = c->boundingBox;
+        *out_flip = (p != NULL) ? p->flip_bits : 0U;
+        return true;
+    }
+    return false;
+}
+
 /* ---- Caret flips with the popup side: a top-placed target -> popup BELOW -> caret on the panel TOP edge
  *      pointing UP (no flip); a bottom-pinned target -> edge-flip ABOVE -> caret on the panel BOTTOM edge
  *      pointing DOWN (FLIP_Y). The side that drives the flip is read from the popup result probe. ---- */
@@ -252,18 +282,30 @@ static void test_tooltip_caret_flips_with_side(void) {
     nt_ui_tooltip_style_t below = caret_style();
     nt_pointer_t over_top = pointer_at(TGT_W * 0.5F, TGT_H * 0.5F);
     reveal_at(&over_top, &below, false);
-    TEST_ASSERT_EQUAL_UINT8(NT_UI_POPUP_BELOW, nt_ui_tooltip_test_last_side());
-    TEST_ASSERT_TRUE(nt_ui_tooltip_test_last_caret_present());
-    TEST_ASSERT_EQUAL_UINT8(0U, nt_ui_tooltip_test_last_caret_flip()); /* up: art's native direction */
+    Clay_BoundingBox panel = {0};
+    Clay_BoundingBox caret = {0};
+    uint8_t flip = 0U;
+    float radius = 0.0F;
+    const nt_ui_bbox_t target_top = nt_ui_get_bbox(s_fx.ctx, TGT_ID);
+    TEST_ASSERT_TRUE(target_top.found);
+    TEST_ASSERT_TRUE(tooltip_panel_rect(&panel, &radius));
+    TEST_ASSERT_TRUE_MESSAGE(panel.y >= target_top.y + target_top.height - 0.5F, "room beneath: the panel must sit BELOW the target");
+    TEST_ASSERT_TRUE_MESSAGE(tooltip_caret((float)below.caret_size, &caret, &flip), "a resolvable caret ref must emit the caret");
+    TEST_ASSERT_TRUE_MESSAGE(caret.y + caret.height <= panel.y + 0.5F, "a BELOW panel wears its caret on the TOP edge");
+    TEST_ASSERT_EQUAL_UINT8(0U, flip); /* up: art's native direction */
 
     /* ABOVE: target pinned to the bottom border -> edge-flip ABOVE -> caret points down (FLIP_Y). The
      * pointer must land on the bottom-pinned target rect (its top is near the bottom of the viewport). */
     nt_ui_tooltip_style_t above = caret_style();
     nt_pointer_t over_bottom = pointer_at(TGT_W * 0.5F, TGT_BOTTOM_Y + (TGT_H * 0.5F));
     reveal_at(&over_bottom, &above, true);
-    TEST_ASSERT_EQUAL_UINT8(NT_UI_POPUP_ABOVE, nt_ui_tooltip_test_last_side());
-    TEST_ASSERT_TRUE(nt_ui_tooltip_test_last_caret_present());
-    TEST_ASSERT_EQUAL_UINT8((uint8_t)NT_SPRITE_FLAG_FLIP_Y, nt_ui_tooltip_test_last_caret_flip());
+    const nt_ui_bbox_t target_bottom = nt_ui_get_bbox(s_fx.ctx, TGT_ID);
+    TEST_ASSERT_TRUE(target_bottom.found);
+    TEST_ASSERT_TRUE(tooltip_panel_rect(&panel, &radius));
+    TEST_ASSERT_TRUE_MESSAGE(panel.y + panel.height <= target_bottom.y + 0.5F, "pinned to the bottom border: the panel must flip ABOVE the target");
+    TEST_ASSERT_TRUE(tooltip_caret((float)above.caret_size, &caret, &flip));
+    TEST_ASSERT_TRUE_MESSAGE(caret.y >= panel.y + panel.height - 0.5F, "an ABOVE panel wears its caret on the BOTTOM edge");
+    TEST_ASSERT_EQUAL_UINT8((uint8_t)NT_SPRITE_FLAG_FLIP_Y, flip);
 }
 
 /* ---- Panel art path drops cornerRadius (IMAGE bg can't round, same rule as dropdown/menu/tabbar): with
@@ -276,16 +318,17 @@ static void test_tooltip_panel_art_no_corner_radius(void) {
     art.corner_radius = 8U; /* set but MUST be ignored under art */
     nt_pointer_t over = pointer_at(TGT_W * 0.5F, TGT_H * 0.5F);
     reveal_at(&over, &art, false);
-    TEST_ASSERT_TRUE(nt_ui_tooltip_test_last_panel_art());
-    TEST_ASSERT_TRUE(float_near(nt_ui_tooltip_test_last_panel_corner_radius(), 0.0F, 0.0001F));
+    Clay_BoundingBox panel = {0};
+    float radius = 0.0F;
+    TEST_ASSERT_FALSE_MESSAGE(tooltip_panel_rect(&panel, &radius), "an art panel emits an IMAGE, so there is no rectangle to round");
 
     /* Flat fallback (no art): the rounded rect is kept. */
     nt_ui_tooltip_style_t flat = test_style();
     flat.corner_radius = 8U;
     nt_pointer_t over2 = pointer_at(TGT_W * 0.5F, TGT_H * 0.5F);
     reveal_at(&over2, &flat, false);
-    TEST_ASSERT_FALSE(nt_ui_tooltip_test_last_panel_art());
-    TEST_ASSERT_TRUE(float_near(nt_ui_tooltip_test_last_panel_corner_radius(), 8.0F, 0.0001F));
+    TEST_ASSERT_TRUE_MESSAGE(tooltip_panel_rect(&panel, &radius), "the flat panel must emit its rounded rectangle");
+    TEST_ASSERT_TRUE(float_near(radius, 8.0F, 0.0001F));
 }
 
 /* ---- The timer cell uses a SALTED id distinct from the target id (no aliasing of the target's own

--- a/tests/unit/test_ui_tooltip.c
+++ b/tests/unit/test_ui_tooltip.c
@@ -244,19 +244,51 @@ static void reveal_at(nt_pointer_t *over, nt_ui_tooltip_style_t *st, bool at_bot
     }
 }
 
-/* The tooltip panel is the frame's only lifted-band RECTANGLE — the target and its label live in the
- * base band, and the tooltip is the only overlay these tests declare. Returns false under panel art,
- * where the panel emits an IMAGE and no rectangle exists to carry a cornerRadius. */
+/* The tooltip panel is the HIGHEST-band rectangle in the frame: the target and its label sit in the
+ * base band, and the panel's own drop-shadow floats one band UNDER it, so "first lifted rectangle"
+ * would pick the shadow. Returns false under panel art, where the panel emits an IMAGE and no
+ * rectangle exists to carry a cornerRadius. */
 static bool tooltip_panel_rect(Clay_BoundingBox *out_box, float *out_radius) {
+    int32_t best = 0;
+    bool found = false;
     for (int32_t i = 0; i < s_fx.ctx->frozen_cmds.length; ++i) {
         const Clay_RenderCommand *c = &s_fx.ctx->frozen_cmds.internalArray[i];
-        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_RECTANGLE && c->zIndex > 0) {
+        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_RECTANGLE && c->zIndex > 0 && (!found || c->zIndex > best)) {
+            best = c->zIndex;
             *out_box = c->boundingBox;
             *out_radius = c->renderData.rectangle.cornerRadius.topLeft;
+            found = true;
+        }
+    }
+    return found;
+}
+
+/* An image command of the given width — used to prove the art panel IS a picture, not just absent. */
+static bool tooltip_image_of_width(float width, Clay_BoundingBox *out_box) {
+    for (int32_t i = 0; i < s_fx.ctx->frozen_cmds.length; ++i) {
+        const Clay_RenderCommand *c = &s_fx.ctx->frozen_cmds.internalArray[i];
+        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_IMAGE && float_near(c->boundingBox.width, width, 0.5F)) {
+            *out_box = c->boundingBox;
             return true;
         }
     }
     return false;
+}
+
+/* The caret carries no zIndex of its own, so it covers the panel only because its floating root is
+ * registered later. Pin that ordering: a moved declaration or an unstable sort would bury it. */
+static bool caret_paints_after_panel(float caret_size) {
+    int32_t panel_at = -1;
+    int32_t caret_at = -1;
+    for (int32_t i = 0; i < s_fx.ctx->frozen_cmds.length; ++i) {
+        const Clay_RenderCommand *c = &s_fx.ctx->frozen_cmds.internalArray[i];
+        if (c->commandType == CLAY_RENDER_COMMAND_TYPE_RECTANGLE && c->zIndex > 0) {
+            panel_at = i;
+        } else if (c->commandType == CLAY_RENDER_COMMAND_TYPE_IMAGE && float_near(c->boundingBox.width, caret_size, 0.5F)) {
+            caret_at = i;
+        }
+    }
+    return panel_at >= 0 && caret_at > panel_at;
 }
 
 /* The caret is the only square image of caret_size in these frames; its flip bits ride the payload. */
@@ -274,35 +306,42 @@ static bool tooltip_caret(float caret_size, Clay_BoundingBox *out_box, uint8_t *
     return false;
 }
 
-/* ---- Caret flips with the popup side: a top-placed target -> popup BELOW -> caret on the panel TOP edge
- *      pointing UP (no flip); a bottom-pinned target -> edge-flip ABOVE -> caret on the panel BOTTOM edge
- *      pointing DOWN (FLIP_Y). The side that drives the flip is read from the popup result probe. ---- */
-static void test_tooltip_caret_flips_with_side(void) {
-    /* BELOW: target at the top, room beneath -> caret points up, no flip. */
+/* ---- BELOW: a top-placed target leaves room beneath, so the panel attaches under it and wears its
+ *      caret on the TOP edge, unflipped (the art points up natively). ---- */
+static void test_tooltip_caret_below(void) {
     nt_ui_tooltip_style_t below = caret_style();
     nt_pointer_t over_top = pointer_at(TGT_W * 0.5F, TGT_H * 0.5F);
     reveal_at(&over_top, &below, false);
+
     Clay_BoundingBox panel = {0};
     Clay_BoundingBox caret = {0};
     uint8_t flip = 0U;
     float radius = 0.0F;
-    const nt_ui_bbox_t target_top = nt_ui_get_bbox(s_fx.ctx, TGT_ID);
-    TEST_ASSERT_TRUE(target_top.found);
+    const nt_ui_bbox_t target = nt_ui_get_bbox(s_fx.ctx, TGT_ID);
+    TEST_ASSERT_TRUE(target.found);
     TEST_ASSERT_TRUE(tooltip_panel_rect(&panel, &radius));
-    TEST_ASSERT_TRUE_MESSAGE(panel.y >= target_top.y + target_top.height - 0.5F, "room beneath: the panel must sit BELOW the target");
+    TEST_ASSERT_TRUE_MESSAGE(float_near(panel.y, target.y + target.height, 0.5F), "BELOW attaches the panel's top edge to the target's bottom edge (CENTER would land elsewhere)");
     TEST_ASSERT_TRUE_MESSAGE(tooltip_caret((float)below.caret_size, &caret, &flip), "a resolvable caret ref must emit the caret");
     TEST_ASSERT_TRUE_MESSAGE(caret.y + caret.height <= panel.y + 0.5F, "a BELOW panel wears its caret on the TOP edge");
-    TEST_ASSERT_EQUAL_UINT8(0U, flip); /* up: art's native direction */
+    TEST_ASSERT_TRUE_MESSAGE(caret_paints_after_panel((float)below.caret_size), "the caret must paint AFTER its panel");
+    TEST_ASSERT_EQUAL_UINT8(0U, flip);
+}
 
-    /* ABOVE: target pinned to the bottom border -> edge-flip ABOVE -> caret points down (FLIP_Y). The
-     * pointer must land on the bottom-pinned target rect (its top is near the bottom of the viewport). */
+/* ---- ABOVE: a bottom-pinned target forces the edge-flip, so the panel attaches over it and the caret
+ *      moves to the BOTTOM edge pointing down (FLIP_Y). ---- */
+static void test_tooltip_caret_above_on_flip(void) {
     nt_ui_tooltip_style_t above = caret_style();
     nt_pointer_t over_bottom = pointer_at(TGT_W * 0.5F, TGT_BOTTOM_Y + (TGT_H * 0.5F));
     reveal_at(&over_bottom, &above, true);
-    const nt_ui_bbox_t target_bottom = nt_ui_get_bbox(s_fx.ctx, TGT_ID);
-    TEST_ASSERT_TRUE(target_bottom.found);
+
+    Clay_BoundingBox panel = {0};
+    Clay_BoundingBox caret = {0};
+    uint8_t flip = 0U;
+    float radius = 0.0F;
+    const nt_ui_bbox_t target = nt_ui_get_bbox(s_fx.ctx, TGT_ID);
+    TEST_ASSERT_TRUE(target.found);
     TEST_ASSERT_TRUE(tooltip_panel_rect(&panel, &radius));
-    TEST_ASSERT_TRUE_MESSAGE(panel.y + panel.height <= target_bottom.y + 0.5F, "pinned to the bottom border: the panel must flip ABOVE the target");
+    TEST_ASSERT_TRUE_MESSAGE(float_near(panel.y + panel.height, target.y, 0.5F), "ABOVE attaches the panel's bottom edge to the target's top edge");
     TEST_ASSERT_TRUE(tooltip_caret((float)above.caret_size, &caret, &flip));
     TEST_ASSERT_TRUE_MESSAGE(caret.y >= panel.y + panel.height - 0.5F, "an ABOVE panel wears its caret on the BOTTOM edge");
     TEST_ASSERT_EQUAL_UINT8((uint8_t)NT_SPRITE_FLAG_FLIP_Y, flip);
@@ -312,23 +351,27 @@ static void test_tooltip_caret_flips_with_side(void) {
  *      a resolvable panel_art ref the panel uses art and applies NO cornerRadius even when corner_radius
  *      is set; the flat fallback (no art) keeps its rounded rect. ---- */
 static void test_tooltip_panel_art_no_corner_radius(void) {
-    /* Art path: cornerRadius must be 0 regardless of style->corner_radius. */
+    /* Flat fallback first, so its rectangle gives the panel size the art run must reproduce. */
+    Clay_BoundingBox panel = {0};
+    float radius = 0.0F;
+    nt_ui_tooltip_style_t flat = test_style();
+    flat.corner_radius = 8U;
+    nt_pointer_t over_flat = pointer_at(TGT_W * 0.5F, TGT_H * 0.5F);
+    reveal_at(&over_flat, &flat, false);
+    TEST_ASSERT_TRUE_MESSAGE(tooltip_panel_rect(&panel, &radius), "the flat panel must emit its rounded rectangle");
+    TEST_ASSERT_TRUE(float_near(radius, 8.0F, 0.0001F));
+    const float panel_w = panel.width;
+
+    /* Art path, same text and padding: the panel becomes an IMAGE of the same width, and an image has no
+     * rectangle to round — which is WHY corner_radius cannot apply, not merely that it was zeroed. */
     nt_ui_tooltip_style_t art = test_style();
     art.panel_art = nt_atlas_ref_idx(s_fx.atlas.handle, 0U, s_fx.atlas.white_region_idx);
     art.corner_radius = 8U; /* set but MUST be ignored under art */
-    nt_pointer_t over = pointer_at(TGT_W * 0.5F, TGT_H * 0.5F);
-    reveal_at(&over, &art, false);
-    Clay_BoundingBox panel = {0};
-    float radius = 0.0F;
-    TEST_ASSERT_FALSE_MESSAGE(tooltip_panel_rect(&panel, &radius), "an art panel emits an IMAGE, so there is no rectangle to round");
-
-    /* Flat fallback (no art): the rounded rect is kept. */
-    nt_ui_tooltip_style_t flat = test_style();
-    flat.corner_radius = 8U;
-    nt_pointer_t over2 = pointer_at(TGT_W * 0.5F, TGT_H * 0.5F);
-    reveal_at(&over2, &flat, false);
-    TEST_ASSERT_TRUE_MESSAGE(tooltip_panel_rect(&panel, &radius), "the flat panel must emit its rounded rectangle");
-    TEST_ASSERT_TRUE(float_near(radius, 8.0F, 0.0001F));
+    nt_pointer_t over_art = pointer_at(TGT_W * 0.5F, TGT_H * 0.5F);
+    reveal_at(&over_art, &art, false);
+    Clay_BoundingBox art_panel = {0};
+    TEST_ASSERT_TRUE_MESSAGE(tooltip_image_of_width(panel_w, &art_panel), "the art panel must ship as an image of the panel's size");
+    TEST_ASSERT_FALSE_MESSAGE(tooltip_panel_rect(&panel, &radius), "and emit no rectangle, so there is nothing to round");
 }
 
 /* ---- The timer cell uses a SALTED id distinct from the target id (no aliasing of the target's own
@@ -346,7 +389,8 @@ int main(void) {
     RUN_TEST(test_tooltip_hide_on_leave);
     RUN_TEST(test_tooltip_declares_no_catcher);
     RUN_TEST(test_tooltip_no_double_mutation);
-    RUN_TEST(test_tooltip_caret_flips_with_side);
+    RUN_TEST(test_tooltip_caret_below);
+    RUN_TEST(test_tooltip_caret_above_on_flip);
     RUN_TEST(test_tooltip_panel_art_no_corner_radius);
     RUN_TEST(test_tooltip_timer_id_salted);
     return UNITY_END();


### PR DESCRIPTION
Fixes #433.

## Root cause

The issue reports the slider thumb as culled by `clipTo=CLAY_CLIP_TO_ATTACHED_PARENT`. Measured behaviour says otherwise: inside a plain floating parent no scissor is emitted at all (`clipElementId` resolves to 0), and the thumb IS emitted — it just sorts first. Clay sorts every floating tree root globally by its own `zIndex`, and a nested floating inherits nothing, so the thumb (zIndex 0) sorted under the modal panel band (999/1000) and was painted over by the backdrop and the panel.

The same sort has a second consequence: a child root processed before its parent reads the parent's bounding box from the previous frame. That is the one-frame position lag, and on the first frame an empty clip rect — which is what trips `nt_ui.c:1409` when the enclosing floating is also a clip container.

The class is wider than the slider: `nt_ui_input`'s caret, selection highlight and text wrapper use the same pattern (the whole line drew under the modal backdrop), and the tooltip's `zIndex = ±1` deltas were global, not relative. Only `nt_ui_scroll` had a hand-rolled fix.

## Change

NT patch 4 in the vendored `clay.h`: a floating element declared inside another floating gets `parent_z + own_z`, tracked with an `openFloatingZStack` next to the existing `openClipElementStack`. `zIndex` now reads as a stacking context, like CSS. A child at delta 0 ties with its parent and, because the sort is stable and the parent root is registered first, always paints after it with a fresh parent bbox — which fixes the ordering and the stale-bbox lag in one move.

Engine bands become deltas, a net deletion:

- popup-core declares one `modal_zband_stride` above whatever encloses it instead of computing `stride*(depth+1)`.
- the scrollbar drops its manual popup-band lift and the test-only zIndex mirror that existed to check it.
- slider, input and tooltip need no change at all.

## Breaking change

A game floating with a large `zIndex` declared inside a panel no longer escapes that panel; it stacks above the panel only. To draw over everything, declare it outside. Pre-1.0, no shim.

## Verification

`scripts/check.sh --push` green (native-debug + ctest, wasm-debug, wasm-release, submodule consumption).

Three regression tests, each checked by mutation (breaking the inheritance makes them fail):

- `test_thumb_above_modal_band_first_frame` — slider in a modal with `.clip`: thumb paints after the panel and is placed correctly on the FIRST frame; it runs `nt_ui_walk`, so it also covers the `nt_ui.c:1409` abort (without the patch the test process dies on the assert).
- `test_field_text_above_modal_band` — text field in a modal.
- `test_dropdown_long_list_scrollbar_above_popup_band` — rewritten off the deleted accessor onto real paint order; plus `test_scrollbar_standalone_no_z_lift` for the no-enclosing-floating case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmFPqMaHPu4N7g3hBZZTvb
