### PR TITLE
ui: walker segments paint order by the baked band, not Clay's partial zIndex (#435)

### DIFF
--- a/docs/spec/ui/nt-ui.md
+++ b/docs/spec/ui/nt-ui.md
@@ -56,8 +56,8 @@ one stride per level, themselves included, when every enclosing floating
 is an engine overlay. A widget's own floating parts declare delta 0 and
 paint above their container's content of the same layer because they are
 declared last — which also means a floating declared AFTER one of them in
-the same band and layer paints over it, so a scrollbar yields to a tooltip
-opened later in the same panel. There is no way out
+the same band and layer paints over it, so a scrollbar yields to a slider
+thumb declared later in the same panel. There is no way out
 of an enclosing stacking context: a game floating that must stay under
 all UI belongs at the root level.
 
@@ -65,8 +65,9 @@ The value Clay stores and reports for a floating is the accumulated
 band, not the declared delta. `nt_ui` bakes that band per element in
 `build_tree` and the walker segments paint order on it — the `zIndex`
 field of individual render commands is never read (Clay fills it only for
-RECTANGLE, TEXT and the clip SCISSOR). Paint order is band asc, then
-`layer` asc, then declaration; SCISSOR/CUSTOM are hard barriers. An
+RECTANGLE, TEXT and the floating root's clip SCISSOR). Paint order is band
+asc, then `layer` asc within each barrier-delimited run, then declaration;
+SCISSOR/CUSTOM are hard barriers. An
 accumulated band that would saturate `int16`
 raises a Clay error, which `nt_ui` asserts on rather than silently
 merging two bands. That caps what a game floating may declare: its own

--- a/docs/spec/ui/nt-ui.md
+++ b/docs/spec/ui/nt-ui.md
@@ -54,23 +54,22 @@ Bands accumulate with declaration nesting, NOT with attachment:
 declared as one `modal_zband_stride` each, so nested overlays accumulate
 one stride per level, themselves included, when every enclosing floating
 is an engine overlay. A widget's own floating parts declare delta 0 and
-paint above their container's content of the same layer because they are
-declared last — which also means a floating declared AFTER one of them in
-the same band and layer paints over it, so a scrollbar yields to a slider
-thumb declared later in the same panel. There is no way out
+paint above their container's content because they are declared last;
+they clipTo the container, which opens a SCISSOR barrier, so `layer`
+never reorders them against it — and a floating declared AFTER one of
+them in the same band paints over it. There is no way out
 of an enclosing stacking context: a game floating that must stay under
 all UI belongs at the root level.
 
 The value Clay stores and reports for a floating is the accumulated
-band, not the declared delta. `nt_ui` bakes that band per element in
-`build_tree` and the walker segments paint order on it — the `zIndex`
-field of individual render commands is never read (Clay fills it only for
-RECTANGLE, TEXT and the floating root's clip SCISSOR). Paint order is band
-asc, then `layer` asc within each barrier-delimited run, then declaration;
-SCISSOR/CUSTOM are hard barriers. An
-accumulated band that would saturate `int16`
-raises a Clay error, which `nt_ui` asserts on rather than silently
-merging two bands. That caps what a game floating may declare: its own
+band, not the declared delta. `nt_ui` bakes that band per element and
+the walker orders on it — the `zIndex` field of individual render
+commands is never read by the engine (Clay fills it only for RECTANGLE,
+TEXT and the floating root's clip SCISSOR). Paint order is band asc, then
+`layer` asc within each barrier-delimited run, then declaration;
+SCISSOR/CUSTOM are hard barriers. An accumulated band that would saturate
+`int16` raises a Clay error, which `nt_ui` asserts on rather than
+silently merging two bands. That caps what a game floating may declare: its own
 `zIndex` plus one stride per overlay level nested inside it must still
 fit `int16`.
 

--- a/docs/spec/ui/nt-ui.md
+++ b/docs/spec/ui/nt-ui.md
@@ -54,17 +54,20 @@ Bands accumulate with declaration nesting, NOT with attachment:
 declared as one `modal_zband_stride` each, so nested overlays accumulate
 one stride per level, themselves included, when every enclosing floating
 is an engine overlay. A widget's own floating parts declare delta 0 and
-paint above their container's content because they are declared last —
-which also means a floating declared AFTER one of them in the same band
-paints over it, so a scrollbar yields to a tooltip opened later in the
-same panel. There is no way out
+paint above their container's content of the same layer because they are
+declared last — which also means a floating declared AFTER one of them in
+the same band and layer paints over it, so a scrollbar yields to a tooltip
+opened later in the same panel. There is no way out
 of an enclosing stacking context: a game floating that must stay under
 all UI belongs at the root level.
 
 The value Clay stores and reports for a floating is the accumulated
-band, not the declared delta. Among render commands only RECTANGLE, TEXT
-and the clip SCISSOR carry it — Clay leaves `zIndex` at 0 on IMAGE,
-BORDER and CUSTOM. An accumulated band that would saturate `int16`
+band, not the declared delta. `nt_ui` bakes that band per element in
+`build_tree` and the walker segments paint order on it — the `zIndex`
+field of individual render commands is never read (Clay fills it only for
+RECTANGLE, TEXT and the clip SCISSOR). Paint order is band asc, then
+`layer` asc, then declaration; SCISSOR/CUSTOM are hard barriers. An
+accumulated band that would saturate `int16`
 raises a Clay error, which `nt_ui` asserts on rather than silently
 merging two bands. That caps what a game floating may declare: its own
 `zIndex` plus one stride per overlay level nested inside it must still

--- a/docs/spec/ui/nt-ui.md
+++ b/docs/spec/ui/nt-ui.md
@@ -54,10 +54,11 @@ Bands accumulate with declaration nesting, NOT with attachment:
 declared as one `modal_zband_stride` each, so nested overlays accumulate
 one stride per level, themselves included, when every enclosing floating
 is an engine overlay. A widget's own floating parts declare delta 0 and
-paint above their container's content because they are declared last;
-they clipTo the container, which opens a SCISSOR barrier, so `layer`
-never reorders them against it — and a floating declared AFTER one of
-them in the same band paints over it. There is no way out
+paint above their container's content because they are declared last.
+Under a clip ancestor their clipTo opens a SCISSOR barrier, so `layer`
+never reorders them against that content; without one they order by
+`layer` like the rest of the band. A floating declared AFTER one of them
+in the same band paints over it. There is no way out
 of an enclosing stacking context: a game floating that must stay under
 all UI belongs at the root level.
 

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -1548,6 +1548,14 @@ static void emit_custom(const nt_ui_context_t *ctx, const Clay_RenderCommand *c,
 
 // #region walk
 /* SCISSOR/CUSTOM/NONE = hard barriers; never reordered. */
+/* Clay stamps zIndex on RECT/TEXT/SCISSOR only; the baked band covers every command. */
+static int16_t cmd_band(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, int32_t n_elements) {
+    if (c->nt_layout_index < 0 || c->nt_layout_index >= n_elements) {
+        return 0;
+    }
+    return ctx->tree_baked[c->nt_layout_index].zindex;
+}
+
 static bool is_segmentable(Clay_RenderCommandType cmd_type) {
     switch (cmd_type) {
     case CLAY_RENDER_COMMAND_TYPE_RECTANGLE:
@@ -1984,11 +1992,11 @@ static void nt_ui_walk_impl(nt_ui_context_t *ctx, const nt_ui_target_t *target, 
             ++i;
             continue;
         }
-        const int16_t seg_z = c->zIndex;
+        const int16_t seg_z = cmd_band(ctx, c, N_elements);
         int32_t seg_end = i + 1;
         while (seg_end < arr->length) {
             const Clay_RenderCommand *next = &arr->internalArray[seg_end];
-            if (next->zIndex != seg_z || !is_segmentable(next->commandType)) {
+            if (!is_segmentable(next->commandType) || cmd_band(ctx, next, N_elements) != seg_z) {
                 break;
             }
             ++seg_end;

--- a/engine/ui/nt_ui.c
+++ b/engine/ui/nt_ui.c
@@ -1548,12 +1548,11 @@ static void emit_custom(const nt_ui_context_t *ctx, const Clay_RenderCommand *c,
 
 // #region walk
 /* SCISSOR/CUSTOM/NONE = hard barriers; never reordered. */
-/* Clay stamps zIndex on RECT/TEXT/SCISSOR only; the baked band covers every command. */
-static int16_t cmd_band(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, int32_t n_elements) {
-    if (c->nt_layout_index < 0 || c->nt_layout_index >= n_elements) {
-        return 0;
-    }
-    return ctx->tree_baked[c->nt_layout_index].zindex;
+/* Clay stamps zIndex on RECT/TEXT/SCISSOR only; the baked band covers every command. Only synthetic
+ * scissors carry -1, and those are barriers, so a segmentable command always maps to a layout element. */
+static const nt_ui_baked_xform_t *cmd_baked(const nt_ui_context_t *ctx, const Clay_RenderCommand *c, int32_t n_elements) {
+    NT_ASSERT(c->nt_layout_index >= 0 && c->nt_layout_index < n_elements && "segmentable command without layout element");
+    return &ctx->tree_baked[c->nt_layout_index];
 }
 
 static bool is_segmentable(Clay_RenderCommandType cmd_type) {
@@ -1992,11 +1991,11 @@ static void nt_ui_walk_impl(nt_ui_context_t *ctx, const nt_ui_target_t *target, 
             ++i;
             continue;
         }
-        const int16_t seg_z = cmd_band(ctx, c, N_elements);
+        const int16_t seg_z = cmd_baked(ctx, c, N_elements)->zindex;
         int32_t seg_end = i + 1;
         while (seg_end < arr->length) {
             const Clay_RenderCommand *next = &arr->internalArray[seg_end];
-            if (!is_segmentable(next->commandType) || cmd_band(ctx, next, N_elements) != seg_z) {
+            if (!is_segmentable(next->commandType) || cmd_baked(ctx, next, N_elements)->zindex != seg_z) {
                 break;
             }
             ++seg_end;
@@ -2032,10 +2031,10 @@ static void nt_ui_walk_impl(nt_ui_context_t *ctx, const nt_ui_target_t *target, 
                     }
                     const uint8_t layer = cc->userData ? ((const nt_ui_element_data_t *)cc->userData)->layer : 0U;
                     if (layer == current_layer) {
-                        const nt_ui_baked_xform_t b = (cc->nt_layout_index < 0 || cc->nt_layout_index >= N_elements) ? nt_ui_internal_identity_baked() : ctx->tree_baked[cc->nt_layout_index];
-                        memcpy(ws.m, b.m, sizeof ws.m);
-                        ws.accum_opacity = b.opacity;
-                        ws.hierarchy_depth = b.hierarchy_depth;
+                        const nt_ui_baked_xform_t *b = cmd_baked(ctx, cc, N_elements);
+                        memcpy(ws.m, b->m, sizeof ws.m);
+                        ws.accum_opacity = b->opacity;
+                        ws.hierarchy_depth = b->hierarchy_depth;
                         dispatch_command(ctx, cc, scissor_stack, &depth, target, &bind, &ws, &counters, force_screen_space, clip_cache, &clip_cache_len);
                     }
                 }

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -477,7 +477,8 @@ static inline const nt_ui_probe_node_t *nt_ui_probe_collect_owned(const nt_ui_co
 #endif
 // #endregion
 
-/* Order: zIndex asc, then layer asc, then declaration. SCISSOR/CUSTOM are hard barriers. */
+/* Order: band (baked effective zIndex) asc, then layer asc within each barrier-delimited run, then
+ * declaration. SCISSOR/CUSTOM are hard barriers. */
 void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
 
 /* Window delta over the walk; includes CUSTOM-handler draws. */

--- a/engine/ui/nt_ui.h
+++ b/engine/ui/nt_ui.h
@@ -477,8 +477,7 @@ static inline const nt_ui_probe_node_t *nt_ui_probe_collect_owned(const nt_ui_co
 #endif
 // #endregion
 
-/* Order: band (baked effective zIndex) asc, then layer asc within each barrier-delimited run, then
- * declaration. SCISSOR/CUSTOM are hard barriers. */
+/* Order: band (baked zIndex) asc, then layer asc within each barrier-delimited run, then declaration. SCISSOR/CUSTOM are hard barriers. */
 void nt_ui_walk(nt_ui_context_t *ctx, const nt_ui_target_t *target);
 
 /* Window delta over the walk; includes CUSTOM-handler draws. */

--- a/engine/ui/nt_ui_clay_impl.c
+++ b/engine/ui/nt_ui_clay_impl.c
@@ -563,7 +563,7 @@ void nt_ui_internal_build_tree(nt_ui_context_t *ctx) {
             continue;
         }
         Clay__LayoutElementTreeRoot *root = Clay__LayoutElementTreeRootArray_Get(&cc->layoutElementTreeRoots, root_idx);
-        /* Band lives here because Clay stamps zIndex on RECT/TEXT/SCISSOR commands only; the walker segments on it. */
+        /* Band is uniform per tree root; the walker segments on this baked copy, not on command zIndex. */
         const int16_t root_zindex = root->zIndex;
 
         nt_ui_baked_xform_t seed;

--- a/engine/ui/nt_ui_clay_impl.c
+++ b/engine/ui/nt_ui_clay_impl.c
@@ -563,7 +563,7 @@ void nt_ui_internal_build_tree(nt_ui_context_t *ctx) {
             continue;
         }
         Clay__LayoutElementTreeRoot *root = Clay__LayoutElementTreeRootArray_Get(&cc->layoutElementTreeRoots, root_idx);
-        /* Effective Clay zIndex is uniform per tree root (Clay tags every command of a root with it). */
+        /* Band lives here because Clay stamps zIndex on RECT/TEXT/SCISSOR commands only; the walker segments on it. */
         const int16_t root_zindex = root->zIndex;
 
         nt_ui_baked_xform_t seed;

--- a/examples/ui_showcase/main.c
+++ b/examples/ui_showcase/main.c
@@ -67,7 +67,7 @@
 // #endregion
 
 // #region layers + reference resolution
-/* Walker batches RECTs/IMAGEs first, then TEXT within each Clay zIndex. */
+/* Walker batches RECTs/IMAGEs first, then TEXT within each band. */
 #define LAYER_BG 0
 #define LAYER_RADIAL 1     /* flat SDF radials — own layer so they batch as one run */
 #define LAYER_RADIAL_IMG 2 /* textured radial-image — own layer, grouped by reveal material */

--- a/tests/unit/test_helpers/ui_walker_fixture.c
+++ b/tests/unit/test_helpers/ui_walker_fixture.c
@@ -146,3 +146,12 @@ void ui_walker_fixture_shutdown(ui_walker_fixture_t *fx) {
 }
 
 #endif /* NT_TEST_ACCESS */
+
+void ui_walker_fixture_inject_cmds(ui_walker_fixture_t *fx, Clay_RenderCommand *cmds, int32_t count, int32_t capacity) {
+    nt_pointer_t mouse = {0};
+    nt_ui_begin(fx->ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
+    nt_ui_end(fx->ctx);
+    fx->ctx->frozen_cmds.internalArray = cmds;
+    fx->ctx->frozen_cmds.length = count;
+    fx->ctx->frozen_cmds.capacity = capacity;
+}

--- a/tests/unit/test_helpers/ui_walker_fixture.h
+++ b/tests/unit/test_helpers/ui_walker_fixture.h
@@ -41,6 +41,9 @@ typedef struct {
 
 void ui_walker_fixture_init(ui_walker_fixture_t *fx, void *arena, size_t arena_size, ui_walker_fx_bind_t bind);
 void ui_walker_fixture_shutdown(ui_walker_fixture_t *fx);
+/* Installs a hand-built command stream as the frozen frame. Runs an empty frame first so the stream's
+ * nt_layout_index 0 (zeroed) resolves to the baked root: identity transform, band 0. */
+void ui_walker_fixture_inject_cmds(ui_walker_fixture_t *fx, Clay_RenderCommand *cmds, int32_t count, int32_t capacity);
 
 #ifdef __cplusplus
 }

--- a/tests/unit/test_nt_ui_inspector.c
+++ b/tests/unit/test_nt_ui_inspector.c
@@ -1746,15 +1746,20 @@ static void test_inspector_layer_split_collapses_dispatch(void) {
     uint8_t seg_layer[SEG_CAP];
     int seg_pipe[SEG_CAP];
     int32_t seg_len = 0;
-    int32_t prev_z = 0;
+    int16_t prev_z = 0;
     bool prev_z_valid = false;
     uint32_t sim_alternations = 0U;
     for (int32_t i = 0; i <= arr->length; ++i) {
         const Clay_RenderCommand *cc = (i < arr->length) ? &arr->internalArray[i] : NULL;
         const bool is_segmentable = (cc != NULL) && (cc->commandType == CLAY_RENDER_COMMAND_TYPE_RECTANGLE || cc->commandType == CLAY_RENDER_COMMAND_TYPE_BORDER ||
                                                      cc->commandType == CLAY_RENDER_COMMAND_TYPE_IMAGE || cc->commandType == CLAY_RENDER_COMMAND_TYPE_TEXT);
-        /* Segment boundary: end of array, non-segmentable cmd, or zIndex change. */
-        const bool boundary = (cc == NULL) || !is_segmentable || (prev_z_valid && cc->zIndex != prev_z);
+        /* Segment boundary: end of array, non-segmentable cmd, or band change (baked, as the walker reads it). */
+        const nt_ui_baked_xform_t *baked = (cc != NULL) ? nt_ui_internal_test_get_tree_baked(s_fx.ctx, cc->nt_layout_index) : NULL;
+        int16_t cc_z = 0;
+        if (baked != NULL) {
+            cc_z = baked->zindex;
+        }
+        const bool boundary = (cc == NULL) || !is_segmentable || (prev_z_valid && cc_z != prev_z);
         if (boundary) {
             if (seg_len > 0) {
                 /* Insertion sort segment indices by layer ascending. */
@@ -1805,7 +1810,7 @@ static void test_inspector_layer_split_collapses_dispatch(void) {
             seg_pipe[seg_len] = pipe;
             ++seg_len;
         }
-        prev_z = cc->zIndex;
+        prev_z = cc_z;
         prev_z_valid = true;
     }
 

--- a/tests/unit/test_nt_ui_slider.c
+++ b/tests/unit/test_nt_ui_slider.c
@@ -882,8 +882,8 @@ static void test_thumb_above_modal_band_first_frame(void) {
         }
     }
     TEST_ASSERT_TRUE_MESSAGE(panel_at >= 0, "the modal panel must emit its background");
-    /* Command index is paint order here: panel rect and thumb image share the modal band and layer 0,
-     * so the walker keeps declaration order between them. */
+    /* Command index is paint order here: the panel clip and the thumb's clipTo put SCISSOR barriers
+     * between the panel rect and the thumb image, and the walker never reorders across barriers. */
     TEST_ASSERT_TRUE_MESSAGE(thumb_at > panel_at, "thumb must paint AFTER the modal panel, not under it");
 
     /* Frame-1 placement is measured against the track in the SAME frame, so a stale parent bbox shows up

--- a/tests/unit/test_nt_ui_slider.c
+++ b/tests/unit/test_nt_ui_slider.c
@@ -882,8 +882,8 @@ static void test_thumb_above_modal_band_first_frame(void) {
         }
     }
     TEST_ASSERT_TRUE_MESSAGE(panel_at >= 0, "the modal panel must emit its background");
-    /* Command index is paint order here because the two commands sit in different zIndex runs (the panel
-     * rect carries the modal band, the thumb image carries 0), and the walker never reorders across runs. */
+    /* Command index is paint order here: panel rect and thumb image share the modal band and layer 0,
+     * so the walker keeps declaration order between them. */
     TEST_ASSERT_TRUE_MESSAGE(thumb_at > panel_at, "thumb must paint AFTER the modal panel, not under it");
 
     /* Frame-1 placement is measured against the track in the SAME frame, so a stale parent bbox shows up

--- a/tests/unit/test_nt_ui_stats.c
+++ b/tests/unit/test_nt_ui_stats.c
@@ -38,11 +38,7 @@ void tearDown(void) {
     ui_walker_fixture_shutdown(&s_fx);
 }
 
-static void inject_frozen_cmds(int32_t count) {
-    s_fx.ctx->frozen_cmds.internalArray = s_test_cmds;
-    s_fx.ctx->frozen_cmds.length = count;
-    s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
-}
+static void inject_frozen_cmds(int32_t count) { ui_walker_fixture_inject_cmds(&s_fx, s_test_cmds, count, MAX_TEST_CMDS); }
 
 /* The metrics-bridge sub-test needs real nt_metrics + overlay bodies; both compile to no-op stubs
  * on the OFF mirror (NT_UI_DEBUG_TOOLS=OFF, which forces NT_METRICS_ENABLED=OFF). The remaining

--- a/tests/unit/test_nt_ui_transform.c
+++ b/tests/unit/test_nt_ui_transform.c
@@ -123,9 +123,7 @@ static void test_walker_custom_game_handler_fires(void) {
     TEST_ASSERT_EQUAL_PTR(&sentinel, s_game_custom_user);
 }
 
-/* ---- Test: OOB nt_layout_index falls back to identity baked (graceful walker
- *      on Clay's error-path synthetic commands). Empty container scale doesn't
- *      crash. ---- */
+/* ---- Test: an empty scaled container walks without crashing. ---- */
 static void test_walker_empty_container_no_crash(void) {
     nt_ui_transform_t t = nt_ui_transform_defaults();
     t.scale_x = 2.0F;

--- a/tests/unit/test_nt_ui_walker_batching.c
+++ b/tests/unit/test_nt_ui_walker_batching.c
@@ -3,10 +3,12 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "atlas/nt_atlas.h"
 #include "clay.h"
 #include "renderers/nt_sprite_renderer.h"
 #include "test_helpers/ui_walker_fixture.h"
 #include "ui/nt_ui.h"
+#include "ui/nt_ui_image.h"
 #include "ui/nt_ui_internal.h"
 #include "unity.h"
 
@@ -34,19 +36,17 @@ static void inject_frozen_cmds(int32_t count) {
 static const nt_ui_element_data_t k_layer_sprite = {.layer = 0U};
 static const nt_ui_element_data_t k_layer_text = {.layer = 1U};
 
-static void make_rect(int idx, int16_t z, float x) {
+static void make_rect(int idx, float x) {
     Clay_RenderCommand *c = &s_test_cmds[idx];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
-    c->zIndex = z;
     c->boundingBox = (Clay_BoundingBox){.x = x, .y = 0, .width = 10, .height = 10};
     c->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255, .g = 0, .b = 0, .a = 255};
     c->userData = (void *)&k_layer_sprite;
 }
 
-static void make_text(int idx, int16_t z, float x) {
+static void make_text(int idx, float x) {
     Clay_RenderCommand *c = &s_test_cmds[idx];
     c->commandType = CLAY_RENDER_COMMAND_TYPE_TEXT;
-    c->zIndex = z;
     c->boundingBox = (Clay_BoundingBox){.x = x, .y = 0, .width = 10, .height = 10};
     c->renderData.text.stringContents = (Clay_StringSlice){.length = 1, .chars = s_text, .baseChars = s_text};
     c->renderData.text.textColor = (Clay_Color){.r = 255, .g = 255, .b = 255, .a = 255};
@@ -67,12 +67,12 @@ static void custom_cb(const nt_ui_custom_frame_t *frame, void *user) {
 /* RECTs on layer 0 + TEXTs on layer 1: layer sort collapses interleaved
  * RTRTRT to 1 sprite dc (sprites batch, single sprite flush on first TEXT). */
 static void test_same_z_rect_text_batches(void) {
-    make_rect(0, 0, 0);
-    make_text(1, 0, 20);
-    make_rect(2, 0, 40);
-    make_text(3, 0, 60);
-    make_rect(4, 0, 80);
-    make_text(5, 0, 100);
+    make_rect(0, 0);
+    make_text(1, 20);
+    make_rect(2, 40);
+    make_text(3, 60);
+    make_rect(4, 80);
+    make_text(5, 100);
     inject_frozen_cmds(6);
 
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
@@ -83,16 +83,14 @@ static void test_same_z_rect_text_batches(void) {
 
 /* Each scissor transition force-flushes to preserve clip scope. */
 static void test_scissor_is_hard_barrier(void) {
-    make_rect(0, 0, 0);
+    make_rect(0, 0);
     s_test_cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_START;
-    s_test_cmds[1].zIndex = 0;
     s_test_cmds[1].boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 800, .height = 600};
     s_test_cmds[1].renderData.clip.horizontal = true;
     s_test_cmds[1].renderData.clip.vertical = true;
-    make_rect(2, 0, 20);
+    make_rect(2, 20);
     s_test_cmds[3].commandType = CLAY_RENDER_COMMAND_TYPE_SCISSOR_END;
-    s_test_cmds[3].zIndex = 0;
-    make_rect(4, 0, 40);
+    make_rect(4, 40);
     inject_frozen_cmds(5);
 
     const uint32_t calls_before = nt_sprite_renderer_test_draw_call_count();
@@ -108,11 +106,10 @@ static void test_custom_is_hard_barrier(void) {
     nt_ui_set_custom_handler(s_fx.ctx, custom_cb, NULL);
 
     static nt_ui_custom_data_t cd = {.type = NT_UI_CUSTOM_TYPE_GAME, .data = NULL};
-    make_rect(0, 0, 0);
+    make_rect(0, 0);
     s_test_cmds[1].commandType = CLAY_RENDER_COMMAND_TYPE_CUSTOM;
-    s_test_cmds[1].zIndex = 0;
     s_test_cmds[1].renderData.custom.customData = &cd;
-    make_rect(2, 0, 20);
+    make_rect(2, 20);
     inject_frozen_cmds(3);
 
     const uint32_t calls_before = nt_sprite_renderer_test_draw_call_count();
@@ -123,17 +120,78 @@ static void test_custom_is_hard_barrier(void) {
     TEST_ASSERT_EQUAL_UINT32(calls_before + 2U, nt_sprite_renderer_test_draw_call_count());
 }
 
-/* z=0 RECT, z=2 TEXT, z=5 RECT -- TEXT between forces sprite flush. */
-static void test_multi_z_preserves_painter_order(void) {
-    make_rect(0, 0, 0);
-    make_text(1, 2, 20);
-    make_rect(2, 5, 40);
-    inject_frozen_cmds(3);
+/* Real Clay trees: the band comes from build_tree, not from the command's own zIndex. IMAGE quads
+ * emit their centre, RECT quads their corner, so the boxes sit in disjoint x ranges and the last
+ * sprite emit is attributed by range. */
+static const nt_ui_image_style_t k_image_style = {.color_packed = 0xFFFFFFFF, .slice9_scale = 1.0F};
 
+static int last_emit_x(void) {
     nt_ui_target_t target = {.viewport = {0, 0, 800, 600}};
     nt_ui_walk(s_fx.ctx, &target);
+    float pos[3];
+    nt_sprite_renderer_test_last_emit_position(0U, pos);
+    return (int)pos[0];
+}
 
-    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_draw_calls(s_fx.ctx));
+/* Inside one lifted band the layer orders IMAGE(1) after RECT(0) even though Clay stamps
+ * zIndex only on the RECT. */
+static void test_band_layer_orders_image_after_rect_inside_overlay(void) {
+    nt_pointer_t mouse = {0};
+    nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
+    nt_atlas_region_ref_t ref = nt_atlas_ref_idx(s_fx.atlas.handle, 0, s_fx.atlas.white_region_idx);
+    CLAY({.id = CLAY_ID("root"), .layout = {.sizing = {CLAY_SIZING_FIXED(800.0F), CLAY_SIZING_FIXED(600.0F)}}}) {
+        CLAY({.id = CLAY_ID("overlay"),
+              .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .zIndex = 1000, .offset = {.x = 300.0F, .y = 0.0F}},
+              .layout = {.layoutDirection = CLAY_LEFT_TO_RIGHT, .sizing = {CLAY_SIZING_FIXED(200.0F), CLAY_SIZING_FIXED(100.0F)}}}) {
+            nt_ui_image(s_fx.ctx, NT_UI_DATA_LAYER(1), &ref, &k_image_style, &(Clay_ElementDeclaration){.layout = {.sizing = {CLAY_SIZING_FIXED(50.0F), CLAY_SIZING_FIXED(50.0F)}}});
+            CLAY({.id = CLAY_ID("ov_rect"), .layout = {.sizing = {CLAY_SIZING_FIXED(50.0F), CLAY_SIZING_FIXED(50.0F)}}, .backgroundColor = {255.0F, 0, 0, 255.0F}, .userData = NT_UI_CLAY_DATA(0)}) {}
+        }
+    }
+    nt_ui_end(s_fx.ctx);
+
+    /* Image spans [300,350), rect [350,400): the image (layer 1) must paint last. */
+    const int x = last_emit_x();
+    TEST_ASSERT_TRUE_MESSAGE(x >= 300 && x < 350, "overlay IMAGE on layer 1 must paint after the overlay RECT on layer 0");
+}
+
+/* A base-band IMAGE adjacent to an overlay IMAGE (both zIndex 0 on the command) must not share
+ * a segment: the base sprite would paint over the overlay. */
+static void test_band_base_sprite_does_not_paint_over_overlay_image(void) {
+    nt_pointer_t mouse = {0};
+    nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
+    nt_atlas_region_ref_t ref = nt_atlas_ref_idx(s_fx.atlas.handle, 0, s_fx.atlas.white_region_idx);
+    CLAY({.id = CLAY_ID("root"), .layout = {.sizing = {CLAY_SIZING_FIXED(800.0F), CLAY_SIZING_FIXED(600.0F)}}}) {
+        nt_ui_image(s_fx.ctx, NT_UI_DATA_LAYER(7), &ref, &k_image_style, &(Clay_ElementDeclaration){.layout = {.sizing = {CLAY_SIZING_FIXED(40.0F), CLAY_SIZING_FIXED(40.0F)}}});
+        CLAY({.id = CLAY_ID("overlay"),
+              .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .zIndex = 1000, .offset = {.x = 300.0F, .y = 0.0F}},
+              .layout = {.sizing = {CLAY_SIZING_FIXED(200.0F), CLAY_SIZING_FIXED(100.0F)}}}) {
+            nt_ui_image(s_fx.ctx, NT_UI_DATA_LAYER(1), &ref, &k_image_style, &(Clay_ElementDeclaration){.layout = {.sizing = {CLAY_SIZING_FIXED(50.0F), CLAY_SIZING_FIXED(50.0F)}}});
+        }
+    }
+    nt_ui_end(s_fx.ctx);
+
+    /* Base image spans [0,40), overlay image [300,350): the overlay must paint last. */
+    const int x = last_emit_x();
+    TEST_ASSERT_TRUE_MESSAGE(x >= 300, "overlay IMAGE must paint after the base-band IMAGE regardless of layer");
+}
+
+/* Band beats layer across tree roots: base RECT(layer 1) still paints under the overlay RECT(layer 0).
+ * Regression guard — RECTs already carried the band before the walker read the baked one. */
+static void test_band_beats_layer_across_roots(void) {
+    nt_pointer_t mouse = {0};
+    nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
+    CLAY({.id = CLAY_ID("root"), .layout = {.sizing = {CLAY_SIZING_FIXED(800.0F), CLAY_SIZING_FIXED(600.0F)}}}) {
+        CLAY({.id = CLAY_ID("base_rect"), .layout = {.sizing = {CLAY_SIZING_FIXED(40.0F), CLAY_SIZING_FIXED(40.0F)}}, .backgroundColor = {0, 255.0F, 0, 255.0F}, .userData = NT_UI_CLAY_DATA(1)}) {}
+        CLAY({.id = CLAY_ID("overlay"),
+              .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .zIndex = 1000, .offset = {.x = 300.0F, .y = 0.0F}},
+              .layout = {.sizing = {CLAY_SIZING_FIXED(50.0F), CLAY_SIZING_FIXED(50.0F)}},
+              .backgroundColor = {255.0F, 0, 0, 255.0F},
+              .userData = NT_UI_CLAY_DATA(0)}) {}
+    }
+    nt_ui_end(s_fx.ctx);
+
+    const int x = last_emit_x();
+    TEST_ASSERT_TRUE_MESSAGE(x >= 300, "overlay RECT on layer 0 must paint after the base RECT on layer 1");
 }
 
 /* NULL userData defaults to layer 0 -- unlayered count exposes how many
@@ -142,19 +200,16 @@ static void test_unlayered_count_tracks_null_userdata(void) {
     /* Bare setup so userData stays NULL on the first two. */
     Clay_RenderCommand *c0 = &s_test_cmds[0];
     c0->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
-    c0->zIndex = 0;
     c0->boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 10, .height = 10};
     c0->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255, .g = 0, .b = 0, .a = 255};
     c0->userData = NULL;
     Clay_RenderCommand *c1 = &s_test_cmds[1];
     c1->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
-    c1->zIndex = 0;
     c1->boundingBox = (Clay_BoundingBox){.x = 20, .y = 0, .width = 10, .height = 10};
     c1->renderData.rectangle.backgroundColor = (Clay_Color){.r = 0, .g = 255, .b = 0, .a = 255};
     c1->userData = NULL;
     Clay_RenderCommand *c2 = &s_test_cmds[2];
     c2->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
-    c2->zIndex = 0;
     c2->boundingBox = (Clay_BoundingBox){.x = 40, .y = 0, .width = 10, .height = 10};
     c2->renderData.rectangle.backgroundColor = (Clay_Color){.r = 0, .g = 0, .b = 255, .a = 255};
     c2->userData = (void *)&k_layer_sprite; /* explicit layer 0 */
@@ -173,14 +228,12 @@ static void test_layer_sort_sparse_layers(void) {
     /* Declared in reverse order; layer 0 must still render first. */
     Clay_RenderCommand *c0 = &s_test_cmds[0];
     c0->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
-    c0->zIndex = 0;
     c0->boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 10, .height = 10};
     c0->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255, .g = 0, .b = 0, .a = 255};
     c0->userData = (void *)&k_layer_high;
 
     Clay_RenderCommand *c1 = &s_test_cmds[1];
     c1->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
-    c1->zIndex = 0;
     c1->boundingBox = (Clay_BoundingBox){.x = 20, .y = 0, .width = 10, .height = 10};
     c1->renderData.rectangle.backgroundColor = (Clay_Color){.r = 0, .g = 255, .b = 0, .a = 255};
     c1->userData = (void *)&k_layer_low;
@@ -199,14 +252,12 @@ static void test_layer_sort_sparse_layers(void) {
 static void test_layer_sort_overrides_declaration_order(void) {
     Clay_RenderCommand *c0 = &s_test_cmds[0];
     c0->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
-    c0->zIndex = 0;
     c0->boundingBox = (Clay_BoundingBox){.x = 0, .y = 0, .width = 10, .height = 10};
     c0->renderData.rectangle.backgroundColor = (Clay_Color){.r = 255, .g = 0, .b = 0, .a = 255};
     c0->userData = (void *)&k_layer_text;
 
     Clay_RenderCommand *c1 = &s_test_cmds[1];
     c1->commandType = CLAY_RENDER_COMMAND_TYPE_RECTANGLE;
-    c1->zIndex = 0;
     c1->boundingBox = (Clay_BoundingBox){.x = 20, .y = 0, .width = 10, .height = 10};
     c1->renderData.rectangle.backgroundColor = (Clay_Color){.r = 0, .g = 255, .b = 0, .a = 255};
     c1->userData = (void *)&k_layer_sprite;
@@ -226,7 +277,9 @@ int main(void) {
     RUN_TEST(test_same_z_rect_text_batches);
     RUN_TEST(test_scissor_is_hard_barrier);
     RUN_TEST(test_custom_is_hard_barrier);
-    RUN_TEST(test_multi_z_preserves_painter_order);
+    RUN_TEST(test_band_layer_orders_image_after_rect_inside_overlay);
+    RUN_TEST(test_band_base_sprite_does_not_paint_over_overlay_image);
+    RUN_TEST(test_band_beats_layer_across_roots);
     RUN_TEST(test_unlayered_count_tracks_null_userdata);
     RUN_TEST(test_layer_sort_overrides_declaration_order);
     RUN_TEST(test_layer_sort_sparse_layers);

--- a/tests/unit/test_nt_ui_walker_batching.c
+++ b/tests/unit/test_nt_ui_walker_batching.c
@@ -27,6 +27,9 @@ void setUp(void) {
 void tearDown(void) { ui_walker_fixture_shutdown(&s_fx); }
 
 static void inject_frozen_cmds(int32_t count) {
+    for (int32_t k = 0; k < count; ++k) {
+        s_test_cmds[k].nt_layout_index = -1; /* synthetic: no layout element, band 0 */
+    }
     s_fx.ctx->frozen_cmds.internalArray = s_test_cmds;
     s_fx.ctx->frozen_cmds.length = count;
     s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
@@ -120,9 +123,9 @@ static void test_custom_is_hard_barrier(void) {
     TEST_ASSERT_EQUAL_UINT32(calls_before + 2U, nt_sprite_renderer_test_draw_call_count());
 }
 
-/* Real Clay trees: the band comes from build_tree, not from the command's own zIndex. IMAGE quads
- * emit their centre, RECT quads their corner, so the boxes sit in disjoint x ranges and the last
- * sprite emit is attributed by range. */
+/* Real Clay trees: the band comes from build_tree, not from the command's own zIndex. Vertex 0 of an
+ * IMAGE lands at the bbox centre with the fixture's origin-(0,0) white region, a RECT's at its corner,
+ * so the boxes sit in disjoint x ranges and the last sprite emit is attributed by range. */
 static const nt_ui_image_style_t k_image_style = {.color_packed = 0xFFFFFFFF, .slice9_scale = 1.0F};
 
 static int last_emit_x(void) {
@@ -151,6 +154,8 @@ static void test_band_layer_orders_image_after_rect_inside_overlay(void) {
 
     /* Image spans [300,350), rect [350,400): the image (layer 1) must paint last. */
     const int x = last_emit_x();
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_rect_command_count(s_fx.ctx));
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_ui_get_last_walk_image_command_count(s_fx.ctx));
     TEST_ASSERT_TRUE_MESSAGE(x >= 300 && x < 350, "overlay IMAGE on layer 1 must paint after the overlay RECT on layer 0");
 }
 
@@ -172,11 +177,11 @@ static void test_band_base_sprite_does_not_paint_over_overlay_image(void) {
 
     /* Base image spans [0,40), overlay image [300,350): the overlay must paint last. */
     const int x = last_emit_x();
+    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_image_command_count(s_fx.ctx));
     TEST_ASSERT_TRUE_MESSAGE(x >= 300, "overlay IMAGE must paint after the base-band IMAGE regardless of layer");
 }
 
-/* Band beats layer across tree roots: base RECT(layer 1) still paints under the overlay RECT(layer 0).
- * Regression guard — RECTs already carried the band before the walker read the baked one. */
+/* Band beats layer across tree roots: base RECT(layer 1) still paints under the overlay RECT(layer 0). */
 static void test_band_beats_layer_across_roots(void) {
     nt_pointer_t mouse = {0};
     nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
@@ -191,7 +196,24 @@ static void test_band_beats_layer_across_roots(void) {
     nt_ui_end(s_fx.ctx);
 
     const int x = last_emit_x();
+    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_rect_command_count(s_fx.ctx));
     TEST_ASSERT_TRUE_MESSAGE(x >= 300, "overlay RECT on layer 0 must paint after the base RECT on layer 1");
+}
+
+/* Same band, same layer: declaration order is the last key. */
+static void test_same_band_same_layer_keeps_declaration_order(void) {
+    nt_pointer_t mouse = {0};
+    nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
+    CLAY({.id = CLAY_ID("root"), .layout = {.layoutDirection = CLAY_LEFT_TO_RIGHT, .sizing = {CLAY_SIZING_FIXED(800.0F), CLAY_SIZING_FIXED(600.0F)}}}) {
+        CLAY({.id = CLAY_ID("first"), .layout = {.sizing = {CLAY_SIZING_FIXED(40.0F), CLAY_SIZING_FIXED(40.0F)}}, .backgroundColor = {0, 255.0F, 0, 255.0F}, .userData = NT_UI_CLAY_DATA(0)}) {}
+        CLAY({.id = CLAY_ID("second"), .layout = {.sizing = {CLAY_SIZING_FIXED(40.0F), CLAY_SIZING_FIXED(40.0F)}}, .backgroundColor = {255.0F, 0, 0, 255.0F}, .userData = NT_UI_CLAY_DATA(0)}) {}
+    }
+    nt_ui_end(s_fx.ctx);
+
+    /* First rect spans [0,40), second [40,80): the second must paint last. */
+    const int x = last_emit_x();
+    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_rect_command_count(s_fx.ctx));
+    TEST_ASSERT_TRUE_MESSAGE(x >= 40, "later-declared RECT of the same band and layer must paint last");
 }
 
 /* NULL userData defaults to layer 0 -- unlayered count exposes how many
@@ -280,6 +302,7 @@ int main(void) {
     RUN_TEST(test_band_layer_orders_image_after_rect_inside_overlay);
     RUN_TEST(test_band_base_sprite_does_not_paint_over_overlay_image);
     RUN_TEST(test_band_beats_layer_across_roots);
+    RUN_TEST(test_same_band_same_layer_keeps_declaration_order);
     RUN_TEST(test_unlayered_count_tracks_null_userdata);
     RUN_TEST(test_layer_sort_overrides_declaration_order);
     RUN_TEST(test_layer_sort_sparse_layers);

--- a/tests/unit/test_nt_ui_walker_batching.c
+++ b/tests/unit/test_nt_ui_walker_batching.c
@@ -26,14 +26,7 @@ void setUp(void) {
 
 void tearDown(void) { ui_walker_fixture_shutdown(&s_fx); }
 
-static void inject_frozen_cmds(int32_t count) {
-    for (int32_t k = 0; k < count; ++k) {
-        s_test_cmds[k].nt_layout_index = -1; /* synthetic: no layout element, band 0 */
-    }
-    s_fx.ctx->frozen_cmds.internalArray = s_test_cmds;
-    s_fx.ctx->frozen_cmds.length = count;
-    s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
-}
+static void inject_frozen_cmds(int32_t count) { ui_walker_fixture_inject_cmds(&s_fx, s_test_cmds, count, MAX_TEST_CMDS); }
 
 /* File-scope so layer data outlives walk (compound literal would scope out). */
 static const nt_ui_element_data_t k_layer_sprite = {.layer = 0U};

--- a/tests/unit/test_nt_ui_walker_batching.c
+++ b/tests/unit/test_nt_ui_walker_batching.c
@@ -123,9 +123,8 @@ static void test_custom_is_hard_barrier(void) {
     TEST_ASSERT_EQUAL_UINT32(calls_before + 2U, nt_sprite_renderer_test_draw_call_count());
 }
 
-/* Real Clay trees: the band comes from build_tree, not from the command's own zIndex. Vertex 0 of an
- * IMAGE lands at the bbox centre with the fixture's origin-(0,0) white region, a RECT's at its corner,
- * so the boxes sit in disjoint x ranges and the last sprite emit is attributed by range. */
+/* Vertex 0 of an IMAGE lands at the bbox centre with the fixture's origin-(0,0) white region, a RECT's
+ * at its corner, so the boxes sit in disjoint x ranges and the last sprite emit is attributed by range. */
 static const nt_ui_image_style_t k_image_style = {.color_packed = 0xFFFFFFFF, .slice9_scale = 1.0F};
 
 static int last_emit_x(void) {
@@ -179,25 +178,6 @@ static void test_band_base_sprite_does_not_paint_over_overlay_image(void) {
     const int x = last_emit_x();
     TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_image_command_count(s_fx.ctx));
     TEST_ASSERT_TRUE_MESSAGE(x >= 300, "overlay IMAGE must paint after the base-band IMAGE regardless of layer");
-}
-
-/* Band beats layer across tree roots: base RECT(layer 1) still paints under the overlay RECT(layer 0). */
-static void test_band_beats_layer_across_roots(void) {
-    nt_pointer_t mouse = {0};
-    nt_ui_begin(s_fx.ctx, 800.0F, 600.0F, 0.0F, &mouse, 1);
-    CLAY({.id = CLAY_ID("root"), .layout = {.sizing = {CLAY_SIZING_FIXED(800.0F), CLAY_SIZING_FIXED(600.0F)}}}) {
-        CLAY({.id = CLAY_ID("base_rect"), .layout = {.sizing = {CLAY_SIZING_FIXED(40.0F), CLAY_SIZING_FIXED(40.0F)}}, .backgroundColor = {0, 255.0F, 0, 255.0F}, .userData = NT_UI_CLAY_DATA(1)}) {}
-        CLAY({.id = CLAY_ID("overlay"),
-              .floating = {.attachTo = CLAY_ATTACH_TO_ROOT, .zIndex = 1000, .offset = {.x = 300.0F, .y = 0.0F}},
-              .layout = {.sizing = {CLAY_SIZING_FIXED(50.0F), CLAY_SIZING_FIXED(50.0F)}},
-              .backgroundColor = {255.0F, 0, 0, 255.0F},
-              .userData = NT_UI_CLAY_DATA(0)}) {}
-    }
-    nt_ui_end(s_fx.ctx);
-
-    const int x = last_emit_x();
-    TEST_ASSERT_EQUAL_UINT32(2U, nt_ui_get_last_walk_rect_command_count(s_fx.ctx));
-    TEST_ASSERT_TRUE_MESSAGE(x >= 300, "overlay RECT on layer 0 must paint after the base RECT on layer 1");
 }
 
 /* Same band, same layer: declaration order is the last key. */
@@ -301,7 +281,6 @@ int main(void) {
     RUN_TEST(test_custom_is_hard_barrier);
     RUN_TEST(test_band_layer_orders_image_after_rect_inside_overlay);
     RUN_TEST(test_band_base_sprite_does_not_paint_over_overlay_image);
-    RUN_TEST(test_band_beats_layer_across_roots);
     RUN_TEST(test_same_band_same_layer_keeps_declaration_order);
     RUN_TEST(test_unlayered_count_tracks_null_userdata);
     RUN_TEST(test_layer_sort_overrides_declaration_order);

--- a/tests/unit/test_nt_ui_walker_custom.c
+++ b/tests/unit/test_nt_ui_walker_custom.c
@@ -39,11 +39,7 @@ void setUp(void) {
 
 void tearDown(void) { ui_walker_fixture_shutdown(&s_fx); }
 
-static void inject_frozen_cmds(int32_t count) {
-    s_fx.ctx->frozen_cmds.internalArray = s_test_cmds;
-    s_fx.ctx->frozen_cmds.length = count;
-    s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
-}
+static void inject_frozen_cmds(int32_t count) { ui_walker_fixture_inject_cmds(&s_fx, s_test_cmds, count, MAX_TEST_CMDS); }
 
 /* registered handler is called with (clay_cmd, userdata). */
 static void test_custom_handler_invoked(void) {

--- a/tests/unit/test_nt_ui_walker_dispatch.c
+++ b/tests/unit/test_nt_ui_walker_dispatch.c
@@ -63,11 +63,7 @@ void tearDown(void) { ui_walker_fixture_shutdown(&s_fx); }
 
 /* Inject a synthetic frozen_cmds array into the ctx so the walker iterates
  * a known-shape command list. Bypasses Clay declaration machinery. */
-static void inject_frozen_cmds(int32_t count) {
-    s_fx.ctx->frozen_cmds.internalArray = s_test_cmds;
-    s_fx.ctx->frozen_cmds.length = count;
-    s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
-}
+static void inject_frozen_cmds(int32_t count) { ui_walker_fixture_inject_cmds(&s_fx, s_test_cmds, count, MAX_TEST_CMDS); }
 
 /* ---- Tests ---- */
 

--- a/tests/unit/test_nt_ui_walker_flush.c
+++ b/tests/unit/test_nt_ui_walker_flush.c
@@ -27,11 +27,7 @@ void setUp(void) {
 
 void tearDown(void) { ui_walker_fixture_shutdown(&s_fx); }
 
-static void inject_frozen_cmds(int32_t count) {
-    s_fx.ctx->frozen_cmds.internalArray = s_test_cmds;
-    s_fx.ctx->frozen_cmds.length = count;
-    s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
-}
+static void inject_frozen_cmds(int32_t count) { ui_walker_fixture_inject_cmds(&s_fx, s_test_cmds, count, MAX_TEST_CMDS); }
 
 /* walker exit flushes both sprite and text renderers. After
  * emitting 1 RECT into the sprite renderer's staging, the staging vertex

--- a/tests/unit/test_nt_ui_walker_readonly.c
+++ b/tests/unit/test_nt_ui_walker_readonly.c
@@ -35,11 +35,7 @@ void tearDown(void) {
     s_setup_bind = UI_WALKER_FX_BIND_ALL;
 }
 
-static void inject_frozen_cmds(int32_t count) {
-    s_fx.ctx->frozen_cmds.internalArray = s_test_cmds;
-    s_fx.ctx->frozen_cmds.length = count;
-    s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
-}
+static void inject_frozen_cmds(int32_t count) { ui_walker_fixture_inject_cmds(&s_fx, s_test_cmds, count, MAX_TEST_CMDS); }
 
 /* two walks against same ctx+target produce identical probe state. */
 static void test_second_walk_identical(void) {

--- a/tests/unit/test_nt_ui_walker_scissor.c
+++ b/tests/unit/test_nt_ui_walker_scissor.c
@@ -26,11 +26,7 @@ void setUp(void) {
 
 void tearDown(void) { ui_walker_fixture_shutdown(&s_fx); }
 
-static void inject_frozen_cmds(int32_t count) {
-    s_fx.ctx->frozen_cmds.internalArray = s_test_cmds;
-    s_fx.ctx->frozen_cmds.length = count;
-    s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
-}
+static void inject_frozen_cmds(int32_t count) { ui_walker_fixture_inject_cmds(&s_fx, s_test_cmds, count, MAX_TEST_CMDS); }
 
 /* 8 nested SCISSOR_START / 8 SCISSOR_END must succeed (depth 8
  * is at the limit but not over). */

--- a/tests/unit/test_ui_radial.c
+++ b/tests/unit/test_ui_radial.c
@@ -69,11 +69,7 @@ void setUp(void) {
 
 void tearDown(void) { ui_walker_fixture_shutdown(&s_fx); }
 
-static void inject_frozen_cmds(int32_t count) {
-    s_fx.ctx->frozen_cmds.internalArray = s_test_cmds;
-    s_fx.ctx->frozen_cmds.length = count;
-    s_fx.ctx->frozen_cmds.capacity = MAX_TEST_CMDS;
-}
+static void inject_frozen_cmds(int32_t count) { ui_walker_fixture_inject_cmds(&s_fx, s_test_cmds, count, MAX_TEST_CMDS); }
 
 /* ---- Route A: CUSTOM handler binds the radial material + emits ---- */
 


### PR DESCRIPTION
Closes #435.

## Problem

`nt_ui_walk` split the frozen command stream into layer-sorted segments on `Clay_RenderCommand.zIndex`. Clay stamps that field only on RECTANGLE, TEXT and the floating root's clip SCISSOR; IMAGE, BORDER, CUSTOM and per-element clip SCISSORs ship with 0. Inside any lifted band (modal, popup, menu, tooltip) the stream read `1000, 0, 0, 1000` and fragmented into one- or two-command runs, so the "band, then layer, then declaration" contract in `nt_ui.h` did not hold there.

Reproduced with real Clay trees on the walker fixture (both tests fail on master):
- overlay z=1000 with IMAGE(layer 1) declared before RECT(layer 0): the rect painted over the image;
- base IMAGE(layer 7) directly followed by an overlay whose first command is an IMAGE(layer 1): both z0, one segment, the base sprite painted over the overlay. This is the case the issue listed as "not established".

## Fix

The engine already bakes the effective band per element in `build_tree` (`nt_ui_baked_xform_t.zindex`) and reads it at dispatch for the transform. The walker now segments on that band (`cmd_baked`, one pointer-returning lookup shared with the layer dispatch). A segmentable command always maps to a layout element (only synthetic scissors carry -1, and those are barriers), so the lookup asserts instead of falling back; the barrier path keeps its identity fallback. The command's own `zIndex` is no longer read anywhere in the engine. No Clay patch: a vendored stamp in the shared initializer would fix the same bug but keep two sources for one fact and add a fifth NT patch to carry across Clay updates.

Also: the false "Clay tags every command of a root with it" comment in `build_tree`, stale comments (slider test, showcase), the header contract line, and the spec paragraph — it now states the paint contract (band, then layer within a barrier-delimited run, then declaration), the "same layer" qualifier on delta-0 floating parts, and a correct delta-0 example.

## Behaviour change

Game content inside a lifted band that put an IMAGE or BORDER on a *lower* layer than an earlier RECT/TEXT and relied on it still painting on top (declaration order won because the segment fragmented) now paints under, exactly as it already did in the base band. Engine widgets draw their IMAGE/BORDER parts on the same layer as their fill rect (menu icons, dropdown chevron, tooltip caret, slider thumb), so their order is unchanged.

## Tests

- `test_nt_ui_walker_batching.c`: two real-tree repros (fail on master, pass here) and a declaration-order pin; each asserts its command counts so a dropped element cannot pass it vacuously. Replaces `test_multi_z_preserves_painter_order`. Tests that inject hand-built command streams run an empty frame first through one fixture helper (eight duplicated helpers removed), so their zeroed `nt_layout_index` resolves to the baked root; the helpers drop the dead `zIndex` parameter.
- `test_nt_ui_inspector.c`: the alternation simulation reads the baked band like the walker.
- Two multi-agent review rounds (principles, UI ordering, tests-as-spec; then minimalism, architecture alternatives, principles + devil's advocate for the Clay-stamp option): no P0/P1; P2s applied in commits 3-4. Architecture verdict: walker-on-baked-band ranked first of six candidates; the Clay-stamp alternative needs two vendored lines (BORDER has its own initializer) and repeats the failure class of #435.
- `check.sh --push` green: 136/136 ctest, native-release, wasm-debug, wasm-release, submodule.

## Visual pass

Done on `ui_showcase` (native-debug): Modals, Dropdown, Menu, Tooltip, Sliders&Progress, Images&Slice9, RichText, Scroll � no regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HmFPqMaHPu4N7g3hBZZTvb




