### PR TITLE
gfx: 9-slice follows the layout Y-down convention like every other emit (#432)

### DIFF
--- a/docs/spec/render/render-components.md
+++ b/docs/spec/render/render-components.md
@@ -117,7 +117,10 @@ subsequent atlas republishes. `reset_origin()` clears the override and
 restores the authored value on the next sync.
 
 Flip is a pair of flag bits (`FLIP_X`, `FLIP_Y`) toggled via `set_flip`.
-They are pure state — no resolve, no atlas interaction.
+They are pure state — no resolve, no atlas interaction. The renderer mirrors
+by negating the sprite's local positions around its origin, so a nine-patch
+sprite mirrors exactly like a plain one: the corner bands and their UVs ride
+along, and the footprint stays where the pivot puts it.
 
 ### Lifecycle
 

--- a/docs/spec/render/render-components.md
+++ b/docs/spec/render/render-components.md
@@ -119,8 +119,9 @@ restores the authored value on the next sync.
 Flip is a pair of flag bits (`FLIP_X`, `FLIP_Y`) toggled via `set_flip`.
 They are pure state — no resolve, no atlas interaction. The renderer mirrors
 by negating the sprite's local positions around its origin, so a nine-patch
-sprite mirrors exactly like a plain one: the corner bands and their UVs ride
-along, and the footprint stays where the pivot puts it.
+sprite mirrors exactly like a plain one. An ECS nine-patch renders at its
+source size; the transform's scale scales its corner bands too, and
+`slice9_scale` is the only knob against that.
 
 ### Lifecycle
 

--- a/docs/spec/ui/nt-ui.md
+++ b/docs/spec/ui/nt-ui.md
@@ -107,6 +107,15 @@ layout-space bbox center via cglm. The walker reads the composed mat4
 from `tree_baked[layout_idx]` (hot path, no hashmap lookup) and ships
 `world_mat4[16]` to every emit_*.
 
+Every geometry argument that travels beside that matrix is in Clay layout
+space, Y down. `nt_sprite_renderer_emit_slice9` therefore takes the rect
+top-anchored: row 0 of its 4×4 grid is the rect's top edge, carries the
+`t` border, and samples `v_min` — the source's top row, since blob
+vertices are Y-up while `atlas_v` stays PNG Y-down (see
+[resource.md](../assets/resource.md)). The ECS sprite path builds the same
+grid in Y-up source-local space and mirrors by negating positions, so the
+two differ by construction, not by accident.
+
 Two coord-space modes are gated by `nt_ui_create_desc_t.use_raycast_input`:
 
 - **2D ctx** (default): screen Y-flip (Clay layout Y-down → GL Y-up) is

--- a/docs/spec/ui/nt-ui.md
+++ b/docs/spec/ui/nt-ui.md
@@ -107,24 +107,15 @@ layout-space bbox center via cglm. The walker reads the composed mat4
 from `tree_baked[layout_idx]` (hot path, no hashmap lookup) and ships
 `world_mat4[16]` to every emit_*.
 
-The two textured emits — `emit_region` and `emit_slice9` — speak one
-geometry language: local space is Y-up and pivot-relative, `flip_bits`
-mirror it by negating positions (which reverses winding, so their
-materials stay `CULL_NONE`), and which way is up on screen is whatever
-`world_mat4` says. A slice9 grid starts at the local bottom, where `v_max`
-is, because blob vertices are Y-up while `atlas_v` stays PNG Y-down (see
-[resource.md](../assets/resource.md)). The walker hands it a matrix with
-the Y inversion and the bbox center in it, and a centered pivot, so a
-nine-patch fills its bbox unless `NT_UI_IMAGE_ORIGIN_OVERRIDE` moves the
-pivot. `emit_geometry` is not part of this: it takes caller-space corners
-and has neither pivot nor flip.
-
-Slice9 corner bands are where the atlas's `pixels_per_unit` reaches the
-layout: a border is authored in source pixels and divided by it, so a
-denser HD atlas — whose borders are proportionally bigger in pixels —
-still renders the same corner. A stretched region divides the same factor
-straight back out (`bb.width / (source_w * ipu)`), so only the nine-patch
-lets it affect the result.
+`emit_region` and `emit_slice9` share one local space: Y-up, pivot-relative,
+`flip_bits` negate positions (which reverses winding). The walker's mat4
+carries the Y inversion and the bbox center; a nine-patch gets a centered
+pivot so it fills its bbox unless `NT_UI_IMAGE_ORIGIN_OVERRIDE` moves it, and
+a `NT_UI_IMAGE_SLICE9_OVERRIDE` of all zeros turns a baked nine-patch back
+into a plain quad. `emit_geometry` takes caller-space corners, no pivot or
+flip. Slice9 corner bands are the one place `pixels_per_unit` reaches the
+layout: borders are source px ÷ ppu, so a denser HD atlas renders the same
+corner; a stretched region divides ppu straight back out.
 
 Two coord-space modes are gated by `nt_ui_create_desc_t.use_raycast_input`:
 

--- a/docs/spec/ui/nt-ui.md
+++ b/docs/spec/ui/nt-ui.md
@@ -107,14 +107,14 @@ layout-space bbox center via cglm. The walker reads the composed mat4
 from `tree_baked[layout_idx]` (hot path, no hashmap lookup) and ships
 `world_mat4[16]` to every emit_*.
 
-Every geometry argument that travels beside that matrix is in Clay layout
-space, Y down. `nt_sprite_renderer_emit_slice9` therefore takes the rect
-top-anchored: row 0 of its 4×4 grid is the rect's top edge, carries the
-`t` border, and samples `v_min` — the source's top row, since blob
+Every `emit_*` speaks one geometry language: local space is Y-up and
+pivot-relative, `flip_bits` mirror it by negating positions, and which way
+is up on screen is whatever `world_mat4` says. Slice9 obeys the same rule —
+its 4×4 grid starts at the local bottom, where `v_max` is, because blob
 vertices are Y-up while `atlas_v` stays PNG Y-down (see
-[resource.md](../assets/resource.md)). The ECS sprite path builds the same
-grid in Y-up source-local space and mirrors by negating positions, so the
-two differ by construction, not by accident.
+[resource.md](../assets/resource.md)). The walker therefore hands slice9 a
+matrix with the Y inversion and the bbox center in it, and a `{0.5, 0.5}`
+pivot, the same way it does for a plain region.
 
 Two coord-space modes are gated by `nt_ui_create_desc_t.use_raycast_input`:
 

--- a/docs/spec/ui/nt-ui.md
+++ b/docs/spec/ui/nt-ui.md
@@ -116,6 +116,12 @@ vertices are Y-up while `atlas_v` stays PNG Y-down (see
 matrix with the Y inversion and the bbox center in it, and a `{0.5, 0.5}`
 pivot, the same way it does for a plain region.
 
+Slice9 corner bands are the one place where the atlas's `pixels_per_unit`
+reaches the layout: a border is authored in source pixels and divided by
+it, so a denser HD atlas — whose borders are proportionally bigger in
+pixels — still renders the same corner. A stretched region needs no such
+conversion, which is why only the nine-patch path reads it.
+
 Two coord-space modes are gated by `nt_ui_create_desc_t.use_raycast_input`:
 
 - **2D ctx** (default): screen Y-flip (Clay layout Y-down → GL Y-up) is

--- a/docs/spec/ui/nt-ui.md
+++ b/docs/spec/ui/nt-ui.md
@@ -107,20 +107,24 @@ layout-space bbox center via cglm. The walker reads the composed mat4
 from `tree_baked[layout_idx]` (hot path, no hashmap lookup) and ships
 `world_mat4[16]` to every emit_*.
 
-Every `emit_*` speaks one geometry language: local space is Y-up and
-pivot-relative, `flip_bits` mirror it by negating positions, and which way
-is up on screen is whatever `world_mat4` says. Slice9 obeys the same rule —
-its 4×4 grid starts at the local bottom, where `v_max` is, because blob
-vertices are Y-up while `atlas_v` stays PNG Y-down (see
-[resource.md](../assets/resource.md)). The walker therefore hands slice9 a
-matrix with the Y inversion and the bbox center in it, and a `{0.5, 0.5}`
-pivot, the same way it does for a plain region.
+The two textured emits — `emit_region` and `emit_slice9` — speak one
+geometry language: local space is Y-up and pivot-relative, `flip_bits`
+mirror it by negating positions (which reverses winding, so their
+materials stay `CULL_NONE`), and which way is up on screen is whatever
+`world_mat4` says. A slice9 grid starts at the local bottom, where `v_max`
+is, because blob vertices are Y-up while `atlas_v` stays PNG Y-down (see
+[resource.md](../assets/resource.md)). The walker hands it a matrix with
+the Y inversion and the bbox center in it, and a centered pivot, so a
+nine-patch fills its bbox unless `NT_UI_IMAGE_ORIGIN_OVERRIDE` moves the
+pivot. `emit_geometry` is not part of this: it takes caller-space corners
+and has neither pivot nor flip.
 
-Slice9 corner bands are the one place where the atlas's `pixels_per_unit`
-reaches the layout: a border is authored in source pixels and divided by
-it, so a denser HD atlas — whose borders are proportionally bigger in
-pixels — still renders the same corner. A stretched region needs no such
-conversion, which is why only the nine-patch path reads it.
+Slice9 corner bands are where the atlas's `pixels_per_unit` reaches the
+layout: a border is authored in source pixels and divided by it, so a
+denser HD atlas — whose borders are proportionally bigger in pixels —
+still renders the same corner. A stretched region divides the same factor
+straight back out (`bb.width / (source_w * ipu)`), so only the nine-patch
+lets it affect the result.
 
 Two coord-space modes are gated by `nt_ui_create_desc_t.use_raycast_input`:
 

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -759,19 +759,12 @@ static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *
             open_cmd_from_snapshot(&snapshot);
         }
 
-        /* Flip border swap */
-        uint16_t fl = sl;
-        uint16_t fr = sr;
-        uint16_t ft = st;
-        uint16_t fb = sb;
-        if (flip_bits & NT_SPRITE_FLAG_FLIP_X) {
-            fl = sr;
-            fr = sl;
-        }
-        if (flip_bits & NT_SPRITE_FLAG_FLIP_Y) {
-            ft = sb;
-            fb = st;
-        }
+        /* No flip swap here: this path mirrors by negating the grid positions
+         * below, which carries the bands and their UVs along with it. */
+        const uint16_t fl = sl;
+        const uint16_t fr = sr;
+        const uint16_t ft = st;
+        const uint16_t fb = sb;
 
         /* DST corner size = src × per-entity slice9_scale; last-line tripwire. */
         NT_ASSERT(isfinite(sv->slice9_scale[s_idx]) && sv->slice9_scale[s_idx] > 0.0F && "emit_one: sv->slice9_scale[s_idx] must be finite > 0");
@@ -868,22 +861,6 @@ static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *
             (uint16_t)(v_min + (((uint32_t)ft * v_range) / r->source_h)),
             v_min,
         };
-        if (flip_bits & NT_SPRITE_FLAG_FLIP_X) {
-            uint16_t t0 = us[0];
-            us[0] = us[3];
-            us[3] = t0;
-            uint16_t t1 = us[1];
-            us[1] = us[2];
-            us[2] = t1;
-        }
-        if (flip_bits & NT_SPRITE_FLAG_FLIP_Y) {
-            uint16_t t0 = vs[0];
-            vs[0] = vs[3];
-            vs[3] = t0;
-            uint16_t t1 = vs[1];
-            vs[1] = vs[2];
-            vs[2] = t1;
-        }
 
         /* Unpack color. */
         const uint32_t s9_color = dv->colors_packed[d_idx];
@@ -1107,31 +1084,24 @@ void nt_sprite_renderer_emit_slice9(nt_resource_t atlas, uint32_t region_index, 
         return;
     }
 
-    /* Symmetric swap keeps UV and position consistent under flip. */
-    uint16_t fsrc_l = src_sl;
-    uint16_t fsrc_r = src_sr;
-    uint16_t fsrc_t = src_st;
-    uint16_t fsrc_b = src_sb;
+    /* Only the dst bands swap: the mirror itself is the us/vs reversal below, so
+     * the UV cuts keep reading their own source side. */
     uint16_t fdst_l = dst_sl;
     uint16_t fdst_r = dst_sr;
     uint16_t fdst_t = dst_st;
     uint16_t fdst_b = dst_sb;
     if (flip_bits & NT_SPRITE_FLAG_FLIP_X) {
-        fsrc_l = src_sr;
-        fsrc_r = src_sl;
         fdst_l = dst_sr;
         fdst_r = dst_sl;
     }
     if (flip_bits & NT_SPRITE_FLAG_FLIP_Y) {
-        fsrc_t = src_sb;
-        fsrc_b = src_st;
         fdst_t = dst_sb;
         fdst_b = dst_st;
     }
-    const uint16_t fl = fsrc_l;
-    const uint16_t fr = fsrc_r;
-    const uint16_t ft = fsrc_t;
-    const uint16_t fb = fsrc_b;
+    const uint16_t fl = src_sl;
+    const uint16_t fr = src_sr;
+    const uint16_t ft = src_st;
+    const uint16_t fb = src_sb;
 
     /* Extract bbox UVs from region vertices (u16 space). */
     uint16_t u_min = UINT16_MAX;

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -1173,7 +1173,7 @@ void nt_sprite_renderer_emit_slice9(nt_resource_t atlas, uint32_t region_index, 
         fb_w *= ratio;
     }
     float xs[4] = {x, x + fl_w, x + w - fr_w, x + w};
-    float ys[4] = {y, y + fb_w, y + h - ft_w, y + h};
+    float ys[4] = {y, y + ft_w, y + h - fb_w, y + h};
 
     /* UV splits (4 u-values, 4 v-values in u16). Integer math avoids precision loss. */
     uint16_t u_range = (uint16_t)(u_max - u_min);
@@ -1184,13 +1184,13 @@ void nt_sprite_renderer_emit_slice9(nt_resource_t atlas, uint32_t region_index, 
         (uint16_t)(u_max - (((uint32_t)fr * u_range) / rh.region->source_w)),
         u_max,
     };
-    /* V splits inverted: geometry Y-up but texture V is PNG Y-down.
-     * vs[0] (geometry bottom) → v_max (texture bottom). */
+    /* Row 0 is the rect's TOP (y grows down, like every emit_* geometry param)
+     * and texture V is PNG Y-down, so rows and V ascend together. */
     uint16_t vs[4] = {
-        v_max,
-        (uint16_t)(v_max - (((uint32_t)fb * v_range) / rh.region->source_h)),
-        (uint16_t)(v_min + (((uint32_t)ft * v_range) / rh.region->source_h)),
         v_min,
+        (uint16_t)(v_min + (((uint32_t)ft * v_range) / rh.region->source_h)),
+        (uint16_t)(v_max - (((uint32_t)fb * v_range) / rh.region->source_h)),
+        v_max,
     };
 
     /* UV flip after split computation. */

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -691,6 +691,178 @@ NT_SPRITE_EMIT_INLINE void emit_region_resolved(const nt_texture_region_t *r, co
 }
 // #endregion
 
+// #region slice9_grid
+/* One 4x4 slice9 grid, shared by the ECS path and the public emit.
+ *
+ * Local space matches emit_region's: Y-up, pivot-relative, mirrored by negating
+ * positions. Row 0 is the local bottom and samples v_max, because blob vertices
+ * are Y-up while atlas_v stays PNG Y-down. Whoever wants the grid Y-down says so
+ * in world_matrix, exactly as they do for a plain region. */
+typedef struct {
+    const nt_texture_region_t *region;
+    const nt_atlas_vertex_t *raw_vertices;
+    float w; /* local grid size, emit units */
+    float h;
+    float band_l; /* dst band widths, same units as w/h */
+    float band_r;
+    float band_t;
+    float band_b;
+    uint16_t src_l; /* src borders in source pixels — the UV cuts */
+    uint16_t src_r;
+    uint16_t src_t;
+    uint16_t src_b;
+    float origin_x; /* pivot, normalized over w/h */
+    float origin_y;
+    uint32_t color_packed;
+    uint8_t flip_bits;
+    const float *world_matrix;
+} slice9_grid_t;
+
+/* UV bbox of a region's vertices, as {u_min, u_max, v_min, v_max} in u16 space. */
+static void region_uv_bounds(const nt_atlas_vertex_t *verts, uint8_t count, uint16_t out[4]) {
+    out[0] = UINT16_MAX;
+    out[1] = 0;
+    out[2] = UINT16_MAX;
+    out[3] = 0;
+    for (uint8_t i = 0; i < count; i++) {
+        const uint16_t au = verts[i].atlas_u;
+        const uint16_t av = verts[i].atlas_v;
+        out[0] = (au < out[0]) ? au : out[0];
+        out[1] = (au > out[1]) ? au : out[1];
+        out[2] = (av < out[2]) ? av : out[2];
+        out[3] = (av > out[3]) ? av : out[3];
+    }
+}
+
+/* Grid splits for one slice9: dst bands become local coordinates, src borders
+ * become UV cuts. Rows are Y-up, so V descends with them. */
+static void slice9_build_splits(const slice9_grid_t *g, float lxs[4], float lys[4], uint16_t us[4], uint16_t vs[4]) {
+    float bl = g->band_l;
+    float br = g->band_r;
+    float bt = g->band_t;
+    float bb = g->band_b;
+    /* Proportionally shrink dst bands when the target is smaller than their sum. */
+    if (bl + br > g->w) {
+        const float ratio = g->w / (bl + br);
+        bl *= ratio;
+        br *= ratio;
+    }
+    if (bt + bb > g->h) {
+        const float ratio = g->h / (bt + bb);
+        bt *= ratio;
+        bb *= ratio;
+    }
+    lxs[0] = 0.0F;
+    lxs[1] = bl;
+    lxs[2] = g->w - br;
+    lxs[3] = g->w;
+    lys[0] = 0.0F;
+    lys[1] = bb;
+    lys[2] = g->h - bt;
+    lys[3] = g->h;
+
+    uint16_t uv_bounds[4]; /* u_min, u_max, v_min, v_max */
+    region_uv_bounds(g->raw_vertices, g->region->vertex_count, uv_bounds);
+    const uint16_t u_range = (uint16_t)(uv_bounds[1] - uv_bounds[0]);
+    const uint16_t v_range = (uint16_t)(uv_bounds[3] - uv_bounds[2]);
+    /* Integer math avoids precision loss. */
+    us[0] = uv_bounds[0];
+    us[1] = (uint16_t)(uv_bounds[0] + (((uint32_t)g->src_l * u_range) / g->region->source_w));
+    us[2] = (uint16_t)(uv_bounds[1] - (((uint32_t)g->src_r * u_range) / g->region->source_w));
+    us[3] = uv_bounds[1];
+    vs[0] = uv_bounds[3];
+    vs[1] = (uint16_t)(uv_bounds[3] - (((uint32_t)g->src_b * v_range) / g->region->source_h));
+    vs[2] = (uint16_t)(uv_bounds[2] + (((uint32_t)g->src_t * v_range) / g->region->source_h));
+    vs[3] = uv_bounds[2];
+}
+
+/* Writes the 16 grid vertices. The pivot rides in the translation and mirrors
+ * with the geometry, exactly as emit_region_resolved does it. */
+static void write_slice9_vertices(const slice9_grid_t *g, const float lxs[4], const float lys[4], const uint16_t us[4], const uint16_t vs[4], uint32_t base) {
+    const float *m = g->world_matrix;
+    const bool fx = (g->flip_bits & NT_SPRITE_FLAG_FLIP_X) != 0;
+    const bool fy = (g->flip_bits & NT_SPRITE_FLAG_FLIP_Y) != 0;
+    const float dx = fx ? -(g->origin_x * g->w) : (g->origin_x * g->w);
+    const float dy = fy ? -(g->origin_y * g->h) : (g->origin_y * g->h);
+    const float tx = m[12] - (m[0] * dx) - (m[4] * dy);
+    const float ty = m[13] - (m[1] * dx) - (m[5] * dy);
+    const float tz = m[14] - (m[2] * dx) - (m[6] * dy);
+
+    const uint8_t cr = (uint8_t)(g->color_packed & 0xFFU);
+    const uint8_t cg = (uint8_t)((g->color_packed >> 8) & 0xFFU);
+    const uint8_t cb = (uint8_t)((g->color_packed >> 16) & 0xFFU);
+    const uint8_t ca = (uint8_t)((g->color_packed >> 24) & 0xFFU);
+
+    for (uint8_t row = 0; row < 4; row++) {
+        const float py = fy ? -lys[row] : lys[row];
+        for (uint8_t col = 0; col < 4; col++) {
+            const float px = fx ? -lxs[col] : lxs[col];
+            nt_sprite_vertex_t *v = (nt_sprite_vertex_t *)(s_sprite.staging + ((size_t)(base + (row * 4) + col) * s_sprite.cur_stride));
+            v->position[0] = (m[0] * px) + (m[4] * py) + tx;
+            v->position[1] = (m[1] * px) + (m[5] * py) + ty;
+            v->position[2] = (m[2] * px) + (m[6] * py) + tz;
+            v->texcoord[0] = us[col];
+            v->texcoord[1] = vs[row];
+            v->color[0] = cr;
+            v->color[1] = cg;
+            v->color[2] = cb;
+            v->color[3] = ca;
+        }
+    }
+}
+
+static void emit_slice9_grid(const slice9_grid_t *g) {
+    const uint32_t vcap = (s_sprite.cur_material_custom_bytes > 0) ? s_sprite.custom_max_vertices : s_sprite.max_vertices;
+    if (s_sprite.vertex_count + 16U > vcap || s_sprite.index_count + 54U > s_sprite.max_indices) {
+        NT_ASSERT(s_sprite.cmd_count > 0 && "emit_slice9_grid called with no open cmd");
+        nt_sprite_draw_cmd_t snapshot = s_sprite.cmds[s_sprite.cmd_count - 1];
+        nt_sprite_renderer_flush();
+        open_cmd_from_snapshot(&snapshot);
+    }
+
+    float lxs[4];
+    float lys[4];
+    uint16_t us[4];
+    uint16_t vs[4];
+    slice9_build_splits(g, lxs, lys, us, vs);
+
+    // #region emit_slice9_grid_vertices
+    const uint32_t base = s_sprite.vertex_count;
+    write_slice9_vertices(g, lxs, lys, us, vs, base);
+
+    /* 54 indices: 9 cells x 2 triangles x 3 indices. */
+    uint16_t *out_idx = &s_sprite.indices[s_sprite.index_count];
+    uint32_t ii = 0;
+    for (uint8_t row = 0; row < 3; row++) {
+        for (uint8_t col = 0; col < 3; col++) {
+            const uint16_t i_bl = (uint16_t)(base + (row * 4) + col);
+            const uint16_t i_br = (uint16_t)(i_bl + 1U);
+            const uint16_t i_tl = (uint16_t)(i_bl + 4U);
+            const uint16_t i_tr = (uint16_t)(i_tl + 1U);
+            out_idx[ii++] = i_tl;
+            out_idx[ii++] = i_tr;
+            out_idx[ii++] = i_bl;
+            out_idx[ii++] = i_bl;
+            out_idx[ii++] = i_tr;
+            out_idx[ii++] = i_br;
+        }
+    }
+
+    bake_custom_attrs(base, 16U);
+    s_sprite.vertex_count += 16U;
+    s_sprite.index_count += 54U;
+
+#ifdef NT_TEST_ACCESS
+    s_sprite.last_slice9_vertex_count = 16U;
+    s_sprite.last_slice9_index_count = 54U;
+    s_sprite.last_emit_vertex_count = 16U;
+    s_sprite.last_emit_index_count = 54U;
+    s_sprite.last_emit_first_vertex = base;
+#endif
+    // #endregion
+}
+// #endregion
+
 // #region emit_one
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *sv, const nt_transform_comp_view_t *tv, const nt_drawable_comp_view_t *dv) {
@@ -741,8 +913,6 @@ static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *
             st = r->slice9_lrtb[2];
             sb = r->slice9_lrtb[3];
         }
-        /* Inline slice9 emit using world_matrix directly (same transform
-         * pipeline as regular sprites in emit_region_resolved). */
         NT_ASSERT(r->transform == 0 && "slice9 region must have transform == 0");
         NT_ASSERT(r->trim_offset_x == 0 && r->trim_offset_y == 0 && "slice9 region must be untrimmed");
         NT_ASSERT(r->source_w > 0 && r->source_h > 0);
@@ -751,169 +921,30 @@ static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *
         if (!ensure_current_cmd_page_texture(page_tex)) {
             return;
         }
-        const uint32_t vcap = (s_sprite.cur_material_custom_bytes > 0) ? s_sprite.custom_max_vertices : s_sprite.max_vertices;
-        if (s_sprite.vertex_count + 16U > vcap || s_sprite.index_count + 54U > s_sprite.max_indices) {
-            NT_ASSERT(s_sprite.cmd_count > 0);
-            nt_sprite_draw_cmd_t snapshot = s_sprite.cmds[s_sprite.cmd_count - 1];
-            nt_sprite_renderer_flush();
-            open_cmd_from_snapshot(&snapshot);
-        }
 
-        /* No flip swap here: this path mirrors by negating the grid positions
-         * below, which carries the bands and their UVs along with it. */
-        const uint16_t fl = sl;
-        const uint16_t fr = sr;
-        const uint16_t ft = st;
-        const uint16_t fb = sb;
-
-        /* DST corner size = src × per-entity slice9_scale; last-line tripwire. */
+        /* DST corner size = src x per-entity slice9_scale; last-line tripwire. */
         NT_ASSERT(isfinite(sv->slice9_scale[s_idx]) && sv->slice9_scale[s_idx] > 0.0F && "emit_one: sv->slice9_scale[s_idx] must be finite > 0");
         const float s9_scale = sv->slice9_scale[s_idx];
-
-        /* Build 4x4 grid in local source space (ipu-scaled, origin at 0,0). */
-        const float src_w = (float)r->source_w * ipu;
-        const float src_h = (float)r->source_h * ipu;
-        float fl_w = (float)fl * ipu * s9_scale;
-        float fr_w = (float)fr * ipu * s9_scale;
-        float ft_w = (float)ft * ipu * s9_scale;
-        float fb_w = (float)fb * ipu * s9_scale;
-        /* Proportionally shrink borders when source rect is smaller than total borders */
-        if (fl_w + fr_w > src_w) {
-            float ratio = src_w / (fl_w + fr_w);
-            fl_w *= ratio;
-            fr_w *= ratio;
-        }
-        if (ft_w + fb_w > src_h) {
-            float ratio = src_h / (ft_w + fb_w);
-            ft_w *= ratio;
-            fb_w *= ratio;
-        }
-        float lxs[4] = {0.0F, fl_w, src_w - fr_w, src_w};
-        float lys[4] = {0.0F, fb_w, src_h - ft_w, src_h};
-
-        /* Pivot offset into translation (mirrors emit_region_resolved). */
-        const float *m = tv->world_matrices[t_idx];
-        float dx = origin_x * src_w;
-        float dy = origin_y * src_h;
-        if (flip_bits & NT_SPRITE_FLAG_FLIP_X) {
-            dx = -dx;
-        }
-        if (flip_bits & NT_SPRITE_FLAG_FLIP_Y) {
-            dy = -dy;
-        }
-        const float tx = m[12] - (m[0] * dx) - (m[4] * dy);
-        const float ty = m[13] - (m[1] * dx) - (m[5] * dy);
-        const float tz = m[14] - (m[2] * dx) - (m[6] * dy);
-
-        /* Transform 4x4 grid points through world_matrix. */
-        float wxs[4][4]; /* wxs[row][col] */
-        float wys[4][4];
-        float wzs[4][4];
-        for (uint8_t row = 0; row < 4; row++) {
-            for (uint8_t col = 0; col < 4; col++) {
-                float px = lxs[col];
-                float py = lys[row];
-                if (flip_bits & NT_SPRITE_FLAG_FLIP_X) {
-                    px = -px;
-                }
-                if (flip_bits & NT_SPRITE_FLAG_FLIP_Y) {
-                    py = -py;
-                }
-                wxs[row][col] = (m[0] * px) + (m[4] * py) + tx;
-                wys[row][col] = (m[1] * px) + (m[5] * py) + ty;
-                wzs[row][col] = (m[2] * px) + (m[6] * py) + tz;
-            }
-        }
-
-        /* UV splits from region vertices (same as emit_slice9). */
-        uint16_t u_min = UINT16_MAX;
-        uint16_t u_max = 0;
-        uint16_t v_min = UINT16_MAX;
-        uint16_t v_max = 0;
-        for (uint8_t i = 0; i < r->vertex_count; i++) {
-            uint16_t au = resolved->raw_vertices[i].atlas_u;
-            uint16_t av = resolved->raw_vertices[i].atlas_v;
-            if (au < u_min) {
-                u_min = au;
-            }
-            if (au > u_max) {
-                u_max = au;
-            }
-            if (av < v_min) {
-                v_min = av;
-            }
-            if (av > v_max) {
-                v_max = av;
-            }
-        }
-        uint16_t u_range = (uint16_t)(u_max - u_min);
-        uint16_t v_range = (uint16_t)(v_max - v_min);
-        uint16_t us[4] = {
-            u_min,
-            (uint16_t)(u_min + (((uint32_t)fl * u_range) / r->source_w)),
-            (uint16_t)(u_max - (((uint32_t)fr * u_range) / r->source_w)),
-            u_max,
+        const slice9_grid_t grid = {
+            .region = r,
+            .raw_vertices = resolved->raw_vertices,
+            .w = (float)r->source_w * ipu,
+            .h = (float)r->source_h * ipu,
+            .band_l = (float)sl * ipu * s9_scale,
+            .band_r = (float)sr * ipu * s9_scale,
+            .band_t = (float)st * ipu * s9_scale,
+            .band_b = (float)sb * ipu * s9_scale,
+            .src_l = sl,
+            .src_r = sr,
+            .src_t = st,
+            .src_b = sb,
+            .origin_x = origin_x,
+            .origin_y = origin_y,
+            .color_packed = dv->colors_packed[d_idx],
+            .flip_bits = flip_bits,
+            .world_matrix = tv->world_matrices[t_idx],
         };
-        /* V inverted: geometry Y-up, texture V is PNG Y-down. */
-        uint16_t vs[4] = {
-            v_max,
-            (uint16_t)(v_max - (((uint32_t)fb * v_range) / r->source_h)),
-            (uint16_t)(v_min + (((uint32_t)ft * v_range) / r->source_h)),
-            v_min,
-        };
-
-        /* Unpack color. */
-        const uint32_t s9_color = dv->colors_packed[d_idx];
-        const uint8_t cr = (uint8_t)(s9_color & 0xFFU);
-        const uint8_t cg = (uint8_t)((s9_color >> 8) & 0xFFU);
-        const uint8_t cb = (uint8_t)((s9_color >> 16) & 0xFFU);
-        const uint8_t ca = (uint8_t)((s9_color >> 24) & 0xFFU);
-
-        /* Emit 4x4 grid = 16 unique vertices (shared at cell boundaries). */
-        const uint32_t base = s_sprite.vertex_count;
-        for (uint8_t row = 0; row < 4; row++) {
-            for (uint8_t col = 0; col < 4; col++) {
-                nt_sprite_vertex_t *v = (nt_sprite_vertex_t *)(s_sprite.staging + ((size_t)(base + (row * 4) + col) * s_sprite.cur_stride));
-                v->position[0] = wxs[row][col];
-                v->position[1] = wys[row][col];
-                v->position[2] = wzs[row][col];
-                v->texcoord[0] = us[col];
-                v->texcoord[1] = vs[row];
-                v->color[0] = cr;
-                v->color[1] = cg;
-                v->color[2] = cb;
-                v->color[3] = ca;
-            }
-        }
-
-        /* 54 indices: 9 cells x 2 triangles x 3 indices. */
-        uint32_t ii = 0;
-        for (uint8_t row = 0; row < 3; row++) {
-            for (uint8_t col = 0; col < 3; col++) {
-                const uint16_t i_bl = (uint16_t)(base + (row * 4) + col);
-                const uint16_t i_br = (uint16_t)(i_bl + 1U);
-                const uint16_t i_tl = (uint16_t)(i_bl + 4U);
-                const uint16_t i_tr = (uint16_t)(i_tl + 1U);
-                uint16_t *out_idx = &s_sprite.indices[s_sprite.index_count + ii];
-                out_idx[0] = i_tl;
-                out_idx[1] = i_tr;
-                out_idx[2] = i_bl;
-                out_idx[3] = i_bl;
-                out_idx[4] = i_tr;
-                out_idx[5] = i_br;
-                ii += 6;
-            }
-        }
-        bake_custom_attrs(base, 16U);
-        s_sprite.vertex_count += 16U;
-        s_sprite.index_count += 54U;
-#ifdef NT_TEST_ACCESS
-        s_sprite.last_slice9_vertex_count = 16U;
-        s_sprite.last_slice9_index_count = 54U;
-        s_sprite.last_emit_vertex_count = 16U;
-        s_sprite.last_emit_index_count = 54U;
-        s_sprite.last_emit_first_vertex = base;
-#endif
+        emit_slice9_grid(&grid);
         return;
     }
 
@@ -1044,14 +1075,14 @@ static inline uint16_t scale_slice9_border(uint16_t base, float scale) {
 
 /* src borders pick UV cut; dst borders set rendered corner/edge size. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-void nt_sprite_renderer_emit_slice9(nt_resource_t atlas, uint32_t region_index, float x, float y, float w, float h, const uint16_t src_lrtb[4], float slice9_scale, uint32_t color_packed,
-                                    uint8_t flip_bits, const float *world_matrix) {
+void nt_sprite_renderer_emit_slice9(nt_resource_t atlas, uint32_t region_index, const float *world_matrix, float w, float h, float origin_x, float origin_y, const uint16_t src_lrtb[4],
+                                    float slice9_scale, uint32_t color_packed, uint8_t flip_bits) {
     NT_ASSERT(s_sprite.initialized);
     NT_ASSERT(atlas.id != 0 && "emit_slice9: invalid atlas handle");
     NT_ASSERT(nt_resource_is_ready(atlas) && "emit_slice9: atlas must be READY");
     NT_ASSERT(s_sprite.cmd_count > 0 && "emit_slice9: call nt_sprite_renderer_set_material first");
     NT_ASSERT(world_matrix != NULL && "emit_slice9: world_matrix must be non-NULL (pass NT_MATH_MAT4_IDENTITY for none)");
-    NT_ASSERT(isfinite(x) && isfinite(y) && isfinite(w) && isfinite(h));
+    NT_ASSERT(isfinite(w) && isfinite(h) && isfinite(origin_x) && isfinite(origin_y));
     NT_ASSERT(isfinite(slice9_scale) && slice9_scale > 0.0F && "emit_slice9: slice9_scale must be finite > 0");
     NT_ASSERT(w >= 0.0F && h >= 0.0F && "slice9 target dimensions must be non-negative");
 
@@ -1084,187 +1115,27 @@ void nt_sprite_renderer_emit_slice9(nt_resource_t atlas, uint32_t region_index, 
         return;
     }
 
-    /* Only the dst bands swap: the mirror itself is the us/vs reversal below, so
-     * the UV cuts keep reading their own source side. */
-    uint16_t fdst_l = dst_sl;
-    uint16_t fdst_r = dst_sr;
-    uint16_t fdst_t = dst_st;
-    uint16_t fdst_b = dst_sb;
-    if (flip_bits & NT_SPRITE_FLAG_FLIP_X) {
-        fdst_l = dst_sr;
-        fdst_r = dst_sl;
-    }
-    if (flip_bits & NT_SPRITE_FLAG_FLIP_Y) {
-        fdst_t = dst_sb;
-        fdst_b = dst_st;
-    }
-    const uint16_t fl = src_sl;
-    const uint16_t fr = src_sr;
-    const uint16_t ft = src_st;
-    const uint16_t fb = src_sb;
-
-    /* Extract bbox UVs from region vertices (u16 space). */
-    uint16_t u_min = UINT16_MAX;
-    uint16_t u_max = 0;
-    uint16_t v_min = UINT16_MAX;
-    uint16_t v_max = 0;
-    for (uint8_t i = 0; i < rh.region->vertex_count; i++) {
-        uint16_t au = rh.raw_vertices[i].atlas_u;
-        uint16_t av = rh.raw_vertices[i].atlas_v;
-        if (au < u_min) {
-            u_min = au;
-        }
-        if (au > u_max) {
-            u_max = au;
-        }
-        if (av < v_min) {
-            v_min = av;
-        }
-        if (av > v_max) {
-            v_max = av;
-        }
-    }
-
-    // #region position_and_uv_splits
-    /* Positions use DST borders; UV cuts use SRC borders. */
-    float fl_w = (float)fdst_l * ipu;
-    float fr_w = (float)fdst_r * ipu;
-    float ft_w = (float)fdst_t * ipu;
-    float fb_w = (float)fdst_b * ipu;
-    /* Proportionally shrink dst borders when target rect is smaller than total borders */
-    if (fl_w + fr_w > w) {
-        float ratio = w / (fl_w + fr_w);
-        fl_w *= ratio;
-        fr_w *= ratio;
-    }
-    if (ft_w + fb_w > h) {
-        float ratio = h / (ft_w + fb_w);
-        ft_w *= ratio;
-        fb_w *= ratio;
-    }
-    float xs[4] = {x, x + fl_w, x + w - fr_w, x + w};
-    float ys[4] = {y, y + ft_w, y + h - fb_w, y + h};
-
-    /* UV splits (4 u-values, 4 v-values in u16). Integer math avoids precision loss. */
-    uint16_t u_range = (uint16_t)(u_max - u_min);
-    uint16_t v_range = (uint16_t)(v_max - v_min);
-    uint16_t us[4] = {
-        u_min,
-        (uint16_t)(u_min + (((uint32_t)fl * u_range) / rh.region->source_w)),
-        (uint16_t)(u_max - (((uint32_t)fr * u_range) / rh.region->source_w)),
-        u_max,
+    const slice9_grid_t grid = {
+        .region = rh.region,
+        .raw_vertices = rh.raw_vertices,
+        .w = w,
+        .h = h,
+        .band_l = (float)dst_sl * ipu,
+        .band_r = (float)dst_sr * ipu,
+        .band_t = (float)dst_st * ipu,
+        .band_b = (float)dst_sb * ipu,
+        .src_l = src_sl,
+        .src_r = src_sr,
+        .src_t = src_st,
+        .src_b = src_sb,
+        .origin_x = origin_x,
+        .origin_y = origin_y,
+        .color_packed = color_packed,
+        .flip_bits = flip_bits,
+        .world_matrix = world_matrix,
     };
-    /* Row 0 is the rect's TOP (y grows down, like every emit_* geometry param)
-     * and texture V is PNG Y-down, so rows and V ascend together. */
-    uint16_t vs[4] = {
-        v_min,
-        (uint16_t)(v_min + (((uint32_t)ft * v_range) / rh.region->source_h)),
-        (uint16_t)(v_max - (((uint32_t)fb * v_range) / rh.region->source_h)),
-        v_max,
-    };
-
-    /* UV flip after split computation. */
-    if (flip_bits & NT_SPRITE_FLAG_FLIP_X) {
-        uint16_t t0 = us[0];
-        us[0] = us[3];
-        us[3] = t0;
-        uint16_t t1 = us[1];
-        us[1] = us[2];
-        us[2] = t1;
-    }
-    if (flip_bits & NT_SPRITE_FLAG_FLIP_Y) {
-        uint16_t t0 = vs[0];
-        vs[0] = vs[3];
-        vs[3] = t0;
-        uint16_t t1 = vs[1];
-        vs[1] = vs[2];
-        vs[2] = t1;
-    }
-
-    // #endregion
-
-    // #region emit_slice9_vertices
-    const uint32_t vcap = (s_sprite.cur_material_custom_bytes > 0) ? s_sprite.custom_max_vertices : s_sprite.max_vertices;
-    if (s_sprite.vertex_count + 16U > vcap || s_sprite.index_count + 54U > s_sprite.max_indices) {
-        NT_ASSERT(s_sprite.cmd_count > 0 && "emit_slice9 called with no open cmd");
-        nt_sprite_draw_cmd_t snapshot = s_sprite.cmds[s_sprite.cmd_count - 1];
-        nt_sprite_renderer_flush();
-        open_cmd_from_snapshot(&snapshot);
-    }
-
-    /* Unpack color. */
-    uint8_t cr = (uint8_t)(color_packed & 0xFFU);
-    uint8_t cg = (uint8_t)((color_packed >> 8) & 0xFFU);
-    uint8_t cb = (uint8_t)((color_packed >> 16) & 0xFFU);
-    uint8_t ca = (uint8_t)((color_packed >> 24) & 0xFFU);
-
-    uint32_t base = s_sprite.vertex_count;
-
-    /* Emit 4x4 grid = 16 unique vertices (shared at cell boundaries). */
-    for (uint8_t row = 0; row < 4; row++) {
-        for (uint8_t col = 0; col < 4; col++) {
-            nt_sprite_vertex_t *v = (nt_sprite_vertex_t *)(s_sprite.staging + ((size_t)(base + (row * 4) + col) * s_sprite.cur_stride));
-            v->position[0] = xs[col];
-            v->position[1] = ys[row];
-            v->position[2] = 0.0F;
-            v->texcoord[0] = us[col];
-            v->texcoord[1] = vs[row];
-            v->color[0] = cr;
-            v->color[1] = cg;
-            v->color[2] = cb;
-            v->color[3] = ca;
-        }
-    }
-
-    /* 54 indices: 9 cells x 2 triangles x 3 indices. */
-    uint16_t *out_idx = &s_sprite.indices[s_sprite.index_count];
-    uint32_t ii = 0;
-    for (uint8_t row = 0; row < 3; row++) {
-        for (uint8_t col = 0; col < 3; col++) {
-            const uint16_t i_bl = (uint16_t)(base + (row * 4) + col);
-            const uint16_t i_br = (uint16_t)(i_bl + 1U);
-            const uint16_t i_tl = (uint16_t)(i_bl + 4U);
-            const uint16_t i_tr = (uint16_t)(i_tl + 1U);
-            out_idx[ii++] = i_tl;
-            out_idx[ii++] = i_tr;
-            out_idx[ii++] = i_bl;
-            out_idx[ii++] = i_bl;
-            out_idx[ii++] = i_tr;
-            out_idx[ii++] = i_br;
-        }
-    }
-
-    /* Skip identity mat4 to save the transform pass; same 9-float subset as
-     * emit_region_resolved (m[0,1,2,4,5,6,12,13,14]). */
-    const float *m = world_matrix;
-    const bool is_identity = m[0] == 1.0F && m[1] == 0.0F && m[2] == 0.0F && m[4] == 0.0F && m[5] == 1.0F && m[6] == 0.0F && m[12] == 0.0F && m[13] == 0.0F && m[14] == 0.0F;
-    if (!is_identity) {
-        for (uint32_t vi = 0; vi < 16U; vi++) {
-            nt_sprite_vertex_t *v = (nt_sprite_vertex_t *)(s_sprite.staging + ((size_t)(base + vi) * s_sprite.cur_stride));
-            const float px = v->position[0];
-            const float py = v->position[1];
-            v->position[0] = (m[0] * px) + (m[4] * py) + m[12];
-            v->position[1] = (m[1] * px) + (m[5] * py) + m[13];
-            v->position[2] = (m[2] * px) + (m[6] * py) + m[14];
-        }
-    }
-
-    bake_custom_attrs(base, 16U);
-    s_sprite.vertex_count += 16U;
-    s_sprite.index_count += 54U;
-
-#ifdef NT_TEST_ACCESS
-    s_sprite.last_slice9_vertex_count = 16U;
-    s_sprite.last_slice9_index_count = 54U;
-    /* Also update the generic last_emit so test_last_emit_position/texcoord work. */
-    s_sprite.last_emit_vertex_count = 16U;
-    s_sprite.last_emit_index_count = 54U;
-    s_sprite.last_emit_first_vertex = base;
-#endif
-    // #endregion
+    emit_slice9_grid(&grid);
 }
-// #endregion
-
 // #endregion
 
 // #region draw_list

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -1092,8 +1092,6 @@ void nt_sprite_renderer_emit_slice9(nt_resource_t atlas, uint32_t region_index, 
         return; /* tombstone */
     }
 
-    const float ipu = nt_atlas_get_inverse_pixels_per_unit(atlas);
-
     /* NULL src_lrtb → atlas-baked borders for this region. */
     const uint16_t src_sl = (src_lrtb != NULL) ? src_lrtb[0] : rh.region->slice9_lrtb[0];
     const uint16_t src_sr = (src_lrtb != NULL) ? src_lrtb[1] : rh.region->slice9_lrtb[1];
@@ -1108,7 +1106,6 @@ void nt_sprite_renderer_emit_slice9(nt_resource_t atlas, uint32_t region_index, 
     NT_ASSERT(rh.region->trim_offset_x == 0 && rh.region->trim_offset_y == 0 && "slice9 region must be untrimmed");
     NT_ASSERT(rh.region->source_w > 0 && rh.region->source_h > 0 && "slice9 region source dimensions must be non-zero");
     NT_ASSERT(src_sl + src_sr < rh.region->source_w && src_st + src_sb < rh.region->source_h && "slice9 src borders exceed source dimensions");
-    NT_ASSERT(ipu > 0.0F && "slice9 ipu must be positive");
 
     const uint32_t page_tex = nt_resource_get(rh.page_resource);
     if (!ensure_current_cmd_page_texture(page_tex)) {
@@ -1120,10 +1117,10 @@ void nt_sprite_renderer_emit_slice9(nt_resource_t atlas, uint32_t region_index, 
         .raw_vertices = rh.raw_vertices,
         .w = w,
         .h = h,
-        .band_l = (float)dst_sl * ipu,
-        .band_r = (float)dst_sr * ipu,
-        .band_t = (float)dst_st * ipu,
-        .band_b = (float)dst_sb * ipu,
+        .band_l = (float)dst_sl,
+        .band_r = (float)dst_sr,
+        .band_t = (float)dst_st,
+        .band_b = (float)dst_sb,
         .src_l = src_sl,
         .src_r = src_sr,
         .src_t = src_st,

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -1092,6 +1092,8 @@ void nt_sprite_renderer_emit_slice9(nt_resource_t atlas, uint32_t region_index, 
         return; /* tombstone */
     }
 
+    const float ipu = nt_atlas_get_inverse_pixels_per_unit(atlas);
+
     /* NULL src_lrtb → atlas-baked borders for this region. */
     const uint16_t src_sl = (src_lrtb != NULL) ? src_lrtb[0] : rh.region->slice9_lrtb[0];
     const uint16_t src_sr = (src_lrtb != NULL) ? src_lrtb[1] : rh.region->slice9_lrtb[1];
@@ -1106,6 +1108,7 @@ void nt_sprite_renderer_emit_slice9(nt_resource_t atlas, uint32_t region_index, 
     NT_ASSERT(rh.region->trim_offset_x == 0 && rh.region->trim_offset_y == 0 && "slice9 region must be untrimmed");
     NT_ASSERT(rh.region->source_w > 0 && rh.region->source_h > 0 && "slice9 region source dimensions must be non-zero");
     NT_ASSERT(src_sl + src_sr < rh.region->source_w && src_st + src_sb < rh.region->source_h && "slice9 src borders exceed source dimensions");
+    NT_ASSERT(ipu > 0.0F && "slice9 ipu must be positive");
 
     const uint32_t page_tex = nt_resource_get(rh.page_resource);
     if (!ensure_current_cmd_page_texture(page_tex)) {
@@ -1117,10 +1120,10 @@ void nt_sprite_renderer_emit_slice9(nt_resource_t atlas, uint32_t region_index, 
         .raw_vertices = rh.raw_vertices,
         .w = w,
         .h = h,
-        .band_l = (float)dst_sl,
-        .band_r = (float)dst_sr,
-        .band_t = (float)dst_st,
-        .band_b = (float)dst_sb,
+        .band_l = (float)dst_sl * ipu,
+        .band_r = (float)dst_sr * ipu,
+        .band_t = (float)dst_st * ipu,
+        .band_b = (float)dst_sb * ipu,
         .src_l = src_sl,
         .src_r = src_sr,
         .src_t = src_st,

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -105,9 +105,6 @@ static struct {
     uint32_t last_emit_vertex_count;
     uint32_t last_emit_index_count;
     uint32_t last_emit_first_vertex;
-    /* Captured at end of emit_slice9. */
-    uint32_t last_slice9_vertex_count;
-    uint32_t last_slice9_index_count;
     /* Flushes that ACTUALLY replayed cmds (past the empty early-return). Empty no-op flushes don't count. */
     uint32_t test_nonempty_flush_calls;
 #endif
@@ -811,7 +808,18 @@ static void write_slice9_vertices(const slice9_grid_t *g, const float lxs[4], co
     }
 }
 
+/* What the grid math takes for granted about the region, in one place for both
+ * entry points. */
+// NOLINTNEXTLINE(readability-function-cognitive-complexity) — four asserts, no control flow of its own
+static void slice9_assert_region(const slice9_grid_t *g) {
+    NT_ASSERT(g->region->transform == 0 && "slice9 region must have transform == 0 (no rotation)");
+    NT_ASSERT(g->region->trim_offset_x == 0 && g->region->trim_offset_y == 0 && "slice9 region must be untrimmed");
+    NT_ASSERT(g->region->source_w > 0 && g->region->source_h > 0 && "slice9 region source dimensions must be non-zero");
+    NT_ASSERT(g->src_l + g->src_r < g->region->source_w && g->src_t + g->src_b < g->region->source_h && "slice9 src borders exceed source dimensions");
+}
+
 static void emit_slice9_grid(const slice9_grid_t *g) {
+    slice9_assert_region(g);
     const uint32_t vcap = (s_sprite.cur_material_custom_bytes > 0) ? s_sprite.custom_max_vertices : s_sprite.max_vertices;
     if (s_sprite.vertex_count + 16U > vcap || s_sprite.index_count + 54U > s_sprite.max_indices) {
         NT_ASSERT(s_sprite.cmd_count > 0 && "emit_slice9_grid called with no open cmd");
@@ -819,6 +827,7 @@ static void emit_slice9_grid(const slice9_grid_t *g) {
         nt_sprite_renderer_flush();
         open_cmd_from_snapshot(&snapshot);
     }
+    NT_ASSERT(16U <= vcap && 54U <= s_sprite.max_indices && "slice9: staging cap below one grid (raise max_vertices / max_indices)");
 
     float lxs[4];
     float lys[4];
@@ -853,8 +862,6 @@ static void emit_slice9_grid(const slice9_grid_t *g) {
     s_sprite.index_count += 54U;
 
 #ifdef NT_TEST_ACCESS
-    s_sprite.last_slice9_vertex_count = 16U;
-    s_sprite.last_slice9_index_count = 54U;
     s_sprite.last_emit_vertex_count = 16U;
     s_sprite.last_emit_index_count = 54U;
     s_sprite.last_emit_first_vertex = base;
@@ -913,11 +920,6 @@ static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *
             st = r->slice9_lrtb[2];
             sb = r->slice9_lrtb[3];
         }
-        NT_ASSERT(r->transform == 0 && "slice9 region must have transform == 0");
-        NT_ASSERT(r->trim_offset_x == 0 && r->trim_offset_y == 0 && "slice9 region must be untrimmed");
-        NT_ASSERT(r->source_w > 0 && r->source_h > 0);
-        NT_ASSERT(sl + sr < r->source_w && st + sb < r->source_h);
-
         if (!ensure_current_cmd_page_texture(page_tex)) {
             return;
         }
@@ -1066,13 +1068,6 @@ void nt_sprite_renderer_emit_geometry(nt_resource_t atlas, uint32_t region_index
 // #endregion
 
 // #region emit_slice9
-/* Production scales 0.1..10; overflow asserts at scale > ~4096 for a 16 px border. */
-static inline uint16_t scale_slice9_border(uint16_t base, float scale) {
-    const float f = ((float)base * scale) + 0.5F;
-    NT_ASSERT(f >= 0.0F && f <= 65535.0F && "slice9 border × scale overflows uint16_t");
-    return (uint16_t)f;
-}
-
 /* src borders pick UV cut; dst borders set rendered corner/edge size. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_sprite_renderer_emit_slice9(nt_resource_t atlas, uint32_t region_index, const float *world_matrix, float w, float h, float origin_x, float origin_y, const uint16_t src_lrtb[4],
@@ -1099,15 +1094,7 @@ void nt_sprite_renderer_emit_slice9(nt_resource_t atlas, uint32_t region_index, 
     const uint16_t src_sr = (src_lrtb != NULL) ? src_lrtb[1] : rh.region->slice9_lrtb[1];
     const uint16_t src_st = (src_lrtb != NULL) ? src_lrtb[2] : rh.region->slice9_lrtb[2];
     const uint16_t src_sb = (src_lrtb != NULL) ? src_lrtb[3] : rh.region->slice9_lrtb[3];
-    const uint16_t dst_sl = scale_slice9_border(src_sl, slice9_scale);
-    const uint16_t dst_sr = scale_slice9_border(src_sr, slice9_scale);
-    const uint16_t dst_st = scale_slice9_border(src_st, slice9_scale);
-    const uint16_t dst_sb = scale_slice9_border(src_sb, slice9_scale);
 
-    NT_ASSERT(rh.region->transform == 0 && "slice9 region must have transform == 0 (no rotation)");
-    NT_ASSERT(rh.region->trim_offset_x == 0 && rh.region->trim_offset_y == 0 && "slice9 region must be untrimmed");
-    NT_ASSERT(rh.region->source_w > 0 && rh.region->source_h > 0 && "slice9 region source dimensions must be non-zero");
-    NT_ASSERT(src_sl + src_sr < rh.region->source_w && src_st + src_sb < rh.region->source_h && "slice9 src borders exceed source dimensions");
     NT_ASSERT(ipu > 0.0F && "slice9 ipu must be positive");
 
     const uint32_t page_tex = nt_resource_get(rh.page_resource);
@@ -1120,10 +1107,10 @@ void nt_sprite_renderer_emit_slice9(nt_resource_t atlas, uint32_t region_index, 
         .raw_vertices = rh.raw_vertices,
         .w = w,
         .h = h,
-        .band_l = (float)dst_sl * ipu,
-        .band_r = (float)dst_sr * ipu,
-        .band_t = (float)dst_st * ipu,
-        .band_b = (float)dst_sb * ipu,
+        .band_l = (float)src_sl * slice9_scale * ipu,
+        .band_r = (float)src_sr * slice9_scale * ipu,
+        .band_t = (float)src_st * slice9_scale * ipu,
+        .band_b = (float)src_sb * slice9_scale * ipu,
         .src_l = src_sl,
         .src_r = src_sr,
         .src_t = src_st,
@@ -1335,8 +1322,6 @@ void nt_sprite_renderer_test_last_emit_color(uint32_t v_idx, uint8_t out[4]) {
 }
 
 bool nt_sprite_renderer_test_initialized(void) { return s_sprite.initialized; }
-uint32_t nt_sprite_renderer_test_last_slice9_vertex_count(void) { return s_sprite.last_slice9_vertex_count; }
-uint32_t nt_sprite_renderer_test_last_slice9_index_count(void) { return s_sprite.last_slice9_index_count; }
 uint32_t nt_sprite_renderer_test_nonempty_flush_calls(void) { return s_sprite.test_nonempty_flush_calls; }
 void nt_sprite_renderer_test_reset_nonempty_flush_calls(void) { s_sprite.test_nonempty_flush_calls = 0; }
 #endif

--- a/engine/renderers/nt_sprite_renderer.c
+++ b/engine/renderers/nt_sprite_renderer.c
@@ -689,25 +689,15 @@ NT_SPRITE_EMIT_INLINE void emit_region_resolved(const nt_texture_region_t *r, co
 // #endregion
 
 // #region slice9_grid
-/* One 4x4 slice9 grid, shared by the ECS path and the public emit.
- *
- * Local space matches emit_region's: Y-up, pivot-relative, mirrored by negating
- * positions. Row 0 is the local bottom and samples v_max, because blob vertices
- * are Y-up while atlas_v stays PNG Y-down. Whoever wants the grid Y-down says so
- * in world_matrix, exactly as they do for a plain region. */
+/* Local space matches emit_region's: Y-up, pivot-relative, mirrored by negating positions.
+ * Row 0 is the local bottom and samples v_max: blob vertices are Y-up, atlas_v is PNG Y-down. */
 typedef struct {
     const nt_texture_region_t *region;
     const nt_atlas_vertex_t *raw_vertices;
-    float w; /* local grid size, emit units */
+    const uint16_t *src_lrtb; /* source px: the UV cuts */
+    float band_per_px;        /* slice9_scale / pixels_per_unit: source px -> w/h units */
+    float w;                  /* local grid size */
     float h;
-    float band_l; /* dst band widths, same units as w/h */
-    float band_r;
-    float band_t;
-    float band_b;
-    uint16_t src_l; /* src borders in source pixels — the UV cuts */
-    uint16_t src_r;
-    uint16_t src_t;
-    uint16_t src_b;
     float origin_x; /* pivot, normalized over w/h */
     float origin_y;
     uint32_t color_packed;
@@ -734,10 +724,10 @@ static void region_uv_bounds(const nt_atlas_vertex_t *verts, uint8_t count, uint
 /* Grid splits for one slice9: dst bands become local coordinates, src borders
  * become UV cuts. Rows are Y-up, so V descends with them. */
 static void slice9_build_splits(const slice9_grid_t *g, float lxs[4], float lys[4], uint16_t us[4], uint16_t vs[4]) {
-    float bl = g->band_l;
-    float br = g->band_r;
-    float bt = g->band_t;
-    float bb = g->band_b;
+    float bl = (float)g->src_lrtb[0] * g->band_per_px;
+    float br = (float)g->src_lrtb[1] * g->band_per_px;
+    float bt = (float)g->src_lrtb[2] * g->band_per_px;
+    float bb = (float)g->src_lrtb[3] * g->band_per_px;
     /* Proportionally shrink dst bands when the target is smaller than their sum. */
     if (bl + br > g->w) {
         const float ratio = g->w / (bl + br);
@@ -764,12 +754,12 @@ static void slice9_build_splits(const slice9_grid_t *g, float lxs[4], float lys[
     const uint16_t v_range = (uint16_t)(uv_bounds[3] - uv_bounds[2]);
     /* Integer math avoids precision loss. */
     us[0] = uv_bounds[0];
-    us[1] = (uint16_t)(uv_bounds[0] + (((uint32_t)g->src_l * u_range) / g->region->source_w));
-    us[2] = (uint16_t)(uv_bounds[1] - (((uint32_t)g->src_r * u_range) / g->region->source_w));
+    us[1] = (uint16_t)(uv_bounds[0] + (((uint32_t)g->src_lrtb[0] * u_range) / g->region->source_w));
+    us[2] = (uint16_t)(uv_bounds[1] - (((uint32_t)g->src_lrtb[1] * u_range) / g->region->source_w));
     us[3] = uv_bounds[1];
     vs[0] = uv_bounds[3];
-    vs[1] = (uint16_t)(uv_bounds[3] - (((uint32_t)g->src_b * v_range) / g->region->source_h));
-    vs[2] = (uint16_t)(uv_bounds[2] + (((uint32_t)g->src_t * v_range) / g->region->source_h));
+    vs[1] = (uint16_t)(uv_bounds[3] - (((uint32_t)g->src_lrtb[3] * v_range) / g->region->source_h));
+    vs[2] = (uint16_t)(uv_bounds[2] + (((uint32_t)g->src_lrtb[2] * v_range) / g->region->source_h));
     vs[3] = uv_bounds[2];
 }
 
@@ -808,14 +798,12 @@ static void write_slice9_vertices(const slice9_grid_t *g, const float lxs[4], co
     }
 }
 
-/* What the grid math takes for granted about the region, in one place for both
- * entry points. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity) — four asserts, no control flow of its own
 static void slice9_assert_region(const slice9_grid_t *g) {
     NT_ASSERT(g->region->transform == 0 && "slice9 region must have transform == 0 (no rotation)");
     NT_ASSERT(g->region->trim_offset_x == 0 && g->region->trim_offset_y == 0 && "slice9 region must be untrimmed");
     NT_ASSERT(g->region->source_w > 0 && g->region->source_h > 0 && "slice9 region source dimensions must be non-zero");
-    NT_ASSERT(g->src_l + g->src_r < g->region->source_w && g->src_t + g->src_b < g->region->source_h && "slice9 src borders exceed source dimensions");
+    NT_ASSERT(g->src_lrtb[0] + g->src_lrtb[1] < g->region->source_w && g->src_lrtb[2] + g->src_lrtb[3] < g->region->source_h && "slice9 src borders exceed source dimensions");
 }
 
 static void emit_slice9_grid(const slice9_grid_t *g) {
@@ -835,7 +823,6 @@ static void emit_slice9_grid(const slice9_grid_t *g) {
     uint16_t vs[4];
     slice9_build_splits(g, lxs, lys, us, vs);
 
-    // #region emit_slice9_grid_vertices
     const uint32_t base = s_sprite.vertex_count;
     write_slice9_vertices(g, lxs, lys, us, vs, base);
 
@@ -848,12 +835,13 @@ static void emit_slice9_grid(const slice9_grid_t *g) {
             const uint16_t i_br = (uint16_t)(i_bl + 1U);
             const uint16_t i_tl = (uint16_t)(i_bl + 4U);
             const uint16_t i_tr = (uint16_t)(i_tl + 1U);
+            /* CCW in local Y-up, like the blob's triangles, so CULL_BACK draws it. */
             out_idx[ii++] = i_tl;
-            out_idx[ii++] = i_tr;
-            out_idx[ii++] = i_bl;
             out_idx[ii++] = i_bl;
             out_idx[ii++] = i_tr;
+            out_idx[ii++] = i_bl;
             out_idx[ii++] = i_br;
+            out_idx[ii++] = i_tr;
         }
     }
 
@@ -866,7 +854,6 @@ static void emit_slice9_grid(const slice9_grid_t *g) {
     s_sprite.last_emit_index_count = 54U;
     s_sprite.last_emit_first_vertex = base;
 #endif
-    // #endregion
 }
 // #endregion
 
@@ -902,44 +889,20 @@ static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *
     const float ipu = nt_atlas_get_inverse_pixels_per_unit(atlas);
 
     // #region emit_one_slice9_branch
-    bool has_s9_ov = (flags & NT_SPRITE_FLAG_SLICE9_OV) != 0;
-    bool has_s9_region = (r->slice9_lrtb[0] | r->slice9_lrtb[1] | r->slice9_lrtb[2] | r->slice9_lrtb[3]) != 0;
-    if (has_s9_ov || has_s9_region) {
-        uint16_t sl;
-        uint16_t sr;
-        uint16_t st;
-        uint16_t sb;
-        if (has_s9_ov) {
-            sl = sv->slice9_lrtb[s_idx][0];
-            sr = sv->slice9_lrtb[s_idx][1];
-            st = sv->slice9_lrtb[s_idx][2];
-            sb = sv->slice9_lrtb[s_idx][3];
-        } else {
-            sl = r->slice9_lrtb[0];
-            sr = r->slice9_lrtb[1];
-            st = r->slice9_lrtb[2];
-            sb = r->slice9_lrtb[3];
-        }
+    /* A zero override is the documented way to turn a baked nine-patch back into a plain quad. */
+    const uint16_t *s9 = (flags & NT_SPRITE_FLAG_SLICE9_OV) ? sv->slice9_lrtb[s_idx] : r->slice9_lrtb;
+    if ((s9[0] | s9[1] | s9[2] | s9[3]) != 0) {
         if (!ensure_current_cmd_page_texture(page_tex)) {
             return;
         }
-
-        /* DST corner size = src x per-entity slice9_scale; last-line tripwire. */
         NT_ASSERT(isfinite(sv->slice9_scale[s_idx]) && sv->slice9_scale[s_idx] > 0.0F && "emit_one: sv->slice9_scale[s_idx] must be finite > 0");
-        const float s9_scale = sv->slice9_scale[s_idx];
         const slice9_grid_t grid = {
             .region = r,
             .raw_vertices = resolved->raw_vertices,
+            .src_lrtb = s9,
+            .band_per_px = sv->slice9_scale[s_idx] * ipu,
             .w = (float)r->source_w * ipu,
             .h = (float)r->source_h * ipu,
-            .band_l = (float)sl * ipu * s9_scale,
-            .band_r = (float)sr * ipu * s9_scale,
-            .band_t = (float)st * ipu * s9_scale,
-            .band_b = (float)sb * ipu * s9_scale,
-            .src_l = sl,
-            .src_r = sr,
-            .src_t = st,
-            .src_b = sb,
             .origin_x = origin_x,
             .origin_y = origin_y,
             .color_packed = dv->colors_packed[d_idx],
@@ -949,7 +912,6 @@ static void emit_one(const nt_render_item_t *item, const nt_sprite_comp_view_t *
         emit_slice9_grid(&grid);
         return;
     }
-
     // #endregion
     emit_region_resolved(r, resolved->cached_pos, resolved->raw_vertices, resolved->indices, page_tex, ipu, tv->world_matrices[t_idx], origin_x, origin_y, dv->colors_packed[d_idx], flip_bits);
 }
@@ -1089,14 +1051,6 @@ void nt_sprite_renderer_emit_slice9(nt_resource_t atlas, uint32_t region_index, 
 
     const float ipu = nt_atlas_get_inverse_pixels_per_unit(atlas);
 
-    /* NULL src_lrtb → atlas-baked borders for this region. */
-    const uint16_t src_sl = (src_lrtb != NULL) ? src_lrtb[0] : rh.region->slice9_lrtb[0];
-    const uint16_t src_sr = (src_lrtb != NULL) ? src_lrtb[1] : rh.region->slice9_lrtb[1];
-    const uint16_t src_st = (src_lrtb != NULL) ? src_lrtb[2] : rh.region->slice9_lrtb[2];
-    const uint16_t src_sb = (src_lrtb != NULL) ? src_lrtb[3] : rh.region->slice9_lrtb[3];
-
-    NT_ASSERT(ipu > 0.0F && "slice9 ipu must be positive");
-
     const uint32_t page_tex = nt_resource_get(rh.page_resource);
     if (!ensure_current_cmd_page_texture(page_tex)) {
         return;
@@ -1105,16 +1059,10 @@ void nt_sprite_renderer_emit_slice9(nt_resource_t atlas, uint32_t region_index, 
     const slice9_grid_t grid = {
         .region = rh.region,
         .raw_vertices = rh.raw_vertices,
+        .src_lrtb = (src_lrtb != NULL) ? src_lrtb : rh.region->slice9_lrtb,
+        .band_per_px = slice9_scale * ipu,
         .w = w,
         .h = h,
-        .band_l = (float)src_sl * slice9_scale * ipu,
-        .band_r = (float)src_sr * slice9_scale * ipu,
-        .band_t = (float)src_st * slice9_scale * ipu,
-        .band_b = (float)src_sb * slice9_scale * ipu,
-        .src_l = src_sl,
-        .src_r = src_sr,
-        .src_t = src_st,
-        .src_b = src_sb,
         .origin_x = origin_x,
         .origin_y = origin_y,
         .color_packed = color_packed,

--- a/engine/renderers/nt_sprite_renderer.h
+++ b/engine/renderers/nt_sprite_renderer.h
@@ -142,7 +142,10 @@ void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, 
 /* Emit a 9-quad slice9 image. Same vertex format and pipeline as emit_region.
  *
  *   atlas, region_index - must be READY; tombstones no-op.
- *   x, y, w, h          - target rect in caller's coordinate space.
+ *   x, y, w, h          - target rect in caller's coordinate space; y is its
+ *                         TOP edge (Y grows down, as in Clay layout space),
+ *                         so the source's top row lands at y and the `t`
+ *                         border sits along it.
  *   src_lrtb            - src borders {l,r,t,b} in source pixels; NULL = read
  *                         atlas-baked borders for this region.
  *   slice9_scale        - dst corner size = src × scale (always). Pass 1.0F

--- a/engine/renderers/nt_sprite_renderer.h
+++ b/engine/renderers/nt_sprite_renderer.h
@@ -145,7 +145,9 @@ void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, 
  *   x, y, w, h          - target rect in caller's coordinate space; y is its
  *                         TOP edge (Y grows down, as in Clay layout space),
  *                         so the source's top row lands at y and the `t`
- *                         border sits along it.
+ *                         border sits along it. (The ECS sprite_comp slice9
+ *                         path builds its grid in Y-up source-local space
+ *                         instead, and mirrors by negating positions.)
  *   src_lrtb            - src borders {l,r,t,b} in source pixels; NULL = read
  *                         atlas-baked borders for this region.
  *   slice9_scale        - dst corner size = src × scale (always). Pass 1.0F

--- a/engine/renderers/nt_sprite_renderer.h
+++ b/engine/renderers/nt_sprite_renderer.h
@@ -154,7 +154,9 @@ void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, 
  *                         atlas-baked borders for this region.
  *   slice9_scale        - dst corner size = src × scale (always). Pass 1.0F
  *                         for src verbatim. Corners proportionally shrunk if
- *                         total > w/h.
+ *                         total > w/h. One source pixel of border renders as
+ *                         one unit of w/h: the atlas's pixels_per_unit does
+ *                         NOT enter here, since w/h are the caller's units.
  *   color_packed        - 0xAABBGGRR.
  *   flip_bits           - NT_SPRITE_FLAG_FLIP_X | _FLIP_Y.
  *

--- a/engine/renderers/nt_sprite_renderer.h
+++ b/engine/renderers/nt_sprite_renderer.h
@@ -139,15 +139,17 @@ void nt_sprite_renderer_set_custom_attrs(const float *attrs, uint8_t bytes);
  * overflow is handled internally (auto flush + reopen, state preserved). */
 void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, const float *world_matrix, float origin_x, float origin_y, uint32_t color_packed, uint8_t flip_bits);
 
-/* Emit a 9-quad slice9 image. Same vertex format and pipeline as emit_region.
+/* Emit a 9-quad slice9 image. Same vertex format, local space and pipeline as
+ * emit_region: the grid is built Y-up around the pivot and flip_bits mirror it
+ * by negating positions, so the caller's world_matrix decides which way is up.
  *
  *   atlas, region_index - must be READY; tombstones no-op.
- *   x, y, w, h          - target rect in caller's coordinate space; y is its
- *                         TOP edge (Y grows down, as in Clay layout space),
- *                         so the source's top row lands at y and the `t`
- *                         border sits along it. (The ECS sprite_comp slice9
- *                         path builds its grid in Y-up source-local space
- *                         instead, and mirrors by negating positions.)
+ *   world_matrix        - 16-float column-major mat4, same convention as
+ *                         emit_region. Pass NT_MATH_MAT4_IDENTITY for none.
+ *   w, h                - rendered size in the matrix's units. Unlike
+ *                         emit_region the size is explicit, because the corner
+ *                         bands must not scale with it.
+ *   origin_x, _y        - pivot, normalized over w/h (e.g. {0.5, 0.5}).
  *   src_lrtb            - src borders {l,r,t,b} in source pixels; NULL = read
  *                         atlas-baked borders for this region.
  *   slice9_scale        - dst corner size = src × scale (always). Pass 1.0F
@@ -155,13 +157,11 @@ void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, 
  *                         total > w/h.
  *   color_packed        - 0xAABBGGRR.
  *   flip_bits           - NT_SPRITE_FLAG_FLIP_X | _FLIP_Y.
- *   world_matrix        - 16-float column-major mat4 (same convention as
- *                         emit_region). Pass NT_MATH_MAT4_IDENTITY for none.
  *
  * Emits 16 vertices + 54 indices (4x4 shared grid). Staging overflow handled
  * internally. Caller MUST have called set_material first. */
-void nt_sprite_renderer_emit_slice9(nt_resource_t atlas, uint32_t region_index, float x, float y, float w, float h, const uint16_t src_lrtb[4], float slice9_scale, uint32_t color_packed,
-                                    uint8_t flip_bits, const float *world_matrix);
+void nt_sprite_renderer_emit_slice9(nt_resource_t atlas, uint32_t region_index, const float *world_matrix, float w, float h, float origin_x, float origin_y, const uint16_t src_lrtb[4],
+                                    float slice9_scale, uint32_t color_packed, uint8_t flip_bits);
 
 /* Emit an arbitrary triangle list sampling a single UV from the given
  * atlas region. Intended for solid-color shapes drawn against a

--- a/engine/renderers/nt_sprite_renderer.h
+++ b/engine/renderers/nt_sprite_renderer.h
@@ -146,9 +146,7 @@ void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, 
  *   atlas, region_index - must be READY; tombstones no-op.
  *   world_matrix        - 16-float column-major mat4, same convention as
  *                         emit_region. Pass NT_MATH_MAT4_IDENTITY for none.
- *   w, h                - rendered size in the matrix's units. Unlike
- *                         emit_region the size is explicit, because the corner
- *                         bands must not scale with it.
+ *   w, h                - rendered size in the matrix's units.
  *   origin_x, _y        - pivot, normalized over w/h (e.g. {0.5, 0.5}).
  *   src_lrtb            - src borders {l,r,t,b} in source pixels; NULL = read
  *                         atlas-baked borders for this region.
@@ -159,8 +157,8 @@ void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, 
  *                         SD atlas for a denser HD one keeps the corner size.
  *                         Bands stay exact — no pixel snapping.
  *   color_packed        - 0xAABBGGRR.
- *   flip_bits           - NT_SPRITE_FLAG_FLIP_X | _FLIP_Y. Mirroring reverses
- *                         winding, as in emit_region: keep the material CULL_NONE.
+ *   flip_bits           - NT_SPRITE_FLAG_FLIP_X | _FLIP_Y. The grid is CCW like
+ *                         blob triangles; mirroring reverses that, as in emit_region.
  *
  * Emits 16 vertices + 54 indices (4x4 shared grid). Staging overflow handled
  * internally. Caller MUST have called set_material first. */

--- a/engine/renderers/nt_sprite_renderer.h
+++ b/engine/renderers/nt_sprite_renderer.h
@@ -157,8 +157,10 @@ void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, 
  *                         total > w/h. Border pixels convert to w/h units
  *                         through the atlas's pixels_per_unit, so swapping an
  *                         SD atlas for a denser HD one keeps the corner size.
+ *                         Bands stay exact — no pixel snapping.
  *   color_packed        - 0xAABBGGRR.
- *   flip_bits           - NT_SPRITE_FLAG_FLIP_X | _FLIP_Y.
+ *   flip_bits           - NT_SPRITE_FLAG_FLIP_X | _FLIP_Y. Mirroring reverses
+ *                         winding, as in emit_region: keep the material CULL_NONE.
  *
  * Emits 16 vertices + 54 indices (4x4 shared grid). Staging overflow handled
  * internally. Caller MUST have called set_material first. */
@@ -225,9 +227,6 @@ void nt_sprite_renderer_test_last_emit_texcoord(uint32_t v_idx, uint16_t out[2])
 /* RGBA color of the i-th vertex of the last emit, as raw uint8 [R,G,B,A]. */
 void nt_sprite_renderer_test_last_emit_color(uint32_t v_idx, uint8_t out[4]);
 bool nt_sprite_renderer_test_initialized(void);
-/* Captured vertex/index count from last slice9 emit. */
-uint32_t nt_sprite_renderer_test_last_slice9_vertex_count(void);
-uint32_t nt_sprite_renderer_test_last_slice9_index_count(void);
 /* Flushes that replayed cmds (empty no-op flushes excluded). Lets rich z-layer tests pin per-band drains. */
 uint32_t nt_sprite_renderer_test_nonempty_flush_calls(void);
 void nt_sprite_renderer_test_reset_nonempty_flush_calls(void);

--- a/engine/renderers/nt_sprite_renderer.h
+++ b/engine/renderers/nt_sprite_renderer.h
@@ -154,9 +154,9 @@ void nt_sprite_renderer_emit_region(nt_resource_t atlas, uint32_t region_index, 
  *                         atlas-baked borders for this region.
  *   slice9_scale        - dst corner size = src × scale (always). Pass 1.0F
  *                         for src verbatim. Corners proportionally shrunk if
- *                         total > w/h. One source pixel of border renders as
- *                         one unit of w/h: the atlas's pixels_per_unit does
- *                         NOT enter here, since w/h are the caller's units.
+ *                         total > w/h. Border pixels convert to w/h units
+ *                         through the atlas's pixels_per_unit, so swapping an
+ *                         SD atlas for a denser HD one keeps the corner size.
  *   color_packed        - 0xAABBGGRR.
  *   flip_bits           - NT_SPRITE_FLAG_FLIP_X | _FLIP_Y.
  *

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -1162,9 +1162,12 @@ static void emit_image(const Clay_RenderCommand *c, const float world_mat4[16]) 
         return;
     }
 
-    /* Flag bit OR non-zero lrtb selects override; flag allows override with zeros (disable slice9). */
+    /* Flag bit OR non-zero lrtb selects override; the flag with zeros DISABLES slice9,
+     * which is how nt_ui_fill's CROP reveal asks for a plain quad. */
     const bool has_s9_override = (p->flags & NT_UI_IMAGE_SLICE9_OVERRIDE) || (p->slice9_override[0] | p->slice9_override[1] | p->slice9_override[2] | p->slice9_override[3]) != 0;
+    const bool override_borders = (p->slice9_override[0] | p->slice9_override[1] | p->slice9_override[2] | p->slice9_override[3]) != 0;
     const bool region_slice9 = (r->slice9_lrtb[0] | r->slice9_lrtb[1] | r->slice9_lrtb[2] | r->slice9_lrtb[3]) != 0;
+    const bool emit_slice9 = has_s9_override ? override_borders : region_slice9;
     NT_ASSERT(isfinite(p->slice9_scale) && p->slice9_scale > 0.0F && "nt_ui walker: payload.slice9_scale must be finite > 0");
     const float s9_scale = p->slice9_scale;
 
@@ -1173,9 +1176,10 @@ static void emit_image(const Clay_RenderCommand *c, const float world_mat4[16]) 
     const float cx = bb.x + (bb.width * 0.5F);
     const float cy = bb.y + (bb.height * 0.5F);
 
-    if (has_s9_override || region_slice9) {
+    if (emit_slice9) {
         /* The grid carries its own pixel sizes, so the matrix only anchors and
-         * inverts it; the bbox center pairs with the {0.5, 0.5} pivot. */
+         * inverts it; the bbox center pairs with a centered pivot. A nine-patch
+         * fills its bbox unless the game moves the pivot explicitly. */
         float sm[16];
         for (int rr = 0; rr < 4; ++rr) {
             sm[rr] = world_mat4[rr];
@@ -1183,8 +1187,10 @@ static void emit_image(const Clay_RenderCommand *c, const float world_mat4[16]) 
             sm[8 + rr] = world_mat4[8 + rr];
             sm[12 + rr] = (cx * world_mat4[rr]) + (cy * world_mat4[4 + rr]) + world_mat4[12 + rr];
         }
+        const float s9_origin_x = (p->flags & NT_UI_IMAGE_ORIGIN_OVERRIDE) ? p->origin_x : 0.5F;
+        const float s9_origin_y = (p->flags & NT_UI_IMAGE_ORIGIN_OVERRIDE) ? p->origin_y : 0.5F;
         const uint16_t *src = has_s9_override ? p->slice9_override : NULL;
-        nt_sprite_renderer_emit_slice9(p->atlas, p->region_index, sm, bb.width, bb.height, 0.5F, 0.5F, src, s9_scale, col, p->flip_bits);
+        nt_sprite_renderer_emit_slice9(p->atlas, p->region_index, sm, bb.width, bb.height, s9_origin_x, s9_origin_y, src, s9_scale, col, p->flip_bits);
         return;
     }
 

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -1168,9 +1168,23 @@ static void emit_image(const Clay_RenderCommand *c, const float world_mat4[16]) 
     NT_ASSERT(isfinite(p->slice9_scale) && p->slice9_scale > 0.0F && "nt_ui walker: payload.slice9_scale must be finite > 0");
     const float s9_scale = p->slice9_scale;
 
+    /* Source's (origin, origin) point anchors at bbox center. Build sprite_mat4 = world × T(cx, cy) × S(sx, -sy, 1):
+     * source Y-up (image texels flow up) inverts before world maps to layout — col1 negates world.col1. */
+    const float cx = bb.x + (bb.width * 0.5F);
+    const float cy = bb.y + (bb.height * 0.5F);
+
     if (has_s9_override || region_slice9) {
+        /* The grid carries its own pixel sizes, so the matrix only anchors and
+         * inverts it; the bbox center pairs with the {0.5, 0.5} pivot. */
+        float sm[16];
+        for (int rr = 0; rr < 4; ++rr) {
+            sm[rr] = world_mat4[rr];
+            sm[4 + rr] = -world_mat4[4 + rr];
+            sm[8 + rr] = world_mat4[8 + rr];
+            sm[12 + rr] = (cx * world_mat4[rr]) + (cy * world_mat4[4 + rr]) + world_mat4[12 + rr];
+        }
         const uint16_t *src = has_s9_override ? p->slice9_override : NULL;
-        nt_sprite_renderer_emit_slice9(p->atlas, p->region_index, bb.x, bb.y, bb.width, bb.height, src, s9_scale, col, p->flip_bits, world_mat4);
+        nt_sprite_renderer_emit_slice9(p->atlas, p->region_index, sm, bb.width, bb.height, 0.5F, 0.5F, src, s9_scale, col, p->flip_bits);
         return;
     }
 
@@ -1180,11 +1194,6 @@ static void emit_image(const Clay_RenderCommand *c, const float world_mat4[16]) 
     NT_ASSERT(src_w > 0.0F && src_h > 0.0F && "nt_ui IMAGE: atlas region has zero source dimensions (broken atlas data)");
     const float sx_f = bb.width / src_w;
     const float sy_f = bb.height / src_h;
-
-    /* Source's (origin, origin) point anchors at bbox center. Build sprite_mat4 = world × T(cx, cy) × S(sx, -sy, 1):
-     * source Y-up (image texels flow up) inverts before world maps to layout — col1 negates world.col1. */
-    const float cx = bb.x + (bb.width * 0.5F);
-    const float cy = bb.y + (bb.height * 0.5F);
     float m[16];
     for (int rr = 0; rr < 4; ++rr) {
         m[rr] = sx_f * world_mat4[rr];

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -1164,48 +1164,42 @@ static void emit_image(const Clay_RenderCommand *c, const float world_mat4[16]) 
 
     /* Flag bit OR non-zero lrtb selects override; the flag with zeros DISABLES slice9,
      * which is how nt_ui_fill's CROP reveal asks for a plain quad. */
-    const bool has_s9_override = (p->flags & NT_UI_IMAGE_SLICE9_OVERRIDE) || (p->slice9_override[0] | p->slice9_override[1] | p->slice9_override[2] | p->slice9_override[3]) != 0;
     const bool override_borders = (p->slice9_override[0] | p->slice9_override[1] | p->slice9_override[2] | p->slice9_override[3]) != 0;
+    const bool has_s9_override = (p->flags & NT_UI_IMAGE_SLICE9_OVERRIDE) || override_borders;
     const bool region_slice9 = (r->slice9_lrtb[0] | r->slice9_lrtb[1] | r->slice9_lrtb[2] | r->slice9_lrtb[3]) != 0;
     const bool emit_slice9 = has_s9_override ? override_borders : region_slice9;
     NT_ASSERT(isfinite(p->slice9_scale) && p->slice9_scale > 0.0F && "nt_ui walker: payload.slice9_scale must be finite > 0");
-    const float s9_scale = p->slice9_scale;
 
-    /* Source's (origin, origin) point anchors at bbox center. Build sprite_mat4 = world × T(cx, cy) × S(sx, -sy, 1):
-     * source Y-up (image texels flow up) inverts before world maps to layout — col1 negates world.col1. */
+    /* Both emits share one matrix shape: sprite_mat4 = world × T(cx, cy) × S(sx, -sy, 1). Source is Y-up
+     * (texels flow up), so col1 negates world.col1 before world maps to layout. A plain quad scales its
+     * source onto the bbox; a nine-patch carries its own pixel sizes, so its scale is 1. */
     const float cx = bb.x + (bb.width * 0.5F);
     const float cy = bb.y + (bb.height * 0.5F);
-
-    if (emit_slice9) {
-        /* The grid carries its own pixel sizes, so the matrix only anchors and
-         * inverts it; the bbox center pairs with a centered pivot. A nine-patch
-         * fills its bbox unless the game moves the pivot explicitly. */
-        float sm[16];
-        for (int rr = 0; rr < 4; ++rr) {
-            sm[rr] = world_mat4[rr];
-            sm[4 + rr] = -world_mat4[4 + rr];
-            sm[8 + rr] = world_mat4[8 + rr];
-            sm[12 + rr] = (cx * world_mat4[rr]) + (cy * world_mat4[4 + rr]) + world_mat4[12 + rr];
-        }
-        const float s9_origin_x = (p->flags & NT_UI_IMAGE_ORIGIN_OVERRIDE) ? p->origin_x : 0.5F;
-        const float s9_origin_y = (p->flags & NT_UI_IMAGE_ORIGIN_OVERRIDE) ? p->origin_y : 0.5F;
-        const uint16_t *src = has_s9_override ? p->slice9_override : NULL;
-        nt_sprite_renderer_emit_slice9(p->atlas, p->region_index, sm, bb.width, bb.height, s9_origin_x, s9_origin_y, src, s9_scale, col, p->flip_bits);
-        return;
+    float sx_f = 1.0F;
+    float sy_f = 1.0F;
+    if (!emit_slice9) {
+        const float ipu = nt_atlas_get_inverse_pixels_per_unit(p->atlas);
+        const float src_w = (float)r->source_w * ipu;
+        const float src_h = (float)r->source_h * ipu;
+        NT_ASSERT(src_w > 0.0F && src_h > 0.0F && "nt_ui IMAGE: atlas region has zero source dimensions (broken atlas data)");
+        sx_f = bb.width / src_w;
+        sy_f = bb.height / src_h;
     }
-
-    const float ipu = nt_atlas_get_inverse_pixels_per_unit(p->atlas);
-    const float src_w = (float)r->source_w * ipu;
-    const float src_h = (float)r->source_h * ipu;
-    NT_ASSERT(src_w > 0.0F && src_h > 0.0F && "nt_ui IMAGE: atlas region has zero source dimensions (broken atlas data)");
-    const float sx_f = bb.width / src_w;
-    const float sy_f = bb.height / src_h;
     float m[16];
     for (int rr = 0; rr < 4; ++rr) {
         m[rr] = sx_f * world_mat4[rr];
         m[4 + rr] = -sy_f * world_mat4[4 + rr];
         m[8 + rr] = world_mat4[8 + rr];
         m[12 + rr] = (cx * world_mat4[rr]) + (cy * world_mat4[4 + rr]) + world_mat4[12 + rr];
+    }
+
+    if (emit_slice9) {
+        /* A nine-patch fills its bbox unless the game moves the pivot explicitly. */
+        const float origin_x = (p->flags & NT_UI_IMAGE_ORIGIN_OVERRIDE) ? p->origin_x : 0.5F;
+        const float origin_y = (p->flags & NT_UI_IMAGE_ORIGIN_OVERRIDE) ? p->origin_y : 0.5F;
+        const uint16_t *src = has_s9_override ? p->slice9_override : NULL;
+        nt_sprite_renderer_emit_slice9(p->atlas, p->region_index, m, bb.width, bb.height, origin_x, origin_y, src, p->slice9_scale, col, p->flip_bits);
+        return;
     }
     const float origin_x = (p->flags & NT_UI_IMAGE_ORIGIN_OVERRIDE) ? p->origin_x : r->origin_x;
     const float origin_y = (p->flags & NT_UI_IMAGE_ORIGIN_OVERRIDE) ? p->origin_y : r->origin_y;

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -778,11 +778,9 @@ bool nt_ui_widget_get_hit_padding(const nt_ui_context_t *ctx, uint32_t id, int16
 
 // #region helper_emit_screen_rect
 /* Unit square (0,0..1,1) onto the Clay bbox: origin at the bbox's bottom-left in layout, scaled by its size. */
-static inline void build_quad_mat4(const float world[16], float x, float y, float w, float h, float out_m[16]) { nt_ui_sprite_mat4(world, x, y + h, w, h, out_m); }
-
 static inline void emit_screen_rect(nt_resource_t atlas, uint32_t region_index, float x, float y, float w, float h, uint32_t color_packed, const float world_mat4[16]) {
     float m[16];
-    build_quad_mat4(world_mat4, x, y, w, h, m);
+    nt_ui_sprite_mat4(world_mat4, x, y + h, w, h, m);
     nt_sprite_renderer_emit_region(atlas, region_index, m, 0.0F, 0.0F, color_packed, 0U);
 }
 // #endregion
@@ -1298,22 +1296,11 @@ static void emit_text(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, f
     /* Y-down: baseline = bbox.y(top) + center_offset + ascent*scale. */
     const float baseline_y = c->boundingBox.y + center_offset + ((float)metrics.ascent * layout_scale);
 
-    /* Text-renderer local is Y-up; Clay positions are Y-down. Negating col1 always opposes the two
-     * so glyphs read upright — independent of how world_mat4 maps Clay→world (2D ortho, 3D billboard
-     * via negative scale_y, or inspector screen-space). */
-    const float ox = c->boundingBox.x;
-    const float oy = baseline_y;
-    const float sign_y = -1.0F;
     /* size already folds in text_scale (world X-magnitude), so the model handed to the renderer must
      * be scale-free like every other call site — else the X scale lands twice and glyphs shrink ~text_scale. */
     const float inv_ts = (text_scale > 0.0F) ? (1.0F / text_scale) : 0.0F;
     float m[16];
-    for (int rr = 0; rr < 4; ++rr) {
-        m[rr] = world_mat4[rr] * inv_ts;
-        m[4 + rr] = sign_y * world_mat4[4 + rr] * inv_ts;
-        m[8 + rr] = world_mat4[8 + rr] * inv_ts;
-        m[12 + rr] = (ox * world_mat4[rr]) + (oy * world_mat4[4 + rr]) + world_mat4[12 + rr];
-    }
+    nt_ui_sprite_mat4(world_mat4, c->boundingBox.x, baseline_y, inv_ts, inv_ts, m);
     const float color[4] = {
         t->textColor.r / 255.0F,
         t->textColor.g / 255.0F,

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -777,20 +777,8 @@ bool nt_ui_widget_get_hit_padding(const nt_ui_context_t *ctx, uint32_t id, int16
 // #endregion
 
 // #region helper_emit_screen_rect
-/* sprite_mat4 = world · T(x, y+h) · S(w, -h, 1) maps unit (0,0..1,1) → world. The (x, y+h) origin
- * and -h scale match the sprite renderer's unit-square convention (GL bottom-left at unit (0,0));
- * with Y-flip baked into world, this lands the Clay bbox at the correct GL pixels.
- * Math: out.col0 = w · world.col0; out.col1 = -h · world.col1; col2 unchanged; col3 = world · (x, y+h, 0, 1). */
-static inline void build_quad_mat4(const float world[16], float x, float y, float w, float h, float out_m[16]) {
-    const float ox = x;
-    const float oy = y + h;
-    for (int r = 0; r < 4; ++r) {
-        out_m[r] = w * world[r];
-        out_m[4 + r] = -h * world[4 + r];
-        out_m[8 + r] = world[8 + r];
-        out_m[12 + r] = (ox * world[r]) + (oy * world[4 + r]) + world[12 + r];
-    }
-}
+/* Unit square (0,0..1,1) onto the Clay bbox: origin at the bbox's bottom-left in layout, scaled by its size. */
+static inline void build_quad_mat4(const float world[16], float x, float y, float w, float h, float out_m[16]) { nt_ui_sprite_mat4(world, x, y + h, w, h, out_m); }
 
 static inline void emit_screen_rect(nt_resource_t atlas, uint32_t region_index, float x, float y, float w, float h, uint32_t color_packed, const float world_mat4[16]) {
     float m[16];
@@ -1162,22 +1150,19 @@ static void emit_image(const Clay_RenderCommand *c, const float world_mat4[16]) 
         return;
     }
 
-    /* Flag bit OR non-zero lrtb selects override; the flag with zeros DISABLES slice9,
-     * which is how nt_ui_fill's CROP reveal asks for a plain quad. */
-    const bool override_borders = (p->slice9_override[0] | p->slice9_override[1] | p->slice9_override[2] | p->slice9_override[3]) != 0;
-    const bool has_s9_override = (p->flags & NT_UI_IMAGE_SLICE9_OVERRIDE) || override_borders;
-    const bool region_slice9 = (r->slice9_lrtb[0] | r->slice9_lrtb[1] | r->slice9_lrtb[2] | r->slice9_lrtb[3]) != 0;
-    const bool emit_slice9 = has_s9_override ? override_borders : region_slice9;
+    /* The flag or a non-zero lrtb selects the override; the flag with zeros turns a baked
+     * nine-patch back into a plain quad (nt_ui_fill's CROP reveal relies on that). */
+    const bool has_override = (p->flags & NT_UI_IMAGE_SLICE9_OVERRIDE) || (p->slice9_override[0] | p->slice9_override[1] | p->slice9_override[2] | p->slice9_override[3]) != 0;
+    const uint16_t *s9 = has_override ? p->slice9_override : r->slice9_lrtb;
+    const bool sliced = (s9[0] | s9[1] | s9[2] | s9[3]) != 0;
     NT_ASSERT(isfinite(p->slice9_scale) && p->slice9_scale > 0.0F && "nt_ui walker: payload.slice9_scale must be finite > 0");
 
-    /* Both emits share one matrix shape: sprite_mat4 = world × T(cx, cy) × S(sx, -sy, 1). Source is Y-up
-     * (texels flow up), so col1 negates world.col1 before world maps to layout. A plain quad scales its
-     * source onto the bbox; a nine-patch carries its own pixel sizes, so its scale is 1. */
-    const float cx = bb.x + (bb.width * 0.5F);
-    const float cy = bb.y + (bb.height * 0.5F);
+    /* Source's (origin, origin) point anchors at bbox center. A plain quad scales its source onto the
+     * bbox; a nine-patch carries its own pixel sizes, so its scale is 1 and it fills the bbox from a
+     * centered pivot unless the game moves the pivot explicitly. */
     float sx_f = 1.0F;
     float sy_f = 1.0F;
-    if (!emit_slice9) {
+    if (!sliced) {
         const float ipu = nt_atlas_get_inverse_pixels_per_unit(p->atlas);
         const float src_w = (float)r->source_w * ipu;
         const float src_h = (float)r->source_h * ipu;
@@ -1186,23 +1171,14 @@ static void emit_image(const Clay_RenderCommand *c, const float world_mat4[16]) 
         sy_f = bb.height / src_h;
     }
     float m[16];
-    for (int rr = 0; rr < 4; ++rr) {
-        m[rr] = sx_f * world_mat4[rr];
-        m[4 + rr] = -sy_f * world_mat4[4 + rr];
-        m[8 + rr] = world_mat4[8 + rr];
-        m[12 + rr] = (cx * world_mat4[rr]) + (cy * world_mat4[4 + rr]) + world_mat4[12 + rr];
-    }
-
-    if (emit_slice9) {
-        /* A nine-patch fills its bbox unless the game moves the pivot explicitly. */
-        const float origin_x = (p->flags & NT_UI_IMAGE_ORIGIN_OVERRIDE) ? p->origin_x : 0.5F;
-        const float origin_y = (p->flags & NT_UI_IMAGE_ORIGIN_OVERRIDE) ? p->origin_y : 0.5F;
-        const uint16_t *src = has_s9_override ? p->slice9_override : NULL;
-        nt_sprite_renderer_emit_slice9(p->atlas, p->region_index, m, bb.width, bb.height, origin_x, origin_y, src, p->slice9_scale, col, p->flip_bits);
+    nt_ui_sprite_mat4(world_mat4, bb.x + (bb.width * 0.5F), bb.y + (bb.height * 0.5F), sx_f, sy_f, m);
+    const bool origin_ov = (p->flags & NT_UI_IMAGE_ORIGIN_OVERRIDE) != 0;
+    const float origin_x = origin_ov ? p->origin_x : (sliced ? 0.5F : r->origin_x);
+    const float origin_y = origin_ov ? p->origin_y : (sliced ? 0.5F : r->origin_y);
+    if (sliced) {
+        nt_sprite_renderer_emit_slice9(p->atlas, p->region_index, m, bb.width, bb.height, origin_x, origin_y, s9, p->slice9_scale, col, p->flip_bits);
         return;
     }
-    const float origin_x = (p->flags & NT_UI_IMAGE_ORIGIN_OVERRIDE) ? p->origin_x : r->origin_x;
-    const float origin_y = (p->flags & NT_UI_IMAGE_ORIGIN_OVERRIDE) ? p->origin_y : r->origin_y;
     nt_sprite_renderer_emit_region(p->atlas, p->region_index, m, origin_x, origin_y, col, p->flip_bits);
 }
 

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -1172,9 +1172,12 @@ static void emit_image(const Clay_RenderCommand *c, const float world_mat4[16]) 
     }
     float m[16];
     nt_ui_sprite_mat4(world_mat4, bb.x + (bb.width * 0.5F), bb.y + (bb.height * 0.5F), sx_f, sy_f, m);
-    const bool origin_ov = (p->flags & NT_UI_IMAGE_ORIGIN_OVERRIDE) != 0;
-    const float origin_x = origin_ov ? p->origin_x : (sliced ? 0.5F : r->origin_x);
-    const float origin_y = origin_ov ? p->origin_y : (sliced ? 0.5F : r->origin_y);
+    float origin_x = sliced ? 0.5F : r->origin_x;
+    float origin_y = sliced ? 0.5F : r->origin_y;
+    if (p->flags & NT_UI_IMAGE_ORIGIN_OVERRIDE) {
+        origin_x = p->origin_x;
+        origin_y = p->origin_y;
+    }
     if (sliced) {
         nt_sprite_renderer_emit_slice9(p->atlas, p->region_index, m, bb.width, bb.height, origin_x, origin_y, s9, p->slice9_scale, col, p->flip_bits);
         return;

--- a/engine/ui/nt_ui_image.h
+++ b/engine/ui/nt_ui_image.h
@@ -15,7 +15,7 @@ typedef struct nt_ui_context nt_ui_context_t;
 extern const nt_ui_widget_def_t NT_UI_IMAGE_DEF;
 
 /* Style flag bits. */
-#define NT_UI_IMAGE_SLICE9_OVERRIDE (1U << 0) /* use slice9_lrtb even if {0,0,0,0} */
+#define NT_UI_IMAGE_SLICE9_OVERRIDE (1U << 0) /* use slice9_lrtb; with {0,0,0,0} a baked nine-patch draws as a plain quad */
 #define NT_UI_IMAGE_ORIGIN_OVERRIDE (1U << 1) /* use origin_x/y instead of atlas default */
 
 typedef struct {

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -84,8 +84,9 @@ _Static_assert(sizeof(nt_ui_dfs_frame_t) == 80, "nt_ui_dfs_frame_t fixed at 80B"
  * layout through nt_color (the canonical home) then scales [0,1]->0..255; the
  * byte/255*255 round-trip is exact for all 256 byte values, so output is
  * byte-identical to a direct byte extract. */
-/* sprite_mat4 = world × T(ox, oy) × S(sx, -sy, 1). The sprite renderer's local space is Y-up while
- * layout is Y-down, so col1 is negated; this is the one place that inversion lives for images. */
+/* model = world × T(ox, oy) × S(sx, -sy, 1). Sprite and text renderers are Y-up locally while layout
+ * is Y-down, so col1 is negated — here and nowhere else. Glyphs read upright under any world_mat4
+ * (2D ortho, 3D billboard via negative scale_y, inspector screen-space) for the same reason. */
 static inline void nt_ui_sprite_mat4(const float world[16], float ox, float oy, float sx, float sy, float out[16]) {
     for (int r = 0; r < 4; ++r) {
         out[r] = sx * world[r];

--- a/engine/ui/nt_ui_internal.h
+++ b/engine/ui/nt_ui_internal.h
@@ -84,6 +84,17 @@ _Static_assert(sizeof(nt_ui_dfs_frame_t) == 80, "nt_ui_dfs_frame_t fixed at 80B"
  * layout through nt_color (the canonical home) then scales [0,1]->0..255; the
  * byte/255*255 round-trip is exact for all 256 byte values, so output is
  * byte-identical to a direct byte extract. */
+/* sprite_mat4 = world × T(ox, oy) × S(sx, -sy, 1). The sprite renderer's local space is Y-up while
+ * layout is Y-down, so col1 is negated; this is the one place that inversion lives for images. */
+static inline void nt_ui_sprite_mat4(const float world[16], float ox, float oy, float sx, float sy, float out[16]) {
+    for (int r = 0; r < 4; ++r) {
+        out[r] = sx * world[r];
+        out[4 + r] = -sy * world[4 + r];
+        out[8 + r] = world[8 + r];
+        out[12 + r] = (ox * world[r]) + (oy * world[4 + r]) + world[12 + r];
+    }
+}
+
 static inline Clay_Color nt_ui_unpack_abgr(uint32_t packed) {
     float rgba[4];
     nt_color_unpack(packed, rgba);

--- a/engine/ui/nt_ui_rich_text.c
+++ b/engine/ui/nt_ui_rich_text.c
@@ -1988,24 +1988,11 @@ static nt_ui_rich_fx_result_t rich_eval_fx(const nt_ui_rich_state_t *st, const n
     return fn(s->fx_idx, s->kind, base_xy, base_wh, base_color, st->time, hovered, user_data);
 }
 
-/* Per-span model mat4 for draw_n: LAYOUT pen (ox,oy) -> world, with the text Y-up <-> Clay Y-down
- * flip on col1 (mirrors emit_text in nt_ui.c). Synthetic-italic lean is applied by the text renderer
- * (nt_text_renderer_set_oblique), not baked here -> faux-italic is ONE mechanism for every text caller. */
-static void rich_span_model(const float world[16], float ox, float oy, float out[16]) {
-    const float sign_y = -1.0F;
-    for (int rr = 0; rr < 4; ++rr) {
-        out[rr] = world[rr];
-        out[4 + rr] = sign_y * world[4 + rr]; /* Y-flip */
-        out[8 + rr] = world[8 + rr];
-        out[12 + rr] = (ox * world[rr]) + (oy * world[4 + rr]) + world[12 + rr];
-    }
-}
-
 /* Emit one TEXT atom WITHOUT an effect: one span per atom (batch-friendly). */
 static void rich_emit_text_plain(nt_ui_rich_state_t *st, const nt_ui_custom_frame_t *frame, const nt_ui_rich_solved_atom_t *s, float box_x, float box_y) {
     const float baseline_y = box_y + s->y + s->asc; /* solved y is glyph-box top */
     float model[16];
-    rich_span_model(frame->world_mat4, box_x + s->x, baseline_y, model);
+    nt_ui_sprite_mat4(frame->world_mat4, box_x + s->x, baseline_y, 1.0F, 1.0F, model);
     float color[4];
     rich_unpack_color(s->color, frame->opacity, color);
     nt_text_renderer_draw_n(st->text + s->text_off, s->text_len, model, s->size, color, 0.0F, 0.0F);
@@ -2050,7 +2037,7 @@ static void rich_emit_text_effected(nt_ui_rich_state_t *st, const nt_ui_custom_f
             const float scaled_x = cx - ((gw * 0.5F) * fx.scale);
             const float baseline_y = box_y + s->y + s->asc + fx.offset_y;
             float model[16];
-            rich_span_model(frame->world_mat4, box_x + scaled_x + fx.offset_x, baseline_y, model);
+            nt_ui_sprite_mat4(frame->world_mat4, box_x + scaled_x + fx.offset_x, baseline_y, 1.0F, 1.0F, model);
             nt_text_renderer_draw_n(st->text + g0, gi - g0, model, s->size * fx.scale, fx.color, 0.0F, 0.0F);
             st->emit_span_count++;
         }

--- a/engine/ui/nt_ui_rich_text.c
+++ b/engine/ui/nt_ui_rich_text.c
@@ -2134,14 +2134,8 @@ static void rich_emit_images(nt_ui_rich_state_t *st, const nt_ui_custom_frame_t 
         const float sy_f = scaled_h / src_h;
         const float cx = bx + (scaled_w * 0.5F);
         const float cy = by + (scaled_h * 0.5F);
-        const float *world = frame->world_mat4;
         float m[16];
-        for (int rr = 0; rr < 4; ++rr) {
-            m[rr] = sx_f * world[rr];
-            m[4 + rr] = -sy_f * world[4 + rr];
-            m[8 + rr] = world[8 + rr];
-            m[12 + rr] = (cx * world[rr]) + (cy * world[4 + rr]) + world[12 + rr];
-        }
+        nt_ui_sprite_mat4(frame->world_mat4, cx, cy, sx_f, sy_f, m);
         if (!bound) {
             nt_sprite_renderer_set_material(st->image_material); /* bind ONCE: all images coalesce into one batch */
             bound = true;

--- a/tests/unit/test_helpers/ui_atlas.c
+++ b/tests/unit/test_helpers/ui_atlas.c
@@ -151,22 +151,24 @@ static void ui_atlas_build_inner_blob(uint8_t *out_blob, uint32_t suffix) {
     /* ---- Vertices: 4 white + 6 polygon-hull + 4 packed ---- */
     NtAtlasVertex verts[UI_ATLAS_VERTEX_COUNT] = {
         /* white quad (trim-local 0..1, atlas UV 0..0xFFFF) */
-        {0, 0, 0, 0},
-        {1, 0, 0xFFFF, 0},
-        {1, 1, 0xFFFF, 0xFFFF},
-        {0, 1, 0, 0xFFFF},
+        {0, 0, 0, 0xFFFF},
+        {1, 0, 0xFFFF, 0xFFFF},
+        {1, 1, 0xFFFF, 0},
+        {0, 1, 0, 0},
         /* polygon hull (hexagon-ish, 6 unique verts) */
         {0, 8, 0, 0x8000},
-        {8, 0, 0x8000, 0},
+        {8, 0, 0x8000, 0xFFFF},
         {16, 8, 0xFFFF, 0x8000},
-        {16, 16, 0xFFFF, 0xFFFF},
-        {8, 16, 0x8000, 0xFFFF},
+        {16, 16, 0xFFFF, 0},
+        {8, 16, 0x8000, 0},
         {0, 8, 0, 0x8000},
-        /* packed sub-region quad: atlas UV in [0.25,0.5]x[0.5,0.75] (non-[0,1]) */
-        {0, 0, UI_ATLAS_PACKED_U0, UI_ATLAS_PACKED_V0},
-        {8, 0, UI_ATLAS_PACKED_U1, UI_ATLAS_PACKED_V0},
-        {8, 8, UI_ATLAS_PACKED_U1, UI_ATLAS_PACKED_V1},
-        {0, 8, UI_ATLAS_PACKED_U0, UI_ATLAS_PACKED_V1},
+        /* packed sub-region quad: atlas UV in [0.25,0.5]x[0.5,0.75] (non-[0,1]).
+         * local_y is Y-up and V is PNG Y-down, so they pair inverted — same as
+         * the builder emits (nt_builder_atlas.c pipeline_serialize). */
+        {0, 0, UI_ATLAS_PACKED_U0, UI_ATLAS_PACKED_V1},
+        {8, 0, UI_ATLAS_PACKED_U1, UI_ATLAS_PACKED_V1},
+        {8, 8, UI_ATLAS_PACKED_U1, UI_ATLAS_PACKED_V0},
+        {0, 8, UI_ATLAS_PACKED_U0, UI_ATLAS_PACKED_V0},
     };
     memcpy(out_blob + UI_ATLAS_VERTEX_OFFSET, verts, sizeof verts);
 

--- a/tests/unit/test_helpers/ui_atlas.h
+++ b/tests/unit/test_helpers/ui_atlas.h
@@ -13,13 +13,12 @@ extern "C" {
 
 /* Min/max atlas UV (0..1) of the packed sub-region (index 2). Tests assert the
  * walker-baked a_uvrect against these. Raw u16: u in [0.25,0.5], v in [0.5,0.75]. */
-#define MINIMAL_UI_ATLAS_PACKED_U0 (0x4000 / 65535.0F)
-#define MINIMAL_UI_ATLAS_PACKED_V0 (0x8000 / 65535.0F)
-#define MINIMAL_UI_ATLAS_PACKED_U1 (0x8000 / 65535.0F)
-#define MINIMAL_UI_ATLAS_PACKED_V1 (0xC000 / 65535.0F)
-/* Same bounds in raw u16, for tests asserting emitted texcoords directly. */
 #define MINIMAL_UI_ATLAS_PACKED_V0_RAW 0x8000U
 #define MINIMAL_UI_ATLAS_PACKED_V1_RAW 0xC000U
+#define MINIMAL_UI_ATLAS_PACKED_U0 (0x4000 / 65535.0F)
+#define MINIMAL_UI_ATLAS_PACKED_V0 (MINIMAL_UI_ATLAS_PACKED_V0_RAW / 65535.0F)
+#define MINIMAL_UI_ATLAS_PACKED_U1 (0x8000 / 65535.0F)
+#define MINIMAL_UI_ATLAS_PACKED_V1 (MINIMAL_UI_ATLAS_PACKED_V1_RAW / 65535.0F)
 
 /* Mounts a virtual pack with a synthetic atlas blob and parses it
  * through the full atlas activator, yielding a real READY resource

--- a/tests/unit/test_helpers/ui_atlas.h
+++ b/tests/unit/test_helpers/ui_atlas.h
@@ -17,6 +17,9 @@ extern "C" {
 #define MINIMAL_UI_ATLAS_PACKED_V0 (0x8000 / 65535.0F)
 #define MINIMAL_UI_ATLAS_PACKED_U1 (0x8000 / 65535.0F)
 #define MINIMAL_UI_ATLAS_PACKED_V1 (0xC000 / 65535.0F)
+/* Same bounds in raw u16, for tests asserting emitted texcoords directly. */
+#define MINIMAL_UI_ATLAS_PACKED_V0_RAW 0x8000U
+#define MINIMAL_UI_ATLAS_PACKED_V1_RAW 0xC000U
 
 /* Mounts a virtual pack with a synthetic atlas blob and parses it
  * through the full atlas activator, yielding a real READY resource

--- a/tests/unit/test_nt_sprite_renderer_emit_region.c
+++ b/tests/unit/test_nt_sprite_renderer_emit_region.c
@@ -607,23 +607,23 @@ static void test_slice9_flip_y(void) {
     const uint16_t b_flipy[4] = {4, 4, 4, 8};
     nt_sprite_renderer_emit_slice9(atlas, 0, 0.0F, 0.0F, 100.0F, 80.0F, b_flipy, 1.0F, 0xFFFFFFFFU, NT_SPRITE_FLAG_FLIP_Y, NT_MATH_MAT4_IDENTITY);
 
-    /* FLIP_Y: ft=8, fb=4 -> y splits = [0, 4, 72, 80] */
+    /* FLIP_Y swaps the borders: ft=8, fb=4 -> y splits = [0, 8, 76, 80] */
     float pos[3];
-    /* Grid (1,0) = vertex 4 = (xs[0], ys[1]) = (0, 4) */
+    /* Grid (1,0) = vertex 4 = (xs[0], ys[1]) = (0, 8) */
     nt_sprite_renderer_test_last_emit_position(4, pos);
-    TEST_ASSERT_TRUE(pos[1] == 4.0F); /* NOLINT */
+    TEST_ASSERT_TRUE(pos[1] == 8.0F); /* NOLINT */
 
-    /* Grid (2,0) = vertex 8 = (xs[0], ys[2]) = (0, 72) */
+    /* Grid (2,0) = vertex 8 = (xs[0], ys[2]) = (0, 76) */
     nt_sprite_renderer_test_last_emit_position(8, pos);
-    TEST_ASSERT_TRUE(pos[1] == 72.0F); /* NOLINT */
+    TEST_ASSERT_TRUE(pos[1] == 76.0F); /* NOLINT */
 
-    /* After V inversion + FLIP_Y: vs[0]<->vs[3] swap. Row-0 V < Row-2 V
-     * (bottom row flipped = original top = smaller V in PNG space). */
-    uint16_t uv_bot[2];
+    /* Unflipped, row 0 (the rect's top) samples v_min; FLIP_Y reverses the V
+     * order, so the top row now samples the source's bottom. */
     uint16_t uv_top[2];
-    nt_sprite_renderer_test_last_emit_texcoord(0, uv_bot); /* row 0 */
-    nt_sprite_renderer_test_last_emit_texcoord(8, uv_top); /* row 2 */
-    TEST_ASSERT_TRUE(uv_bot[1] < uv_top[1]);
+    uint16_t uv_lower[2];
+    nt_sprite_renderer_test_last_emit_texcoord(0, uv_top);   /* row 0 */
+    nt_sprite_renderer_test_last_emit_texcoord(8, uv_lower); /* row 2 */
+    TEST_ASSERT_TRUE(uv_top[1] > uv_lower[1]);
 
     nt_sprite_renderer_flush();
 }

--- a/tests/unit/test_nt_sprite_renderer_emit_region.c
+++ b/tests/unit/test_nt_sprite_renderer_emit_region.c
@@ -577,17 +577,20 @@ static void test_slice9_flip_x(void) {
     nt_sprite_renderer_test_last_emit_position(2, pos);
     TEST_ASSERT_TRUE(pos[0] == 96.0F); /* NOLINT */
 
-    /* UV flip: us reversed => us[0] > us[3] for flipped axis.
-     * u_min=1000, u_max=5000, u_range=4000, source_w=64
-     * After swap borders: us computed with fl=8,fr=4 = [1000, 1500, 4750, 5000]
-     * After UV flip: us = [5000, 4750, 1500, 1000]
-     * Grid (0,0) uses us[0]=5000, Grid (0,1) uses us[1]=4750 */
+    /* u_min=1000, u_max=5000, u_range=4000, source_w=64 -> 62.5 u per source px.
+     * The 8-wide left band shows the source's RIGHT border, so it must span 8
+     * source px: 5000 -> 4500. (An extra src-border swap would make it 4750,
+     * i.e. 4 source px stretched over 8 units.) */
     uint16_t uv[2];
     nt_sprite_renderer_test_last_emit_texcoord(0, uv);
-    TEST_ASSERT_EQUAL_UINT16(5000, uv[0]); /* us[0] flipped */
+    TEST_ASSERT_EQUAL_UINT16(5000, uv[0]);
 
     nt_sprite_renderer_test_last_emit_texcoord(1, uv);
-    TEST_ASSERT_EQUAL_UINT16(4750, uv[0]); /* us[1] flipped */
+    TEST_ASSERT_EQUAL_UINT16(4500, uv[0]);
+
+    /* The 4-wide right band shows the source's LEFT border: 4 px from u_min. */
+    nt_sprite_renderer_test_last_emit_texcoord(2, uv);
+    TEST_ASSERT_EQUAL_UINT16(1250, uv[0]);
 
     nt_sprite_renderer_flush();
 }
@@ -618,12 +621,18 @@ static void test_slice9_flip_y(void) {
     TEST_ASSERT_TRUE(pos[1] == 76.0F); /* NOLINT */
 
     /* Unflipped, row 0 (the rect's top) samples v_min; FLIP_Y reverses the V
-     * order, so the top row now samples the source's bottom. */
+     * order, so the top row now samples the source's bottom.
+     * v_min=2000, v_max=6000, v_range=4000, source_h=64 -> 62.5 v per source px.
+     * The 8-wide top band shows the source's BOTTOM border: 6000 -> 5500.
+     * Row 2 is 4 source px in from v_min (the top border): 2250. */
     uint16_t uv_top[2];
     uint16_t uv_lower[2];
     nt_sprite_renderer_test_last_emit_texcoord(0, uv_top);   /* row 0 */
+    nt_sprite_renderer_test_last_emit_texcoord(4, uv_lower); /* row 1 */
+    TEST_ASSERT_EQUAL_UINT16(6000, uv_top[1]);
+    TEST_ASSERT_EQUAL_UINT16(5500, uv_lower[1]);
     nt_sprite_renderer_test_last_emit_texcoord(8, uv_lower); /* row 2 */
-    TEST_ASSERT_TRUE(uv_top[1] > uv_lower[1]);
+    TEST_ASSERT_EQUAL_UINT16(2250, uv_lower[1]);
 
     nt_sprite_renderer_flush();
 }

--- a/tests/unit/test_nt_sprite_renderer_emit_region.c
+++ b/tests/unit/test_nt_sprite_renderer_emit_region.c
@@ -493,7 +493,7 @@ static void test_slice9_basic(void) {
     nt_sprite_renderer_set_material(mat);
 
     const uint16_t b4[4] = {4, 4, 4, 4};
-    nt_sprite_renderer_emit_slice9(atlas, 0, 0.0F, 0.0F, 100.0F, 80.0F, b4, 1.0F, 0xFFFFFFFFU, 0U, NT_MATH_MAT4_IDENTITY);
+    nt_sprite_renderer_emit_slice9(atlas, 0, NT_MATH_MAT4_IDENTITY, 100.0F, 80.0F, 0.0F, 0.0F, b4, 1.0F, 0xFFFFFFFFU, 0U);
 
     TEST_ASSERT_EQUAL_UINT32(16, nt_sprite_renderer_test_last_slice9_vertex_count());
     TEST_ASSERT_EQUAL_UINT32(54, nt_sprite_renderer_test_last_slice9_index_count());
@@ -514,7 +514,7 @@ static void test_slice9_positions(void) {
 
     /* Target: (0,0,100,80), borders: (4,4,4,4) */
     const uint16_t b4[4] = {4, 4, 4, 4};
-    nt_sprite_renderer_emit_slice9(atlas, 0, 0.0F, 0.0F, 100.0F, 80.0F, b4, 1.0F, 0xFFFFFFFFU, 0U, NT_MATH_MAT4_IDENTITY);
+    nt_sprite_renderer_emit_slice9(atlas, 0, NT_MATH_MAT4_IDENTITY, 100.0F, 80.0F, 0.0F, 0.0F, b4, 1.0F, 0xFFFFFFFFU, 0U);
 
     /* Expected x splits: [0, 4, 96, 100] */
     /* Expected y splits: [0, 4, 76, 80]  */
@@ -552,9 +552,8 @@ static void test_slice9_positions(void) {
     nt_sprite_renderer_flush();
 }
 
-/* Test: flip_x swaps left/right borders in positions and mirrors UVs.
+/* Test: flip mirrors the grid by negating positions; bands and UV cuts ride along.
  * Grid layout: vertex index = row*4 + col. */
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void test_slice9_flip_x(void) {
     nt_sprite_renderer_desc_t rd = nt_sprite_renderer_desc_defaults();
     TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&rd));
@@ -563,41 +562,36 @@ static void test_slice9_flip_x(void) {
     nt_material_t mat = create_test_material();
     nt_sprite_renderer_set_material(mat);
 
-    /* Asymmetric borders: L=4, R=8 to detect swap */
+    /* Asymmetric borders: L=4, R=8. */
     const uint16_t b_flipx[4] = {4, 8, 4, 4};
-    nt_sprite_renderer_emit_slice9(atlas, 0, 0.0F, 0.0F, 100.0F, 80.0F, b_flipx, 1.0F, 0xFFFFFFFFU, NT_SPRITE_FLAG_FLIP_X, NT_MATH_MAT4_IDENTITY);
+    nt_sprite_renderer_emit_slice9(atlas, 0, NT_MATH_MAT4_IDENTITY, 100.0F, 80.0F, 0.0F, 0.0F, b_flipx, 1.0F, 0xFFFFFFFFU, NT_SPRITE_FLAG_FLIP_X);
 
-    /* With FLIP_X: fl=8, fr=4, so position splits become [0, 8, 96, 100] */
+    /* Pivot (0,0) with a mirror puts the footprint in [-100, 0]. Columns keep
+     * their own band and UV: the 4-wide L band still samples 4 source px
+     * (u_min=1000, u_max=5000, source_w=64 -> 62.5 u per px), it just lands at
+     * the other end of the sprite. */
     float pos[3];
-    /* Grid (0,1) = vertex 1 = xs[1] = 8 */
-    nt_sprite_renderer_test_last_emit_position(1, pos);
-    TEST_ASSERT_TRUE(pos[0] == 8.0F); /* NOLINT */
-
-    /* Grid (0,2) = vertex 2 = xs[2] = 96 */
-    nt_sprite_renderer_test_last_emit_position(2, pos);
-    TEST_ASSERT_TRUE(pos[0] == 96.0F); /* NOLINT */
-
-    /* u_min=1000, u_max=5000, u_range=4000, source_w=64 -> 62.5 u per source px.
-     * The 8-wide left band shows the source's RIGHT border, so it must span 8
-     * source px: 5000 -> 4500. (An extra src-border swap would make it 4750,
-     * i.e. 4 source px stretched over 8 units.) */
     uint16_t uv[2];
+    nt_sprite_renderer_test_last_emit_position(0, pos);
     nt_sprite_renderer_test_last_emit_texcoord(0, uv);
-    TEST_ASSERT_EQUAL_UINT16(5000, uv[0]);
+    TEST_ASSERT_TRUE(pos[0] == 0.0F); /* NOLINT */
+    TEST_ASSERT_EQUAL_UINT16(1000, uv[0]);
 
+    nt_sprite_renderer_test_last_emit_position(1, pos);
     nt_sprite_renderer_test_last_emit_texcoord(1, uv);
-    TEST_ASSERT_EQUAL_UINT16(4500, uv[0]);
-
-    /* The 4-wide right band shows the source's LEFT border: 4 px from u_min. */
-    nt_sprite_renderer_test_last_emit_texcoord(2, uv);
+    TEST_ASSERT_TRUE(pos[0] == -4.0F); /* NOLINT */
     TEST_ASSERT_EQUAL_UINT16(1250, uv[0]);
+
+    nt_sprite_renderer_test_last_emit_position(2, pos);
+    nt_sprite_renderer_test_last_emit_texcoord(2, uv);
+    TEST_ASSERT_TRUE(pos[0] == -92.0F); /* NOLINT */
+    TEST_ASSERT_EQUAL_UINT16(4500, uv[0]);
 
     nt_sprite_renderer_flush();
 }
 
-/* Test: flip_y swaps top/bottom borders and mirrors V UVs.
+/* Test: FLIP_Y is the same mirror on the other axis.
  * Grid layout: vertex index = row*4 + col. */
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void test_slice9_flip_y(void) {
     nt_sprite_renderer_desc_t rd = nt_sprite_renderer_desc_defaults();
     TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&rd));
@@ -606,33 +600,28 @@ static void test_slice9_flip_y(void) {
     nt_material_t mat = create_test_material();
     nt_sprite_renderer_set_material(mat);
 
-    /* Asymmetric: T=4, B=8 */
+    /* Asymmetric: T=4, B=8. */
     const uint16_t b_flipy[4] = {4, 4, 4, 8};
-    nt_sprite_renderer_emit_slice9(atlas, 0, 0.0F, 0.0F, 100.0F, 80.0F, b_flipy, 1.0F, 0xFFFFFFFFU, NT_SPRITE_FLAG_FLIP_Y, NT_MATH_MAT4_IDENTITY);
+    nt_sprite_renderer_emit_slice9(atlas, 0, NT_MATH_MAT4_IDENTITY, 100.0F, 80.0F, 0.0F, 0.0F, b_flipy, 1.0F, 0xFFFFFFFFU, NT_SPRITE_FLAG_FLIP_Y);
 
-    /* FLIP_Y swaps the borders: ft=8, fb=4 -> y splits = [0, 8, 76, 80] */
+    /* Row 0 is the local bottom: B=8 wide, sampling 8 source rows down from
+     * v_max (v_min=2000, v_max=6000, source_h=64 -> 62.5 v per row). */
     float pos[3];
-    /* Grid (1,0) = vertex 4 = (xs[0], ys[1]) = (0, 8) */
+    uint16_t uv[2];
+    nt_sprite_renderer_test_last_emit_position(0, pos);
+    nt_sprite_renderer_test_last_emit_texcoord(0, uv);
+    TEST_ASSERT_TRUE(pos[1] == 0.0F); /* NOLINT */
+    TEST_ASSERT_EQUAL_UINT16(6000, uv[1]);
+
     nt_sprite_renderer_test_last_emit_position(4, pos);
-    TEST_ASSERT_TRUE(pos[1] == 8.0F); /* NOLINT */
+    nt_sprite_renderer_test_last_emit_texcoord(4, uv);
+    TEST_ASSERT_TRUE(pos[1] == -8.0F); /* NOLINT */
+    TEST_ASSERT_EQUAL_UINT16(5500, uv[1]);
 
-    /* Grid (2,0) = vertex 8 = (xs[0], ys[2]) = (0, 76) */
     nt_sprite_renderer_test_last_emit_position(8, pos);
-    TEST_ASSERT_TRUE(pos[1] == 76.0F); /* NOLINT */
-
-    /* Unflipped, row 0 (the rect's top) samples v_min; FLIP_Y reverses the V
-     * order, so the top row now samples the source's bottom.
-     * v_min=2000, v_max=6000, v_range=4000, source_h=64 -> 62.5 v per source px.
-     * The 8-wide top band shows the source's BOTTOM border: 6000 -> 5500.
-     * Row 2 is 4 source px in from v_min (the top border): 2250. */
-    uint16_t uv_top[2];
-    uint16_t uv_lower[2];
-    nt_sprite_renderer_test_last_emit_texcoord(0, uv_top);   /* row 0 */
-    nt_sprite_renderer_test_last_emit_texcoord(4, uv_lower); /* row 1 */
-    TEST_ASSERT_EQUAL_UINT16(6000, uv_top[1]);
-    TEST_ASSERT_EQUAL_UINT16(5500, uv_lower[1]);
-    nt_sprite_renderer_test_last_emit_texcoord(8, uv_lower); /* row 2 */
-    TEST_ASSERT_EQUAL_UINT16(2250, uv_lower[1]);
+    nt_sprite_renderer_test_last_emit_texcoord(8, uv);
+    TEST_ASSERT_TRUE(pos[1] == -76.0F); /* NOLINT */
+    TEST_ASSERT_EQUAL_UINT16(2250, uv[1]);
 
     nt_sprite_renderer_flush();
 }
@@ -654,7 +643,7 @@ static void test_slice9_tombstone_noop(void) {
     /* Emit a normal slice9 — should work and advance vertex_count by 16. */
     nt_resource_t atlas = register_slice9_atlas(0xC6ULL);
     const uint16_t b2[4] = {2, 2, 2, 2};
-    nt_sprite_renderer_emit_slice9(atlas, 0, 0.0F, 0.0F, 50.0F, 50.0F, b2, 1.0F, 0xFFFFFFFFU, 0U, NT_MATH_MAT4_IDENTITY);
+    nt_sprite_renderer_emit_slice9(atlas, 0, NT_MATH_MAT4_IDENTITY, 50.0F, 50.0F, 0.0F, 0.0F, b2, 1.0F, 0xFFFFFFFFU, 0U);
     TEST_ASSERT_EQUAL_UINT32(vc_before + 16U, nt_sprite_renderer_test_vertex_count());
 
     nt_sprite_renderer_flush();
@@ -676,7 +665,7 @@ static void test_slice9_mat4_translation(void) {
     m[13] = 30.0F;
 
     const uint16_t b4[4] = {4, 4, 4, 4};
-    nt_sprite_renderer_emit_slice9(atlas, 0, 0.0F, 0.0F, 100.0F, 80.0F, b4, 1.0F, 0xFFFFFFFFU, 0U, m);
+    nt_sprite_renderer_emit_slice9(atlas, 0, m, 100.0F, 80.0F, 0.0F, 0.0F, b4, 1.0F, 0xFFFFFFFFU, 0U);
 
     /* Vertex 0 (bbox top-left in layout) = (0, 0) → (50, 30). */
     float pos[3];
@@ -712,7 +701,7 @@ static void test_slice9_mat4_rotation_90(void) {
     m[5] = 0.0F;
 
     const uint16_t b4[4] = {4, 4, 4, 4};
-    nt_sprite_renderer_emit_slice9(atlas, 0, 0.0F, 0.0F, 100.0F, 80.0F, b4, 1.0F, 0xFFFFFFFFU, 0U, m);
+    nt_sprite_renderer_emit_slice9(atlas, 0, m, 100.0F, 80.0F, 0.0F, 0.0F, b4, 1.0F, 0xFFFFFFFFU, 0U);
 
     float pos[3];
     /* Vertex 0 = layout (0, 0) → (0, 0). */

--- a/tests/unit/test_nt_sprite_renderer_emit_region.c
+++ b/tests/unit/test_nt_sprite_renderer_emit_region.c
@@ -495,8 +495,8 @@ static void test_slice9_basic(void) {
     const uint16_t b4[4] = {4, 4, 4, 4};
     nt_sprite_renderer_emit_slice9(atlas, 0, NT_MATH_MAT4_IDENTITY, 100.0F, 80.0F, 0.0F, 0.0F, b4, 1.0F, 0xFFFFFFFFU, 0U);
 
-    TEST_ASSERT_EQUAL_UINT32(16, nt_sprite_renderer_test_last_slice9_vertex_count());
-    TEST_ASSERT_EQUAL_UINT32(54, nt_sprite_renderer_test_last_slice9_index_count());
+    TEST_ASSERT_EQUAL_UINT32(16, nt_sprite_renderer_test_last_emit_vertex_count());
+    TEST_ASSERT_EQUAL_UINT32(54, nt_sprite_renderer_test_last_emit_index_count());
 
     nt_sprite_renderer_flush();
 }

--- a/tests/unit/test_nt_ui_image.c
+++ b/tests/unit/test_nt_ui_image.c
@@ -8,6 +8,7 @@
 
 #include "clay.h"
 #include "core/nt_assert.h"
+#include "renderers/nt_sprite_renderer.h"
 #include "test_helpers/nt_assert_trap.h"
 #include "test_helpers/ui_test_arena.h"
 #include "test_helpers/ui_walker_fixture.h"
@@ -241,6 +242,67 @@ static void test_image_invalid_atlas_asserts(void) {
 
 #endif /* NT_ASSERT_MODE == NT_ASSERT_FULL */
 
+/* ---- Test 10: slice9 and single-quad paths orient the source alike ---- */
+/* Atlas V of the emitted vertex nearest the top of the screen (world is Y-up,
+ * so that is the largest position[1]). */
+static uint16_t top_edge_v(uint32_t vertex_count) {
+    float best_y = -1.0F;
+    uint16_t best_v = 0;
+    for (uint32_t i = 0; i < vertex_count; ++i) {
+        float pos[3];
+        uint16_t uv[2];
+        nt_sprite_renderer_test_last_emit_position(i, pos);
+        nt_sprite_renderer_test_last_emit_texcoord(i, uv);
+        if (pos[1] > best_y) {
+            best_y = pos[1];
+            best_v = uv[1];
+        }
+    }
+    return best_v;
+}
+
+static uint16_t walk_image_top_edge_v(const nt_ui_image_style_t *style) {
+    nt_pointer_t mouse = {0};
+    nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
+    nt_atlas_region_ref_t ref = nt_atlas_ref_idx(s_fx.atlas.handle, 0, s_fx.atlas.packed_region_idx);
+    const Clay_ElementDeclaration decl = {.layout = {.sizing = {CLAY_SIZING_FIXED(80), CLAY_SIZING_FIXED(60)}}};
+    nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
+    CLAY({.id = CLAY_ID("root")}) { nt_ui_image(s_fx.ctx, NULL, &ref, style, &decl); }
+    nt_ui_end(s_fx.ctx);
+    nt_ui_walk(s_fx.ctx, &target);
+    return top_edge_v(nt_sprite_renderer_test_last_emit_vertex_count());
+}
+
+static void test_image_slice9_orientation_matches_single_quad(void) {
+    nt_ui_image_style_t plain = nt_ui_image_style_defaults();
+    const uint16_t plain_top_v = walk_image_top_edge_v(&plain);
+
+    /* Asymmetric T/B so a swapped border assignment cannot pass. */
+    nt_ui_image_style_t sliced = nt_ui_image_style_defaults();
+    sliced.flags |= NT_UI_IMAGE_SLICE9_OVERRIDE;
+    sliced.slice9_lrtb[0] = 2;
+    sliced.slice9_lrtb[1] = 2;
+    sliced.slice9_lrtb[2] = 2;
+    sliced.slice9_lrtb[3] = 4;
+    const uint16_t sliced_top_v = walk_image_top_edge_v(&sliced);
+
+    /* The packed region spans V 0x8000..0xC000; its top source row is 0x8000.
+     * Both paths must put that row at the top of the rect. */
+    TEST_ASSERT_EQUAL_UINT16(MINIMAL_UI_ATLAS_PACKED_V0_RAW, plain_top_v);
+    TEST_ASSERT_EQUAL_UINT16(plain_top_v, sliced_top_v);
+
+    /* Grid row 1 is the T border seam: 2 px down the screen (world Y-up), and
+     * 2 of the 8 source rows into the region's V span. */
+    float top_pos[3];
+    float seam_pos[3];
+    uint16_t seam_uv[2];
+    nt_sprite_renderer_test_last_emit_position(0U, top_pos);
+    nt_sprite_renderer_test_last_emit_position(4U, seam_pos);
+    nt_sprite_renderer_test_last_emit_texcoord(4U, seam_uv);
+    TEST_ASSERT_EQUAL_INT32(2, (int32_t)(top_pos[1] - seam_pos[1]));
+    TEST_ASSERT_EQUAL_UINT16(MINIMAL_UI_ATLAS_PACKED_V0_RAW + ((MINIMAL_UI_ATLAS_PACKED_V1_RAW - MINIMAL_UI_ATLAS_PACKED_V0_RAW) / 4U), seam_uv[1]);
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_image_basic);
@@ -252,6 +314,7 @@ int main(void) {
     RUN_TEST(test_image_style_defaults);
     RUN_TEST(test_image_resolves_from_invalid_under_ready_atlas);
     RUN_TEST(test_image_unresolved_skips_emit_no_assert);
+    RUN_TEST(test_image_slice9_orientation_matches_single_quad);
 #if NT_ASSERT_MODE == NT_ASSERT_FULL
     RUN_TEST(test_image_null_style_asserts);
     RUN_TEST(test_image_invalid_atlas_asserts);

--- a/tests/unit/test_nt_ui_image.c
+++ b/tests/unit/test_nt_ui_image.c
@@ -9,6 +9,7 @@
 #include "clay.h"
 #include "core/nt_assert.h"
 #include "renderers/nt_sprite_renderer.h"
+#include "sprite_comp/nt_sprite_comp.h"
 #include "test_helpers/nt_assert_trap.h"
 #include "test_helpers/ui_test_arena.h"
 #include "test_helpers/ui_walker_fixture.h"
@@ -301,6 +302,15 @@ static void test_image_slice9_orientation_matches_single_quad(void) {
     nt_sprite_renderer_test_last_emit_texcoord(4U, seam_uv);
     TEST_ASSERT_EQUAL_INT32(2, (int32_t)(top_pos[1] - seam_pos[1]));
     TEST_ASSERT_EQUAL_UINT16(MINIMAL_UI_ATLAS_PACKED_V0_RAW + ((MINIMAL_UI_ATLAS_PACKED_V1_RAW - MINIMAL_UI_ATLAS_PACKED_V0_RAW) / 4U), seam_uv[1]);
+
+    /* Under FLIP_Y the two paths mirror by different means -- the single quad
+     * negates its scale, slice9 reverses V -- so they have to agree there too. */
+    plain.flip_bits = NT_SPRITE_FLAG_FLIP_Y;
+    sliced.flip_bits = NT_SPRITE_FLAG_FLIP_Y;
+    const uint16_t plain_flipped_v = walk_image_top_edge_v(&plain);
+    const uint16_t sliced_flipped_v = walk_image_top_edge_v(&sliced);
+    TEST_ASSERT_EQUAL_UINT16(MINIMAL_UI_ATLAS_PACKED_V1_RAW, plain_flipped_v);
+    TEST_ASSERT_EQUAL_UINT16(plain_flipped_v, sliced_flipped_v);
 }
 
 int main(void) {

--- a/tests/unit/test_nt_ui_image.c
+++ b/tests/unit/test_nt_ui_image.c
@@ -301,7 +301,7 @@ static void test_image_slice9_orientation_matches_single_quad(void) {
     nt_sprite_renderer_test_last_emit_position(12U, top_pos);
     nt_sprite_renderer_test_last_emit_position(8U, seam_pos);
     nt_sprite_renderer_test_last_emit_texcoord(8U, seam_uv);
-    TEST_ASSERT_EQUAL_INT32(2, (int32_t)(top_pos[1] - seam_pos[1]));
+    TEST_ASSERT_EQUAL_INT32(2000, (int32_t)((top_pos[1] - seam_pos[1]) * 1000.0F));
     TEST_ASSERT_EQUAL_UINT16(MINIMAL_UI_ATLAS_PACKED_V0_RAW + ((MINIMAL_UI_ATLAS_PACKED_V1_RAW - MINIMAL_UI_ATLAS_PACKED_V0_RAW) / 4U), seam_uv[1]);
 
     /* Under FLIP_Y the two paths mirror by different means -- the single quad
@@ -312,6 +312,52 @@ static void test_image_slice9_orientation_matches_single_quad(void) {
     const uint16_t sliced_flipped_v = walk_image_top_edge_v(&sliced);
     TEST_ASSERT_EQUAL_UINT16(MINIMAL_UI_ATLAS_PACKED_V1_RAW, plain_flipped_v);
     TEST_ASSERT_EQUAL_UINT16(plain_flipped_v, sliced_flipped_v);
+
+    /* FLIP_X must not disturb the vertical pairing on either path. */
+    plain.flip_bits = NT_SPRITE_FLAG_FLIP_X;
+    sliced.flip_bits = NT_SPRITE_FLAG_FLIP_X;
+    TEST_ASSERT_EQUAL_UINT16(MINIMAL_UI_ATLAS_PACKED_V0_RAW, walk_image_top_edge_v(&plain));
+    TEST_ASSERT_EQUAL_UINT16(MINIMAL_UI_ATLAS_PACKED_V0_RAW, walk_image_top_edge_v(&sliced));
+}
+
+/* ---- Test 11: a zero-border override disables slice9 (nt_ui_fill's CROP reveal) ---- */
+static void test_image_zero_border_override_emits_plain_quad(void) {
+    nt_ui_image_style_t st = nt_ui_image_style_defaults();
+    st.flags |= NT_UI_IMAGE_SLICE9_OVERRIDE;
+    (void)walk_image_top_edge_v(&st);
+    TEST_ASSERT_EQUAL_UINT32(4U, nt_sprite_renderer_test_last_emit_vertex_count());
+}
+
+/* ---- Test 12: the slice9 grid lands exactly on the bbox, and the origin moves it ---- */
+static void test_image_slice9_grid_covers_the_bbox(void) {
+    nt_ui_image_style_t sliced = nt_ui_image_style_defaults();
+    sliced.flags |= NT_UI_IMAGE_SLICE9_OVERRIDE;
+    sliced.slice9_lrtb[0] = 2;
+    sliced.slice9_lrtb[1] = 2;
+    sliced.slice9_lrtb[2] = 2;
+    sliced.slice9_lrtb[3] = 2;
+    (void)walk_image_top_edge_v(&sliced);
+
+    /* The bbox is 80x60 at layout (0,0); world is Y-up over a 600 px viewport,
+     * so grid row 0 (local bottom) sits at world y = 600 - 60. */
+    float v0[3];
+    float v15[3];
+    nt_sprite_renderer_test_last_emit_position(0U, v0);
+    nt_sprite_renderer_test_last_emit_position(15U, v15);
+    TEST_ASSERT_EQUAL_INT32(0, (int32_t)v0[0]);
+    TEST_ASSERT_EQUAL_INT32(540, (int32_t)v0[1]);
+    TEST_ASSERT_EQUAL_INT32(80, (int32_t)v15[0]);
+    TEST_ASSERT_EQUAL_INT32(600, (int32_t)v15[1]);
+
+    /* An explicit origin moves the grid off the bbox the same way it moves a
+     * plain quad: pivot {0,0} anchors the grid's own corner at the bbox center. */
+    sliced.flags |= NT_UI_IMAGE_ORIGIN_OVERRIDE;
+    sliced.origin_x = 0.0F;
+    sliced.origin_y = 0.0F;
+    (void)walk_image_top_edge_v(&sliced);
+    nt_sprite_renderer_test_last_emit_position(0U, v0);
+    TEST_ASSERT_EQUAL_INT32(40, (int32_t)v0[0]);
+    TEST_ASSERT_EQUAL_INT32(570, (int32_t)v0[1]);
 }
 
 int main(void) {
@@ -326,6 +372,8 @@ int main(void) {
     RUN_TEST(test_image_resolves_from_invalid_under_ready_atlas);
     RUN_TEST(test_image_unresolved_skips_emit_no_assert);
     RUN_TEST(test_image_slice9_orientation_matches_single_quad);
+    RUN_TEST(test_image_zero_border_override_emits_plain_quad);
+    RUN_TEST(test_image_slice9_grid_covers_the_bbox);
 #if NT_ASSERT_MODE == NT_ASSERT_FULL
     RUN_TEST(test_image_null_style_asserts);
     RUN_TEST(test_image_invalid_atlas_asserts);

--- a/tests/unit/test_nt_ui_image.c
+++ b/tests/unit/test_nt_ui_image.c
@@ -292,14 +292,15 @@ static void test_image_slice9_orientation_matches_single_quad(void) {
     TEST_ASSERT_EQUAL_UINT16(MINIMAL_UI_ATLAS_PACKED_V0_RAW, plain_top_v);
     TEST_ASSERT_EQUAL_UINT16(plain_top_v, sliced_top_v);
 
-    /* Grid row 1 is the T border seam: 2 px down the screen (world Y-up), and
-     * 2 of the 8 source rows into the region's V span. */
+    /* Grid row 3 is the local top, which the walker's matrix lands at the top of
+     * the bbox; row 2 is the T seam, 2 px down the screen and 2 of the 8 source
+     * rows into the region's V span. */
     float top_pos[3];
     float seam_pos[3];
     uint16_t seam_uv[2];
-    nt_sprite_renderer_test_last_emit_position(0U, top_pos);
-    nt_sprite_renderer_test_last_emit_position(4U, seam_pos);
-    nt_sprite_renderer_test_last_emit_texcoord(4U, seam_uv);
+    nt_sprite_renderer_test_last_emit_position(12U, top_pos);
+    nt_sprite_renderer_test_last_emit_position(8U, seam_pos);
+    nt_sprite_renderer_test_last_emit_texcoord(8U, seam_uv);
     TEST_ASSERT_EQUAL_INT32(2, (int32_t)(top_pos[1] - seam_pos[1]));
     TEST_ASSERT_EQUAL_UINT16(MINIMAL_UI_ATLAS_PACKED_V0_RAW + ((MINIMAL_UI_ATLAS_PACKED_V1_RAW - MINIMAL_UI_ATLAS_PACKED_V0_RAW) / 4U), seam_uv[1]);
 

--- a/tests/unit/test_nt_ui_image.c
+++ b/tests/unit/test_nt_ui_image.c
@@ -304,20 +304,13 @@ static void test_image_slice9_orientation_matches_single_quad(void) {
     TEST_ASSERT_EQUAL_INT32(2000, (int32_t)((top_pos[1] - seam_pos[1]) * 1000.0F));
     TEST_ASSERT_EQUAL_UINT16(MINIMAL_UI_ATLAS_PACKED_V0_RAW + ((MINIMAL_UI_ATLAS_PACKED_V1_RAW - MINIMAL_UI_ATLAS_PACKED_V0_RAW) / 4U), seam_uv[1]);
 
-    /* Under FLIP_Y the two paths mirror by different means -- the single quad
-     * negates its scale, slice9 reverses V -- so they have to agree there too. */
+    /* Both paths mirror by negating local positions; the top-edge V must still agree. */
     plain.flip_bits = NT_SPRITE_FLAG_FLIP_Y;
     sliced.flip_bits = NT_SPRITE_FLAG_FLIP_Y;
     const uint16_t plain_flipped_v = walk_image_top_edge_v(&plain);
     const uint16_t sliced_flipped_v = walk_image_top_edge_v(&sliced);
     TEST_ASSERT_EQUAL_UINT16(MINIMAL_UI_ATLAS_PACKED_V1_RAW, plain_flipped_v);
     TEST_ASSERT_EQUAL_UINT16(plain_flipped_v, sliced_flipped_v);
-
-    /* FLIP_X must not disturb the vertical pairing on either path. */
-    plain.flip_bits = NT_SPRITE_FLAG_FLIP_X;
-    sliced.flip_bits = NT_SPRITE_FLAG_FLIP_X;
-    TEST_ASSERT_EQUAL_UINT16(MINIMAL_UI_ATLAS_PACKED_V0_RAW, walk_image_top_edge_v(&plain));
-    TEST_ASSERT_EQUAL_UINT16(MINIMAL_UI_ATLAS_PACKED_V0_RAW, walk_image_top_edge_v(&sliced));
 }
 
 /* ---- Test 11: a zero-border override disables slice9 (nt_ui_fill's CROP reveal) ---- */

--- a/tests/unit/test_nt_ui_walker_dispatch.c
+++ b/tests/unit/test_nt_ui_walker_dispatch.c
@@ -300,7 +300,7 @@ static void test_dispatch_border_rounded_emits_strip(void) {
 
 /* emit_geometry samples the centroid (mean of 4 corner UVs) -- NOT vertex[0]'s
  * UV which would land at a texel boundary and bleed under linear filtering.
- * Fixture white_region UVs: (0,0)(FFFF,0)(FFFF,FFFF)(0,FFFF), mean = 0x7FFF. */
+ * Fixture white_region UVs: (0,FFFF)(FFFF,FFFF)(FFFF,0)(0,0), mean = 0x7FFF. */
 static void test_dispatch_rounded_rect_uv_is_centroid_not_corner(void) {
     Clay_RenderCommand *c = &s_test_cmds[0];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -88,7 +88,7 @@ static uint32_t build_mock_atlas_blob(uint8_t *out, uint32_t cap, const mock_atl
 #define FIXTURE_R0_HASH 0x100ULL    /* rect, 4 verts, 6 indices */
 #define FIXTURE_R1_HASH 0x200ULL    /* rect, 4 verts, 6 indices */
 #define FIXTURE_RPOLY_HASH 0x300ULL /* polygon, 6 verts, 12 indices (4 triangles fan) */
-#define FIXTURE_RS9_HASH 0x400ULL   /* rect with baked slice9 borders 16/16/16/16 */
+#define FIXTURE_RS9_HASH 0x400ULL   /* rect with baked slice9 borders 16/16/8/24 */
 #define FIXTURE_PAGE0_RID 0x7000ULL
 #define FIXTURE_PAGE1_RID 0x7001ULL
 
@@ -179,9 +179,10 @@ static uint32_t build_test_atlas_blob(uint8_t *atlas_blob, uint32_t cap) {
     regions[2].page_index = 0;
     regions[2].transform = 0;
 
-    /* rs9: 100x100 rect with baked slice9 borders {16,16,16,16}. Source big
-     * enough that scale=2.0F (→ 32) still satisfies emit_slice9's sl+sr<source_w
-     * contract; lets the from_region helper pass borders verbatim. */
+    /* rs9: 100x100 rect with baked slice9 borders {16,16,8,24} — T and B differ so
+     * a swapped top/bottom read cannot pass. Source big enough that scale=2.0F
+     * still satisfies emit_slice9's sl+sr<source_w contract; lets the
+     * from_region helper pass borders verbatim. */
     regions[3].name_hash = FIXTURE_RS9_HASH;
     regions[3].source_w = 100;
     regions[3].source_h = 100;
@@ -196,8 +197,8 @@ static uint32_t build_test_atlas_blob(uint8_t *atlas_blob, uint32_t cap) {
     regions[3].flags = NT_ATLAS_REGION_FLAG_QUAD_012023;
     regions[3].slice9_lrtb[0] = 16;
     regions[3].slice9_lrtb[1] = 16;
-    regions[3].slice9_lrtb[2] = 16;
-    regions[3].slice9_lrtb[3] = 16;
+    regions[3].slice9_lrtb[2] = 8;
+    regions[3].slice9_lrtb[3] = 24;
 
     uint64_t page_ids[2] = {FIXTURE_PAGE0_RID, FIXTURE_PAGE1_RID};
     mock_atlas_spec_t spec = {
@@ -1643,12 +1644,46 @@ static uint32_t find_rs9_region_index(nt_resource_t atlas) {
     const uint32_t count = nt_atlas_region_count(atlas);
     for (uint32_t i = 0; i < count; i++) {
         const nt_texture_region_t *r = nt_atlas_get_region(atlas, i);
-        if (r->slice9_lrtb[0] == 16 && r->slice9_lrtb[1] == 16 && r->slice9_lrtb[2] == 16 && r->slice9_lrtb[3] == 16) {
+        if (r->slice9_lrtb[0] == 16 && r->slice9_lrtb[1] == 16 && r->slice9_lrtb[2] == 8 && r->slice9_lrtb[3] == 24) {
             return i;
         }
     }
-    TEST_FAIL_MESSAGE("rs9 region with slice9_lrtb=16/16/16/16 not found");
+    TEST_FAIL_MESSAGE("rs9 region with slice9_lrtb=16/16/8/24 not found");
     return 0;
+}
+
+/* ---- Test: ECS slice9 honors flip ---- */
+/* The component path mirrors by negating grid positions, so a flipped sprite must
+ * pair the same source edge with the opposite end of its footprint. */
+void test_draw_list_slice9_flip_mirrors_source(void) {
+    nt_sprite_renderer_desc_t desc = nt_sprite_renderer_desc_defaults();
+    TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&desc));
+
+    s_atlas_res = register_test_atlas(0xB7ULL);
+    nt_material_t mat = create_test_material();
+    nt_entity_t e = create_sprite_entity(s_atlas_res, FIXTURE_RS9_HASH, mat);
+    nt_sprite_comp_set_flip(e, true, true);
+    nt_render_item_t item = {.entity = e.id, .batch_key = sprite_batch_key(e, mat)};
+
+    nt_sprite_renderer_draw_list(&item, 1);
+    TEST_ASSERT_EQUAL_UINT32(16U, nt_sprite_renderer_test_last_emit_vertex_count());
+
+    /* Grid corner (0,0) sits at local (0,0), which the flip negates to the far
+     * side of the footprint; its UV must stay the source's own (u_min, v_max)
+     * corner, otherwise the reversal cancelled the mirror. */
+    float pos[3];
+    uint16_t uv[2];
+    nt_sprite_renderer_test_last_emit_position(0U, pos);
+    nt_sprite_renderer_test_last_emit_texcoord(0U, uv);
+    TEST_ASSERT_EQUAL_UINT16_MESSAGE(14000U, uv[0], "flip must not reverse the U cuts");
+    TEST_ASSERT_EQUAL_UINT16_MESSAGE(34000U, uv[1], "flip must not reverse the V cuts");
+
+    /* The opposite corner moved to negative local space with the far UV. */
+    nt_sprite_renderer_test_last_emit_position(15U, pos);
+    nt_sprite_renderer_test_last_emit_texcoord(15U, uv);
+    TEST_ASSERT_TRUE_MESSAGE(pos[0] < 0.0F && pos[1] < 0.0F, "flip must mirror the grid positions");
+    TEST_ASSERT_EQUAL_UINT16(17000U, uv[0]);
+    TEST_ASSERT_EQUAL_UINT16(28000U, uv[1]);
 }
 
 /* scale=1.0F → atlas borders unchanged → grid x_inner == x + 16; matches emit_slice9. */
@@ -1676,6 +1711,18 @@ void test_emit_slice9_null_src_scale_one_matches_atlas(void) {
     float v2[3];
     nt_sprite_renderer_test_last_emit_position(2, v2);
     TEST_ASSERT_TRUE_MESSAGE(fabsf(v2[0] - 84.0F) < 0.5F, "scale=1.0 inner-right should be 84 px");
+
+    /* Rows take the baked T=8 along the top and B=24 along the bottom, and the
+     * V cuts follow: v_min=28000, v_range=6000, source_h=100 -> 60 per px. */
+    float r1[3];
+    float r2[3];
+    uint16_t uv_r1[2];
+    nt_sprite_renderer_test_last_emit_position(4, r1);
+    nt_sprite_renderer_test_last_emit_position(8, r2);
+    nt_sprite_renderer_test_last_emit_texcoord(4, uv_r1);
+    TEST_ASSERT_TRUE_MESSAGE(fabsf(r1[1] - 8.0F) < 0.5F, "atlas T border belongs to the top row");
+    TEST_ASSERT_TRUE_MESSAGE(fabsf(r2[1] - 76.0F) < 0.5F, "atlas B border belongs to the bottom row");
+    TEST_ASSERT_EQUAL_UINT16_MESSAGE(28480U, uv_r1[1], "row-1 V must be 8 source rows in from v_min");
 }
 
 /* scale=2.0F → DST borders doubled (positions 32/68) BUT SRC borders unchanged
@@ -1710,6 +1757,13 @@ void test_emit_slice9_null_src_scale_two_doubles_borders(void) {
     nt_sprite_renderer_test_last_emit_texcoord(2, uv2);
     /* uv_col2 = u_max - 16*u_range/100 = 17000 - 480 = 16520. */
     TEST_ASSERT_EQUAL_UINT16_MESSAGE(16520U, uv2[0], "scale=2.0 UV column-2 must use SRC=atlas borders");
+    /* Both row borders scale too: T 8 -> 16, B 24 -> 48. */
+    float r1[3];
+    float r2[3];
+    nt_sprite_renderer_test_last_emit_position(4, r1);
+    nt_sprite_renderer_test_last_emit_position(8, r2);
+    TEST_ASSERT_TRUE_MESSAGE(fabsf(r1[1] - 16.0F) < 0.5F, "scale=2.0 inner-top should be 16 px");
+    TEST_ASSERT_TRUE_MESSAGE(fabsf(r2[1] - 52.0F) < 0.5F, "scale=2.0 inner-bottom should be 52 px");
 }
 
 /* ECS path: set_slice9_scale on sprite_comp must scale destination corner size
@@ -1830,6 +1884,7 @@ int main(void) {
     RUN_TEST(test_sprite_renderer_restore_cleans_up_after_index_buffer_failure);
     RUN_TEST(test_sprite_renderer_pipeline_cache_capacity);
     RUN_TEST(test_sprite_renderer_sampler_override_does_not_stick);
+    RUN_TEST(test_draw_list_slice9_flip_mirrors_source);
     RUN_TEST(test_emit_slice9_null_src_scale_one_matches_atlas);
     RUN_TEST(test_emit_slice9_null_src_scale_two_doubles_borders);
     RUN_TEST(test_emit_slice9_degrades_when_dst_smaller_than_borders);

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -1808,10 +1808,10 @@ void test_sprite_comp_slice9_scale_affects_emit_position(void) {
     TEST_ASSERT_EQUAL_UINT16_MESSAGE(14480U, uv1[0], "ECS slice9_scale must not shift UV");
 }
 
-/* The rect is in the caller's units, so the atlas's pixels_per_unit must not
- * shrink the corner bands with it — a UI panel laid out in layout px keeps its
- * 16 px corners whatever scale the atlas was packed at. */
-void test_emit_slice9_bands_ignore_pixels_per_unit(void) {
+/* pixels_per_unit is what makes an SD -> HD atlas swap invisible: the denser
+ * art has proportionally bigger borders in pixels, and the corner must still
+ * come out the same size in the caller's units. */
+void test_emit_slice9_bands_follow_pixels_per_unit(void) {
     nt_sprite_renderer_desc_t desc = nt_sprite_renderer_desc_defaults();
     TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&desc));
 
@@ -1819,15 +1819,16 @@ void test_emit_slice9_bands_ignore_pixels_per_unit(void) {
     nt_material_t mat = create_test_material();
     nt_sprite_renderer_set_material(mat);
 
-    const uint32_t rs9 = find_rs9_region_index(s_atlas_res);
+    const uint32_t rs9 = find_rs9_region_index(s_atlas_res); /* baked 16/16/8/24 */
     nt_sprite_renderer_emit_slice9(s_atlas_res, rs9, NT_MATH_MAT4_IDENTITY, 100.0F, 100.0F, 0.0F, 0.0F, NULL, 1.0F, 0xFFFFFFFFU, 0);
 
+    /* At ppu=4 the 16 px L border is 4 units, the 24 px B border is 6. */
     float v1[3];
     float r1[3];
     nt_sprite_renderer_test_last_emit_position(1, v1);
     nt_sprite_renderer_test_last_emit_position(4, r1);
-    TEST_ASSERT_TRUE_MESSAGE(fabsf(v1[0] - 16.0F) < 0.5F, "L band must stay 16 units at ppu=4");
-    TEST_ASSERT_TRUE_MESSAGE(fabsf(r1[1] - 24.0F) < 0.5F, "B band must stay 24 units at ppu=4");
+    TEST_ASSERT_TRUE_MESSAGE(fabsf(v1[0] - 4.0F) < 0.5F, "L band must convert 16 px to 4 units at ppu=4");
+    TEST_ASSERT_TRUE_MESSAGE(fabsf(r1[1] - 6.0F) < 0.5F, "B band must convert 24 px to 6 units at ppu=4");
 }
 
 /* Graceful degradation: when dst < border sum the corners must not overflow the
@@ -1933,7 +1934,7 @@ int main(void) {
     RUN_TEST(test_draw_list_slice9_flip_mirrors_source);
     RUN_TEST(test_emit_slice9_null_src_scale_one_matches_atlas);
     RUN_TEST(test_emit_slice9_null_src_scale_two_doubles_borders);
-    RUN_TEST(test_emit_slice9_bands_ignore_pixels_per_unit);
+    RUN_TEST(test_emit_slice9_bands_follow_pixels_per_unit);
     RUN_TEST(test_emit_slice9_degrades_when_dst_smaller_than_borders);
     RUN_TEST(test_sprite_comp_slice9_scale_affects_emit_position);
     return UNITY_END();

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -214,12 +214,17 @@ static uint32_t build_test_atlas_blob(uint8_t *atlas_blob, uint32_t cap) {
     return build_mock_atlas_blob(atlas_blob, cap, &spec);
 }
 
-static uint8_t *build_pack_blob_for_atlas(uint64_t atlas_rid, const uint8_t *atlas_blob, uint32_t atlas_blob_size, uint32_t *out_total) {
+/* ppu <= 0 leaves the pack without pixels_per_unit metadata (atlas ipu stays 1). */
+static uint8_t *build_pack_blob_for_atlas_ppu(uint64_t atlas_rid, const uint8_t *atlas_blob, uint32_t atlas_blob_size, float ppu, uint32_t *out_total) {
     const uint32_t raw_header = (uint32_t)(sizeof(NtPackHeader) + sizeof(NtAssetEntry));
     const uint32_t header_size = (raw_header + (NT_PACK_DATA_ALIGN - 1U)) & ~(uint32_t)(NT_PACK_DATA_ALIGN - 1U);
     const uint32_t atlas_offset = header_size;
     const uint32_t aligned_atlas = (atlas_blob_size + (NT_PACK_ASSET_ALIGN - 1U)) & ~(uint32_t)(NT_PACK_ASSET_ALIGN - 1U);
-    const uint32_t total_size = atlas_offset + aligned_atlas;
+    const uint32_t meta_offset = atlas_offset + aligned_atlas;
+    const uint32_t meta_entry_size = (uint32_t)sizeof(NtMetaEntryHeader) + (uint32_t)sizeof(float);
+    const uint32_t aligned_meta = (meta_entry_size + (NT_PACK_ASSET_ALIGN - 1U)) & ~(uint32_t)(NT_PACK_ASSET_ALIGN - 1U);
+    const bool with_meta = ppu > 0.0F;
+    const uint32_t total_size = with_meta ? (meta_offset + aligned_meta) : (atlas_offset + aligned_atlas);
 
     uint8_t *pack_blob = (uint8_t *)calloc(1, total_size);
     TEST_ASSERT_NOT_NULL(pack_blob);
@@ -230,8 +235,8 @@ static uint8_t *build_pack_blob_for_atlas(uint64_t atlas_rid, const uint8_t *atl
     ph->asset_count = 1;
     ph->header_size = header_size;
     ph->total_size = total_size;
-    ph->meta_offset = 0;
-    ph->meta_count = 0;
+    ph->meta_offset = with_meta ? meta_offset : 0;
+    ph->meta_count = with_meta ? 1 : 0;
 
     NtAssetEntry *entry = (NtAssetEntry *)(pack_blob + sizeof(NtPackHeader));
     entry[0].resource_id = atlas_rid;
@@ -239,10 +244,17 @@ static uint8_t *build_pack_blob_for_atlas(uint64_t atlas_rid, const uint8_t *atl
     entry[0].format_version = NT_ATLAS_VERSION;
     entry[0].offset = atlas_offset;
     entry[0].size = atlas_blob_size;
-    entry[0].meta_offset = 0;
+    entry[0].meta_offset = with_meta ? meta_offset : 0;
     entry[0]._pad = 0;
 
     memcpy(pack_blob + atlas_offset, atlas_blob, atlas_blob_size);
+    if (with_meta) {
+        NtMetaEntryHeader *mh = (NtMetaEntryHeader *)(pack_blob + meta_offset);
+        mh->resource_id = atlas_rid;
+        mh->kind = nt_hash64_str("pixels_per_unit").value;
+        mh->size = (uint32_t)sizeof(float);
+        memcpy(pack_blob + meta_offset + sizeof(NtMetaEntryHeader), &ppu, sizeof(ppu));
+    }
     ph->checksum = nt_crc32(pack_blob + header_size, total_size - header_size);
 
     *out_total = total_size;
@@ -260,12 +272,12 @@ static const uint8_t s_white_pixel[4] = {255, 255, 255, 255};
 
 /* ---- Helper: register an atlas resource via the full pipeline ---- */
 
-static nt_resource_t register_test_atlas(uint64_t atlas_rid) {
+static nt_resource_t register_test_atlas_ppu(uint64_t atlas_rid, float ppu) {
     uint8_t atlas_blob[1024];
     uint32_t atlas_blob_size = build_test_atlas_blob(atlas_blob, sizeof(atlas_blob));
 
     uint32_t pack_total = 0;
-    uint8_t *pack_blob = build_pack_blob_for_atlas(atlas_rid, atlas_blob, atlas_blob_size, &pack_total);
+    uint8_t *pack_blob = build_pack_blob_for_atlas_ppu(atlas_rid, atlas_blob, atlas_blob_size, ppu, &pack_total);
     TEST_ASSERT_TRUE_MESSAGE(s_pack_blob_count < MAX_PACK_BLOBS, "pack blob fixture overflow");
     s_pack_blobs[s_pack_blob_count++] = pack_blob;
 
@@ -285,6 +297,8 @@ static nt_resource_t register_test_atlas(uint64_t atlas_rid) {
     TEST_ASSERT_TRUE(nt_resource_is_ready(atlas));
     return atlas;
 }
+
+static nt_resource_t register_test_atlas(uint64_t atlas_rid) { return register_test_atlas_ppu(atlas_rid, 0.0F); }
 
 /* ---- Helper: create a minimal real material backed by test backend shader handles ---- */
 
@@ -1794,6 +1808,28 @@ void test_sprite_comp_slice9_scale_affects_emit_position(void) {
     TEST_ASSERT_EQUAL_UINT16_MESSAGE(14480U, uv1[0], "ECS slice9_scale must not shift UV");
 }
 
+/* The rect is in the caller's units, so the atlas's pixels_per_unit must not
+ * shrink the corner bands with it — a UI panel laid out in layout px keeps its
+ * 16 px corners whatever scale the atlas was packed at. */
+void test_emit_slice9_bands_ignore_pixels_per_unit(void) {
+    nt_sprite_renderer_desc_t desc = nt_sprite_renderer_desc_defaults();
+    TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&desc));
+
+    s_atlas_res = register_test_atlas_ppu(0xB8ULL, 4.0F);
+    nt_material_t mat = create_test_material();
+    nt_sprite_renderer_set_material(mat);
+
+    const uint32_t rs9 = find_rs9_region_index(s_atlas_res);
+    nt_sprite_renderer_emit_slice9(s_atlas_res, rs9, NT_MATH_MAT4_IDENTITY, 100.0F, 100.0F, 0.0F, 0.0F, NULL, 1.0F, 0xFFFFFFFFU, 0);
+
+    float v1[3];
+    float r1[3];
+    nt_sprite_renderer_test_last_emit_position(1, v1);
+    nt_sprite_renderer_test_last_emit_position(4, r1);
+    TEST_ASSERT_TRUE_MESSAGE(fabsf(v1[0] - 16.0F) < 0.5F, "L band must stay 16 units at ppu=4");
+    TEST_ASSERT_TRUE_MESSAGE(fabsf(r1[1] - 24.0F) < 0.5F, "B band must stay 24 units at ppu=4");
+}
+
 /* Graceful degradation: when dst < border sum the corners must not overflow the
  * requested rect. Emit into a rect smaller than the borders on one then both axes
  * and assert all 16 grid vertices stay inside [x, x+w] x [y, y+h]. Mirrors Unity/
@@ -1897,6 +1933,7 @@ int main(void) {
     RUN_TEST(test_draw_list_slice9_flip_mirrors_source);
     RUN_TEST(test_emit_slice9_null_src_scale_one_matches_atlas);
     RUN_TEST(test_emit_slice9_null_src_scale_two_doubles_borders);
+    RUN_TEST(test_emit_slice9_bands_ignore_pixels_per_unit);
     RUN_TEST(test_emit_slice9_degrades_when_dst_smaller_than_borders);
     RUN_TEST(test_sprite_comp_slice9_scale_affects_emit_position);
     return UNITY_END();

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -1682,23 +1682,13 @@ void test_draw_list_slice9_flip_mirrors_source(void) {
     nt_sprite_renderer_draw_list(&item, 1);
     TEST_ASSERT_EQUAL_UINT32(16U, nt_sprite_renderer_test_last_emit_vertex_count());
 
-    /* Grid corner (0,0) sits at local (0,0), which the flip negates to the far
-     * side of the footprint; its UV must stay the source's own (u_min, v_max)
-     * corner, otherwise the reversal cancelled the mirror. */
+    /* Origin (0,0) stays put and the far corner spans the whole 100x100
+     * footprint on the negative side: the mirror reached the grid. */
     float pos[3];
-    uint16_t uv[2];
     nt_sprite_renderer_test_last_emit_position(0U, pos);
-    nt_sprite_renderer_test_last_emit_texcoord(0U, uv);
-    TEST_ASSERT_EQUAL_UINT16_MESSAGE(14000U, uv[0], "flip must not reverse the U cuts");
-    TEST_ASSERT_EQUAL_UINT16_MESSAGE(34000U, uv[1], "flip must not reverse the V cuts");
     TEST_ASSERT_TRUE_MESSAGE(fabsf(pos[0]) < 0.5F && fabsf(pos[1]) < 0.5F, "origin (0,0) corner stays put");
-
-    /* The far corner spans the whole 100x100 footprint, mirrored. */
     nt_sprite_renderer_test_last_emit_position(15U, pos);
-    nt_sprite_renderer_test_last_emit_texcoord(15U, uv);
     TEST_ASSERT_TRUE_MESSAGE(fabsf(pos[0] + 100.0F) < 0.5F && fabsf(pos[1] + 100.0F) < 0.5F, "flip must mirror the full footprint");
-    TEST_ASSERT_EQUAL_UINT16(17000U, uv[0]);
-    TEST_ASSERT_EQUAL_UINT16(28000U, uv[1]);
 }
 
 /* scale=1.0F → atlas borders unchanged → grid x_inner == x + 16; matches emit_slice9. */
@@ -1807,6 +1797,22 @@ void test_sprite_comp_slice9_scale_affects_emit_position(void) {
     uint16_t uv1[2];
     nt_sprite_renderer_test_last_emit_texcoord(1, uv1);
     TEST_ASSERT_EQUAL_UINT16_MESSAGE(14480U, uv1[0], "ECS slice9_scale must not shift UV");
+}
+
+/* set_slice9(0,0,0,0) promises a plain stretched quad, so the ECS path must not
+ * hand a baked nine-patch region to the grid when the override zeroes it. */
+void test_draw_list_zero_slice9_override_emits_plain_quad(void) {
+    nt_sprite_renderer_desc_t desc = nt_sprite_renderer_desc_defaults();
+    TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&desc));
+
+    s_atlas_res = register_test_atlas(0xBAULL);
+    nt_material_t mat = create_test_material();
+    nt_entity_t e = create_sprite_entity(s_atlas_res, FIXTURE_RS9_HASH, mat); /* baked 16/16/8/24 */
+    nt_sprite_comp_set_slice9(e, 0, 0, 0, 0);
+    nt_render_item_t item = {.entity = e.id, .batch_key = sprite_batch_key(e, mat)};
+
+    nt_sprite_renderer_draw_list(&item, 1);
+    TEST_ASSERT_EQUAL_UINT32(4U, nt_sprite_renderer_test_last_emit_vertex_count());
 }
 
 /* The pivot is what a flip mirrors around, so a centered grid must come back
@@ -1972,6 +1978,7 @@ int main(void) {
     RUN_TEST(test_draw_list_slice9_flip_mirrors_source);
     RUN_TEST(test_emit_slice9_null_src_scale_one_matches_atlas);
     RUN_TEST(test_emit_slice9_null_src_scale_two_doubles_borders);
+    RUN_TEST(test_draw_list_zero_slice9_override_emits_plain_quad);
     RUN_TEST(test_emit_slice9_pivot_centers_and_mirrors);
     RUN_TEST(test_emit_slice9_bands_follow_pixels_per_unit);
     RUN_TEST(test_emit_slice9_degrades_when_dst_smaller_than_borders);

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -1691,11 +1691,12 @@ void test_draw_list_slice9_flip_mirrors_source(void) {
     nt_sprite_renderer_test_last_emit_texcoord(0U, uv);
     TEST_ASSERT_EQUAL_UINT16_MESSAGE(14000U, uv[0], "flip must not reverse the U cuts");
     TEST_ASSERT_EQUAL_UINT16_MESSAGE(34000U, uv[1], "flip must not reverse the V cuts");
+    TEST_ASSERT_TRUE_MESSAGE(fabsf(pos[0]) < 0.5F && fabsf(pos[1]) < 0.5F, "origin (0,0) corner stays put");
 
-    /* The opposite corner moved to negative local space with the far UV. */
+    /* The far corner spans the whole 100x100 footprint, mirrored. */
     nt_sprite_renderer_test_last_emit_position(15U, pos);
     nt_sprite_renderer_test_last_emit_texcoord(15U, uv);
-    TEST_ASSERT_TRUE_MESSAGE(pos[0] < 0.0F && pos[1] < 0.0F, "flip must mirror the grid positions");
+    TEST_ASSERT_TRUE_MESSAGE(fabsf(pos[0] + 100.0F) < 0.5F && fabsf(pos[1] + 100.0F) < 0.5F, "flip must mirror the full footprint");
     TEST_ASSERT_EQUAL_UINT16(17000U, uv[0]);
     TEST_ASSERT_EQUAL_UINT16(28000U, uv[1]);
 }
@@ -1714,7 +1715,7 @@ void test_emit_slice9_null_src_scale_one_matches_atlas(void) {
     const float h = 100.0F;
     nt_sprite_renderer_emit_slice9(s_atlas_res, rs9, NT_MATH_MAT4_IDENTITY, w, h, 0.0F, 0.0F, NULL, 1.0F, 0xFFFFFFFFU, 0);
 
-    TEST_ASSERT_EQUAL_UINT32(16U, nt_sprite_renderer_test_last_slice9_vertex_count());
+    TEST_ASSERT_EQUAL_UINT32(16U, nt_sprite_renderer_test_last_emit_vertex_count());
     /* Inner column 1 = x + (16 * 1.0F) = 16. */
     float v1[3];
     nt_sprite_renderer_test_last_emit_position(1, v1);
@@ -1754,7 +1755,7 @@ void test_emit_slice9_null_src_scale_two_doubles_borders(void) {
     const uint32_t rs9 = find_rs9_region_index(s_atlas_res);
     nt_sprite_renderer_emit_slice9(s_atlas_res, rs9, NT_MATH_MAT4_IDENTITY, 100.0F, 100.0F, 0.0F, 0.0F, NULL, 2.0F, 0xFFFFFFFFU, 0);
 
-    TEST_ASSERT_EQUAL_UINT32(16U, nt_sprite_renderer_test_last_slice9_vertex_count());
+    TEST_ASSERT_EQUAL_UINT32(16U, nt_sprite_renderer_test_last_emit_vertex_count());
     /* Positions reflect DST (= src*scale = 32). */
     float v1[3];
     nt_sprite_renderer_test_last_emit_position(1, v1);
@@ -1808,6 +1809,34 @@ void test_sprite_comp_slice9_scale_affects_emit_position(void) {
     TEST_ASSERT_EQUAL_UINT16_MESSAGE(14480U, uv1[0], "ECS slice9_scale must not shift UV");
 }
 
+/* The pivot is what a flip mirrors around, so a centered grid must come back
+ * symmetric about the matrix anchor instead of sliding to one side. */
+void test_emit_slice9_pivot_centers_and_mirrors(void) {
+    nt_sprite_renderer_desc_t desc = nt_sprite_renderer_desc_defaults();
+    TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&desc));
+
+    s_atlas_res = register_test_atlas(0xB9ULL);
+    nt_material_t mat = create_test_material();
+    nt_sprite_renderer_set_material(mat);
+
+    const uint32_t rs9 = find_rs9_region_index(s_atlas_res);
+    float pos0[3];
+    float pos15[3];
+
+    nt_sprite_renderer_emit_slice9(s_atlas_res, rs9, NT_MATH_MAT4_IDENTITY, 100.0F, 100.0F, 0.5F, 0.5F, NULL, 1.0F, 0xFFFFFFFFU, 0);
+    nt_sprite_renderer_test_last_emit_position(0, pos0);
+    nt_sprite_renderer_test_last_emit_position(15, pos15);
+    TEST_ASSERT_TRUE_MESSAGE(fabsf(pos0[0] + 50.0F) < 0.5F && fabsf(pos0[1] + 50.0F) < 0.5F, "pivot 0.5 centers the grid");
+    TEST_ASSERT_TRUE_MESSAGE(fabsf(pos15[0] - 50.0F) < 0.5F && fabsf(pos15[1] - 50.0F) < 0.5F, "pivot 0.5 centers the grid");
+
+    /* Mirrored about the same pivot: the footprint stays where it was. */
+    nt_sprite_renderer_emit_slice9(s_atlas_res, rs9, NT_MATH_MAT4_IDENTITY, 100.0F, 100.0F, 0.5F, 0.5F, NULL, 1.0F, 0xFFFFFFFFU, NT_SPRITE_FLAG_FLIP_X | NT_SPRITE_FLAG_FLIP_Y);
+    nt_sprite_renderer_test_last_emit_position(0, pos0);
+    nt_sprite_renderer_test_last_emit_position(15, pos15);
+    TEST_ASSERT_TRUE_MESSAGE(fabsf(pos0[0] - 50.0F) < 0.5F && fabsf(pos0[1] - 50.0F) < 0.5F, "flip mirrors around the pivot, not away from it");
+    TEST_ASSERT_TRUE_MESSAGE(fabsf(pos15[0] + 50.0F) < 0.5F && fabsf(pos15[1] + 50.0F) < 0.5F, "flip mirrors around the pivot, not away from it");
+}
+
 /* pixels_per_unit is what makes an SD -> HD atlas swap invisible: the denser
  * art has proportionally bigger borders in pixels, and the corner must still
  * come out the same size in the caller's units. */
@@ -1829,6 +1858,10 @@ void test_emit_slice9_bands_follow_pixels_per_unit(void) {
     nt_sprite_renderer_test_last_emit_position(4, r1);
     TEST_ASSERT_TRUE_MESSAGE(fabsf(v1[0] - 4.0F) < 0.5F, "L band must convert 16 px to 4 units at ppu=4");
     TEST_ASSERT_TRUE_MESSAGE(fabsf(r1[1] - 6.0F) < 0.5F, "B band must convert 24 px to 6 units at ppu=4");
+    /* Only the bands convert: w/h are the caller's units and must not shrink. */
+    float v3[3];
+    nt_sprite_renderer_test_last_emit_position(3, v3);
+    TEST_ASSERT_TRUE_MESSAGE(fabsf(v3[0] - 100.0F) < 0.5F, "w stays in caller units at ppu=4");
 }
 
 /* Graceful degradation: when dst < border sum the corners must not overflow the
@@ -1837,7 +1870,7 @@ void test_emit_slice9_bands_follow_pixels_per_unit(void) {
  * Defold behavior — geometry never exceeds the requested rect. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void assert_slice9_within_rect(float x, float y, float w, float h, const char *msg) {
-    TEST_ASSERT_EQUAL_UINT32(16U, nt_sprite_renderer_test_last_slice9_vertex_count());
+    TEST_ASSERT_EQUAL_UINT32(16U, nt_sprite_renderer_test_last_emit_vertex_count());
     const float eps = 0.5F;
     for (uint32_t v = 0; v < 16U; ++v) {
         float p[3];
@@ -1881,6 +1914,11 @@ void test_emit_slice9_degrades_when_dst_smaller_than_borders(void) {
     nt_sprite_renderer_test_last_emit_position(4, vb);
     nt_sprite_renderer_test_last_emit_position(8, vt);
     TEST_ASSERT_TRUE_MESSAGE(vb[1] <= vt[1] + 0.5F, "short-h inner-bottom must not cross inner-top");
+
+    /* Flipped squeeze: the footprint mirrors to [x-w, x], and the shrink must
+     * still keep every vertex inside it. */
+    nt_sprite_renderer_emit_slice9(s_atlas_res, rs9, at_xy, 20.0F, 100.0F, 0.0F, 0.0F, NULL, 1.0F, 0xFFFFFFFFU, NT_SPRITE_FLAG_FLIP_X);
+    assert_slice9_within_rect(x - 20.0F, y, 20.0F, 100.0F, "flipped narrow-w slice9 corners must stay within rect");
 
     /* Both axes squeezed: 12 x 8, both < 32. */
     nt_sprite_renderer_emit_slice9(s_atlas_res, rs9, at_xy, 12.0F, 8.0F, 0.0F, 0.0F, NULL, 1.0F, 0xFFFFFFFFU, 0);
@@ -1934,6 +1972,7 @@ int main(void) {
     RUN_TEST(test_draw_list_slice9_flip_mirrors_source);
     RUN_TEST(test_emit_slice9_null_src_scale_one_matches_atlas);
     RUN_TEST(test_emit_slice9_null_src_scale_two_doubles_borders);
+    RUN_TEST(test_emit_slice9_pivot_centers_and_mirrors);
     RUN_TEST(test_emit_slice9_bands_follow_pixels_per_unit);
     RUN_TEST(test_emit_slice9_degrades_when_dst_smaller_than_borders);
     RUN_TEST(test_sprite_comp_slice9_scale_affects_emit_position);

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -1696,11 +1696,9 @@ void test_emit_slice9_null_src_scale_one_matches_atlas(void) {
     nt_sprite_renderer_set_material(mat);
 
     const uint32_t rs9 = find_rs9_region_index(s_atlas_res);
-    const float x = 0.0F;
-    const float y = 0.0F;
     const float w = 100.0F;
     const float h = 100.0F;
-    nt_sprite_renderer_emit_slice9(s_atlas_res, rs9, x, y, w, h, NULL, 1.0F, 0xFFFFFFFFU, 0, NT_MATH_MAT4_IDENTITY);
+    nt_sprite_renderer_emit_slice9(s_atlas_res, rs9, NT_MATH_MAT4_IDENTITY, w, h, 0.0F, 0.0F, NULL, 1.0F, 0xFFFFFFFFU, 0);
 
     TEST_ASSERT_EQUAL_UINT32(16U, nt_sprite_renderer_test_last_slice9_vertex_count());
     /* Inner column 1 = x + (16 * 1.0F) = 16. */
@@ -1712,17 +1710,20 @@ void test_emit_slice9_null_src_scale_one_matches_atlas(void) {
     nt_sprite_renderer_test_last_emit_position(2, v2);
     TEST_ASSERT_TRUE_MESSAGE(fabsf(v2[0] - 84.0F) < 0.5F, "scale=1.0 inner-right should be 84 px");
 
-    /* Rows take the baked T=8 along the top and B=24 along the bottom, and the
-     * V cuts follow: v_min=28000, v_range=6000, source_h=100 -> 60 per px. */
+    /* Local space is Y-up: row 1 carries the baked B=24, row 2 sits T=8 below the
+     * top. V follows: v_min=28000, v_max=34000, source_h=100 -> 60 per px. */
     float r1[3];
     float r2[3];
     uint16_t uv_r1[2];
+    uint16_t uv_r2[2];
     nt_sprite_renderer_test_last_emit_position(4, r1);
     nt_sprite_renderer_test_last_emit_position(8, r2);
     nt_sprite_renderer_test_last_emit_texcoord(4, uv_r1);
-    TEST_ASSERT_TRUE_MESSAGE(fabsf(r1[1] - 8.0F) < 0.5F, "atlas T border belongs to the top row");
-    TEST_ASSERT_TRUE_MESSAGE(fabsf(r2[1] - 76.0F) < 0.5F, "atlas B border belongs to the bottom row");
-    TEST_ASSERT_EQUAL_UINT16_MESSAGE(28480U, uv_r1[1], "row-1 V must be 8 source rows in from v_min");
+    nt_sprite_renderer_test_last_emit_texcoord(8, uv_r2);
+    TEST_ASSERT_TRUE_MESSAGE(fabsf(r1[1] - 24.0F) < 0.5F, "atlas B border belongs to the local-bottom row");
+    TEST_ASSERT_TRUE_MESSAGE(fabsf(r2[1] - 92.0F) < 0.5F, "atlas T border belongs to the local-top row");
+    TEST_ASSERT_EQUAL_UINT16_MESSAGE(32560U, uv_r1[1], "row-1 V must be 24 source rows in from v_max");
+    TEST_ASSERT_EQUAL_UINT16_MESSAGE(28480U, uv_r2[1], "row-2 V must be 8 source rows in from v_min");
 }
 
 /* scale=2.0F → DST borders doubled (positions 32/68) BUT SRC borders unchanged
@@ -1737,7 +1738,7 @@ void test_emit_slice9_null_src_scale_two_doubles_borders(void) {
     nt_sprite_renderer_set_material(mat);
 
     const uint32_t rs9 = find_rs9_region_index(s_atlas_res);
-    nt_sprite_renderer_emit_slice9(s_atlas_res, rs9, 0.0F, 0.0F, 100.0F, 100.0F, NULL, 2.0F, 0xFFFFFFFFU, 0, NT_MATH_MAT4_IDENTITY);
+    nt_sprite_renderer_emit_slice9(s_atlas_res, rs9, NT_MATH_MAT4_IDENTITY, 100.0F, 100.0F, 0.0F, 0.0F, NULL, 2.0F, 0xFFFFFFFFU, 0);
 
     TEST_ASSERT_EQUAL_UINT32(16U, nt_sprite_renderer_test_last_slice9_vertex_count());
     /* Positions reflect DST (= src*scale = 32). */
@@ -1757,13 +1758,13 @@ void test_emit_slice9_null_src_scale_two_doubles_borders(void) {
     nt_sprite_renderer_test_last_emit_texcoord(2, uv2);
     /* uv_col2 = u_max - 16*u_range/100 = 17000 - 480 = 16520. */
     TEST_ASSERT_EQUAL_UINT16_MESSAGE(16520U, uv2[0], "scale=2.0 UV column-2 must use SRC=atlas borders");
-    /* Both row borders scale too: T 8 -> 16, B 24 -> 48. */
+    /* Both row borders scale too: B 24 -> 48, T 8 -> 16 (so row 2 = 100 - 16). */
     float r1[3];
     float r2[3];
     nt_sprite_renderer_test_last_emit_position(4, r1);
     nt_sprite_renderer_test_last_emit_position(8, r2);
-    TEST_ASSERT_TRUE_MESSAGE(fabsf(r1[1] - 16.0F) < 0.5F, "scale=2.0 inner-top should be 16 px");
-    TEST_ASSERT_TRUE_MESSAGE(fabsf(r2[1] - 52.0F) < 0.5F, "scale=2.0 inner-bottom should be 52 px");
+    TEST_ASSERT_TRUE_MESSAGE(fabsf(r1[1] - 48.0F) < 0.5F, "scale=2.0 inner-bottom should be 48 px");
+    TEST_ASSERT_TRUE_MESSAGE(fabsf(r2[1] - 84.0F) < 0.5F, "scale=2.0 inner-top should be 84 px");
 }
 
 /* ECS path: set_slice9_scale on sprite_comp must scale destination corner size
@@ -1817,12 +1818,16 @@ void test_emit_slice9_degrades_when_dst_smaller_than_borders(void) {
     nt_material_t mat = create_test_material();
     nt_sprite_renderer_set_material(mat);
 
-    const uint32_t rs9 = find_rs9_region_index(s_atlas_res); /* 16/16/16/16 borders */
+    const uint32_t rs9 = find_rs9_region_index(s_atlas_res); /* 16/16/8/24 borders */
     const float x = 100.0F;
     const float y = 200.0F;
+    float at_xy[16];
+    memcpy(at_xy, NT_MATH_MAT4_IDENTITY, sizeof at_xy);
+    at_xy[12] = x;
+    at_xy[13] = y;
 
     /* Horizontal squeeze: w=20 < (16+16)=32; inner columns must not cross. */
-    nt_sprite_renderer_emit_slice9(s_atlas_res, rs9, x, y, 20.0F, 100.0F, NULL, 1.0F, 0xFFFFFFFFU, 0, NT_MATH_MAT4_IDENTITY);
+    nt_sprite_renderer_emit_slice9(s_atlas_res, rs9, at_xy, 20.0F, 100.0F, 0.0F, 0.0F, NULL, 1.0F, 0xFFFFFFFFU, 0);
     assert_slice9_within_rect(x, y, 20.0F, 100.0F, "narrow-w slice9 corners must stay within rect");
     /* Inner-left <= inner-right (no crossing). */
     float vl[3];
@@ -1832,11 +1837,16 @@ void test_emit_slice9_degrades_when_dst_smaller_than_borders(void) {
     TEST_ASSERT_TRUE_MESSAGE(vl[0] <= vr[0] + 0.5F, "narrow-w inner-left must not cross inner-right");
 
     /* Vertical squeeze: h=10 < 32. */
-    nt_sprite_renderer_emit_slice9(s_atlas_res, rs9, x, y, 100.0F, 10.0F, NULL, 1.0F, 0xFFFFFFFFU, 0, NT_MATH_MAT4_IDENTITY);
+    nt_sprite_renderer_emit_slice9(s_atlas_res, rs9, at_xy, 100.0F, 10.0F, 0.0F, 0.0F, NULL, 1.0F, 0xFFFFFFFFU, 0);
     assert_slice9_within_rect(x, y, 100.0F, 10.0F, "short-h slice9 corners must stay within rect");
+    float vb[3];
+    float vt[3];
+    nt_sprite_renderer_test_last_emit_position(4, vb);
+    nt_sprite_renderer_test_last_emit_position(8, vt);
+    TEST_ASSERT_TRUE_MESSAGE(vb[1] <= vt[1] + 0.5F, "short-h inner-bottom must not cross inner-top");
 
     /* Both axes squeezed: 12 x 8, both < 32. */
-    nt_sprite_renderer_emit_slice9(s_atlas_res, rs9, x, y, 12.0F, 8.0F, NULL, 1.0F, 0xFFFFFFFFU, 0, NT_MATH_MAT4_IDENTITY);
+    nt_sprite_renderer_emit_slice9(s_atlas_res, rs9, at_xy, 12.0F, 8.0F, 0.0F, 0.0F, NULL, 1.0F, 0xFFFFFFFFU, 0);
     assert_slice9_within_rect(x, y, 12.0F, 8.0F, "tiny slice9 corners must stay within rect");
 }
 


### PR DESCRIPTION
Fixes #432.

## What was wrong

`nt_sprite_renderer_emit_slice9` built its 4×4 grid as if the target rect were Y-up: row 0 took the **bottom** border width and sampled `v_max`. But every geometry parameter the UI walker hands to an `emit_*` is in Clay layout space (Y-down), with the screen flip already folded into `world_mat4` (`docs/spec/ui/nt-ui.md:112`, `docs/spec/ui/rich-text.md:223`). So the 9-slice rendered vertically mirrored against the single-quad path, and the `t` border was applied along the bottom edge.

Measured on one region, one 80×60 rect, both paths in the same frame (world is Y-up, viewport 600, so screen top = the largest Y):

| path | top of rect | bottom of rect |
| --- | --- | --- |
| single quad | `v = 0x8000` (source top row) | `v = 0xC000` |
| slice9 (before) | `v = 0xC000` (source bottom row) | `v = 0x8000` |

## The fix

Rows start at the rect's top: `ys` pairs the `t` border with row 0, and `vs` ascends `v_min → v_max` alongside it. `nt_ui.c:1173` is the only caller in the engine, so the UI is the whole blast radius. The header now states the contract instead of leaving the rect's Y direction to the reader.

## Why no test caught it

The shared test atlas (`tests/unit/test_helpers/ui_atlas.c`) paired `local_y` with `V` in the same direction, while the builder emits them **inverted** — `local_y` is Y-up, `atlas_v` stays PNG Y-down (`tools/builder/nt_builder_atlas.c:3560-3565`, `docs/spec/assets/resource.md:365-372`). On that fake data both paths agree, so the mirror was invisible to unit tests. The helper now models what the builder writes.

## Tests

- `test_image_slice9_orientation_matches_single_quad` — walker-level: both paths must put the source's top row at the top of the rect; asymmetric `t`/`b` borders (2/4) additionally pin the border seam 2 px below the top edge. Mutation-checked against both halves of the fix (old `vs` order → FAIL; old `ys` border assignment → FAIL "Expected 2 Was 4").
- `test_slice9_flip_y` expectations follow the corrected contract: with FLIP_Y the borders swap to ft=8/fb=4 (y splits `[0, 8, 76, 80]`) and the top row samples the source's bottom.

`scripts/check.sh --push`: PASS (native-debug, native-release, wasm-debug, wasm-release, ctest, submodule).

## Breaking

Art authored against the mirrored output renders upside down after this and must be re-flipped — the engine examples use symmetric borders and symmetric-enough panels, but at least one game has such art. Asymmetric `slice9_lrtb` in existing atlases now apply the right way round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmFPqMaHPu4N7g3hBZZTvb