### PR TITLE
build: isolate test probes from native release libraries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,10 +23,12 @@ If code and spec diverge, flag it explicitly in the response. Do not silently "n
 - **Standard**: C17
 - **Why C17**: broader compiler, Emscripten toolchain, and build environment support
 - **NT_STATIC_CRT** (CMake option, default ON): pins the static release CRT on Windows. Consumers embedding builder + runtime in one exe set OFF to inherit their own `CMAKE_MSVC_RUNTIME_LIBRARY`. All pinning goes through `nt_set_static_crt(_cxx)` — never raw `-U_DLL` (gated by `scripts/check_crt_pins.sh`).
-- **NT_TEST_ACCESS** (CMake option, default ON): builds `tests/` and hands the module test-probe
-  surfaces (`// #region test_access`) to the engine libraries the tests link. `native-release` pins it
-  OFF, so perf measurement (`bunnymark`, `bench_shapes`, `atlas_bench`) and the release `builder` run
-  the same code wasm ships. Test TUs still compile under NDEBUG in `native-release-test`.
+- **NT_BUILD_TESTS** (CMake option, default ON): builds `tests/`, which is also what hands the
+  `NT_TEST_ACCESS` compile define — the module test-probe surfaces (`// #region test_access`) — to the
+  engine libraries the tests link. `native-release` pins it OFF, so perf measurement (`bunnymark`,
+  `bench_shapes`, `atlas_bench`) and the release `builder` carry no probe state or probe bookkeeping,
+  the way wasm always has (`tests/` has always been `if(NOT EMSCRIPTEN)`). On a wasm preset the option
+  gates only the ctest targets. Test TUs meet NDEBUG in `native-release-test`, a CI-only job.
 - **NT_HYBRID_HPG** (CMake option, default ON): exe exports the NVIDIA/AMD hint symbols so hybrid-GPU Windows laptops run games on the discrete GPU. OFF for battery-friendly games/tools; the user's per-app Windows graphics preference always overrides the hint.
 
 If specific build, check, or run commands appear in the repo, keep them up to date in this file.
@@ -154,6 +156,8 @@ Environment differences a local Windows host cannot reproduce:
 - **CI debug ctest runs under ASan/LeakSanitizer** — an `NT_TEST_EXPECT_ASSERT` that longjmps past a live `malloc` fails the test with a leak report printed *after* Unity's `OK`; code an assert-trip test crosses must hold no heap (stack or preallocated buffers).
 - **CI ctest must stay serial** — the real-GL tests share one xvfb display; parallel ctest there fails `glfwInit`. Local `-j` is safe (desktop GL); the real-GL tests hold `RESOURCE_LOCK gl_display` (list in `cmake/test_target.cmake`).
 - **CI native-release passes a global `-DNT_ASSERT_MODE`** — a per-target `-D` collides (`-Wmacro-redefined` under `-Werror`). Force a different assert mode via a wrapper TU with `#undef`/`#define` (pattern: `tests/unit/test_helpers/nt_atlas_assert_off_tu.c`).
+- **Test TUs are not built by a local `--push`** — `native-release` pins `NT_BUILD_TESTS=OFF`, so a
+  `-Wunused` that only NDEBUG shows in a `tests/` file first fires in CI's `native-release-test` job.
 - **Local tidy can false-green NEW files** — before pushing new test/tool files run `clang-tidy -p build/_cmake/tidy-ci <file>` directly (the devapi-enabled DB check.sh creates; plain native-debug lacks devapi TUs); that reproduces CI.
 
 ## Test-infra & debugging gotchas

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,10 @@ If code and spec diverge, flag it explicitly in the response. Do not silently "n
 - **Standard**: C17
 - **Why C17**: broader compiler, Emscripten toolchain, and build environment support
 - **NT_STATIC_CRT** (CMake option, default ON): pins the static release CRT on Windows. Consumers embedding builder + runtime in one exe set OFF to inherit their own `CMAKE_MSVC_RUNTIME_LIBRARY`. All pinning goes through `nt_set_static_crt(_cxx)` — never raw `-U_DLL` (gated by `scripts/check_crt_pins.sh`).
+- **NT_TEST_ACCESS** (CMake option, default ON): builds `tests/` and hands the module test-probe
+  surfaces (`// #region test_access`) to the engine libraries the tests link. `native-release` pins it
+  OFF, so perf measurement (`bunnymark`, `bench_shapes`, `atlas_bench`) and the release `builder` run
+  the same code wasm ships. Test TUs still compile under NDEBUG in `native-release-test`.
 - **NT_HYBRID_HPG** (CMake option, default ON): exe exports the NVIDIA/AMD hint symbols so hybrid-GPU Windows laptops run games on the discrete GPU. OFF for battery-friendly games/tools; the user's per-app Windows graphics preference always overrides the hint.
 
 If specific build, check, or run commands appear in the repo, keep them up to date in this file.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,10 +63,10 @@ option(NT_METRICS_ENABLED "Build the dev-only nt_metrics perf collector." ${NT_U
 option(NT_INTROSPECT_ENABLED "Build the dev-only entity introspection facility." ${NT_UI_DEBUG_TOOLS})
 # Set OFF for a read-only deployment tier; the devapi entity-write group hard-requires it. Build-wide below so component apply()/registration agree without linking introspect.
 option(NT_INTROSPECT_WRITE_ENABLED "Build the dev-only component write (apply) hooks." ${NT_INTROSPECT_ENABLED})
-# The module test-probe surfaces (`// #region test_access`). tests/ hands the define to the engine
-# libraries it links, so OFF is expressed by skipping tests/ entirely: a release measurement build
-# must carry no probe state and no probe bookkeeping in its draw and emit paths.
-option(NT_TEST_ACCESS "Build the unit tests and the module test-probe surfaces they read." ON)
+# OFF skips tests/ entirely, which is also how a build ends up without the NT_TEST_ACCESS compile
+# define: tests/ is what hands that define to the engine libraries it links. A release measurement
+# build must carry no probe state and no probe bookkeeping in its draw and emit paths.
+option(NT_BUILD_TESTS "Build the unit tests (they compile the engine test-probe surfaces in)." ON)
 
 # Master gate for the devapi command layer (engine/devapi). OFF excludes the
 # subdir entirely so release binaries contain zero devapi object code.
@@ -320,7 +320,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
         add_subdirectory(tools/research/hash_benchmark)
         add_subdirectory(tools/research/atlas_bench)
     endif()
-    if(NT_TEST_ACCESS)
+    if(NT_BUILD_TESTS)
         add_subdirectory(tests)
     endif()
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,11 @@ option(NT_METRICS_ENABLED "Build the dev-only nt_metrics perf collector." ${NT_U
 option(NT_INTROSPECT_ENABLED "Build the dev-only entity introspection facility." ${NT_UI_DEBUG_TOOLS})
 # Set OFF for a read-only deployment tier; the devapi entity-write group hard-requires it. Build-wide below so component apply()/registration agree without linking introspect.
 option(NT_INTROSPECT_WRITE_ENABLED "Build the dev-only component write (apply) hooks." ${NT_INTROSPECT_ENABLED})
+# The module test-probe surfaces (`// #region test_access`). tests/ hands the define to the engine
+# libraries it links, so OFF is expressed by skipping tests/ entirely: a release measurement build
+# must carry no probe state and no probe bookkeeping in its draw and emit paths.
+option(NT_TEST_ACCESS "Build the unit tests and the module test-probe surfaces they read." ON)
+
 # Master gate for the devapi command layer (engine/devapi). OFF excludes the
 # subdir entirely so release binaries contain zero devapi object code.
 option(NT_DEVAPI_ENABLED "Build the devapi command layer (engine/devapi)." OFF)
@@ -315,5 +320,7 @@ if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
         add_subdirectory(tools/research/hash_benchmark)
         add_subdirectory(tools/research/atlas_bench)
     endif()
-    add_subdirectory(tests)
+    if(NT_TEST_ACCESS)
+        add_subdirectory(tests)
+    endif()
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -112,6 +112,7 @@
             "binaryDir": "${sourceDir}/build/_cmake/native-release",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
+                "NT_TEST_ACCESS": "OFF",
                 "NT_UI_DEBUG_TOOLS": "OFF",
                 "NT_LOG_RING_ENABLED": "OFF",
                 "NT_METRICS_ENABLED": "OFF",
@@ -135,6 +136,7 @@
             "binaryDir": "${sourceDir}/build/_cmake/native-release-test",
             "cacheVariables": {
                 "NT_ASSERT_MODE": "2",
+                "NT_TEST_ACCESS": "ON",
                 "NT_UI_DEBUG_TOOLS": "ON",
                 "NT_LOG_RING_ENABLED": "ON",
                 "NT_METRICS_ENABLED": "ON",

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -112,7 +112,7 @@
             "binaryDir": "${sourceDir}/build/_cmake/native-release",
             "cacheVariables": {
                 "CMAKE_BUILD_TYPE": "Release",
-                "NT_TEST_ACCESS": "OFF",
+                "NT_BUILD_TESTS": "OFF",
                 "NT_UI_DEBUG_TOOLS": "OFF",
                 "NT_LOG_RING_ENABLED": "OFF",
                 "NT_METRICS_ENABLED": "OFF",
@@ -136,7 +136,7 @@
             "binaryDir": "${sourceDir}/build/_cmake/native-release-test",
             "cacheVariables": {
                 "NT_ASSERT_MODE": "2",
-                "NT_TEST_ACCESS": "ON",
+                "NT_BUILD_TESTS": "ON",
                 "NT_UI_DEBUG_TOOLS": "ON",
                 "NT_LOG_RING_ENABLED": "ON",
                 "NT_METRICS_ENABLED": "ON",

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -1714,8 +1714,6 @@ void nt_gfx_test_viewport_rect(int out[4]) {
 
 uint32_t nt_gfx_test_bound_pipeline(void) { return s_gfx.bound_pipeline; }
 
-uint32_t nt_gfx_test_bound_program(void) { return (s_gfx.bound_pipeline != 0) ? s_gfx.pipeline_programs[nt_pool_slot_index(s_gfx.bound_pipeline)] : 0; }
-
 uint32_t nt_gfx_test_bound_vertex_input(void) { return s_gfx.bound_vertex_input; }
 
 uint8_t nt_gfx_test_texture_set_state(void) { return s_gfx.texture_set_state; }

--- a/engine/graphics/nt_gfx.c
+++ b/engine/graphics/nt_gfx.c
@@ -161,46 +161,6 @@ _Static_assert(NT_GFX_MAX_TEXTURE_SLOTS <= 8, "texture unit masks are uint8_t");
 
 static void discard_texture_set(void) { s_gfx.texture_set_state = NT_GFX_TEXTURE_SET_NONE; }
 
-#ifdef NT_TEST_ACCESS
-static nt_gfx_test_draw_t s_test_draws[128];
-static uint32_t s_test_draw_count;
-static bool s_test_draw_enabled;
-static bool s_test_draw_overflow;
-
-void nt_gfx_test_draw_trace_reset(bool enabled) {
-    s_test_draw_count = 0;
-    s_test_draw_overflow = false;
-    s_test_draw_enabled = enabled;
-}
-
-uint32_t nt_gfx_test_draw_trace_count(void) { return s_test_draw_count; }
-bool nt_gfx_test_draw_trace_overflowed(void) { return s_test_draw_overflow; }
-
-nt_gfx_test_draw_t nt_gfx_test_draw_trace_at(uint32_t index) {
-    NT_ASSERT(index < s_test_draw_count);
-    return s_test_draws[index];
-}
-
-static void test_record_draw(uint32_t first_vertex, uint32_t num_vertices, uint32_t first_index, uint32_t num_indices, uint32_t instance_count) {
-    if (!s_test_draw_enabled) {
-        return;
-    }
-    if (s_test_draw_count == sizeof(s_test_draws) / sizeof(s_test_draws[0])) {
-        s_test_draw_overflow = true;
-        return;
-    }
-    s_test_draws[s_test_draw_count++] = (nt_gfx_test_draw_t){
-        .pipeline = {s_gfx.bound_pipeline},
-        .program = {s_gfx.pipeline_programs[nt_pool_slot_index(s_gfx.bound_pipeline)]},
-        .first_vertex = first_vertex,
-        .num_vertices = num_vertices,
-        .first_index = first_index,
-        .num_indices = num_indices,
-        .instance_count = instance_count,
-    };
-}
-#endif
-
 /* ---- Global UBO block registration ---- */
 
 void nt_gfx_register_global_block(const char *name, uint32_t binding_slot) {
@@ -231,9 +191,6 @@ void nt_gfx_get_global_blocks(const nt_global_block_t **blocks, uint32_t *count)
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_gfx_init(const nt_gfx_desc_t *desc) {
-#ifdef NT_TEST_ACCESS
-    nt_gfx_test_draw_trace_reset(false);
-#endif
     NT_ASSERT(desc);
     NT_ASSERT(desc->max_shaders > 0 && "nt_gfx_desc_t.max_shaders is 0 -- use nt_gfx_desc_defaults() or set explicitly");
     NT_ASSERT(desc->max_programs > 0 && "nt_gfx_desc_t.max_programs is 0 -- use nt_gfx_desc_defaults() or set explicitly");
@@ -1757,6 +1714,8 @@ void nt_gfx_test_viewport_rect(int out[4]) {
 
 uint32_t nt_gfx_test_bound_pipeline(void) { return s_gfx.bound_pipeline; }
 
+uint32_t nt_gfx_test_bound_program(void) { return (s_gfx.bound_pipeline != 0) ? s_gfx.pipeline_programs[nt_pool_slot_index(s_gfx.bound_pipeline)] : 0; }
+
 uint32_t nt_gfx_test_bound_vertex_input(void) { return s_gfx.bound_vertex_input; }
 
 uint8_t nt_gfx_test_texture_set_state(void) { return s_gfx.texture_set_state; }
@@ -1966,9 +1925,6 @@ void nt_gfx_draw(uint32_t first_vertex, uint32_t num_vertices) {
 
     g_nt_gfx.frame_stats.draw_calls++;
     g_nt_gfx.frame_stats.vertices += num_vertices;
-#ifdef NT_TEST_ACCESS
-    test_record_draw(first_vertex, num_vertices, 0, 0, 1);
-#endif
     nt_gfx_backend_draw(first_vertex, num_vertices);
 }
 
@@ -1998,9 +1954,6 @@ void nt_gfx_draw_instanced(uint32_t first_vertex, uint32_t num_vertices, uint32_
     g_nt_gfx.frame_stats.draw_calls_instanced++;
     g_nt_gfx.frame_stats.vertices += num_vertices * instance_count;
     g_nt_gfx.frame_stats.instances += instance_count;
-#ifdef NT_TEST_ACCESS
-    test_record_draw(first_vertex, num_vertices, 0, 0, instance_count);
-#endif
     nt_gfx_backend_draw_instanced(first_vertex, num_vertices, instance_count);
 }
 
@@ -2030,9 +1983,6 @@ void nt_gfx_draw_indexed(uint32_t first_index, uint32_t num_indices, uint32_t nu
     g_nt_gfx.frame_stats.draw_calls++;
     g_nt_gfx.frame_stats.vertices += num_vertices;
     g_nt_gfx.frame_stats.indices += num_indices;
-#ifdef NT_TEST_ACCESS
-    test_record_draw(0, num_vertices, first_index, num_indices, 1);
-#endif
     nt_gfx_backend_draw_indexed(first_index, num_indices, s_gfx.bound_index_type);
 }
 
@@ -2064,9 +2014,6 @@ void nt_gfx_draw_indexed_instanced(uint32_t first_index, uint32_t num_indices, u
     g_nt_gfx.frame_stats.vertices += num_vertices * instance_count;
     g_nt_gfx.frame_stats.indices += num_indices * instance_count;
     g_nt_gfx.frame_stats.instances += instance_count;
-#ifdef NT_TEST_ACCESS
-    test_record_draw(0, num_vertices, first_index, num_indices, instance_count);
-#endif
     nt_gfx_backend_draw_indexed_instanced(first_index, num_indices, instance_count, s_gfx.bound_index_type);
 }
 
@@ -2556,21 +2503,11 @@ static bool mesh_blob_valid(const uint8_t *data, uint32_t size) {
     return true;
 }
 
-#ifdef NT_TEST_ACCESS
-static uint32_t s_test_last_mesh_vertex_hash;
-static uint32_t s_test_last_mesh_index_hash;
-uint32_t nt_gfx_test_last_mesh_vertex_hash(void) { return s_test_last_mesh_vertex_hash; }
-uint32_t nt_gfx_test_last_mesh_index_hash(void) { return s_test_last_mesh_index_hash; }
-#endif
-
 /* Uploads the IBO from the wire index block (decoding MESHOPT first).
  * *out_ibo stays {0} for non-indexed meshes; returns false on failure
  * (nothing left to clean up). */
 static bool mesh_make_ibo(const NtMeshAssetHeader *hdr, const uint8_t *index_data, nt_buffer_t *out_ibo) {
     *out_ibo = (nt_buffer_t){0};
-#ifdef NT_TEST_ACCESS
-    s_test_last_mesh_index_hash = 0;
-#endif
     if (hdr->index_type == 0 || hdr->index_count == 0) {
         return true;
     }
@@ -2590,9 +2527,6 @@ static bool mesh_make_ibo(const NtMeshAssetHeader *hdr, const uint8_t *index_dat
         }
         gpu_index_data = idx_tmp;
     }
-#ifdef NT_TEST_ACCESS
-    s_test_last_mesh_index_hash = nt_hash32(gpu_index_data, gpu_index_size).value;
-#endif
     *out_ibo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
         .type = NT_BUFFER_INDEX,
         .usage = NT_USAGE_IMMUTABLE,
@@ -2639,9 +2573,6 @@ uint32_t nt_gfx_activate_mesh(const uint8_t *data, uint32_t size) {
         gpu_vertex_data = soa_tmp;
     }
 
-#ifdef NT_TEST_ACCESS
-    s_test_last_mesh_vertex_hash = (hdr->vertex_data_size > 0) ? nt_hash32(gpu_vertex_data, hdr->vertex_data_size).value : 0;
-#endif
     nt_buffer_t vbo = nt_gfx_make_buffer(&(nt_buffer_desc_t){
         .type = NT_BUFFER_VERTEX,
         .usage = NT_USAGE_IMMUTABLE,

--- a/engine/graphics/nt_gfx.h
+++ b/engine/graphics/nt_gfx.h
@@ -751,32 +751,12 @@ uint16_t nt_gfx_max_meshes(void);
 
 // #region test_access
 #ifdef NT_TEST_ACCESS
-typedef struct {
-    nt_pipeline_t pipeline;
-    nt_program_t program;
-    uint32_t first_vertex;
-    uint32_t num_vertices;
-    uint32_t first_index;
-    uint32_t num_indices;
-    uint32_t instance_count;
-} nt_gfx_test_draw_t;
-
-void nt_gfx_test_draw_trace_reset(bool enabled);
-uint32_t nt_gfx_test_draw_trace_count(void);
-nt_gfx_test_draw_t nt_gfx_test_draw_trace_at(uint32_t index);
-bool nt_gfx_test_draw_trace_overflowed(void);
-
 /* Read back the cached scissor rect [x, y, w, h] from the last
  * nt_gfx_set_scissor call. Out-param must be a 4-element int array. */
 void nt_gfx_test_scissor_rect(int out[4]);
 /* Read back the cached viewport rect [x, y, w, h] from the last
  * nt_gfx_set_viewport call. Out-param must be a 4-element int array. */
 void nt_gfx_test_viewport_rect(int out[4]);
-/* Hash (nt_hash32) of the GPU-form bytes the last nt_gfx_activate_mesh
- * uploaded -- pins that wire decode actually ran at the upload boundary.
- * Index hash is 0 for a non-indexed mesh. */
-uint32_t nt_gfx_test_last_mesh_vertex_hash(void);
-uint32_t nt_gfx_test_last_mesh_index_hash(void);
 #endif
 // #endregion
 

--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -179,8 +179,6 @@ uint32_t nt_gfx_test_texture_backend_id(nt_texture_t tex);
 uint32_t nt_gfx_test_render_target_backend_id(nt_render_target_t rt);
 /* Pass-scoped bound state, read from its owner: the front-end. */
 uint32_t nt_gfx_test_bound_pipeline(void);
-/* Full program handle the bound pipeline borrows; 0 when no pipeline is bound. */
-uint32_t nt_gfx_test_bound_program(void);
 uint32_t nt_gfx_test_bound_vertex_input(void);
 uint8_t nt_gfx_test_texture_set_state(void);
 bool nt_gfx_test_program_sampler_info(nt_program_t prog, nt_hash32_t name, nt_gfx_sampler_info_t *out_info);

--- a/engine/graphics/nt_gfx_internal.h
+++ b/engine/graphics/nt_gfx_internal.h
@@ -179,6 +179,8 @@ uint32_t nt_gfx_test_texture_backend_id(nt_texture_t tex);
 uint32_t nt_gfx_test_render_target_backend_id(nt_render_target_t rt);
 /* Pass-scoped bound state, read from its owner: the front-end. */
 uint32_t nt_gfx_test_bound_pipeline(void);
+/* Full program handle the bound pipeline borrows; 0 when no pipeline is bound. */
+uint32_t nt_gfx_test_bound_program(void);
 uint32_t nt_gfx_test_bound_vertex_input(void);
 uint8_t nt_gfx_test_texture_set_state(void);
 bool nt_gfx_test_program_sampler_info(nt_program_t prog, nt_hash32_t name, nt_gfx_sampler_info_t *out_info);

--- a/engine/postfx/nt_postfx_blur.c
+++ b/engine/postfx/nt_postfx_blur.c
@@ -69,9 +69,6 @@ static struct {
      * module active so the next one retries, with the pass skipped meanwhile. */
     bool initialized;
     bool gpu_ready;
-#ifdef NT_TEST_ACCESS
-    uint32_t draw_count;
-#endif
 } s_blur;
 
 /* Fixed uniform names: hashed once at init, the blur path sets them every pass. */
@@ -406,9 +403,6 @@ static void draw_blur_pass(nt_texture_t source, nt_render_target_t target, const
     upload_kernel(radius, packed);
     nt_gfx_draw(0, 3);
     nt_gfx_end_pass();
-#ifdef NT_TEST_ACCESS
-    s_blur.draw_count++;
-#endif
 }
 
 void nt_postfx_blur_gaussian(const nt_postfx_blur_pass_t *pass) {
@@ -429,9 +423,5 @@ void nt_postfx_blur_gaussian(const nt_postfx_blur_pass_t *pass) {
 #ifdef NT_TEST_ACCESS
 uint32_t nt_postfx_blur_test_build_kernel(float radius, float sigma, float out_weights[NT_POSTFX_BLUR_MAX_KERNEL]) { return build_kernel(radius, sigma, out_weights); }
 
-uint32_t nt_postfx_blur_test_draw_count(void) { return s_blur.draw_count; }
-
 const char *nt_postfx_blur_test_fs_source(void) { return s_blur_fs_src; }
-
-void nt_postfx_blur_test_reset_counters(void) { s_blur.draw_count = 0; }
 #endif

--- a/engine/postfx/nt_postfx_blur.h
+++ b/engine/postfx/nt_postfx_blur.h
@@ -31,8 +31,6 @@ void nt_postfx_blur_gaussian(const nt_postfx_blur_pass_t *pass);
 // #region test_access
 #ifdef NT_TEST_ACCESS
 uint32_t nt_postfx_blur_test_build_kernel(float radius, float sigma, float out_weights[NT_POSTFX_BLUR_MAX_KERNEL]);
-uint32_t nt_postfx_blur_test_draw_count(void);
-void nt_postfx_blur_test_reset_counters(void);
 /* Borrowed static fragment source; never freed or modified by the caller. */
 const char *nt_postfx_blur_test_fs_source(void);
 #endif

--- a/scripts/bench_hull_tolerance.sh
+++ b/scripts/bench_hull_tolerance.sh
@@ -193,9 +193,17 @@ done
 if [[ ! -f "build/_cmake/${PRESET}/CMakeCache.txt" ]]; then
     cmake --preset "$PRESET"
 fi
-echo "=== Building atlas_bench and focused acceptance (${PRESET}) ==="
-cmake --build "build/_cmake/${PRESET}" --target atlas_bench test_builder
-ctest --test-dir "build/_cmake/${PRESET}" -R '^test_builder$' --output-on-failure
+echo "=== Building atlas_bench (${PRESET}) ==="
+cmake --build "build/_cmake/${PRESET}" --target atlas_bench
+
+# native-release carries no test targets (NT_BUILD_TESTS=OFF, so its builder measures what
+# ships); the acceptance run moves to the debug preset, which always has them.
+if [[ ! -f "build/_cmake/native-debug/CMakeCache.txt" ]]; then
+    cmake --preset native-debug
+fi
+echo "=== Focused builder acceptance (native-debug) ==="
+cmake --build build/_cmake/native-debug --target test_builder
+ctest --test-dir build/_cmake/native-debug -R '^test_builder$' --output-on-failure
 
 BENCH_BASE="build/tools/research/${PRESET}/atlas_bench"
 if [[ -x "${BENCH_BASE}.exe" ]]; then

--- a/scripts/bench_hull_tolerance.sh
+++ b/scripts/bench_hull_tolerance.sh
@@ -193,6 +193,10 @@ done
 if [[ ! -f "build/_cmake/${PRESET}/CMakeCache.txt" ]]; then
     cmake --preset "$PRESET"
 fi
+if [[ "$PRESET" == native-release ]] && ! grep -q '^NT_BUILD_TESTS:BOOL=OFF$' "build/_cmake/${PRESET}/CMakeCache.txt"; then
+    echo "ERROR: native-release cache has NT_BUILD_TESTS != OFF — reconfigure it: cmake --preset native-release" >&2
+    exit 1
+fi
 echo "=== Building atlas_bench (${PRESET}) ==="
 cmake --build "build/_cmake/${PRESET}" --target atlas_bench
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -199,7 +199,7 @@ if [ "$MODE" = "default" ] && ! printf '%s\n' "$CHANGED_NAMES_ALL" | grep -qE "$
     CTEST_ARGS=(-E '^(test_atlas_hull_visual_report|test_atlas_transform_sweep_guard|test_bench_hull_tolerance_guard)$')
 fi
 CTEST_LOG="$NATIVE_BUILD_DIR/check-ctest.log" # kept on disk; overwritten per run
-ctest --test-dir "$NATIVE_BUILD_DIR" -j "$(nproc)" --output-on-failure "${CTEST_ARGS[@]}" > "$CTEST_LOG" 2>&1 &
+ctest --test-dir "$NATIVE_BUILD_DIR" -j "$(nproc)" --output-on-failure --no-tests=error "${CTEST_ARGS[@]}" > "$CTEST_LOG" 2>&1 &
 CTEST_PID=$!
 echo "(backgrounded, pid $CTEST_PID)"
 

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -248,9 +248,10 @@ fi
 collect_ctest
 
 if [ "$MODE" = "push" ]; then
-    # Release compiles the same TUs with NDEBUG (asserts -> TRAP, so NT_ASSERT_FULL-only code drops out)
-    # and -O2: a test registered behind an assert-mode guard, or a variable only an assert reads, is
-    # -Wunused under -Werror here and nowhere in the debug builds. Mirrors ci.yml's native-release job.
+    # Release compiles the ENGINE TUs with NDEBUG (asserts -> TRAP, so NT_ASSERT_FULL-only code drops
+    # out) and -O2: a variable only an assert reads is -Wunused under -Werror here and nowhere in the
+    # debug builds. tests/ is NOT in this build (NT_BUILD_TESTS=OFF) -- test TUs meet NDEBUG only in
+    # ci.yml's native-release-test job. Mirrors ci.yml's native-release job.
     step "build (native-release)"
     NR_CACHE="build/_cmake/native-release/CMakeCache.txt"
     if [ ! -f "$NR_CACHE" ]; then
@@ -262,6 +263,12 @@ if [ "$MODE" = "push" ]; then
     # compiles again and the -Wunused class the step exists for disappears.
     if ! grep -q '^NT_ASSERT_MODE:STRING=$' "$NR_CACHE"; then
         echo "ERROR: native-release cache overrides NT_ASSERT_MODE — it must stay empty (auto -> TRAP)."
+        exit 1
+    fi
+    # The preset pins NT_BUILD_TESTS=OFF, but a directory configured before that pin keeps the
+    # option default (ON) across an implicit reconfigure -- probes back in, measurements instrumented.
+    if ! grep -q '^NT_BUILD_TESTS:BOOL=OFF$' "$NR_CACHE"; then
+        echo "ERROR: native-release cache has NT_BUILD_TESTS != OFF — reconfigure it: cmake --preset native-release"
         exit 1
     fi
     cmake --build build/_cmake/native-release

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Native unit tests (Unity framework via CTest)
 # WASM tests run through CTest via Node.js when available
 #
-# This whole directory is gated by the NT_TEST_ACCESS option (top-level CMakeLists.txt):
+# This whole directory is gated by the NT_BUILD_TESTS option (top-level CMakeLists.txt):
 # skipping it is how a release measurement build ends up with no probe surface at all.
 # NT_TEST_ACCESS: single shared define that gates every module's test
 # surface (the `// #region test_access` block at the bottom of each

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 # Native unit tests (Unity framework via CTest)
 # WASM tests run through CTest via Node.js when available
 #
+# This whole directory is gated by the NT_TEST_ACCESS option (top-level CMakeLists.txt):
+# skipping it is how a release measurement build ends up with no probe surface at all.
 # NT_TEST_ACCESS: single shared define that gates every module's test
 # surface (the `// #region test_access` block at the bottom of each
 # header). Applied at directory level here so all binaries below pick

--- a/tests/unit/test_gfx.c
+++ b/tests/unit/test_gfx.c
@@ -1944,7 +1944,7 @@ void test_activate_mesh_soa_wire_decodes(void) {
         memcpy(expected + ((size_t)v * 16), wire + ((size_t)v * 12), 12);
         memcpy(expected + ((size_t)v * 16) + 12, wire + 36 + ((size_t)v * 4), 4);
     }
-    TEST_ASSERT_EQUAL_HEX32(nt_hash32(expected, VD).value, nt_gfx_test_last_mesh_vertex_hash());
+    TEST_ASSERT_EQUAL_HEX32(nt_hash32(expected, VD).value, nt_gfx_fake_last_vertex_buffer_hash());
     nt_gfx_deactivate_mesh(handle);
 }
 
@@ -1988,7 +1988,7 @@ void test_activate_mesh_meshopt_wire_decodes(void) {
     TEST_ASSERT_NOT_EQUAL_UINT32(0, info->ibo.id);
     /* The UPLOADED bytes must be the decoded canonical triangle list */
     static const uint16_t expected_idx[24] = {0, 1, 5, 5, 1, 6, 6, 1, 2, 6, 2, 7, 7, 2, 3, 7, 3, 8, 8, 3, 4, 8, 4, 9};
-    TEST_ASSERT_EQUAL_HEX32(nt_hash32(expected_idx, sizeof(expected_idx)).value, nt_gfx_test_last_mesh_index_hash());
+    TEST_ASSERT_EQUAL_HEX32(nt_hash32(expected_idx, sizeof(expected_idx)).value, nt_gfx_fake_last_index_buffer_hash());
     nt_gfx_deactivate_mesh(handle);
 }
 

--- a/tests/unit/test_helpers/nt_gfx_fake.c
+++ b/tests/unit/test_helpers/nt_gfx_fake.c
@@ -95,6 +95,8 @@ static uint32_t s_fake_uniform_vec4_count;
 static uint32_t s_fake_bind_pipeline_count;
 static uint32_t s_fake_update_texture_count;
 static uint32_t s_fake_update_buffer_count;
+static uint32_t s_fake_last_vertex_buffer_hash;
+static uint32_t s_fake_last_index_buffer_hash;
 static uint32_t s_fake_backend_restore_count;
 static uint32_t s_fake_gpu_caps_probe_count;
 static uint16_t s_fake_last_render_target_width;
@@ -159,6 +161,8 @@ void nt_gfx_fake_uniform_vec4_value_at(uint32_t index, float out[4]) {
 }
 uint32_t nt_gfx_fake_update_texture_count(void) { return s_fake_update_texture_count; }
 uint32_t nt_gfx_fake_update_buffer_count(void) { return s_fake_update_buffer_count; }
+uint32_t nt_gfx_fake_last_vertex_buffer_hash(void) { return s_fake_last_vertex_buffer_hash; }
+uint32_t nt_gfx_fake_last_index_buffer_hash(void) { return s_fake_last_index_buffer_hash; }
 uint32_t nt_gfx_fake_backend_restore_count(void) { return s_fake_backend_restore_count; }
 uint32_t nt_gfx_fake_gpu_caps_probe_count(void) { return s_fake_gpu_caps_probe_count; }
 uint16_t nt_gfx_fake_last_render_target_width(void) { return s_fake_last_render_target_width; }
@@ -212,6 +216,8 @@ void nt_gfx_fake_reset(void) {
     s_fake_bind_pipeline_count = 0;
     s_fake_update_texture_count = 0;
     s_fake_update_buffer_count = 0;
+    s_fake_last_vertex_buffer_hash = 0;
+    s_fake_last_index_buffer_hash = 0;
     s_fake_backend_restore_count = 0;
     s_fake_gpu_caps_probe_count = 0;
     s_fake_last_render_target_width = 0;
@@ -241,8 +247,46 @@ void nt_gfx_fake_reset(void) {
     s_fake_fail_next_render_target_resize = false;
 }
 
+static nt_gfx_fake_draw_t s_fake_draws[128];
+static uint32_t s_fake_draw_count;
+static bool s_fake_draw_enabled;
+static bool s_fake_draw_overflow;
+
+void nt_gfx_fake_draw_trace_reset(bool enabled) {
+    s_fake_draw_count = 0;
+    s_fake_draw_overflow = false;
+    s_fake_draw_enabled = enabled;
+}
+
+uint32_t nt_gfx_fake_draw_trace_count(void) { return s_fake_draw_count; }
+bool nt_gfx_fake_draw_trace_overflowed(void) { return s_fake_draw_overflow; }
+
+nt_gfx_fake_draw_t nt_gfx_fake_draw_trace_at(uint32_t index) {
+    NT_ASSERT(index < s_fake_draw_count);
+    return s_fake_draws[index];
+}
+
+static void fake_record_draw(uint32_t first_vertex, uint32_t first_index, uint32_t num_indices, uint32_t instance_count) {
+    if (!s_fake_draw_enabled) {
+        return;
+    }
+    if (s_fake_draw_count == sizeof(s_fake_draws) / sizeof(s_fake_draws[0])) {
+        s_fake_draw_overflow = true;
+        return;
+    }
+    s_fake_draws[s_fake_draw_count++] = (nt_gfx_fake_draw_t){
+        .pipeline = {nt_gfx_test_bound_pipeline()},
+        .program = {nt_gfx_test_bound_program()},
+        .first_vertex = first_vertex,
+        .first_index = first_index,
+        .num_indices = num_indices,
+        .instance_count = instance_count,
+    };
+}
+
 bool nt_gfx_backend_init(const nt_gfx_desc_t *desc) {
     NT_ASSERT(desc != NULL);
+    nt_gfx_fake_draw_trace_reset(false);
     free(s_fake_program_table);
     s_fake_max_programs = desc->max_programs;
     /* Init-only: a mid-test reset must never re-issue a texture id that is still live. */
@@ -382,7 +426,15 @@ void nt_gfx_backend_bind_vertex_input(uint32_t backend_handle) {
 }
 
 uint32_t nt_gfx_backend_create_buffer(const nt_buffer_desc_t *desc) {
-    (void)desc;
+    /* Hash at the upload boundary: the only place the GPU-form bytes exist. */
+    if (desc->data != NULL && desc->size > 0) {
+        uint32_t h = nt_hash32(desc->data, desc->size).value;
+        if (desc->type == NT_BUFFER_INDEX) {
+            s_fake_last_index_buffer_hash = h;
+        } else {
+            s_fake_last_vertex_buffer_hash = h;
+        }
+    }
     bool fail = (s_fake_fail_buffer_creates & 1U) != 0;
     s_fake_fail_buffer_creates >>= 1U;
     if (fail) {
@@ -604,26 +656,22 @@ void nt_gfx_backend_set_uniform_int(uint32_t program_backend, uint32_t name_hash
 }
 
 void nt_gfx_backend_draw(uint32_t first_vertex, uint32_t num_vertices) {
-    (void)first_vertex;
+    fake_record_draw(first_vertex, 0, 0, 1);
     (void)num_vertices;
 }
 
 void nt_gfx_backend_draw_indexed(uint32_t first_index, uint32_t num_indices, uint8_t index_type) {
-    (void)first_index;
-    (void)num_indices;
+    fake_record_draw(0, first_index, num_indices, 1);
     (void)index_type;
 }
 
 void nt_gfx_backend_draw_instanced(uint32_t first_vertex, uint32_t num_vertices, uint32_t instance_count) {
-    (void)first_vertex;
+    fake_record_draw(first_vertex, 0, 0, instance_count);
     (void)num_vertices;
-    (void)instance_count;
 }
 
 void nt_gfx_backend_draw_indexed_instanced(uint32_t first_index, uint32_t num_indices, uint32_t instance_count, uint8_t index_type) {
-    (void)first_index;
-    (void)num_indices;
-    (void)instance_count;
+    fake_record_draw(0, first_index, num_indices, instance_count);
     (void)index_type;
 }
 

--- a/tests/unit/test_helpers/nt_gfx_fake.c
+++ b/tests/unit/test_helpers/nt_gfx_fake.c
@@ -277,9 +277,10 @@ static void fake_record_draw(uint32_t num_indices, uint32_t instance_count) {
         s_fake_draw_overflow = true;
         return;
     }
+    nt_pipeline_t pipeline = {nt_gfx_test_bound_pipeline()};
     s_fake_draws[s_fake_draw_count++] = (nt_gfx_fake_draw_t){
-        .pipeline = {nt_gfx_test_bound_pipeline()},
-        .program = {nt_gfx_test_bound_program()},
+        .pipeline = pipeline,
+        .program = nt_gfx_pipeline_program(pipeline),
         .num_indices = num_indices,
         .instance_count = instance_count,
     };

--- a/tests/unit/test_helpers/nt_gfx_fake.c
+++ b/tests/unit/test_helpers/nt_gfx_fake.c
@@ -247,6 +247,9 @@ void nt_gfx_fake_reset(void) {
     s_fake_fail_next_render_target_resize = false;
 }
 
+/* Deliberately outside nt_gfx_fake_reset: test_sprite_renderer's capacity-flush test resets the
+ * other observations mid-scenario and still reads draws recorded before that. Scope is the explicit
+ * nt_gfx_fake_draw_trace_reset alone (plus the disarm in backend_init). */
 static nt_gfx_fake_draw_t s_fake_draws[128];
 static uint32_t s_fake_draw_count;
 static bool s_fake_draw_enabled;
@@ -266,7 +269,7 @@ nt_gfx_fake_draw_t nt_gfx_fake_draw_trace_at(uint32_t index) {
     return s_fake_draws[index];
 }
 
-static void fake_record_draw(uint32_t first_vertex, uint32_t first_index, uint32_t num_indices, uint32_t instance_count) {
+static void fake_record_draw(uint32_t num_indices, uint32_t instance_count) {
     if (!s_fake_draw_enabled) {
         return;
     }
@@ -277,8 +280,6 @@ static void fake_record_draw(uint32_t first_vertex, uint32_t first_index, uint32
     s_fake_draws[s_fake_draw_count++] = (nt_gfx_fake_draw_t){
         .pipeline = {nt_gfx_test_bound_pipeline()},
         .program = {nt_gfx_test_bound_program()},
-        .first_vertex = first_vertex,
-        .first_index = first_index,
         .num_indices = num_indices,
         .instance_count = instance_count,
     };
@@ -431,7 +432,7 @@ uint32_t nt_gfx_backend_create_buffer(const nt_buffer_desc_t *desc) {
         uint32_t h = nt_hash32(desc->data, desc->size).value;
         if (desc->type == NT_BUFFER_INDEX) {
             s_fake_last_index_buffer_hash = h;
-        } else {
+        } else if (desc->type == NT_BUFFER_VERTEX) {
             s_fake_last_vertex_buffer_hash = h;
         }
     }
@@ -656,22 +657,26 @@ void nt_gfx_backend_set_uniform_int(uint32_t program_backend, uint32_t name_hash
 }
 
 void nt_gfx_backend_draw(uint32_t first_vertex, uint32_t num_vertices) {
-    fake_record_draw(first_vertex, 0, 0, 1);
+    fake_record_draw(0, 1);
+    (void)first_vertex;
     (void)num_vertices;
 }
 
 void nt_gfx_backend_draw_indexed(uint32_t first_index, uint32_t num_indices, uint8_t index_type) {
-    fake_record_draw(0, first_index, num_indices, 1);
+    fake_record_draw(num_indices, 1);
+    (void)first_index;
     (void)index_type;
 }
 
 void nt_gfx_backend_draw_instanced(uint32_t first_vertex, uint32_t num_vertices, uint32_t instance_count) {
-    fake_record_draw(first_vertex, 0, 0, instance_count);
+    fake_record_draw(0, instance_count);
+    (void)first_vertex;
     (void)num_vertices;
 }
 
 void nt_gfx_backend_draw_indexed_instanced(uint32_t first_index, uint32_t num_indices, uint32_t instance_count, uint8_t index_type) {
-    fake_record_draw(0, first_index, num_indices, instance_count);
+    fake_record_draw(num_indices, instance_count);
+    (void)first_index;
     (void)index_type;
 }
 

--- a/tests/unit/test_helpers/nt_gfx_fake.h
+++ b/tests/unit/test_helpers/nt_gfx_fake.h
@@ -19,9 +19,7 @@ nt_program_t nt_gfx_fake_make_program_typed(const char *const *names, const uint
 typedef struct {
     nt_pipeline_t pipeline;
     nt_program_t program;
-    uint32_t first_vertex; /* 0 on an indexed draw */
-    uint32_t first_index;
-    uint32_t num_indices;
+    uint32_t num_indices; /* 0 on a non-indexed draw: the backend gets no vertex count */
     uint32_t instance_count;
 } nt_gfx_fake_draw_t;
 
@@ -64,8 +62,9 @@ nt_texture_desc_t nt_gfx_fake_last_texture_desc(void);
 uint32_t nt_gfx_fake_last_depth_texture_backend(void);
 uint32_t nt_gfx_fake_update_texture_count(void);
 uint32_t nt_gfx_fake_update_buffer_count(void);
-/* nt_hash32 of the bytes the last created VERTEX / INDEX buffer uploaded --
- * pins that mesh wire decode ran before the upload. 0 until one is created. */
+/* nt_hash32 of the bytes the last created VERTEX / INDEX buffer uploaded -- pins that mesh wire
+ * decode ran before the upload. Scope is per buffer creation, not per mesh: a mesh that creates no
+ * index buffer leaves the previous one readable. Only nt_gfx_fake_reset clears them. */
 uint32_t nt_gfx_fake_last_vertex_buffer_hash(void);
 uint32_t nt_gfx_fake_last_index_buffer_hash(void);
 uint32_t nt_gfx_fake_backend_restore_count(void);

--- a/tests/unit/test_helpers/nt_gfx_fake.h
+++ b/tests/unit/test_helpers/nt_gfx_fake.h
@@ -15,7 +15,7 @@ nt_program_t nt_gfx_fake_make_program_typed(const char *const *names, const uint
 
 /* Draw trace: recorded by the fake backend, so the engine's draw path stays
  * free of test bookkeeping. pipeline/program are the FRONTEND handles bound at
- * draw time, read back through nt_gfx_test_bound_pipeline/_bound_program. */
+ * draw time, read through nt_gfx_test_bound_pipeline and nt_gfx_pipeline_program. */
 typedef struct {
     nt_pipeline_t pipeline;
     nt_program_t program;

--- a/tests/unit/test_helpers/nt_gfx_fake.h
+++ b/tests/unit/test_helpers/nt_gfx_fake.h
@@ -13,6 +13,23 @@ void nt_gfx_fake_set_samplers_typed(const char *const *names, const uint8_t *sam
 nt_program_t nt_gfx_fake_make_program(const char *const *names, uint8_t count);
 nt_program_t nt_gfx_fake_make_program_typed(const char *const *names, const uint8_t *sampler_classes, uint8_t count);
 
+/* Draw trace: recorded by the fake backend, so the engine's draw path stays
+ * free of test bookkeeping. pipeline/program are the FRONTEND handles bound at
+ * draw time, read back through nt_gfx_test_bound_pipeline/_bound_program. */
+typedef struct {
+    nt_pipeline_t pipeline;
+    nt_program_t program;
+    uint32_t first_vertex; /* 0 on an indexed draw */
+    uint32_t first_index;
+    uint32_t num_indices;
+    uint32_t instance_count;
+} nt_gfx_fake_draw_t;
+
+void nt_gfx_fake_draw_trace_reset(bool enabled);
+uint32_t nt_gfx_fake_draw_trace_count(void);
+nt_gfx_fake_draw_t nt_gfx_fake_draw_trace_at(uint32_t index);
+bool nt_gfx_fake_draw_trace_overflowed(void);
+
 /* Test-only backend observations and failure injection. */
 uint32_t nt_gfx_fake_last_sampler(uint32_t slot);
 uint32_t nt_gfx_fake_bind_sampler_count(void);
@@ -47,6 +64,10 @@ nt_texture_desc_t nt_gfx_fake_last_texture_desc(void);
 uint32_t nt_gfx_fake_last_depth_texture_backend(void);
 uint32_t nt_gfx_fake_update_texture_count(void);
 uint32_t nt_gfx_fake_update_buffer_count(void);
+/* nt_hash32 of the bytes the last created VERTEX / INDEX buffer uploaded --
+ * pins that mesh wire decode ran before the upload. 0 until one is created. */
+uint32_t nt_gfx_fake_last_vertex_buffer_hash(void);
+uint32_t nt_gfx_fake_last_index_buffer_hash(void);
 uint32_t nt_gfx_fake_backend_restore_count(void);
 uint32_t nt_gfx_fake_gpu_caps_probe_count(void);
 void nt_gfx_fake_fail_texture_creates(uint8_t mask);

--- a/tests/unit/test_mesh_renderer.c
+++ b/tests/unit/test_mesh_renderer.c
@@ -552,14 +552,14 @@ void test_draw_list_different_materials(void) {
     items[1].entity = e1.id;
     items[1].batch_key = nt_mesh_renderer_batch_key(mat_b, mesh);
 
-    nt_gfx_test_draw_trace_reset(true);
+    nt_gfx_fake_draw_trace_reset(true);
     nt_mesh_renderer_draw_list(items, 2);
 
     TEST_ASSERT_EQUAL_UINT32(2, nt_mesh_renderer_test_draw_call_count());
     /* Creating B's pipeline mid-list must not disturb the state A already bound. */
-    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_test_draw_trace_count());
-    TEST_ASSERT_NOT_EQUAL_UINT32(nt_gfx_test_draw_trace_at(0).pipeline.id, nt_gfx_test_draw_trace_at(1).pipeline.id);
-    nt_gfx_test_draw_trace_reset(false);
+    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_fake_draw_trace_count());
+    TEST_ASSERT_NOT_EQUAL_UINT32(nt_gfx_fake_draw_trace_at(0).pipeline.id, nt_gfx_fake_draw_trace_at(1).pipeline.id);
+    nt_gfx_fake_draw_trace_reset(false);
 }
 
 /* ---- Test 6: alternating materials -> 3 draw calls (no re-batching) ---- */
@@ -666,13 +666,13 @@ void test_neighbouring_programs_one_cull_step_apart_get_their_own_pipelines(void
         {.sort_key = 1, .entity = e1.id, .batch_key = nt_mesh_renderer_batch_key(mat_b, mesh)},
     };
 
-    nt_gfx_test_draw_trace_reset(true);
+    nt_gfx_fake_draw_trace_reset(true);
     nt_mesh_renderer_draw_list(items, 2);
 
     TEST_ASSERT_EQUAL_UINT32(2, nt_mesh_renderer_test_pipeline_cache_count());
-    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_test_draw_trace_count());
-    TEST_ASSERT_EQUAL_UINT32(p0.id, nt_gfx_test_draw_trace_at(0).program.id);
-    TEST_ASSERT_EQUAL_UINT32(p1.id, nt_gfx_test_draw_trace_at(1).program.id);
+    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_fake_draw_trace_count());
+    TEST_ASSERT_EQUAL_UINT32(p0.id, nt_gfx_fake_draw_trace_at(0).program.id);
+    TEST_ASSERT_EQUAL_UINT32(p1.id, nt_gfx_fake_draw_trace_at(1).program.id);
 }
 
 /* An unresolved slot would leave the previous material's texture on the unit, so the
@@ -892,17 +892,17 @@ void test_state_render_state_split(void) {
     fill_items(items, entities, mats, meshes, 3);
 
     nt_gfx_fake_reset();
-    nt_gfx_test_draw_trace_reset(true);
+    nt_gfx_fake_draw_trace_reset(true);
     nt_mesh_renderer_draw_list(items, 3);
 
     TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_fake_pipeline_create_count());
     TEST_ASSERT_EQUAL_UINT32(3, nt_gfx_fake_bind_pipeline_count());
-    TEST_ASSERT_EQUAL_UINT32(3, nt_gfx_test_draw_trace_count());
-    const uint32_t pip_a = nt_gfx_test_draw_trace_at(0).pipeline.id;
-    const uint32_t pip_b = nt_gfx_test_draw_trace_at(1).pipeline.id;
+    TEST_ASSERT_EQUAL_UINT32(3, nt_gfx_fake_draw_trace_count());
+    const uint32_t pip_a = nt_gfx_fake_draw_trace_at(0).pipeline.id;
+    const uint32_t pip_b = nt_gfx_fake_draw_trace_at(1).pipeline.id;
     TEST_ASSERT_NOT_EQUAL_UINT32(pip_a, pip_b);
-    TEST_ASSERT_EQUAL_UINT32(pip_a, nt_gfx_test_draw_trace_at(2).pipeline.id);
-    nt_gfx_test_draw_trace_reset(false);
+    TEST_ASSERT_EQUAL_UINT32(pip_a, nt_gfx_fake_draw_trace_at(2).pipeline.id);
+    nt_gfx_fake_draw_trace_reset(false);
 }
 
 void test_state_runtime_set_param_between_calls(void) {
@@ -937,22 +937,22 @@ void test_state_program_replaced_between_calls(void) {
     fill_items(items, &e, &mat, &mesh, 1);
 
     nt_gfx_fake_reset();
-    nt_gfx_test_draw_trace_reset(true);
+    nt_gfx_fake_draw_trace_reset(true);
     nt_mesh_renderer_draw_list(items, 1);
 
     nt_program_t p2 = create_test_tex_program();
     nt_material_set_program(mat, p2);
     nt_mesh_renderer_draw_list(items, 1);
 
-    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_test_draw_trace_count());
-    const nt_gfx_test_draw_t first = nt_gfx_test_draw_trace_at(0);
-    const nt_gfx_test_draw_t second = nt_gfx_test_draw_trace_at(1);
+    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_fake_draw_trace_count());
+    const nt_gfx_fake_draw_t first = nt_gfx_fake_draw_trace_at(0);
+    const nt_gfx_fake_draw_t second = nt_gfx_fake_draw_trace_at(1);
     TEST_ASSERT_EQUAL_UINT32(p2.id, second.program.id);
     TEST_ASSERT_NOT_EQUAL_UINT32(first.pipeline.id, second.pipeline.id);
     /* Bound state is call-scoped, so the new program's unit is filled again. */
     TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_fake_bound_texture_count());
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_uniform_int_count());
-    nt_gfx_test_draw_trace_reset(false);
+    nt_gfx_fake_draw_trace_reset(false);
 }
 
 /* A material without a sampler override must restore the texture's asset default
@@ -1061,14 +1061,14 @@ void test_state_skip_mid_list_resolves_next_run(void) {
     fill_items(items, entities, mats, meshes, 3);
 
     nt_gfx_fake_reset();
-    nt_gfx_test_draw_trace_reset(true);
+    nt_gfx_fake_draw_trace_reset(true);
     nt_mesh_renderer_draw_list(items, 3);
 
     TEST_ASSERT_EQUAL_UINT32(2, nt_mesh_renderer_test_draw_call_count());
-    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_test_draw_trace_count());
-    TEST_ASSERT_EQUAL_UINT32(nt_gfx_test_draw_trace_at(0).pipeline.id, nt_gfx_test_draw_trace_at(1).pipeline.id);
+    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_fake_draw_trace_count());
+    TEST_ASSERT_EQUAL_UINT32(nt_gfx_fake_draw_trace_at(0).pipeline.id, nt_gfx_fake_draw_trace_at(1).pipeline.id);
     TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_fake_uniform_vec4_count());
-    nt_gfx_test_draw_trace_reset(false);
+    nt_gfx_fake_draw_trace_reset(false);
 }
 
 /* A run whose pipeline could not be created binds nothing, so the run after it
@@ -1088,16 +1088,16 @@ void test_state_pipeline_failure_mid_list_rebinds_next_run(void) {
     /* A's pipeline is created first, so the failure lands on B. */
     nt_mesh_renderer_draw_list(items, 1);
     nt_gfx_fake_reset();
-    nt_gfx_test_draw_trace_reset(true);
+    nt_gfx_fake_draw_trace_reset(true);
     nt_gfx_fake_fail_next_pipeline_create();
     nt_mesh_renderer_draw_list(items, 3);
 
     TEST_ASSERT_EQUAL_UINT32(2, nt_mesh_renderer_test_draw_call_count());
-    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_test_draw_trace_count());
-    TEST_ASSERT_EQUAL_UINT32(nt_gfx_test_draw_trace_at(0).pipeline.id, nt_gfx_test_draw_trace_at(1).pipeline.id);
+    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_fake_draw_trace_count());
+    TEST_ASSERT_EQUAL_UINT32(nt_gfx_fake_draw_trace_at(0).pipeline.id, nt_gfx_fake_draw_trace_at(1).pipeline.id);
     TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_fake_bind_pipeline_count());
     TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_fake_uniform_vec4_count());
-    nt_gfx_test_draw_trace_reset(false);
+    nt_gfx_fake_draw_trace_reset(false);
 }
 
 void test_state_same_tex_same_sampler_diff_params(void) {
@@ -1202,13 +1202,13 @@ void test_color_modes_on_one_program_share_a_pipeline_and_split_vertex_inputs(vo
         items[i] = (nt_render_item_t){.sort_key = i, .entity = e.id, .batch_key = nt_mesh_renderer_batch_key(mats[i], mesh)};
     }
 
-    nt_gfx_test_draw_trace_reset(true);
+    nt_gfx_fake_draw_trace_reset(true);
     nt_mesh_renderer_draw_list(items, 3);
 
     TEST_ASSERT_EQUAL_UINT32(1, nt_mesh_renderer_test_pipeline_cache_count());
     TEST_ASSERT_EQUAL_UINT32(3, nt_mesh_renderer_test_vertex_input_count());
-    TEST_ASSERT_EQUAL_UINT32(3, nt_gfx_test_draw_trace_count());
-    TEST_ASSERT_EQUAL_UINT32(nt_gfx_test_draw_trace_at(0).pipeline.id, nt_gfx_test_draw_trace_at(2).pipeline.id);
+    TEST_ASSERT_EQUAL_UINT32(3, nt_gfx_fake_draw_trace_count());
+    TEST_ASSERT_EQUAL_UINT32(nt_gfx_fake_draw_trace_at(0).pipeline.id, nt_gfx_fake_draw_trace_at(2).pipeline.id);
 }
 
 /* Neighbour test for the mesh vertex-input key: one-step changes of each lane

--- a/tests/unit/test_nt_postfx_blur.c
+++ b/tests/unit/test_nt_postfx_blur.c
@@ -58,7 +58,7 @@ void setUp(void) {
     nt_gfx_fake_reset();
     nt_gfx_fake_set_samplers((const char *const[]){"u_source"}, 1);
     TEST_ASSERT_EQUAL_INT(NT_OK, nt_postfx_blur_init());
-    nt_postfx_blur_test_reset_counters();
+    nt_gfx_fake_draw_trace_reset(true);
 }
 
 void tearDown(void) {
@@ -114,7 +114,7 @@ static void test_invalid_descriptors_assert_without_draw(void) {
     NT_TEST_EXPECT_ASSERT(nt_postfx_blur_gaussian(&(nt_postfx_blur_pass_t){.source = source, .temp = temp, .dest = dest, .radius = NAN}));
     NT_TEST_EXPECT_ASSERT(nt_postfx_blur_gaussian(&(nt_postfx_blur_pass_t){.source = source, .temp = temp, .dest = dest, .radius = 4.0F, .sigma = -1.0F}));
 
-    TEST_ASSERT_EQUAL_UINT32(0, nt_postfx_blur_test_draw_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_draw_trace_count());
 }
 
 static void test_feedback_aliases_assert_without_draw(void) {
@@ -139,7 +139,7 @@ static void test_feedback_aliases_assert_without_draw(void) {
         .radius = 4.0F,
     }));
 
-    TEST_ASSERT_EQUAL_UINT32(0, nt_postfx_blur_test_draw_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_draw_trace_count());
 }
 
 static void test_depth_feedback_alias_asserts_without_draw(void) {
@@ -163,7 +163,7 @@ static void test_depth_feedback_alias_asserts_without_draw(void) {
     }));
     nt_gfx_end_frame();
 
-    TEST_ASSERT_EQUAL_UINT32(0, nt_postfx_blur_test_draw_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_draw_trace_count());
 }
 
 static void test_stale_source_asserts_without_draw(void) {
@@ -185,7 +185,7 @@ static void test_stale_source_asserts_without_draw(void) {
     }));
     nt_gfx_end_frame();
 
-    TEST_ASSERT_EQUAL_UINT32(0, nt_postfx_blur_test_draw_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_draw_trace_count());
 }
 
 static void test_integer_source_asserts_without_draw(void) {
@@ -213,7 +213,7 @@ static void test_integer_source_asserts_without_draw(void) {
     }));
     nt_gfx_end_frame();
 
-    TEST_ASSERT_EQUAL_UINT32(0, nt_postfx_blur_test_draw_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_draw_trace_count());
 }
 
 static void test_blur_outside_frame_asserts_without_draw(void) {
@@ -230,7 +230,7 @@ static void test_blur_outside_frame_asserts_without_draw(void) {
         .dest = dest,
         .radius = 4.0F,
     }));
-    TEST_ASSERT_EQUAL_UINT32(0, nt_postfx_blur_test_draw_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_draw_trace_count());
 }
 
 static void test_blur_inside_active_pass_asserts_without_closing_it(void) {
@@ -249,7 +249,7 @@ static void test_blur_inside_active_pass_asserts_without_closing_it(void) {
         .dest = dest,
         .radius = 4.0F,
     }));
-    TEST_ASSERT_EQUAL_UINT32(0, nt_postfx_blur_test_draw_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_draw_trace_count());
     nt_gfx_end_pass();
     nt_gfx_end_frame();
 }
@@ -276,7 +276,7 @@ static void test_incomplete_targets_assert_without_draw(void) {
         .radius = 4.0F,
     }));
 
-    TEST_ASSERT_EQUAL_UINT32(0, nt_postfx_blur_test_draw_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_draw_trace_count());
     nt_gfx_end_frame();
 }
 
@@ -297,7 +297,7 @@ static void test_mixed_size_targets_assert_without_draw(void) {
     }));
     nt_gfx_end_frame();
 
-    TEST_ASSERT_EQUAL_UINT32(0, nt_postfx_blur_test_draw_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_draw_trace_count());
 }
 
 static void test_enabled_scissor_asserts_without_draw(void) {
@@ -321,7 +321,7 @@ static void test_enabled_scissor_asserts_without_draw(void) {
     nt_gfx_set_scissor_enabled(false);
     nt_gfx_end_frame();
 
-    TEST_ASSERT_EQUAL_UINT32(0, nt_postfx_blur_test_draw_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_draw_trace_count());
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_pass_target_count());
 }
 
@@ -346,7 +346,7 @@ static void test_valid_blur_uses_two_passes_and_no_hidden_target_allocation(void
     nt_gfx_end_frame();
 
     TEST_ASSERT_EQUAL_UINT32(creates_before, nt_gfx_fake_render_target_create_count());
-    TEST_ASSERT_EQUAL_UINT32(2, nt_postfx_blur_test_draw_count());
+    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_fake_draw_trace_count());
     TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_get_frame_draw_calls());
     TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_fake_pass_target_count());
     TEST_ASSERT_EQUAL_UINT32(nt_gfx_test_render_target_backend_id(temp), nt_gfx_fake_pass_target_at(0));
@@ -386,21 +386,21 @@ static void test_failed_restore_is_retried_by_the_next_one(void) {
     /* A pass while the rebuild is still pending skips instead of trapping: the
      * state is recoverable, so it must not crash a game that blurs every frame. */
     nt_gfx_fake_set_context_lost(false);
-    nt_postfx_blur_test_reset_counters();
+    nt_gfx_fake_draw_trace_reset(true);
     nt_gfx_begin_frame();
     nt_postfx_blur_gaussian(&pass);
     nt_gfx_end_frame();
-    TEST_ASSERT_EQUAL_UINT32(0, nt_postfx_blur_test_draw_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_draw_trace_count());
 
     /* Still active, only its GPU objects are gone: the next restore rebuilds
      * rather than asserting on a module that shut itself down. */
     TEST_ASSERT_EQUAL_INT(NT_OK, nt_postfx_blur_restore_gpu());
 
-    nt_postfx_blur_test_reset_counters();
+    nt_gfx_fake_draw_trace_reset(true);
     nt_gfx_begin_frame();
     nt_postfx_blur_gaussian(&pass);
     nt_gfx_end_frame();
-    TEST_ASSERT_EQUAL_UINT32(2, nt_postfx_blur_test_draw_count());
+    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_fake_draw_trace_count());
 }
 
 /* Separate vec4 uniforms and a masked index avoid driver-dependent array bounds

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -717,6 +717,7 @@ void test_sprite_renderer_capacity_flush_keeps_program_until_explicit_setter(voi
     nt_sprite_renderer_emit_region(s_atlas_res, 0, identity, 0, 0, 0xFFFFFFFFU, 0);
     nt_sprite_renderer_flush();
     nt_gfx_fake_draw_trace_reset(true);
+    const uint32_t vertices_before = g_nt_gfx.frame_stats.vertices;
 
     nt_sprite_renderer_set_material(mat);
     for (uint32_t i = 0; i < 4; i++) {
@@ -747,6 +748,8 @@ void test_sprite_renderer_capacity_flush_keeps_program_until_explicit_setter(voi
         nt_gfx_fake_draw_t draw = nt_gfx_fake_draw_trace_at(i);
         TEST_ASSERT_EQUAL_UINT32(i == 0 ? 24 : 6, draw.num_indices);
     }
+    /* 16 + 4 + 4: the per-cmd delta, not 3x the batch total. */
+    TEST_ASSERT_EQUAL_UINT32(24U, g_nt_gfx.frame_stats.vertices - vertices_before);
 }
 
 /* Queued work outlives the program it was built on when the owner destroys it

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -650,13 +650,13 @@ void test_neighbouring_programs_one_depth_write_step_apart_get_their_own_pipelin
         {.sort_key = 1, .entity = e1.id, .batch_key = sprite_batch_key(e1, mat_b)},
     };
 
-    nt_gfx_test_draw_trace_reset(true);
+    nt_gfx_fake_draw_trace_reset(true);
     nt_sprite_renderer_draw_list(items, 2);
 
     TEST_ASSERT_EQUAL_UINT32(2, nt_sprite_renderer_test_pipeline_cache_count());
-    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_test_draw_trace_count());
-    TEST_ASSERT_EQUAL_UINT32(p0.id, nt_gfx_test_draw_trace_at(0).program.id);
-    TEST_ASSERT_EQUAL_UINT32(p1.id, nt_gfx_test_draw_trace_at(1).program.id);
+    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_fake_draw_trace_count());
+    TEST_ASSERT_EQUAL_UINT32(p0.id, nt_gfx_fake_draw_trace_at(0).program.id);
+    TEST_ASSERT_EQUAL_UINT32(p1.id, nt_gfx_fake_draw_trace_at(1).program.id);
 }
 
 /* Context restore drops queued commands and cached pipelines without destroying borrowed programs. */
@@ -716,7 +716,7 @@ void test_sprite_renderer_capacity_flush_keeps_program_until_explicit_setter(voi
     nt_sprite_renderer_set_material(other);
     nt_sprite_renderer_emit_region(s_atlas_res, 0, identity, 0, 0, 0xFFFFFFFFU, 0);
     nt_sprite_renderer_flush();
-    nt_gfx_test_draw_trace_reset(true);
+    nt_gfx_fake_draw_trace_reset(true);
 
     nt_sprite_renderer_set_material(mat);
     for (uint32_t i = 0; i < 4; i++) {
@@ -733,20 +733,19 @@ void test_sprite_renderer_capacity_flush_keeps_program_until_explicit_setter(voi
     TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_fake_bound_texture_count());
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_uniform_int_count());
     TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_fake_bind_pipeline_count());
-    TEST_ASSERT_EQUAL_UINT32(3, nt_gfx_test_draw_trace_count());
-    TEST_ASSERT_FALSE(nt_gfx_test_draw_trace_overflowed());
-    nt_gfx_test_draw_t first = nt_gfx_test_draw_trace_at(0);
-    nt_gfx_test_draw_t second = nt_gfx_test_draw_trace_at(1);
-    nt_gfx_test_draw_t third = nt_gfx_test_draw_trace_at(2);
+    TEST_ASSERT_EQUAL_UINT32(3, nt_gfx_fake_draw_trace_count());
+    TEST_ASSERT_FALSE(nt_gfx_fake_draw_trace_overflowed());
+    nt_gfx_fake_draw_t first = nt_gfx_fake_draw_trace_at(0);
+    nt_gfx_fake_draw_t second = nt_gfx_fake_draw_trace_at(1);
+    nt_gfx_fake_draw_t third = nt_gfx_fake_draw_trace_at(2);
     TEST_ASSERT_EQUAL_UINT32(program_a.id, first.program.id);
     TEST_ASSERT_EQUAL_UINT32(program_a.id, second.program.id);
     TEST_ASSERT_EQUAL_UINT32(program_b.id, third.program.id);
     TEST_ASSERT_EQUAL_UINT32(first.pipeline.id, second.pipeline.id);
     TEST_ASSERT_NOT_EQUAL_UINT32(second.pipeline.id, third.pipeline.id);
     for (uint32_t i = 0; i < 3; i++) {
-        nt_gfx_test_draw_t draw = nt_gfx_test_draw_trace_at(i);
+        nt_gfx_fake_draw_t draw = nt_gfx_fake_draw_trace_at(i);
         TEST_ASSERT_EQUAL_UINT32(i == 0 ? 24 : 6, draw.num_indices);
-        TEST_ASSERT_EQUAL_UINT32(i == 0 ? 16 : 4, draw.num_vertices);
     }
 }
 
@@ -771,19 +770,19 @@ void test_sprite_renderer_flush_drops_cmds_whose_program_died(void) {
 
     nt_program_t replacement = nt_material_get_info(create_test_material())->program;
     nt_material_set_program(mat, replacement);
-    nt_gfx_test_draw_trace_reset(true);
+    nt_gfx_fake_draw_trace_reset(true);
     nt_gfx_destroy_program(dead); /* takes the queued cmd's pipeline with it */
     nt_sprite_renderer_flush();
 
     TEST_ASSERT_EQUAL_UINT32(0, nt_sprite_renderer_test_draw_call_count());
-    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_test_draw_trace_count());
+    TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_draw_trace_count());
     nt_sprite_renderer_set_material(mat);
     nt_sprite_renderer_emit_region(s_atlas_res, 0, identity, 0, 0, 0xFFFFFFFFU, 0);
     nt_sprite_renderer_flush();
-    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_test_draw_trace_count());
-    TEST_ASSERT_EQUAL_UINT32(replacement.id, nt_gfx_test_draw_trace_at(0).program.id);
-    TEST_ASSERT_EQUAL_UINT32(6, nt_gfx_test_draw_trace_at(0).num_indices);
-    TEST_ASSERT_FALSE(nt_gfx_test_draw_trace_overflowed());
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_fake_draw_trace_count());
+    TEST_ASSERT_EQUAL_UINT32(replacement.id, nt_gfx_fake_draw_trace_at(0).program.id);
+    TEST_ASSERT_EQUAL_UINT32(6, nt_gfx_fake_draw_trace_at(0).num_indices);
+    TEST_ASSERT_FALSE(nt_gfx_fake_draw_trace_overflowed());
 }
 
 void test_sprite_renderer_forwards_material_blend_state(void) {
@@ -908,17 +907,17 @@ void test_sprite_renderer_textureless_material_ignores_page_change(void) {
     static const float identity[16] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
 
     nt_gfx_fake_reset();
-    nt_gfx_test_draw_trace_reset(true);
+    nt_gfx_fake_draw_trace_reset(true);
     nt_sprite_renderer_set_material(mat);
     /* Region 0 lives on page 0, region 1 on page 1. */
     nt_sprite_renderer_emit_region(s_atlas_res, 0, identity, 0, 0, 0xFFFFFFFFU, 0);
     nt_sprite_renderer_emit_region(s_atlas_res, 1, identity, 0, 0, 0xFFFFFFFFU, 0);
     nt_sprite_renderer_flush();
 
-    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_test_draw_trace_count());
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_fake_draw_trace_count());
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_bound_texture_count());
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_uniform_int_count());
-    nt_gfx_test_draw_trace_reset(false);
+    nt_gfx_fake_draw_trace_reset(false);
 }
 
 /* An analytic-coverage material takes no page, so an unresolved page must not
@@ -938,14 +937,14 @@ void test_sprite_renderer_textureless_material_emits_without_page(void) {
     static const float identity[16] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
 
     nt_gfx_fake_reset();
-    nt_gfx_test_draw_trace_reset(true);
+    nt_gfx_fake_draw_trace_reset(true);
     nt_sprite_renderer_set_material(mat);
     nt_sprite_renderer_emit_region(s_atlas_res, 0, identity, 0, 0, 0xFFFFFFFFU, 0);
     nt_sprite_renderer_flush();
 
-    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_test_draw_trace_count());
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_fake_draw_trace_count());
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_bound_texture_count());
-    nt_gfx_test_draw_trace_reset(false);
+    nt_gfx_fake_draw_trace_reset(false);
 }
 
 /* The cmd captured its sampler names and the pipeline carries the program, so the
@@ -973,15 +972,15 @@ void test_sprite_renderer_dead_material_cmd_binds_on_program_unit(void) {
     nt_material_destroy(mat);
 
     nt_gfx_fake_reset();
-    nt_gfx_test_draw_trace_reset(true);
+    nt_gfx_fake_draw_trace_reset(true);
     nt_sprite_renderer_flush();
 
-    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_test_draw_trace_count());
+    TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_fake_draw_trace_count());
     TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_fake_bound_texture_count());
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_bound_texture_slot_at(0));
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_uniform_int_count());
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_uniform_vec4_count());
-    nt_gfx_test_draw_trace_reset(false);
+    nt_gfx_fake_draw_trace_reset(false);
 }
 
 /* The page is the material's slot 0, never the program's unit 0: a program that names
@@ -1129,22 +1128,22 @@ void test_sprite_renderer_program_replace_between_immediate_and_draw_list(void) 
     static const float identity[16] = {1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1};
 
     nt_gfx_fake_reset();
-    nt_gfx_test_draw_trace_reset(true);
+    nt_gfx_fake_draw_trace_reset(true);
     nt_sprite_renderer_set_material(mat);
     nt_sprite_renderer_emit_region(s_atlas_res, 0, identity, 0, 0, 0xFFFFFFFFU, 0);
     nt_material_set_program(mat, program_b);
     /* draw_list opens its cmds on the new pipeline without flushing the pending one. */
     nt_sprite_renderer_draw_list(&item, 1);
 
-    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_test_draw_trace_count());
-    TEST_ASSERT_EQUAL_UINT32(program_a.id, nt_gfx_test_draw_trace_at(0).program.id);
-    TEST_ASSERT_EQUAL_UINT32(program_b.id, nt_gfx_test_draw_trace_at(1).program.id);
+    TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_fake_draw_trace_count());
+    TEST_ASSERT_EQUAL_UINT32(program_a.id, nt_gfx_fake_draw_trace_at(0).program.id);
+    TEST_ASSERT_EQUAL_UINT32(program_b.id, nt_gfx_fake_draw_trace_at(1).program.id);
     /* One bind per cmd per sampled slot; the backend GL cache drops the second one.
      * Params are program state and go out twice. */
     TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_fake_bound_texture_count());
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_uniform_int_count());
     TEST_ASSERT_EQUAL_UINT32(2, nt_gfx_fake_uniform_vec4_count());
-    nt_gfx_test_draw_trace_reset(false);
+    nt_gfx_fake_draw_trace_reset(false);
 }
 
 /* A sampler override picks filtering for a texture that still has to exist, so

--- a/tests/unit/test_text_renderer.c
+++ b/tests/unit/test_text_renderer.c
@@ -170,24 +170,23 @@ static void republish_stage(const char *name, uint32_t shader_id) { nt_resource_
  * units the link assigned and asserts the program samples nothing else. */
 static nt_shader_t make_stage(nt_shader_type_t type) { return nt_gfx_make_shader(&(nt_shader_desc_t){.type = type, .source = (type == NT_SHADER_FRAGMENT) ? "f" : "void main(){}"}); }
 
-static nt_gfx_test_draw_t warm_material_program(nt_material_t material, nt_program_t program) {
+static nt_gfx_fake_draw_t warm_material_program(nt_material_t material, nt_program_t program) {
     nt_material_set_program(material, program);
     nt_text_renderer_set_material(material);
-    nt_gfx_test_draw_trace_reset(true);
+    nt_gfx_fake_draw_trace_reset(true);
     draw_and_flush();
-    TEST_ASSERT_EQUAL_UINT32(1U, nt_gfx_test_draw_trace_count());
-    nt_gfx_test_draw_t draw = nt_gfx_test_draw_trace_at(0U);
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_gfx_fake_draw_trace_count());
+    nt_gfx_fake_draw_t draw = nt_gfx_fake_draw_trace_at(0U);
     TEST_ASSERT_EQUAL_UINT32(program.id, draw.program.id);
-    nt_gfx_test_draw_trace_reset(false);
+    nt_gfx_fake_draw_trace_reset(false);
     return draw;
 }
 
-static void assert_text_draw(uint32_t index, nt_gfx_test_draw_t expected, uint32_t glyphs) {
-    nt_gfx_test_draw_t draw = nt_gfx_test_draw_trace_at(index);
+static void assert_text_draw(uint32_t index, nt_gfx_fake_draw_t expected, uint32_t glyphs) {
+    nt_gfx_fake_draw_t draw = nt_gfx_fake_draw_trace_at(index);
     TEST_ASSERT_EQUAL_UINT32(expected.program.id, draw.program.id);
     TEST_ASSERT_EQUAL_UINT32(expected.pipeline.id, draw.pipeline.id);
     TEST_ASSERT_EQUAL_UINT32(glyphs * 6U, draw.num_indices);
-    TEST_ASSERT_EQUAL_UINT32(glyphs * 4U, draw.num_vertices);
     TEST_ASSERT_EQUAL_UINT32(1U, draw.instance_count);
 }
 
@@ -592,7 +591,7 @@ void test_neighbouring_programs_one_cull_step_apart_get_their_own_pipelines(void
     nt_material_t b = nt_material_create(&(nt_material_create_desc_t){.program = p1, .blend = nt_blend_alpha(), .cull_mode = NT_CULL_NONE});
 
     nt_gfx_fake_reset();
-    nt_gfx_test_draw_trace_reset(true);
+    nt_gfx_fake_draw_trace_reset(true);
     nt_text_renderer_set_material(a);
     draw_and_flush();
     nt_text_renderer_set_material(b);
@@ -600,9 +599,9 @@ void test_neighbouring_programs_one_cull_step_apart_get_their_own_pipelines(void
 
     TEST_ASSERT_EQUAL_UINT32(2U, nt_gfx_fake_pipeline_create_count());
     TEST_ASSERT_EQUAL_UINT16(2U, nt_text_renderer_test_pipeline_cache_count());
-    TEST_ASSERT_EQUAL_UINT32(2U, nt_gfx_test_draw_trace_count());
-    TEST_ASSERT_EQUAL_UINT32(p0.id, nt_gfx_test_draw_trace_at(0).program.id);
-    TEST_ASSERT_EQUAL_UINT32(p1.id, nt_gfx_test_draw_trace_at(1).program.id);
+    TEST_ASSERT_EQUAL_UINT32(2U, nt_gfx_fake_draw_trace_count());
+    TEST_ASSERT_EQUAL_UINT32(p0.id, nt_gfx_fake_draw_trace_at(0).program.id);
+    TEST_ASSERT_EQUAL_UINT32(p1.id, nt_gfx_fake_draw_trace_at(1).program.id);
 }
 
 /* Reusing the program slot changes its generation. The first quad of a new batch
@@ -645,13 +644,13 @@ void test_a_replaced_program_does_not_redirect_a_staged_batch(void) {
     nt_material_t mat = create_test_material_with_blend(nt_blend_alpha());
     const nt_program_t first = nt_material_get_info(mat)->program;
     const nt_program_t second = nt_gfx_make_program(make_stage(NT_SHADER_VERTEX), make_stage(NT_SHADER_FRAGMENT));
-    const nt_gfx_test_draw_t first_draw = warm_material_program(mat, first);
-    const nt_gfx_test_draw_t second_draw = warm_material_program(mat, second);
+    const nt_gfx_fake_draw_t first_draw = warm_material_program(mat, first);
+    const nt_gfx_fake_draw_t second_draw = warm_material_program(mat, second);
     nt_material_set_program(mat, first);
 
     nt_gfx_begin_frame();
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
-    nt_gfx_test_draw_trace_reset(true);
+    nt_gfx_fake_draw_trace_reset(true);
     nt_text_renderer_draw("AB", s_identity, 32.0F, s_white, 0.0F, 0.0F);
     nt_material_set_program(mat, second);
     nt_text_renderer_draw("AB", s_identity, 32.0F, s_white, 0.0F, 0.0F);
@@ -661,10 +660,10 @@ void test_a_replaced_program_does_not_redirect_a_staged_batch(void) {
     nt_gfx_end_pass();
     nt_gfx_end_frame();
 
-    TEST_ASSERT_EQUAL_UINT32(2U, nt_gfx_test_draw_trace_count());
+    TEST_ASSERT_EQUAL_UINT32(2U, nt_gfx_fake_draw_trace_count());
     assert_text_draw(0U, first_draw, 4U);
     assert_text_draw(1U, second_draw, 2U);
-    TEST_ASSERT_FALSE(nt_gfx_test_draw_trace_overflowed());
+    TEST_ASSERT_FALSE(nt_gfx_fake_draw_trace_overflowed());
     TEST_ASSERT_EQUAL_UINT32(0U, nt_text_renderer_test_glyph_count());
 }
 
@@ -675,13 +674,13 @@ void test_overflow_flush_reopens_the_batch_pipeline(void) {
     nt_material_t mat = create_test_material_with_blend(nt_blend_alpha());
     const nt_program_t first = nt_material_get_info(mat)->program;
     const nt_program_t second = nt_gfx_make_program(make_stage(NT_SHADER_VERTEX), make_stage(NT_SHADER_FRAGMENT));
-    const nt_gfx_test_draw_t first_draw = warm_material_program(mat, first);
-    const nt_gfx_test_draw_t second_draw = warm_material_program(mat, second);
+    const nt_gfx_fake_draw_t first_draw = warm_material_program(mat, first);
+    const nt_gfx_fake_draw_t second_draw = warm_material_program(mat, second);
     nt_material_set_program(mat, first);
 
     nt_gfx_begin_frame();
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
-    nt_gfx_test_draw_trace_reset(true);
+    nt_gfx_fake_draw_trace_reset(true);
 
     /* Fill staging to one draw short of the cap, under program A. */
     for (uint32_t i = 0; i < (NT_TEXT_RENDERER_MAX_GLYPHS / 2U) - 1U; i++) {
@@ -703,10 +702,10 @@ void test_overflow_flush_reopens_the_batch_pipeline(void) {
 
     /* The B tail must draw. Without reopening it is discarded instead. */
     TEST_ASSERT_EQUAL_UINT32(1U, nt_text_renderer_test_nonempty_flush_calls());
-    TEST_ASSERT_EQUAL_UINT32(2U, nt_gfx_test_draw_trace_count());
+    TEST_ASSERT_EQUAL_UINT32(2U, nt_gfx_fake_draw_trace_count());
     assert_text_draw(0U, first_draw, NT_TEXT_RENDERER_MAX_GLYPHS);
     assert_text_draw(1U, second_draw, 2U);
-    TEST_ASSERT_FALSE(nt_gfx_test_draw_trace_overflowed());
+    TEST_ASSERT_FALSE(nt_gfx_fake_draw_trace_overflowed());
 }
 
 void test_font_cache_flush_preserves_the_entire_run(void) {
@@ -772,17 +771,16 @@ void test_decoration_only_run_opens_its_pipeline(void) {
 
     nt_gfx_begin_frame();
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
-    nt_gfx_test_draw_trace_reset(true);
+    nt_gfx_fake_draw_trace_reset(true);
     nt_text_renderer_draw("A", s_identity, 32.0F, s_white, 0.0F, 0.0F);
     nt_text_renderer_flush();
     nt_gfx_end_pass();
     nt_gfx_end_frame();
-    TEST_ASSERT_EQUAL_UINT32(1U, nt_gfx_test_draw_trace_count());
-    nt_gfx_test_draw_t draw = nt_gfx_test_draw_trace_at(0U);
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_gfx_fake_draw_trace_count());
+    nt_gfx_fake_draw_t draw = nt_gfx_fake_draw_trace_at(0U);
     TEST_ASSERT_EQUAL_UINT32(nt_material_get_info(material)->program.id, draw.program.id);
     TEST_ASSERT_EQUAL_UINT32(12U, draw.num_indices);
-    TEST_ASSERT_EQUAL_UINT32(8U, draw.num_vertices);
-    TEST_ASSERT_FALSE(nt_gfx_test_draw_trace_overflowed());
+    TEST_ASSERT_FALSE(nt_gfx_fake_draw_trace_overflowed());
     nt_text_renderer_set_font(s_font);
     nt_font_destroy(font);
     free(blob);
@@ -793,24 +791,24 @@ void test_destroyed_replaced_program_drops_staged_work(void) {
     const nt_program_t first = nt_material_get_info(material)->program;
     const nt_program_t second = nt_gfx_make_program(make_stage(NT_SHADER_VERTEX), make_stage(NT_SHADER_FRAGMENT));
     (void)warm_material_program(material, first);
-    const nt_gfx_test_draw_t second_draw = warm_material_program(material, second);
+    const nt_gfx_fake_draw_t second_draw = warm_material_program(material, second);
     nt_material_set_program(material, first);
 
     nt_gfx_begin_frame();
     nt_gfx_begin_pass(&(nt_pass_desc_t){.clear_depth = 1.0F});
-    nt_gfx_test_draw_trace_reset(true);
+    nt_gfx_fake_draw_trace_reset(true);
     nt_text_renderer_draw("AB", s_identity, 32.0F, s_white, 0.0F, 0.0F);
     nt_material_set_program(material, second);
     nt_gfx_destroy_program(first);
     nt_text_renderer_flush();
-    TEST_ASSERT_EQUAL_UINT32(0U, nt_gfx_test_draw_trace_count());
+    TEST_ASSERT_EQUAL_UINT32(0U, nt_gfx_fake_draw_trace_count());
     nt_text_renderer_draw("AB", s_identity, 32.0F, s_white, 0.0F, 0.0F);
     nt_text_renderer_flush();
     nt_gfx_end_pass();
     nt_gfx_end_frame();
-    TEST_ASSERT_EQUAL_UINT32(1U, nt_gfx_test_draw_trace_count());
+    TEST_ASSERT_EQUAL_UINT32(1U, nt_gfx_fake_draw_trace_count());
     assert_text_draw(0U, second_draw, 2U);
-    TEST_ASSERT_FALSE(nt_gfx_test_draw_trace_overflowed());
+    TEST_ASSERT_FALSE(nt_gfx_fake_draw_trace_overflowed());
 }
 
 void test_unready_font_skips_glyph_and_decoration_uploads(void) {

--- a/tests/unit/test_text_renderer.c
+++ b/tests/unit/test_text_renderer.c
@@ -780,6 +780,7 @@ void test_decoration_only_run_opens_its_pipeline(void) {
     nt_gfx_fake_draw_t draw = nt_gfx_fake_draw_trace_at(0U);
     TEST_ASSERT_EQUAL_UINT32(nt_material_get_info(material)->program.id, draw.program.id);
     TEST_ASSERT_EQUAL_UINT32(12U, draw.num_indices);
+    TEST_ASSERT_EQUAL_UINT32(8U, g_nt_gfx.frame_stats.vertices); /* glyph + decoration quad */
     TEST_ASSERT_FALSE(nt_gfx_fake_draw_trace_overflowed());
     nt_text_renderer_set_font(s_font);
     nt_font_destroy(font);


### PR DESCRIPTION
Native release examples, benchmarks, and the builder previously linked engine libraries compiled with NT_TEST_ACCESS, including probe state and draw/upload bookkeeping. Gate tests with NT_BUILD_TESTS, disable them in native-release, and keep native-release-test enabled so optimized test coverage remains in CI.

Move draw traces and mesh upload hashes into the existing fake graphics backend, reusing the public pipeline-to-program lookup. Reject empty CTest runs and instrumented release caches before benchmark measurements.

Validation:
- format_and_check.sh: passed; 136/136 native tests and full clang-tidy.
- check.sh --push: passed with pinned Emscripten 4.0.19; native release, WASM debug/release, and submodule consumption.
- Reproduction checks: empty CTest now exits 8; benchmark rejects NT_BUILD_TESTS=ON or missing, and permits OFF.

Closes #427.

