### PR TITLE
Fix resource lifecycle with stable indices and startup type registration

### DIFF
--- a/docs/spec/assets/async-loading.md
+++ b/docs/spec/assets/async-loading.md
@@ -181,9 +181,20 @@ type description with an activator rewinds all packs so skipped types become eli
 An identical repeated registration does not rewind anything. A new mount starts
 at zero. Restoring an evicted blob preserves the cursor because it preserves asset
 states. Growing the global registry may make completed packs scan its new suffix
-once; a stable idle registry needs only the bounded pack walk, not asset scans.
+once. The activation phase of a stable idle registry needs only the bounded
+pack walk. Expired AUTO blobs can still scan owners before eviction, as below.
 Cursor movement alone does not dirty resolve or change the publication epoch.
 Callbacks follow the [resource callback contract](resource.md#resource-callback-contract).
+
+Before evicting an expired, unpinned AUTO blob, scan its live canonical owners.
+Any REGISTERED owner retains the bytes, including owners skipped because their
+type has not yet been registered. A completed cursor means the scan completed,
+not that activation completed. First registration of the type can then resume
+activation without remounting or reloading. READY and FAILED owners do not by
+themselves hold the blob; normal TTL eviction resumes once no owners are waiting.
+Explicit unmount still removes a waiting pack. This uses existing owner state,
+with no pending counter: only would-be evictions incur the scan, exiting at the
+first pending owner. An expired pack waiting for a type can incur it each step.
 
 Any change that can affect publication (`mount`, `unmount`, `set_priority`, asset activation, virtual register/unregister, invalidation, placeholder change, or aux-miss reload scheduling) marks the registry dirty. Dirty frames run a resolve scan over assets to compute each slot's target winner and published winner. Clean frames stay on the O(1) fast path.
 

--- a/docs/spec/assets/async-loading.md
+++ b/docs/spec/assets/async-loading.md
@@ -166,7 +166,8 @@ rejection).
 
 **Eager with a time budget:** `nt_resource_step()` visits packs by registry index,
 then their canonical owners by asset index. Only READY packs with resident bytes
-and REGISTERED owners with an activator are eligible. At least one eligible
+and REGISTERED owners are eligible. Parsing requires an activator for every
+non-BLOB file type, configured before the first mount. At least one eligible
 activation is attempted per step; a zero budget is unlimited. Aliases consume no
 activation attempts and read owner state directly, regardless of which names
 the game requested. BLOB owners become READY during parse. Success and failure
@@ -176,25 +177,21 @@ unmount/remount to retry; restoring evicted bytes alone does not reset its state
 Each pack retains an activation cursor into the asset registry. A budget stop
 leaves it on the eligible owner not yet attempted; a completed scan leaves it at
 the current asset high-water mark. Subsequent steps skip that completed prefix.
-Invalidating file owners rewinds their packs, and first registering a complete
-type description with an activator rewinds all packs so skipped types become eligible.
-An identical repeated registration does not rewind anything. A new mount starts
-at zero. Restoring an evicted blob preserves the cursor because it preserves asset
-states. Growing the global registry may make completed packs scan its new suffix
-once. The activation phase of a stable idle registry needs only the bounded
-pack walk. Expired AUTO blobs can still scan owners before eviction, as below.
+Invalidating file owners rewinds their packs; a new mount starts at zero.
+Restoring an evicted blob preserves the cursor because it preserves asset states.
+Growing the global registry may make completed packs scan its new suffix once.
+The activation phase of a stable idle registry needs only the bounded pack walk.
 Cursor movement alone does not dirty resolve or change the publication epoch.
 Callbacks follow the [resource callback contract](resource.md#resource-callback-contract).
 
-Before evicting an expired, unpinned AUTO blob, scan its live canonical owners.
-Any REGISTERED owner retains the bytes, including owners skipped because their
-type has not yet been registered. A completed cursor means the scan completed,
-not that activation completed. First registration of the type can then resume
-activation without remounting or reloading. READY and FAILED owners do not by
-themselves hold the blob; normal TTL eviction resumes once no owners are waiting.
-Explicit unmount still removes a waiting pack. This uses existing owner state,
-with no pending counter: only would-be evictions incur the scan, exiting at the
-first pending owner. An expired pack waiting for a type can incur it each step.
+An expired, unpinned AUTO blob remains resident while its activation cursor is
+below the asset high-water mark. A budget stop leaves the cursor before the
+pending owner, so eviction cannot remove bytes needed on a later step. Types
+cannot gain activators after mounting, so a completed cursor cannot conceal
+owners waiting for late registration. READY and FAILED owners do not themselves
+hold the blob. The cursor check may conservatively retain a completed pack while
+other registry growth remains unscanned. Explicit unmount still removes a pack
+with pending activation. There is no additional owner scan or pending counter.
 
 Any change that can affect publication (`mount`, `unmount`, `set_priority`, asset activation, virtual register/unregister, invalidation, placeholder change, or aux-miss reload scheduling) marks the registry dirty. Dirty frames run a resolve scan over assets to compute each slot's target winner and published winner. Clean frames stay on the O(1) fast path.
 

--- a/docs/spec/assets/async-loading.md
+++ b/docs/spec/assets/async-loading.md
@@ -176,8 +176,9 @@ unmount/remount to retry; restoring evicted bytes alone does not reset its state
 Each pack retains an activation cursor into the asset registry. A budget stop
 leaves it on the eligible owner not yet attempted; a completed scan leaves it at
 the current asset high-water mark. Subsequent steps skip that completed prefix.
-Invalidating file owners rewinds their packs, and registering a previously absent
-activator rewinds all packs so skipped types become eligible. A new mount starts
+Invalidating file owners rewinds their packs, and first registering a complete
+type description with an activator rewinds all packs so skipped types become eligible.
+An identical repeated registration does not rewind anything. A new mount starts
 at zero. Restoring an evicted blob preserves the cursor because it preserves asset
 states. Growing the global registry may make completed packs scan its new suffix
 once; a stable idle registry needs only the bounded pack walk, not asset scans.

--- a/docs/spec/assets/ntpack.md
+++ b/docs/spec/assets/ntpack.md
@@ -86,7 +86,10 @@ All asset byte ranges and ownership links are checked before any slots are
 reserved or records modified. Parsing requires a file mount; virtual packs
 accept registrations only. Invalid ranges, zero resource IDs or malformed
 owner links reject the pack through the existing recoverable parse error; a
-corrected pack can load into the same mount. Capacity exhaustion asserts.
+corrected pack can load into the same mount. Manifest types outside the defined
+`NT_ASSET_MESH..NT_ASSET_ATLAS` range also reject the pack. Every non-BLOB file
+type requires an activator configured before the first mount; missing one asserts
+before reserving records or retaining bytes. Capacity exhaustion asserts.
 
 Each mount accepts one successful parse, including an empty pack. A later parse
 returns `NT_ERR_INVALID_ARG` even after blob eviction: eviction preserves the

--- a/docs/spec/assets/resource.md
+++ b/docs/spec/assets/resource.md
@@ -111,6 +111,11 @@ Typed wrappers (MeshHandle, TextureHandle) live outside nt_resource — game cod
 - simple assets stay usable from the runtime handle alone
 - aux-backed assets stay published only if their existing `user_data` already belongs to the published winner
 
+AUTO never evicts bytes needed by live REGISTERED canonical owners, including
+owners awaiting first type registration. Only an otherwise eligible expired blob
+scans owners to check this. READY/FAILED owners do not prevent eviction, and
+explicit unmount removes the pack even while activation is pending.
+
 ## Registry state split
 
 Layouts live in `engine/resource/nt_resource_internal.h` (not public API — do not

--- a/docs/spec/assets/resource.md
+++ b/docs/spec/assets/resource.md
@@ -1,7 +1,7 @@
 # Resource System
 
 Two-level resource registry: `NtAssetMeta` per pack asset, `NtResourceSlot` per
-requested resource_id, generational `nt_resource_t` handles, and priority-stacked
+requested resource_id, stable `nt_resource_t` indices, and priority-stacked
 packs with target/published winner resolve. Covers resolve callbacks, blob
 pinning (PIN_BLOB), virtual packs, asset types with the NT_ASSET_FONT and
 NT_ASSET_ATLAS binary formats, placeholder policy, and `nt_hash` identity hashing.
@@ -60,7 +60,7 @@ accounting.
 - `resource_id`: 64-bit xxHash of asset path (`nt_hash64_t`) — stable resource identity
 - `NtAssetMeta`: per-asset metadata entry (one per asset per pack)
 - `NtResourceSlot`: per unique resource requested by game code — holds resolved handle and optional user_data
-- `nt_resource_t`: generational handle to a slot — what game code holds and passes around
+- `nt_resource_t`: stable 32-bit slot index — what game code holds and passes around
 
 Two-level system:
 - **Assets** (MAX_ASSETS): metadata from all packs. Same resource_id can appear in multiple packs.
@@ -76,9 +76,28 @@ For simple runtime-handle asset types (texture, mesh, blob), target and publishe
 
 `resource_id` is a `uint64_t` xxHash (XXH64) of the asset path, wrapped in `nt_hash64_t` for type safety. Game code obtains it via `nt_hash64_str("path")`. The `nt_hash` module provides centralized hashing for both builder and runtime. The registry uses resource_id to match assets across packs and resolve priority.
 
-## Generational handles
+## Stable resource handles
 
-Game code receives `nt_resource_t` — a 32-bit handle encoding slot index (lower 16 bits) and generation (upper 16 bits). Generation detects stale handles within a single init/shutdown lifecycle. After shutdown, all handles are invalid — game code must re-request resources after reinit. Access functions (`nt_resource_get`, `nt_resource_is_ready`) validate generation before returning data. `nt_resource_get()` returns the currently published winner handle. `nt_resource_is_ready()` means "published winner is fully usable", not merely "some runtime handle exists somewhere in the stack."
+`nt_resource_t.id` is a `uint32_t` slot index; zero is invalid. The first request
+of a nonzero resource_id allocates a slot, and repeated request/find calls return
+that same index through unmount, provider changes, reload and remount. Find never
+allocates. Requested slots are never recycled until resource shutdown: there is
+no generation or free queue. After shutdown all handles are invalid; the game
+requests fresh handles after reinit. Equal numbers across registry lifetimes do
+not imply the same resource. Asset records and GPU/material/entity pools retain
+their independent reuse rules and generations where applicable.
+
+`NT_RESOURCE_MAX_SLOTS` (default 2048) counts all unique names requested during
+the registry lifetime, including dependent requests from post-resolve callbacks.
+It is a preallocated capacity; exhausting it asserts. Slot-map indices, counts
+and allocated-prefix scans use uint32_t. The compile-time range is
+`1..UINT32_MAX / 2` because the map has two buckets per slot; actual arrays must
+also fit the target address space. Unmount frees asset records, not requested slots.
+
+Accessors reject zero and unallocated indices with their documented empty results.
+`nt_resource_get()` returns the current published runtime handle.
+`nt_resource_is_ready()` means the published winner is fully usable, not merely
+that a runtime handle exists somewhere in the stack.
 
 Typed wrappers (MeshHandle, TextureHandle) live outside nt_resource — game code or future phases.
 
@@ -105,8 +124,7 @@ mirror them here). The contract is the SPLIT, not the fields:
   Payload headers retain their own format versions. A BLOB's effective handle
   remains its named record index, including zero, rather than its owner's index.
 - **`NtResourceSlot`** — one persistent record per unique resource_id the game
-  asked for. Holds what the game currently sees (`runtime_handle`, `state`,
-  `generation` for stale-handle detection), the published winner's identity
+  asked for. Holds what the game currently sees (`runtime_handle`, `state`), the published winner's identity
   (`resolve_asset_idx`), and the `user_data` built by `on_resolve` with its
   source identity (`user_data_asset_idx`). Change detection compares these
   published fields before replacing them with the next winner.

--- a/docs/spec/assets/resource.md
+++ b/docs/spec/assets/resource.md
@@ -111,10 +111,11 @@ Typed wrappers (MeshHandle, TextureHandle) live outside nt_resource — game cod
 - simple assets stay usable from the runtime handle alone
 - aux-backed assets stay published only if their existing `user_data` already belongs to the published winner
 
-AUTO never evicts bytes needed by live REGISTERED canonical owners, including
-owners awaiting first type registration. Only an otherwise eligible expired blob
-scans owners to check this. READY/FAILED owners do not prevent eviction, and
-explicit unmount removes the pack even while activation is pending.
+AUTO never evicts bytes while the pack has pending activation. The existing
+activation cursor gates eviction until its scan completes; no owner scan or
+pending counter is needed. Every non-BLOB file type has an activator registered
+before mounting. READY/FAILED owners do not prevent eviction, and explicit
+unmount removes the pack even while activation is pending.
 
 ## Registry state split
 
@@ -163,37 +164,33 @@ callback-safe, such as `nt_resource_find`. Only post-resolve may additionally
 request slots and use get-style accessors after publication. Calls into other
 engine modules follow those modules' own contracts.
 
-### Immutable type registration
+### Startup type registration
 
-`nt_resource_register_type(type, desc)` copies a complete `nt_resource_type_desc_t`
-into the registry's fixed type table. The descriptor pointer is borrowed only
-for the call. Its fields are `activate`, `deactivate`, `on_resolve`, `on_cleanup`,
-`on_post_resolve` and `behavior_flags`. Register the complete description before
-activation or publication; callbacks remain registered until resource shutdown.
-Font and atlas init register their complete descriptions. The game explicitly
-registers the gfx activators for the asset types it uses.
+`nt_resource_register_type(type, desc)` copies one complete `nt_resource_type_desc_t`
+into the registry's type table. The descriptor pointer is borrowed only for the
+call. Its fields are `activate`, `deactivate`, `on_resolve`, `on_cleanup`,
+`on_post_resolve` and `behavior_flags`.
 
-The description is fixed by registration, even before any assets exist. An
-identical description (field values, not pointer or padding equality) is a no-op.
-Any changed field asserts before mutation, including after every pack is
-unmounted or the consumer module is shut down. Only resource shutdown/init starts
-a new registration lifetime. No setters or replacement adapters exist.
+Register each type once after resource init and before the first successful
+file or virtual mount. That first mount closes type registration until resource
+shutdown/init, even if every pack is later unmounted. Repeated registration
+asserts, including an identical description. No replace, freeze or finalize API
+exists; parsing and publication do not change type descriptions.
 
-The first registration of a type with an activator may happen after file owners
-were parsed and skipped as REGISTERED. It rewinds the existing activation cursors;
-the next step can activate them. A description explicitly registered without an
-activator cannot later gain one. Simple virtual providers need no empty
-registration: their first publication fixes the zero description. Built-in BLOB
-owners similarly fix the current description when parse makes them READY without
-an activator. Register any callbacks for these types before that first use.
+Font and atlas init register their descriptions, and the game registers the gfx
+activators it uses. Complete those module initializations before mounting packs.
+Simple virtual providers use the empty default without explicit registration.
+BLOB readiness is built in and needs no activator. Other file asset types require
+a configured activator: missing one is a configuration error asserted during
+parse, before any asset records or blob ownership change. Unknown manifest types
+are malformed input and reject the pack through the recoverable parse error.
 
 Registration requires an initialized registry, a valid type-table index, a non-NULL
 descriptor and known flag bits. `on_resolve` requires `on_cleanup`; AUX_BACKED
-requires both. Invalid descriptions assert before becoming fixed, so an attempted
-invalid registration does not prevent a subsequent valid first registration.
-PIN_BLOB is incompatible with virtual assets: both registering a virtual provider
-for a PIN type and first registering a PIN description with existing virtual
-providers assert before mutation. Flags cannot change independently of callbacks.
+requires both. Validation precedes registration, so an invalid description leaves
+the type available for a valid first registration. PIN_BLOB is incompatible with
+virtual assets: registering a virtual provider for a PIN type asserts before
+mutation. Callbacks and flags stay together for the registry lifetime.
 
 ### Resolve callbacks (on_resolve / on_cleanup / on_post_resolve)
 

--- a/docs/spec/assets/resource.md
+++ b/docs/spec/assets/resource.md
@@ -149,7 +149,7 @@ If a higher-priority target winner is not yet publishable, the slot keeps the be
 
 Activate/deactivate, resolve/cleanup and post-resolve callbacks must not change
 resource lifecycle or registrations: init/shutdown/step, mount/unmount/load/parse,
-register/unregister, invalidate, or activators/callbacks/behavior flags. A change
+register/unregister, invalidate, or type registration. A change
 to activation eligibility could rewind a cursor that the active traversal then
 overwrites with its own progress.
 
@@ -158,18 +158,57 @@ callback-safe, such as `nt_resource_find`. Only post-resolve may additionally
 request slots and use get-style accessors after publication. Calls into other
 engine modules follow those modules' own contracts.
 
+### Immutable type registration
+
+`nt_resource_register_type(type, desc)` copies a complete `nt_resource_type_desc_t`
+into the registry's fixed type table. The descriptor pointer is borrowed only
+for the call. Its fields are `activate`, `deactivate`, `on_resolve`, `on_cleanup`,
+`on_post_resolve` and `behavior_flags`. Register the complete description before
+activation or publication; callbacks remain registered until resource shutdown.
+Font and atlas init register their complete descriptions. The game explicitly
+registers the gfx activators for the asset types it uses.
+
+The description is fixed by registration, even before any assets exist. An
+identical description (field values, not pointer or padding equality) is a no-op.
+Any changed field asserts before mutation, including after every pack is
+unmounted or the consumer module is shut down. Only resource shutdown/init starts
+a new registration lifetime. No setters or replacement adapters exist.
+
+The first registration of a type with an activator may happen after file owners
+were parsed and skipped as REGISTERED. It rewinds the existing activation cursors;
+the next step can activate them. A description explicitly registered without an
+activator cannot later gain one. Simple virtual providers need no empty
+registration: their first publication fixes the zero description. Built-in BLOB
+owners similarly fix the current description when parse makes them READY without
+an activator. Register any callbacks for these types before that first use.
+
+Registration requires an initialized registry, a valid type-table index, a non-NULL
+descriptor and known flag bits. `on_resolve` requires `on_cleanup`; AUX_BACKED
+requires both. Invalid descriptions assert before becoming fixed, so an attempted
+invalid registration does not prevent a subsequent valid first registration.
+PIN_BLOB is incompatible with virtual assets: both registering a virtual provider
+for a PIN type and first registering a PIN description with existing virtual
+providers assert before mutation. Flags cannot change independently of callbacks.
+
 ### Resolve callbacks (on_resolve / on_cleanup / on_post_resolve)
 
-Per-asset-type callbacks for auxiliary data that persists across pack stacking. Registered separately from activate/deactivate — asset types that don't use them pay nothing.
+Per-type callbacks manage auxiliary data across pack stacking. Types register
+them with their activator and behavior flags in the same description; unused
+callbacks are NULL.
 
 ```c
 typedef void (*nt_resolve_fn)(const uint8_t *data, uint32_t size, uint32_t runtime_handle, void **user_data);
 typedef void (*nt_cleanup_fn)(void *user_data);
 typedef void (*nt_post_resolve_fn)(const uint8_t *data, uint32_t size, nt_resource_t handle, uint32_t runtime_handle, void *user_data);
 
-nt_resource_set_resolve_callbacks(asset_type, on_resolve, on_cleanup);
-nt_resource_set_post_resolve_callback(asset_type, on_post_resolve);
-nt_resource_set_behavior_flags(asset_type, flags);
+nt_resource_register_type(asset_type, &(nt_resource_type_desc_t){
+    .activate = activate,
+    .deactivate = deactivate,
+    .on_resolve = on_resolve,
+    .on_cleanup = on_cleanup,
+    .on_post_resolve = on_post_resolve,
+    .behavior_flags = flags,
+});
 const void *nt_resource_peek_user_data(handle);
 ```
 
@@ -220,6 +259,10 @@ Two consumption models exist for asset types that derive state from pack bytes:
 The per-asset pin (the published winner of a pinning slot) is exposed for diagnostics as `nt_resource_asset_info_t.blob_pins` and surfaced in the devapi `resource.list` group.
 
 ## GPU context loss recovery
+
+`nt_resource_invalidate(NT_ASSET_BLOB)` asserts before any registry mutation.
+Raw BLOB bytes have no activation to repeat. Invalidation of other asset types
+preserves BLOB owner/alias readiness and resident payloads.
 
 `nt_gfx_begin_frame()` detects a restored context and sets
 `g_nt_gfx.context_restored` for that frame. Resource readiness, resolved runtime

--- a/docs/spec/index.md
+++ b/docs/spec/index.md
@@ -23,7 +23,7 @@ transforms, loads runtime assets from NTPACK packs asynchronously, and provides 
 WebGL 2 render backend and input/platform services (audio is planned). Data flows
 through a small set of composable modules: entities own hierarchy, per-kind
 components hold render state, thin render items are sorted and batched by
-game-chosen policy, and generational handles resolve resources published from
+game-chosen policy, and stable resource indices resolve resources published from
 priority-stacked packs.
 
 The builder is a separate native binary that does the heavy work offline: it imports

--- a/docs/spec/render/architecture.md
+++ b/docs/spec/render/architecture.md
@@ -206,6 +206,10 @@ Texture and sampler travel together in one `nt_gfx_texture_binding_t`; a materia
 without an override selects the texture's asset default. At every material
 transition the renderer resolves the material's declared `nt_resource_t` texture
 handles, and every sprite command submits the complete semantic set once. The
+sprite batch key packs the material pool slot and the currently published GPU
+texture pool slot, resolved from the stable page resource index. Both bindings
+remain live and unchanged from list construction through draw completion; a new
+list resolves the current publication again. The
 gfx front-end maps names to the bound program's canonical units,
 ignores inactive declarations, validates complete active coverage, and calls the
 backend only after the whole set resolves. The backend GL cache drops repeated

--- a/docs/spec/render/items-sorting-batching.md
+++ b/docs/spec/render/items-sorting-batching.md
@@ -95,13 +95,20 @@ alive, neither binding changes, and neither referenced live resource is
 destroyed or has its slot reused.
 
 `nt_sprite_renderer_batch_key(material, page_resource)` packs the material's
-16-bit pool slot and the resolved atlas page resource's 16-bit slot. The page
-resource comes from the sprite component's resolved-region cache, so render-item
-construction does not search the atlas. The game excludes unresolved sprites and
+16-bit pool slot and the current GPU texture's 16-bit pool slot. The page resource
+is a stable uint32 index from the sprite component's resolved-region cache;
+the helper resolves its current texture with one O(1) `nt_resource_get`, without
+searching the atlas. Different resource names publishing the same texture,
+including a shared placeholder, yield equal keys for the same material.
+The game excludes unresolved sprites and
 resolved tombstones before calling the helper; tombstones have no page resource.
 The same bounded-lifetime rule applies through
-`nt_sprite_renderer_draw_list()`: the material binding and resolved page must not
-change. SpriteRenderer still checks the actual page while emitting, so a page
+`nt_sprite_renderer_draw_list()`: the material binding and published GPU texture
+stay live and unchanged from item construction until the call returns. Recompute
+keys for the next list after provider changes; context restore discards old lists.
+A not-yet-loaded page without a placeholder has texture slot zero: sampled
+sprites are skipped at emit, while textureless materials still draw geometry.
+SpriteRenderer still checks the actual page while emitting, so a page
 mismatch inside a run splits safely; this does not relax the material-key
 contract. Transform and drawable color may change after item construction because
 neither renderer's key encodes them.

--- a/docs/spec/render/render-components.md
+++ b/docs/spec/render/render-components.md
@@ -73,7 +73,8 @@ The runtime additionally caches:
 
 - **Resolved region index** — `uint16_t` index into the atlas region table.
 - **Resolved region data** — atlas geometry pointers and the actual page
-  resource used by the renderer and its batch key.
+  resource used by the renderer. The batch-key helper resolves this stable
+  resource index to the currently published GPU texture in O(1).
 - **Atlas revision snapshot** — `uint32_t`, used to detect republish.
 - **Effective origin** — `float[2]`, either authored from the region or
   overridden by the game.

--- a/engine/atlas/nt_atlas.c
+++ b/engine/atlas/nt_atlas.c
@@ -631,10 +631,12 @@ static void atlas_on_post_resolve(const uint8_t *data, uint32_t size, nt_resourc
 // #region public api
 nt_result_t nt_atlas_init(void) {
     NT_ASSERT(!s_atlas.initialized && "nt_atlas_init called twice");
-    nt_resource_set_activator(NT_ASSET_ATLAS, atlas_activate, atlas_deactivate);
-    nt_resource_set_resolve_callbacks(NT_ASSET_ATLAS, atlas_on_resolve, atlas_on_cleanup);
-    nt_resource_set_post_resolve_callback(NT_ASSET_ATLAS, atlas_on_post_resolve);
-    nt_resource_set_behavior_flags(NT_ASSET_ATLAS, NT_RESOURCE_BEHAVIOR_AUX_BACKED);
+    nt_resource_register_type(NT_ASSET_ATLAS, &(nt_resource_type_desc_t){.activate = atlas_activate,
+                                                                         .deactivate = atlas_deactivate,
+                                                                         .on_resolve = atlas_on_resolve,
+                                                                         .on_cleanup = atlas_on_cleanup,
+                                                                         .on_post_resolve = atlas_on_post_resolve,
+                                                                         .behavior_flags = NT_RESOURCE_BEHAVIOR_AUX_BACKED});
     s_atlas.initialized = true;
     return NT_OK;
 }

--- a/engine/font/nt_font.c
+++ b/engine/font/nt_font.c
@@ -1624,9 +1624,9 @@ nt_result_t nt_font_init(const nt_font_desc_t *desc) {
     /* Fonts are zero-copy consumers — a no-op activator marks the slot READY,
      * on_resolve/on_cleanup manage the {blob,size} view, and PIN_BLOB keeps the
      * winning pack blob resident so live glyph reads never dangle. */
-    nt_resource_set_activator(NT_ASSET_FONT, font_activate, font_deactivate);
-    nt_resource_set_resolve_callbacks(NT_ASSET_FONT, font_on_resolve, font_on_cleanup);
-    nt_resource_set_behavior_flags(NT_ASSET_FONT, NT_RESOURCE_BEHAVIOR_PIN_BLOB);
+    nt_resource_register_type(
+        NT_ASSET_FONT, &(nt_resource_type_desc_t){
+                           .activate = font_activate, .deactivate = font_deactivate, .on_resolve = font_on_resolve, .on_cleanup = font_on_cleanup, .behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
 
     s_font.last_resolve_epoch = 0;
     s_font.initialized = true;

--- a/engine/renderers/nt_sprite_renderer.h
+++ b/engine/renderers/nt_sprite_renderer.h
@@ -70,15 +70,15 @@ static inline nt_sprite_renderer_desc_t nt_sprite_renderer_desc_defaults(void) {
     };
 }
 
-/* Only RESOLVED, non-tombstoned sprites have a page_resource. Handles must
- * match current bindings and stay live and unrebound until draw_list returns.
+/* Only RESOLVED, non-tombstoned sprites have a page_resource. Material and the
+ * currently published texture must stay live and unrebound until draw_list returns.
  * Store the returned token unchanged; separate draw_list calls form barriers. */
 static inline uint32_t nt_sprite_renderer_batch_key(nt_material_t material, nt_resource_t page_resource) {
     uint32_t material_slot = nt_pool_slot_index(material.id);
-    uint32_t page_slot = nt_resource_slot_index(page_resource);
     NT_ASSERT(material_slot != 0);
-    NT_ASSERT(page_slot != 0);
-    return (material_slot << NT_POOL_SLOT_SHIFT) | page_slot;
+    NT_ASSERT(page_resource.id != 0);
+    uint32_t texture_slot = nt_pool_slot_index(nt_resource_get(page_resource));
+    return (material_slot << NT_POOL_SLOT_SHIFT) | texture_slot;
 }
 
 /* ---- Lifecycle ---- */

--- a/engine/resource/nt_resource.c
+++ b/engine/resource/nt_resource.c
@@ -26,7 +26,7 @@
 
 /* ---- Slot map: resource_id -> slot index, open-addressing hash table ---- */
 
-#define NT_SLOT_MAP_SIZE (NT_RESOURCE_MAX_SLOTS * 2)
+#define NT_SLOT_MAP_SIZE (NT_RESOURCE_MAX_SLOTS * 2U)
 #define NT_RESOURCE_MAX_RESOLVE_PASSES 4U
 
 /* ---- Module state ---- */
@@ -39,9 +39,8 @@ static struct {
     NtActivatorEntry activators[NT_RESOURCE_MAX_ASSET_TYPES];
     uint16_t free_assets[NT_RESOURCE_MAX_ASSETS];
     uint32_t free_asset_count;
-    uint16_t free_queue[NT_RESOURCE_MAX_SLOTS];
-    uint16_t slot_map[NT_SLOT_MAP_SIZE];
-    uint16_t queue_top;
+    uint32_t slot_map[NT_SLOT_MAP_SIZE];
+    uint32_t slot_count;
     uint32_t next_mount_seq;       /* monotonic counter for mount order tiebreak */
     uint32_t asset_hwm;            /* high-water mark in assets[] */
     uint32_t publication_epoch;    /* bumps when published slot view changes */
@@ -122,29 +121,29 @@ static int16_t find_pack(uint32_t pack_id) {
 
 /* ---- Slot map helpers ---- */
 
-static uint16_t slot_map_find(uint64_t resource_id) {
+static uint32_t slot_map_find(uint64_t resource_id) {
     uint32_t idx = (uint32_t)(resource_id % (uint64_t)NT_SLOT_MAP_SIZE);
     for (uint32_t i = 0; i < NT_SLOT_MAP_SIZE; i++) {
-        uint32_t probe = (idx + i) % NT_SLOT_MAP_SIZE;
-        uint16_t si = s_resource.slot_map[probe];
+        uint32_t si = s_resource.slot_map[idx];
         if (si == 0) {
             return 0;
         }
         if (s_resource.slots[si].resource_id == resource_id) {
             return si;
         }
+        idx = (idx + 1U) % NT_SLOT_MAP_SIZE;
     }
     return 0;
 }
 
-static void slot_map_insert(uint64_t resource_id, uint16_t slot_index) {
+static void slot_map_insert(uint64_t resource_id, uint32_t slot_index) {
     uint32_t idx = (uint32_t)(resource_id % (uint64_t)NT_SLOT_MAP_SIZE);
     for (uint32_t i = 0; i < NT_SLOT_MAP_SIZE; i++) {
-        uint32_t probe = (idx + i) % NT_SLOT_MAP_SIZE;
-        if (s_resource.slot_map[probe] == 0) {
-            s_resource.slot_map[probe] = slot_index;
+        if (s_resource.slot_map[idx] == 0) {
+            s_resource.slot_map[idx] = slot_index;
             return;
         }
+        idx = (idx + 1U) % NT_SLOT_MAP_SIZE;
     }
 }
 
@@ -162,7 +161,7 @@ static uint16_t asset_alloc(void) {
 static void asset_free(uint16_t idx) {
     NtAssetMeta *meta = &s_resource.assets[idx];
     NT_ASSERT(meta->resource_id != 0);
-    uint16_t si = slot_map_find(meta->resource_id);
+    uint32_t si = slot_map_find(meta->resource_id);
     if (si != 0) {
         NtResourceSlot *slot = &s_resource.slots[si];
         /* Reuse can preserve both index and handle; invalidate the old identity first. */
@@ -181,8 +180,6 @@ static void asset_free(uint16_t idx) {
 /* ---- Time helper ---- */
 
 static uint32_t resource_get_time_ms(void) { return (uint32_t)(nt_time_now() * 1000.0); }
-
-static inline nt_resource_t resource_make(uint16_t index, uint16_t gen) { return (nt_resource_t){.id = ((uint32_t)gen << 16) | index}; }
 
 static void resource_bump_publication_epoch(void) {
     s_resource.publication_epoch++;
@@ -245,7 +242,7 @@ static void schedule_pack_redownload_if_needed(NtPackMeta *pack) {
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void resource_resolve_pass(void) {
     NtResolveTemp *resolve_temp = s_resource.resolve_temp;
-    memset(resolve_temp, 0, sizeof(s_resource.resolve_temp));
+    memset(resolve_temp, 0, (s_resource.slot_count + 1U) * sizeof(*resolve_temp));
 
     /* PIN_BLOB pin count is rebuilt from the published winners in D.4 below — clear it first. */
     for (uint16_t pi = 0; pi < NT_RESOURCE_MAX_PACKS; pi++) {
@@ -253,11 +250,7 @@ static void resource_resolve_pass(void) {
     }
 
     /* D.1: Prepare per-pass transient candidates */
-    for (uint16_t si = 1; si <= NT_RESOURCE_MAX_SLOTS; si++) {
-        NtResourceSlot *slot = &s_resource.slots[si];
-        if (slot->resource_id == 0) {
-            continue;
-        }
+    for (uint32_t si = 1; si <= s_resource.slot_count; si++) {
         NtResolveTemp *tmp = &resolve_temp[si];
         tmp->target_prio = INT16_MIN;
         tmp->candidate_prio = INT16_MIN;
@@ -276,7 +269,7 @@ static void resource_resolve_pass(void) {
             continue;
         }
 
-        uint16_t si = slot_map_find(meta->resource_id);
+        uint32_t si = slot_map_find(meta->resource_id);
         if (si == 0) {
             continue;
         }
@@ -324,19 +317,16 @@ static void resource_resolve_pass(void) {
 
     /* D.3: Texture placeholder fallback -- publish placeholder only if no READY asset exists */
     if (s_resource.placeholder_texture != 0) {
-        uint16_t ph_si = slot_map_find(s_resource.placeholder_texture);
+        uint32_t ph_si = slot_map_find(s_resource.placeholder_texture);
         uint32_t ph_handle = 0;
         if (ph_si != 0) {
             ph_handle = resolve_temp[ph_si].candidate_runtime_handle;
         }
 
         if (ph_handle != 0) {
-            for (uint16_t si = 1; si <= NT_RESOURCE_MAX_SLOTS; si++) {
+            for (uint32_t si = 1; si <= s_resource.slot_count; si++) {
                 NtResourceSlot *slot = &s_resource.slots[si];
                 NtResolveTemp *tmp = &resolve_temp[si];
-                if (slot->resource_id == 0) {
-                    continue;
-                }
                 if (tmp->scan_state == NT_ASSET_STATE_READY) {
                     continue;
                 }
@@ -348,11 +338,8 @@ static void resource_resolve_pass(void) {
     }
 
     // #region D.4: Publish the best usable winner and run resolve/cleanup hooks
-    for (uint16_t si = 1; si <= NT_RESOURCE_MAX_SLOTS; si++) {
+    for (uint32_t si = 1; si <= s_resource.slot_count; si++) {
         NtResourceSlot *slot = &s_resource.slots[si];
-        if (slot->resource_id == 0) {
-            continue;
-        }
         NtResolveTemp *tmp = &resolve_temp[si];
 
         uint8_t atype = slot->asset_type;
@@ -429,10 +416,10 @@ static void resource_resolve_pass(void) {
     // #endregion
 
     // #region D.5: Fire on_post_resolve callbacks after the resolve iteration
-    for (uint16_t si = 1; si <= NT_RESOURCE_MAX_SLOTS; si++) {
+    for (uint32_t si = 1; si <= s_resource.slot_count; si++) {
         NtResourceSlot *slot = &s_resource.slots[si];
         const NtResolveTemp *tmp = &resolve_temp[si];
-        if (slot->resource_id == 0 || !tmp->post_resolve_pending || slot->resolve_asset_idx >= s_resource.asset_hwm) {
+        if (!tmp->post_resolve_pending || slot->resolve_asset_idx >= s_resource.asset_hwm) {
             continue;
         }
 
@@ -444,7 +431,7 @@ static void resource_resolve_pass(void) {
         NtAssetMeta *winner = &s_resource.assets[slot->resolve_asset_idx];
         uint32_t size = 0;
         const uint8_t *data = asset_data_ptr(winner, &size);
-        s_resource.activators[atype].on_post_resolve(data, size, resource_make(si, slot->generation), slot->runtime_handle, slot->user_data);
+        s_resource.activators[atype].on_post_resolve(data, size, (nt_resource_t){.id = si}, slot->runtime_handle, slot->user_data);
     }
     // #endregion
 }
@@ -501,12 +488,6 @@ nt_result_t nt_resource_init(const nt_resource_desc_t *desc) {
 
     memset(&s_resource, 0, sizeof(s_resource));
 
-    /* Fill free queue: stack with lowest index on top (first alloc gets 1) */
-    s_resource.queue_top = NT_RESOURCE_MAX_SLOTS;
-    for (uint16_t i = 0; i < NT_RESOURCE_MAX_SLOTS; i++) {
-        s_resource.free_queue[i] = (uint16_t)(NT_RESOURCE_MAX_SLOTS - i); /* top has lowest */
-    }
-
     s_resource.free_asset_count = NT_RESOURCE_MAX_ASSETS;
     for (uint32_t i = 0; i < NT_RESOURCE_MAX_ASSETS; i++) {
         s_resource.free_assets[i] = (uint16_t)(NT_RESOURCE_MAX_ASSETS - 1U - i);
@@ -530,7 +511,7 @@ void nt_resource_shutdown(void) {
         }
     }
     // #region Cleanup remaining user_data (unmount doesn't trigger resolve)
-    for (uint16_t si = 1; si <= NT_RESOURCE_MAX_SLOTS; si++) {
+    for (uint32_t si = 1; si <= s_resource.slot_count; si++) {
         NtResourceSlot *slot = &s_resource.slots[si];
         if (slot->user_data != NULL) {
             uint8_t atype = slot->asset_type;
@@ -814,30 +795,16 @@ step_done:;
 /* ---- Slot allocation helpers ---- */
 
 static nt_resource_t slot_alloc(uint64_t resource_id, uint8_t asset_type) {
-    NT_ASSERT(s_resource.queue_top > 0); /* slot pool full -- raise MAX_SLOTS */
-
-    s_resource.queue_top--;
-    uint16_t index = s_resource.free_queue[s_resource.queue_top];
-
-    NtResourceSlot *slot = &s_resource.slots[index];
-
-    /* Increment generation (skip 0: reserved for invalid handles) */
-    slot->generation++;
-    if (slot->generation == 0) {
-        slot->generation = 1;
-    }
-
-    slot->resource_id = resource_id;
-    slot->runtime_handle = 0;
-    slot->resolve_asset_idx = UINT16_MAX;
-    slot->user_data_asset_idx = UINT16_MAX;
-    slot->asset_type = asset_type;
-    slot->state = NT_ASSET_STATE_REGISTERED;
-    slot->user_data = NULL;
-
+    NT_ASSERT(s_resource.slot_count < NT_RESOURCE_MAX_SLOTS);
+    uint32_t index = ++s_resource.slot_count;
+    s_resource.slots[index] = (NtResourceSlot){
+        .resource_id = resource_id,
+        .resolve_asset_idx = UINT16_MAX,
+        .user_data_asset_idx = UINT16_MAX,
+        .asset_type = asset_type,
+    };
     slot_map_insert(resource_id, index);
-
-    return resource_make(index, slot->generation);
+    return (nt_resource_t){.id = index};
 }
 
 /* ---- Pack management ---- */
@@ -919,9 +886,9 @@ void nt_resource_unmount(nt_hash32_t pack_id) {
     /* Sever every zero-copy provider viewing this pack's blob BEFORE the free, else a font read before
      * the next resolve pass dereferences freed memory. Drop only user_data; the resolve pass handles
      * winner-loss. Copy-out providers without PIN_BLOB survive the free and stay intact here. */
-    for (uint16_t si = 1; si <= NT_RESOURCE_MAX_SLOTS; si++) {
+    for (uint32_t si = 1; si <= s_resource.slot_count; si++) {
         NtResourceSlot *slot = &s_resource.slots[si];
-        if (slot->resource_id == 0 || slot->user_data == NULL || slot->resolve_asset_idx >= s_resource.asset_hwm) {
+        if (slot->user_data == NULL || slot->resolve_asset_idx >= s_resource.asset_hwm) {
             continue;
         }
         if (s_resource.assets[slot->resolve_asset_idx].pack_index != (uint16_t)pack_idx) {
@@ -1134,18 +1101,18 @@ nt_resource_t nt_resource_request(nt_hash64_t resource_id, uint8_t asset_type) {
         return NT_RESOURCE_INVALID;
     }
 
+    NT_ASSERT(resource_id.value != 0);
+
     /* O(1) lookup via slot map (idempotent) */
-    uint16_t existing = slot_map_find(resource_id.value);
+    uint32_t existing = slot_map_find(resource_id.value);
     if (existing != 0) {
         NT_ASSERT(s_resource.slots[existing].asset_type == asset_type);
-        return resource_make(existing, s_resource.slots[existing].generation);
+        return (nt_resource_t){.id = existing};
     }
 
     /* Not found: allocate new slot */
     nt_resource_t handle = slot_alloc(resource_id.value, asset_type);
-    if (handle.id != 0) {
-        s_resource.needs_resolve = true;
-    }
+    s_resource.needs_resolve = true;
     return handle;
 }
 
@@ -1153,77 +1120,47 @@ nt_resource_t nt_resource_find(nt_hash64_t resource_id) {
     if (!s_resource.initialized) {
         return NT_RESOURCE_INVALID;
     }
-    uint16_t existing = slot_map_find(resource_id.value);
+    uint32_t existing = slot_map_find(resource_id.value);
     if (existing != 0) {
-        return resource_make(existing, s_resource.slots[existing].generation);
+        return (nt_resource_t){.id = existing};
     }
     return NT_RESOURCE_INVALID;
 }
 
 uint32_t nt_resource_get(nt_resource_t handle) {
-    if (handle.id == 0) {
-        return 0;
-    }
+    uint32_t index = handle.id;
 
-    uint16_t index = nt_resource_slot_index(handle);
-    uint16_t gen = nt_resource_generation(handle);
-
-    if (index == 0 || index > NT_RESOURCE_MAX_SLOTS) {
+    if (index == 0 || index > s_resource.slot_count) {
         return 0;
-    }
-    if (s_resource.slots[index].generation != gen) {
-        return 0; /* stale handle */
     }
 
     return s_resource.slots[index].runtime_handle;
 }
 
 const void *nt_resource_peek_user_data(nt_resource_t handle) {
-    if (handle.id == 0) {
-        return NULL;
-    }
-    uint16_t idx = nt_resource_slot_index(handle);
-    if (idx == 0 || idx > NT_RESOURCE_MAX_SLOTS) {
+    uint32_t idx = handle.id;
+    if (idx == 0 || idx > s_resource.slot_count) {
         return NULL;
     }
     NtResourceSlot *slot = &s_resource.slots[idx];
-    if (slot->generation != nt_resource_generation(handle)) {
-        return NULL;
-    }
     return slot->user_data;
 }
 
 bool nt_resource_is_ready(nt_resource_t handle) {
-    if (handle.id == 0) {
-        return false;
-    }
+    uint32_t index = handle.id;
 
-    uint16_t index = nt_resource_slot_index(handle);
-    uint16_t gen = nt_resource_generation(handle);
-
-    if (index == 0 || index > NT_RESOURCE_MAX_SLOTS) {
+    if (index == 0 || index > s_resource.slot_count) {
         return false;
-    }
-    if (s_resource.slots[index].generation != gen) {
-        return false; /* stale handle */
     }
 
     return s_resource.slots[index].state == NT_ASSET_STATE_READY;
 }
 
 uint8_t nt_resource_get_state(nt_resource_t handle) {
-    if (handle.id == 0) {
-        return NT_ASSET_STATE_FAILED;
-    }
+    uint32_t index = handle.id;
 
-    uint16_t index = nt_resource_slot_index(handle);
-    uint16_t gen = nt_resource_generation(handle);
-
-    if (index == 0 || index > NT_RESOURCE_MAX_SLOTS) {
+    if (index == 0 || index > s_resource.slot_count) {
         return NT_ASSET_STATE_FAILED;
-    }
-    if (s_resource.slots[index].generation != gen) {
-        return NT_ASSET_STATE_FAILED; /* stale handle */
     }
 
     return s_resource.slots[index].state;
@@ -1231,17 +1168,10 @@ uint8_t nt_resource_get_state(nt_resource_t handle) {
 
 uint32_t nt_resource_publication_epoch(void) { return s_resource.publication_epoch; }
 
-/* Returns 0 for invalid/stale handles; real asset types start at NT_ASSET_MESH = 1. */
+/* Returns 0 for invalid handles; real asset types start at NT_ASSET_MESH = 1. */
 uint8_t nt_resource_get_asset_type(nt_resource_t handle) {
-    if (handle.id == 0) {
-        return 0;
-    }
-    uint16_t index = nt_resource_slot_index(handle);
-    uint16_t gen = nt_resource_generation(handle);
-    if (index == 0 || index > NT_RESOURCE_MAX_SLOTS) {
-        return 0;
-    }
-    if (s_resource.slots[index].generation != gen) {
+    uint32_t index = handle.id;
+    if (index == 0 || index > s_resource.slot_count) {
         return 0;
     }
     return s_resource.slots[index].asset_type;
@@ -1251,18 +1181,10 @@ const uint8_t *nt_resource_get_blob(nt_resource_t handle, uint32_t *out_size) {
     if (out_size) {
         *out_size = 0;
     }
-    if (handle.id == 0) {
-        return NULL;
-    }
+    uint32_t index = handle.id;
 
-    uint16_t index = nt_resource_slot_index(handle);
-    uint16_t gen = nt_resource_generation(handle);
-
-    if (index == 0 || index > NT_RESOURCE_MAX_SLOTS) {
+    if (index == 0 || index > s_resource.slot_count) {
         return NULL;
-    }
-    if (s_resource.slots[index].generation != gen) {
-        return NULL; /* stale handle */
     }
     if (s_resource.slots[index].asset_type != NT_ASSET_BLOB) {
         return NULL; /* not a blob */
@@ -1303,18 +1225,10 @@ const void *nt_resource_get_meta(nt_resource_t handle, nt_hash64_t kind, uint32_
     if (out_size) {
         *out_size = 0;
     }
-    if (handle.id == 0) {
-        return NULL;
-    }
+    uint32_t index = handle.id;
 
-    uint16_t index = nt_resource_slot_index(handle);
-    uint16_t gen = nt_resource_generation(handle);
-
-    if (index == 0 || index > NT_RESOURCE_MAX_SLOTS) {
+    if (index == 0 || index > s_resource.slot_count) {
         return NULL;
-    }
-    if (s_resource.slots[index].generation != gen) {
-        return NULL; /* stale handle */
     }
 
     const NtResourceSlot *slot = &s_resource.slots[index];
@@ -1567,7 +1481,7 @@ bool nt_resource_asset_info(uint16_t i, nt_resource_asset_info_t *out) {
         if (seen == i) {
             /* Report the pack aggregate only for the published winner of a PIN_BLOB slot — that asset pins the blob; others report 0. */
             uint32_t blob_pins = 0;
-            uint16_t si = slot_map_find(meta->resource_id);
+            uint32_t si = slot_map_find(meta->resource_id);
             if (si != 0) {
                 const NtResourceSlot *slot = &s_resource.slots[si];
                 if (slot->asset_type == meta->asset_type && slot->asset_type < NT_RESOURCE_MAX_ASSET_TYPES && slot->resolve_asset_idx == a &&
@@ -1596,9 +1510,9 @@ uint64_t nt_resource_source_of(uint8_t asset_type, uint32_t runtime_handle) {
     }
     /* Scan the canonical slot table (no separate index to desync). A slot publishes one runtime handle
        per resource_id; handles are unique per gfx object, so the first match is the source. */
-    for (uint16_t si = 1; si <= NT_RESOURCE_MAX_SLOTS; si++) {
+    for (uint32_t si = 1; si <= s_resource.slot_count; si++) {
         const NtResourceSlot *slot = &s_resource.slots[si];
-        if (slot->resource_id != 0 && slot->asset_type == asset_type && slot->runtime_handle == runtime_handle) {
+        if (slot->asset_type == asset_type && slot->runtime_handle == runtime_handle) {
             return slot->resource_id;
         }
     }

--- a/engine/resource/nt_resource.c
+++ b/engine/resource/nt_resource.c
@@ -352,10 +352,6 @@ static void resource_resolve_pass(void) {
         const bool next_has_real_winner = tmp->candidate_asset_idx < s_resource.asset_hwm;
         const uint16_t next_asset_idx = tmp->candidate_asset_idx;
         const uint32_t next_handle = tmp->candidate_runtime_handle;
-        if (next_has_real_winner || next_handle != 0) {
-            /* Virtual publication fixes the default description even without explicit registration. */
-            s_resource.types[atype].fixed = true;
-        }
         const bool next_changed = next_has_real_winner && (next_asset_idx != slot->resolve_asset_idx || next_handle != slot->runtime_handle);
         const bool needs_aux_sync = next_has_real_winner && aux_backed && !slot_user_data_synced_for(slot, next_asset_idx);
 
@@ -683,13 +679,6 @@ void nt_resource_step(void) {
                 }
 
                 uint8_t atype = meta->asset_type;
-                if (atype >= NT_RESOURCE_MAX_ASSET_TYPES) {
-                    continue;
-                }
-                if (!s_resource.types[atype].desc.activate) {
-                    continue;
-                }
-
                 /* Check time budget (0 = unlimited).
                  * Guarantee at least 1 activation per step — prevents starvation. */
                 if (activated_any && budget_ms > 0.0F) {
@@ -762,16 +751,7 @@ void nt_resource_step(void) {
             pack->blob_evict_skip_logged = 0; /* no longer pinned — re-arm the one-shot */
             // #endregion
             if (now_ms - pack->blob_last_access_ms >= pack->blob_ttl_ms) {
-                bool pending_activation = false;
-                for (uint32_t ai = 0; ai < s_resource.asset_hwm; ai++) {
-                    const NtAssetMeta *asset = &s_resource.assets[ai];
-                    if (asset->resource_id != 0 && asset->pack_index == pi && asset->owner_asset == ai && asset->state == NT_ASSET_STATE_REGISTERED) {
-                        pending_activation = true;
-                        break;
-                    }
-                }
-                /* A completed cursor can still have skipped owners whose type is not registered. */
-                if (pending_activation) {
+                if (pack->activate_cursor < s_resource.asset_hwm) {
                     continue;
                 }
                 /* Only free blobs owned by resource system (loaded via I/O).
@@ -1041,6 +1021,10 @@ nt_result_t nt_resource_parse_pack(nt_hash32_t pack_id, const uint8_t *blob, uin
     /* Reject the whole pack before reserving any slots. */
     for (uint32_t i = 0; i < h->asset_count; i++) {
         const NtAssetEntry *entry = &entries[i];
+        if (entry->asset_type < NT_ASSET_MESH || entry->asset_type > NT_ASSET_ATLAS) {
+            NT_LOG_ERROR("unsupported asset type");
+            goto parse_done;
+        }
         if (entry->offset < h->header_size || entry->size > blob_size || entry->offset > blob_size - entry->size) {
             NT_LOG_ERROR("entry data outside data region");
             goto parse_done;
@@ -1054,6 +1038,7 @@ nt_result_t nt_resource_parse_pack(nt_hash32_t pack_id, const uint8_t *blob, uin
             NT_LOG_ERROR("invalid alias owner");
             goto parse_done;
         }
+        NT_ASSERT(entry->asset_type == NT_ASSET_BLOB || s_resource.types[entry->asset_type].desc.activate != NULL);
     }
 
     NT_ASSERT(h->asset_count <= s_resource.free_asset_count);
@@ -1077,9 +1062,6 @@ nt_result_t nt_resource_parse_pack(nt_hash32_t pack_id, const uint8_t *blob, uin
             .meta_offset = (entry->meta_offset != 0 && entry->meta_offset >= meta_section_start) ? entry->meta_offset - meta_section_start : NT_NO_METADATA,
             .state = (entry->asset_type == NT_ASSET_BLOB && entry->owner_entry == i) ? NT_ASSET_STATE_READY : NT_ASSET_STATE_REGISTERED,
         };
-        if (meta->state == NT_ASSET_STATE_READY) {
-            s_resource.types[NT_ASSET_BLOB].fixed = true;
-        }
     }
 
     /* Parse metadata section */
@@ -1565,29 +1547,16 @@ void nt_resource_pack_progress(nt_hash32_t pack_id, uint32_t *received, uint32_t
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_resource_register_type(uint8_t asset_type, const nt_resource_type_desc_t *desc) {
     NT_ASSERT(s_resource.initialized);
+    NT_ASSERT(s_resource.next_mount_seq == 1);
     NT_ASSERT(asset_type < NT_RESOURCE_MAX_ASSET_TYPES);
     NT_ASSERT(desc != NULL);
     NT_ASSERT((desc->behavior_flags & ~(NT_RESOURCE_BEHAVIOR_AUX_BACKED | NT_RESOURCE_BEHAVIOR_PIN_BLOB)) == 0);
     NT_ASSERT(desc->on_resolve == NULL || desc->on_cleanup != NULL);
     NT_ASSERT((desc->behavior_flags & NT_RESOURCE_BEHAVIOR_AUX_BACKED) == 0 || (desc->on_resolve != NULL && desc->on_cleanup != NULL));
     NtResourceTypeEntry *entry = &s_resource.types[asset_type];
-    if (entry->fixed) {
-        NT_ASSERT(entry->desc.activate == desc->activate && entry->desc.deactivate == desc->deactivate && entry->desc.on_resolve == desc->on_resolve && entry->desc.on_cleanup == desc->on_cleanup &&
-                  entry->desc.on_post_resolve == desc->on_post_resolve && entry->desc.behavior_flags == desc->behavior_flags);
-        return;
-    }
-    if ((desc->behavior_flags & NT_RESOURCE_BEHAVIOR_PIN_BLOB) != 0) {
-        for (uint32_t i = 0; i < s_resource.asset_hwm; i++) {
-            NT_ASSERT(s_resource.assets[i].resource_id == 0 || s_resource.assets[i].asset_type != asset_type || s_resource.packs[s_resource.assets[i].pack_index].pack_type != NT_PACK_VIRTUAL);
-        }
-    }
+    NT_ASSERT(!entry->registered);
     entry->desc = *desc;
-    entry->fixed = true;
-    if (desc->activate != NULL) {
-        for (uint16_t pi = 0; pi < NT_RESOURCE_MAX_PACKS; pi++) {
-            s_resource.packs[pi].activate_cursor = 0;
-        }
-    }
+    entry->registered = true;
 }
 
 /* ---- Activation time budget ---- */

--- a/engine/resource/nt_resource.c
+++ b/engine/resource/nt_resource.c
@@ -762,6 +762,18 @@ void nt_resource_step(void) {
             pack->blob_evict_skip_logged = 0; /* no longer pinned — re-arm the one-shot */
             // #endregion
             if (now_ms - pack->blob_last_access_ms >= pack->blob_ttl_ms) {
+                bool pending_activation = false;
+                for (uint32_t ai = 0; ai < s_resource.asset_hwm; ai++) {
+                    const NtAssetMeta *asset = &s_resource.assets[ai];
+                    if (asset->resource_id != 0 && asset->pack_index == pi && asset->owner_asset == ai && asset->state == NT_ASSET_STATE_REGISTERED) {
+                        pending_activation = true;
+                        break;
+                    }
+                }
+                /* A completed cursor can still have skipped owners whose type is not registered. */
+                if (pending_activation) {
+                    continue;
+                }
                 /* Only free blobs owned by resource system (loaded via I/O).
                  * Caller-owned blobs (parse_pack direct) have io_type == NT_IO_NONE. */
                 if (pack->io_type != NT_IO_NONE) {

--- a/engine/resource/nt_resource.c
+++ b/engine/resource/nt_resource.c
@@ -36,7 +36,7 @@ static struct {
     NtAssetMeta assets[NT_RESOURCE_MAX_ASSETS];
     NtResourceSlot slots[NT_RESOURCE_MAX_SLOTS + 1];       /* index 0 reserved */
     NtResolveTemp resolve_temp[NT_RESOURCE_MAX_SLOTS + 1]; /* valid only during resource_resolve_pass */
-    NtActivatorEntry activators[NT_RESOURCE_MAX_ASSET_TYPES];
+    NtResourceTypeEntry types[NT_RESOURCE_MAX_ASSET_TYPES];
     uint16_t free_assets[NT_RESOURCE_MAX_ASSETS];
     uint32_t free_asset_count;
     uint32_t slot_map[NT_SLOT_MAP_SIZE];
@@ -295,7 +295,7 @@ static void resource_resolve_pass(void) {
         int16_t prio = s_resource.packs[meta->pack_index].priority;
         uint32_t seq = s_resource.packs[meta->pack_index].mount_seq;
         uint32_t runtime_handle = asset_effective_runtime_handle(ai, meta);
-        uint8_t behavior_flags = s_resource.activators[slot->asset_type].behavior_flags;
+        uint8_t behavior_flags = s_resource.types[slot->asset_type].desc.behavior_flags;
 
         /* Target winner: highest-priority READY asset, even if it is not yet publishable. */
         if (prio > tmp->target_prio || (prio == tmp->target_prio && seq >= tmp->target_seq)) {
@@ -343,7 +343,7 @@ static void resource_resolve_pass(void) {
         NtResolveTemp *tmp = &resolve_temp[si];
 
         uint8_t atype = slot->asset_type;
-        NtActivatorEntry *entry = &s_resource.activators[atype];
+        nt_resource_type_desc_t *entry = &s_resource.types[atype].desc;
         uint8_t behavior_flags = entry->behavior_flags;
         const bool aux_backed = (behavior_flags & NT_RESOURCE_BEHAVIOR_AUX_BACKED) != 0;
 
@@ -352,6 +352,10 @@ static void resource_resolve_pass(void) {
         const bool next_has_real_winner = tmp->candidate_asset_idx < s_resource.asset_hwm;
         const uint16_t next_asset_idx = tmp->candidate_asset_idx;
         const uint32_t next_handle = tmp->candidate_runtime_handle;
+        if (next_has_real_winner || next_handle != 0) {
+            /* Virtual publication fixes the default description even without explicit registration. */
+            s_resource.types[atype].fixed = true;
+        }
         const bool next_changed = next_has_real_winner && (next_asset_idx != slot->resolve_asset_idx || next_handle != slot->runtime_handle);
         const bool needs_aux_sync = next_has_real_winner && aux_backed && !slot_user_data_synced_for(slot, next_asset_idx);
 
@@ -424,14 +428,14 @@ static void resource_resolve_pass(void) {
         }
 
         uint8_t atype = slot->asset_type;
-        if (atype >= NT_RESOURCE_MAX_ASSET_TYPES || s_resource.activators[atype].on_post_resolve == NULL) {
+        if (atype >= NT_RESOURCE_MAX_ASSET_TYPES || s_resource.types[atype].desc.on_post_resolve == NULL) {
             continue;
         }
 
         NtAssetMeta *winner = &s_resource.assets[slot->resolve_asset_idx];
         uint32_t size = 0;
         const uint8_t *data = asset_data_ptr(winner, &size);
-        s_resource.activators[atype].on_post_resolve(data, size, (nt_resource_t){.id = si}, slot->runtime_handle, slot->user_data);
+        s_resource.types[atype].desc.on_post_resolve(data, size, (nt_resource_t){.id = si}, slot->runtime_handle, slot->user_data);
     }
     // #endregion
 }
@@ -515,8 +519,8 @@ void nt_resource_shutdown(void) {
         NtResourceSlot *slot = &s_resource.slots[si];
         if (slot->user_data != NULL) {
             uint8_t atype = slot->asset_type;
-            if (atype < NT_RESOURCE_MAX_ASSET_TYPES && s_resource.activators[atype].on_cleanup) {
-                s_resource.activators[atype].on_cleanup(slot->user_data);
+            if (atype < NT_RESOURCE_MAX_ASSET_TYPES && s_resource.types[atype].desc.on_cleanup) {
+                s_resource.types[atype].desc.on_cleanup(slot->user_data);
             }
             slot->user_data = NULL;
         }
@@ -682,7 +686,7 @@ void nt_resource_step(void) {
                 if (atype >= NT_RESOURCE_MAX_ASSET_TYPES) {
                     continue;
                 }
-                if (!s_resource.activators[atype].activate) {
+                if (!s_resource.types[atype].desc.activate) {
                     continue;
                 }
 
@@ -697,7 +701,7 @@ void nt_resource_step(void) {
                 }
 
                 const uint8_t *asset_data = pack->blob + meta->offset;
-                uint32_t handle = s_resource.activators[atype].activate(asset_data, meta->size);
+                uint32_t handle = s_resource.types[atype].desc.activate(asset_data, meta->size);
                 if (handle != 0) {
                     meta->state = NT_ASSET_STATE_READY;
                     meta->runtime_handle = handle;
@@ -864,8 +868,8 @@ void nt_resource_unmount(nt_hash32_t pack_id) {
             /* Aliases borrow the canonical owner's object. */
             if (s_resource.assets[i].state == NT_ASSET_STATE_READY && s_resource.assets[i].runtime_handle != 0 && pack->pack_type == NT_PACK_FILE && s_resource.assets[i].owner_asset == i) {
                 uint8_t atype = s_resource.assets[i].asset_type;
-                if (atype < NT_RESOURCE_MAX_ASSET_TYPES && s_resource.activators[atype].deactivate) {
-                    s_resource.activators[atype].deactivate(s_resource.assets[i].runtime_handle);
+                if (atype < NT_RESOURCE_MAX_ASSET_TYPES && s_resource.types[atype].desc.deactivate) {
+                    s_resource.types[atype].desc.deactivate(s_resource.assets[i].runtime_handle);
                 }
             }
         }
@@ -895,11 +899,11 @@ void nt_resource_unmount(nt_hash32_t pack_id) {
             continue;
         }
         uint8_t sever_atype = slot->asset_type;
-        if (sever_atype >= NT_RESOURCE_MAX_ASSET_TYPES || (s_resource.activators[sever_atype].behavior_flags & NT_RESOURCE_BEHAVIOR_PIN_BLOB) == 0) {
+        if (sever_atype >= NT_RESOURCE_MAX_ASSET_TYPES || (s_resource.types[sever_atype].desc.behavior_flags & NT_RESOURCE_BEHAVIOR_PIN_BLOB) == 0) {
             continue;
         }
-        if (s_resource.activators[sever_atype].on_cleanup != NULL) {
-            s_resource.activators[sever_atype].on_cleanup(slot->user_data);
+        if (s_resource.types[sever_atype].desc.on_cleanup != NULL) {
+            s_resource.types[sever_atype].desc.on_cleanup(slot->user_data);
         }
         slot->user_data = NULL;
         slot->user_data_asset_idx = UINT16_MAX;
@@ -1061,6 +1065,9 @@ nt_result_t nt_resource_parse_pack(nt_hash32_t pack_id, const uint8_t *blob, uin
             .meta_offset = (entry->meta_offset != 0 && entry->meta_offset >= meta_section_start) ? entry->meta_offset - meta_section_start : NT_NO_METADATA,
             .state = (entry->asset_type == NT_ASSET_BLOB && entry->owner_entry == i) ? NT_ASSET_STATE_READY : NT_ASSET_STATE_REGISTERED,
         };
+        if (meta->state == NT_ASSET_STATE_READY) {
+            s_resource.types[NT_ASSET_BLOB].fixed = true;
+        }
     }
 
     /* Parse metadata section */
@@ -1303,6 +1310,8 @@ nt_result_t nt_resource_register(nt_hash32_t pack_id, nt_hash64_t resource_id, u
     }
 
     NT_ASSERT(resource_id.value != 0);
+    NT_ASSERT(asset_type < NT_RESOURCE_MAX_ASSET_TYPES);
+    NT_ASSERT((s_resource.types[asset_type].desc.behavior_flags & NT_RESOURCE_BEHAVIOR_PIN_BLOB) == 0);
 
     int16_t pack_idx = find_pack(pack_id.value);
     if (pack_idx < 0) {
@@ -1485,7 +1494,7 @@ bool nt_resource_asset_info(uint16_t i, nt_resource_asset_info_t *out) {
             if (si != 0) {
                 const NtResourceSlot *slot = &s_resource.slots[si];
                 if (slot->asset_type == meta->asset_type && slot->asset_type < NT_RESOURCE_MAX_ASSET_TYPES && slot->resolve_asset_idx == a &&
-                    (s_resource.activators[slot->asset_type].behavior_flags & NT_RESOURCE_BEHAVIOR_PIN_BLOB) != 0) {
+                    (s_resource.types[slot->asset_type].desc.behavior_flags & NT_RESOURCE_BEHAVIOR_PIN_BLOB) != 0) {
                     blob_pins = s_resource.packs[meta->pack_index].blob_pins;
                 }
             }
@@ -1539,41 +1548,34 @@ void nt_resource_pack_progress(nt_hash32_t pack_id, uint32_t *received, uint32_t
     }
 }
 
-/* ---- Activator registration ---- */
+/* ---- Type registration ---- */
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
-void nt_resource_set_activator(uint8_t asset_type, nt_activate_fn activate, nt_deactivate_fn deactivate) {
+void nt_resource_register_type(uint8_t asset_type, const nt_resource_type_desc_t *desc) {
+    NT_ASSERT(s_resource.initialized);
     NT_ASSERT(asset_type < NT_RESOURCE_MAX_ASSET_TYPES);
-    NT_ASSERT((s_resource.activators[asset_type].activate == NULL || s_resource.activators[asset_type].activate == activate) && "activator already registered");
-    NT_ASSERT((s_resource.activators[asset_type].deactivate == NULL || s_resource.activators[asset_type].deactivate == deactivate) && "deactivator already registered");
-    if (s_resource.activators[asset_type].activate == NULL && activate != NULL) {
+    NT_ASSERT(desc != NULL);
+    NT_ASSERT((desc->behavior_flags & ~(NT_RESOURCE_BEHAVIOR_AUX_BACKED | NT_RESOURCE_BEHAVIOR_PIN_BLOB)) == 0);
+    NT_ASSERT(desc->on_resolve == NULL || desc->on_cleanup != NULL);
+    NT_ASSERT((desc->behavior_flags & NT_RESOURCE_BEHAVIOR_AUX_BACKED) == 0 || (desc->on_resolve != NULL && desc->on_cleanup != NULL));
+    NtResourceTypeEntry *entry = &s_resource.types[asset_type];
+    if (entry->fixed) {
+        NT_ASSERT(entry->desc.activate == desc->activate && entry->desc.deactivate == desc->deactivate && entry->desc.on_resolve == desc->on_resolve && entry->desc.on_cleanup == desc->on_cleanup &&
+                  entry->desc.on_post_resolve == desc->on_post_resolve && entry->desc.behavior_flags == desc->behavior_flags);
+        return;
+    }
+    if ((desc->behavior_flags & NT_RESOURCE_BEHAVIOR_PIN_BLOB) != 0) {
+        for (uint32_t i = 0; i < s_resource.asset_hwm; i++) {
+            NT_ASSERT(s_resource.assets[i].resource_id == 0 || s_resource.assets[i].asset_type != asset_type || s_resource.packs[s_resource.assets[i].pack_index].pack_type != NT_PACK_VIRTUAL);
+        }
+    }
+    entry->desc = *desc;
+    entry->fixed = true;
+    if (desc->activate != NULL) {
         for (uint16_t pi = 0; pi < NT_RESOURCE_MAX_PACKS; pi++) {
             s_resource.packs[pi].activate_cursor = 0;
         }
     }
-    s_resource.activators[asset_type].activate = activate;
-    s_resource.activators[asset_type].deactivate = deactivate;
-}
-
-// NOLINTNEXTLINE(readability-function-cognitive-complexity)
-void nt_resource_set_resolve_callbacks(uint8_t asset_type, nt_resolve_fn on_resolve, nt_cleanup_fn on_cleanup) {
-    NT_ASSERT(asset_type < NT_RESOURCE_MAX_ASSET_TYPES);
-    NT_ASSERT((s_resource.activators[asset_type].on_resolve == NULL || s_resource.activators[asset_type].on_resolve == on_resolve) && "resolve callbacks already registered");
-    NT_ASSERT((s_resource.activators[asset_type].on_cleanup == NULL || s_resource.activators[asset_type].on_cleanup == on_cleanup) && "cleanup callback already registered");
-    NT_ASSERT((on_resolve == NULL || on_cleanup != NULL) && "on_resolve requires on_cleanup to avoid user_data leak");
-    s_resource.activators[asset_type].on_resolve = on_resolve;
-    s_resource.activators[asset_type].on_cleanup = on_cleanup;
-}
-
-void nt_resource_set_post_resolve_callback(uint8_t asset_type, nt_post_resolve_fn on_post_resolve) {
-    NT_ASSERT(asset_type < NT_RESOURCE_MAX_ASSET_TYPES);
-    NT_ASSERT((s_resource.activators[asset_type].on_post_resolve == NULL || s_resource.activators[asset_type].on_post_resolve == on_post_resolve) && "post-resolve callback already registered");
-    s_resource.activators[asset_type].on_post_resolve = on_post_resolve;
-}
-
-void nt_resource_set_behavior_flags(uint8_t asset_type, uint8_t behavior_flags) {
-    NT_ASSERT(asset_type < NT_RESOURCE_MAX_ASSET_TYPES);
-    s_resource.activators[asset_type].behavior_flags = behavior_flags;
 }
 
 /* ---- Activation time budget ---- */
@@ -1603,6 +1605,7 @@ void nt_resource_set_blob_policy(nt_hash32_t pack_id, uint8_t policy, uint32_t t
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void nt_resource_invalidate(uint8_t asset_type) {
+    NT_ASSERT(asset_type != NT_ASSET_BLOB);
     /* Pass 1: Deactivate and mark assets back to REGISTERED */
     for (uint32_t i = 0; i < s_resource.asset_hwm; i++) {
         NtAssetMeta *meta = &s_resource.assets[i];
@@ -1622,8 +1625,8 @@ void nt_resource_invalidate(uint8_t asset_type) {
         /* Deactivate the owned object once. */
         if (meta->state == NT_ASSET_STATE_READY && meta->runtime_handle != 0) {
             uint8_t atype = meta->asset_type;
-            if (atype < NT_RESOURCE_MAX_ASSET_TYPES && s_resource.activators[atype].deactivate) {
-                s_resource.activators[atype].deactivate(meta->runtime_handle);
+            if (atype < NT_RESOURCE_MAX_ASSET_TYPES && s_resource.types[atype].desc.deactivate) {
+                s_resource.types[atype].desc.deactivate(meta->runtime_handle);
             }
         }
         s_resource.packs[meta->pack_index].activate_cursor = 0;

--- a/engine/resource/nt_resource.h
+++ b/engine/resource/nt_resource.h
@@ -98,12 +98,10 @@ typedef struct {
 } nt_resource_type_desc_t;
 
 /* Copies the complete desc; its pointer is required and borrowed only during this call.
- * Identical repeats are no-ops. Replacements assert until resource shutdown, even after unmount.
- * AUX_BACKED
- * requires resolve + cleanup. First registration may enable waiting file owners.
- * Register before activation/publication: virtual publication or file BLOB readiness fixes
- * the current
- * description, including the implicit empty default. */
+ * Register each type once, before the first successful file or virtual mount.
+ * Repeated or later
+ * registration asserts until resource shutdown/init.
+ * AUX_BACKED requires resolve + cleanup. Simple virtual providers and BLOB need no registration. */
 void nt_resource_register_type(uint8_t asset_type, const nt_resource_type_desc_t *desc);
 
 /* ---- Descriptor ---- */
@@ -147,8 +145,13 @@ nt_result_t nt_resource_set_priority(nt_hash32_t pack_id, int16_t new_priority);
 /* ---- Pack parsing ---- */
 
 /* Requires a file mount not yet successfully parsed; repeat parses return NT_ERR_INVALID_ARG.
- * Without resource-managed I/O, stores caller-owned blob without copying or freeing it;
- * keep it valid and unchanged until unmount/shutdown. Remount to replace parsed data. */
+ * Unknown manifest types reject the pack.
+ * Non-BLOB types require an activator registered before
+ * mounting.
+ * Missing activators assert before records or blob ownership change.
+ * Without resource-managed I/O, borrows the blob until unmount/shutdown.
+ * Keep borrowed bytes valid and unchanged.
+ * Remount to replace parsed data. */
 nt_result_t nt_resource_parse_pack(nt_hash32_t pack_id, const uint8_t *blob, uint32_t blob_size);
 
 /* ---- Resource access ---- */

--- a/engine/resource/nt_resource.h
+++ b/engine/resource/nt_resource.h
@@ -97,14 +97,13 @@ typedef struct {
     uint8_t behavior_flags;
 } nt_resource_type_desc_t;
 
-/* Copies desc for this registry lifetime; desc is required and borrowed only for this call.
- * Register the complete type before activation/publication. Identical repeats are no-ops;
- * any
- * replacement asserts, including after unmount. AUX_BACKED requires resolve + cleanup.
- * First registration may enable file owners still waiting for activation. Virtual publication
- * or file BLOB
- * readiness fixes the default description if none was registered. Unmount and
- * module shutdown never unlock a type; only resource shutdown ends its description's lifetime. */
+/* Copies the complete desc; its pointer is required and borrowed only during this call.
+ * Identical repeats are no-ops. Replacements assert until resource shutdown, even after unmount.
+ * AUX_BACKED
+ * requires resolve + cleanup. First registration may enable waiting file owners.
+ * Register before activation/publication: virtual publication or file BLOB readiness fixes
+ * the current
+ * description, including the implicit empty default. */
 void nt_resource_register_type(uint8_t asset_type, const nt_resource_type_desc_t *desc);
 
 /* ---- Descriptor ---- */
@@ -166,7 +165,7 @@ uint32_t nt_resource_get(nt_resource_t handle);
 bool nt_resource_is_ready(nt_resource_t handle);
 uint8_t nt_resource_get_state(nt_resource_t handle);
 /* Returns the asset type (NT_ASSET_*) the slot was created for. Returns 0
- * for invalid or stale handles. Useful for runtime type checks at API
+ * for invalid handles. Useful for runtime type checks at API
  * boundaries (e.g. nt_atlas_*() asserting it received an atlas resource). */
 uint8_t nt_resource_get_asset_type(nt_resource_t handle);
 /* Advances only during resolve when a published winner, state or auxiliary payload changes.

--- a/engine/resource/nt_resource.h
+++ b/engine/resource/nt_resource.h
@@ -88,6 +88,25 @@ typedef enum {
     NT_RESOURCE_BEHAVIOR_PIN_BLOB = 1 << 1,
 } nt_resource_behavior_t;
 
+typedef struct {
+    nt_activate_fn activate;
+    nt_deactivate_fn deactivate;
+    nt_resolve_fn on_resolve;
+    nt_cleanup_fn on_cleanup;
+    nt_post_resolve_fn on_post_resolve;
+    uint8_t behavior_flags;
+} nt_resource_type_desc_t;
+
+/* Copies desc for this registry lifetime; desc is required and borrowed only for this call.
+ * Register the complete type before activation/publication. Identical repeats are no-ops;
+ * any
+ * replacement asserts, including after unmount. AUX_BACKED requires resolve + cleanup.
+ * First registration may enable file owners still waiting for activation. Virtual publication
+ * or file BLOB
+ * readiness fixes the default description if none was registered. Unmount and
+ * module shutdown never unlock a type; only resource shutdown ends its description's lifetime. */
+void nt_resource_register_type(uint8_t asset_type, const nt_resource_type_desc_t *desc);
+
 /* ---- Descriptor ---- */
 
 typedef struct {
@@ -173,7 +192,9 @@ const void *nt_resource_get_meta(nt_resource_t handle, nt_hash64_t kind, uint32_
  * handle value but does not own/destroy the runtime object; virtual unregister/unmount
  * never call the asset deactivator. Resolve cleanup callbacks may still release
  * per-slot user_data. Register/unregister require a nonzero resource_id.
- * Unregister is virtual-only; file assets are removed by whole-pack unmount. */
+ * A PIN_BLOB type rejects virtual providers before mutation.
+ * Unregister is virtual-only; file assets are removed by
+ * whole-pack unmount. */
 nt_result_t nt_resource_create_pack(nt_hash32_t pack_id, int16_t priority);
 nt_result_t nt_resource_register(nt_hash32_t pack_id, nt_hash64_t resource_id, uint8_t asset_type, uint32_t runtime_handle);
 void nt_resource_unregister(nt_hash32_t pack_id, nt_hash64_t resource_id);
@@ -193,12 +214,6 @@ nt_result_t nt_resource_load_auto(nt_hash32_t pack_id, const char *path);
 nt_pack_state_t nt_resource_pack_state(nt_hash32_t pack_id);
 void nt_resource_pack_progress(nt_hash32_t pack_id, uint32_t *received, uint32_t *total);
 
-/* ---- Activator registration ---- */
-
-void nt_resource_set_activator(uint8_t asset_type, nt_activate_fn activate, nt_deactivate_fn deactivate);
-void nt_resource_set_resolve_callbacks(uint8_t asset_type, nt_resolve_fn on_resolve, nt_cleanup_fn on_cleanup);
-void nt_resource_set_post_resolve_callback(uint8_t asset_type, nt_post_resolve_fn on_post_resolve);
-void nt_resource_set_behavior_flags(uint8_t asset_type, uint8_t behavior_flags);
 /* Borrowed current slot aux pointer. Returns NULL for invalid handles or
  * slots with no current aux data. Non-NULL is valid only until the next resource
  * resolve/cleanup that changes this slot, or shutdown. Resolve/cleanup callbacks
@@ -222,8 +237,10 @@ void nt_resource_set_blob_policy(nt_hash32_t pack_id, uint8_t policy, uint32_t t
 
 /* ---- Context loss recovery ---- */
 
-/* Invalidates non-virtual assets of one type for later reactivation. On
- * context_restored, discard earlier render state and wait for a later resource_step. */
+/* Invalidates non-virtual assets of one type for later reactivation. BLOB asserts:
+ * raw bytes have no activation to repeat. On
+ * context_restored, discard earlier render state and wait for a later
+ * resource_step. */
 void nt_resource_invalidate(uint8_t asset_type);
 
 /* ---- Debug: dump loaded pack contents to log ---- */

--- a/engine/resource/nt_resource.h
+++ b/engine/resource/nt_resource.h
@@ -23,6 +23,9 @@ _Static_assert(NT_RESOURCE_MAX_ASSETS > 0 && NT_RESOURCE_MAX_ASSETS <= UINT16_MA
 #define NT_RESOURCE_MAX_SLOTS 2048
 #endif
 
+/* The slot map reserves two buckets per requested resource. */
+_Static_assert(NT_RESOURCE_MAX_SLOTS > 0 && NT_RESOURCE_MAX_SLOTS <= UINT32_MAX / 2U, "NT_RESOURCE_MAX_SLOTS must be in [1, UINT32_MAX / 2]");
+
 /* ---- Activation time budget (ms per nt_resource_step call) ---- */
 
 #ifndef NT_RESOURCE_ACTIVATE_TIME_BUDGET_MS
@@ -40,19 +43,16 @@ typedef enum {
     NT_PACK_STATE_FAILED,      /* load failed (may retry) */
 } nt_pack_state_t;
 
-/* ---- Resource handle ---- */
+/* ---- Stable resource handle ----
+ * id is a slot index, valid from request until resource shutdown.
+ * Unmount/reload changes the provider, not this identity. Never retain handles
+ * across shutdown/init; indices may be assigned to different names after reinit. */
 
 typedef struct {
     uint32_t id;
 } nt_resource_t;
 
 #define NT_RESOURCE_INVALID ((nt_resource_t){0})
-
-/* ---- Handle encoding: lower 16 bits = slot index, upper 16 bits = generation ---- */
-
-static inline uint16_t nt_resource_slot_index(nt_resource_t r) { return (uint16_t)(r.id & 0xFFFF); }
-
-static inline uint16_t nt_resource_generation(nt_resource_t r) { return (uint16_t)(r.id >> 16); }
 
 /* ---- Activator callback types ---- */
 
@@ -199,7 +199,7 @@ void nt_resource_set_activator(uint8_t asset_type, nt_activate_fn activate, nt_d
 void nt_resource_set_resolve_callbacks(uint8_t asset_type, nt_resolve_fn on_resolve, nt_cleanup_fn on_cleanup);
 void nt_resource_set_post_resolve_callback(uint8_t asset_type, nt_post_resolve_fn on_post_resolve);
 void nt_resource_set_behavior_flags(uint8_t asset_type, uint8_t behavior_flags);
-/* Borrowed current slot aux pointer. Returns NULL for invalid/stale handles or
+/* Borrowed current slot aux pointer. Returns NULL for invalid handles or
  * slots with no current aux data. Non-NULL is valid only until the next resource
  * resolve/cleanup that changes this slot, or shutdown. Resolve/cleanup callbacks
  * own mutation and freeing; caller must not free, mutate, or store it. */

--- a/engine/resource/nt_resource_internal.h
+++ b/engine/resource/nt_resource_internal.h
@@ -51,13 +51,9 @@ typedef enum {
 #define NT_RESOURCE_MAX_ASSET_TYPES 8
 
 typedef struct {
-    nt_activate_fn activate;
-    nt_deactivate_fn deactivate;
-    nt_resolve_fn on_resolve;
-    nt_cleanup_fn on_cleanup;
-    nt_post_resolve_fn on_post_resolve;
-    uint8_t behavior_flags;
-} NtActivatorEntry;
+    nt_resource_type_desc_t desc;
+    bool fixed;
+} NtResourceTypeEntry;
 
 /* ---- Per-asset metadata (one per asset from all packs) ---- */
 

--- a/engine/resource/nt_resource_internal.h
+++ b/engine/resource/nt_resource_internal.h
@@ -52,7 +52,7 @@ typedef enum {
 
 typedef struct {
     nt_resource_type_desc_t desc;
-    bool fixed;
+    bool registered;
 } NtResourceTypeEntry;
 
 /* ---- Per-asset metadata (one per asset from all packs) ---- */

--- a/engine/resource/nt_resource_internal.h
+++ b/engine/resource/nt_resource_internal.h
@@ -120,7 +120,6 @@ typedef struct {
 typedef struct {
     uint64_t resource_id;         /* nt_hash64 value */
     uint32_t runtime_handle;      /* published winner's runtime handle (what game sees) */
-    uint16_t generation;          /* stale-handle detection; incremented on slot reuse */
     uint16_t resolve_asset_idx;   /* index into assets[] of published winner */
     uint16_t user_data_asset_idx; /* asset idx last used to build user_data (aux sync check) */
     uint8_t asset_type;           /* nt_asset_type_t */

--- a/engine/sprite_comp/nt_sprite_comp.c
+++ b/engine/sprite_comp/nt_sprite_comp.c
@@ -136,7 +136,7 @@ static void sprite_on_destroy(nt_entity_t entity) {
 
 #if NT_INTROSPECT_ENABLED
 static void sprite_describe(nt_entity_t entity, nt_introspect_sink *s) {
-    /* atlas is the resource HANDLE (slot+generation), not a name-hash resource_id — emit it as a handle,
+    /* atlas is the resource HANDLE (stable slot), not a name-hash resource_id — emit it as a handle,
        since `resource` on the obs surface always means an nt_hash64 name hash (joinable with resource.list). */
     s->field_ref(s, "atlas", NT_REF_HANDLE, nt_sprite_comp_atlas(entity)->id);
     s->field_bool(s, "resolved", nt_sprite_comp_is_resolved(entity));

--- a/examples/atlas/main.c
+++ b/examples/atlas/main.c
@@ -248,9 +248,9 @@ int main(void) {
     nt_hash_init(&(nt_hash_desc_t){0});
     nt_resource_init(&(nt_resource_desc_t){0});
 
-    nt_resource_set_activator(NT_ASSET_TEXTURE, nt_gfx_activate_texture, nt_gfx_deactivate_texture);
-    nt_resource_set_activator(NT_ASSET_MESH, nt_gfx_activate_mesh, nt_gfx_deactivate_mesh);
-    nt_resource_set_activator(NT_ASSET_SHADER_CODE, nt_gfx_activate_shader, nt_gfx_deactivate_shader);
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_texture, .deactivate = nt_gfx_deactivate_texture});
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_mesh, .deactivate = nt_gfx_deactivate_mesh});
+    nt_resource_register_type(NT_ASSET_SHADER_CODE, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_shader, .deactivate = nt_gfx_deactivate_shader});
 
     s_pack_id = nt_hash32_str("atlas_demo");
 

--- a/examples/bunnymark/main.c
+++ b/examples/bunnymark/main.c
@@ -596,8 +596,8 @@ int main(void) {
     nt_resource_init(&(nt_resource_desc_t){0});
 
     /* Activators */
-    nt_resource_set_activator(NT_ASSET_TEXTURE, nt_gfx_activate_texture, nt_gfx_deactivate_texture);
-    nt_resource_set_activator(NT_ASSET_SHADER_CODE, nt_gfx_activate_shader, nt_gfx_deactivate_shader);
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_texture, .deactivate = nt_gfx_deactivate_texture});
+    nt_resource_register_type(NT_ASSET_SHADER_CODE, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_shader, .deactivate = nt_gfx_deactivate_shader});
     nt_atlas_init();
 
     /* Components — capacity sized for full bunny pool. */

--- a/examples/rtt_showcase/main.c
+++ b/examples/rtt_showcase/main.c
@@ -637,8 +637,8 @@ int main(void) {
     nt_hash_init(&(nt_hash_desc_t){0});
     nt_resource_init(&(nt_resource_desc_t){0});
     nt_mem_scratch_init(SCRATCH_ARENA_SIZE);
-    nt_resource_set_activator(NT_ASSET_TEXTURE, nt_gfx_activate_texture, nt_gfx_deactivate_texture);
-    nt_resource_set_activator(NT_ASSET_SHADER_CODE, nt_gfx_activate_shader, nt_gfx_deactivate_shader);
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_texture, .deactivate = nt_gfx_deactivate_texture});
+    nt_resource_register_type(NT_ASSET_SHADER_CODE, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_shader, .deactivate = nt_gfx_deactivate_shader});
     nt_atlas_init();
     nt_material_init(&(nt_material_desc_t){.max_materials = 4});
     nt_font_init(&(nt_font_desc_t){.max_fonts = 1});

--- a/examples/slice9_demo/main.c
+++ b/examples/slice9_demo/main.c
@@ -577,8 +577,8 @@ int main(int argc, char *argv[]) {
     nt_resource_init(&(nt_resource_desc_t){0});
     nt_mem_scratch_init(SCRATCH_ARENA_SIZE);
 
-    nt_resource_set_activator(NT_ASSET_TEXTURE, nt_gfx_activate_texture, nt_gfx_deactivate_texture);
-    nt_resource_set_activator(NT_ASSET_SHADER_CODE, nt_gfx_activate_shader, nt_gfx_deactivate_shader);
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_texture, .deactivate = nt_gfx_deactivate_texture});
+    nt_resource_register_type(NT_ASSET_SHADER_CODE, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_shader, .deactivate = nt_gfx_deactivate_shader});
     nt_atlas_init();
 
     nt_material_init(&(nt_material_desc_t){.max_materials = 4});

--- a/examples/sponza/main.c
+++ b/examples/sponza/main.c
@@ -663,9 +663,9 @@ int main(void) {
     nt_resource_init(&(nt_resource_desc_t){0});
 
     /* 6. Register GFX activators */
-    nt_resource_set_activator(NT_ASSET_TEXTURE, nt_gfx_activate_texture, nt_gfx_deactivate_texture);
-    nt_resource_set_activator(NT_ASSET_MESH, nt_gfx_activate_mesh, nt_gfx_deactivate_mesh);
-    nt_resource_set_activator(NT_ASSET_SHADER_CODE, nt_gfx_activate_shader, nt_gfx_deactivate_shader);
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_texture, .deactivate = nt_gfx_deactivate_texture});
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_mesh, .deactivate = nt_gfx_deactivate_mesh});
+    nt_resource_register_type(NT_ASSET_SHADER_CODE, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_shader, .deactivate = nt_gfx_deactivate_shader});
 
     /* 7. Material init */
     nt_material_desc_t mat_desc = {.max_materials = 256};

--- a/examples/text/main.c
+++ b/examples/text/main.c
@@ -465,7 +465,7 @@ int main(void) {
     nt_resource_init(&(nt_resource_desc_t){0});
 
     /* 6. Register activators */
-    nt_resource_set_activator(NT_ASSET_SHADER_CODE, nt_gfx_activate_shader, nt_gfx_deactivate_shader);
+    nt_resource_register_type(NT_ASSET_SHADER_CODE, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_shader, .deactivate = nt_gfx_deactivate_shader});
 
     /* 7. Font init */
     nt_font_init(&(nt_font_desc_t){.max_fonts = 4});

--- a/examples/textured_quad/main.c
+++ b/examples/textured_quad/main.c
@@ -409,9 +409,9 @@ int main(void) {
     nt_resource_init(&(nt_resource_desc_t){0});
 
     /* Register GFX activators */
-    nt_resource_set_activator(NT_ASSET_TEXTURE, nt_gfx_activate_texture, nt_gfx_deactivate_texture);
-    nt_resource_set_activator(NT_ASSET_MESH, nt_gfx_activate_mesh, nt_gfx_deactivate_mesh);
-    nt_resource_set_activator(NT_ASSET_SHADER_CODE, nt_gfx_activate_shader, nt_gfx_deactivate_shader);
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_texture, .deactivate = nt_gfx_deactivate_texture});
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_mesh, .deactivate = nt_gfx_deactivate_mesh});
+    nt_resource_register_type(NT_ASSET_SHADER_CODE, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_shader, .deactivate = nt_gfx_deactivate_shader});
 
     /* Compute pack IDs */
     s_base_pack_id = nt_hash32_str("base");

--- a/examples/ui_3d_demo/main.c
+++ b/examples/ui_3d_demo/main.c
@@ -1061,8 +1061,8 @@ int main(int argc, char *argv[]) {
     nt_resource_init(&(nt_resource_desc_t){0});
     nt_mem_scratch_init(SCRATCH_ARENA_SIZE);
 
-    nt_resource_set_activator(NT_ASSET_TEXTURE, nt_gfx_activate_texture, nt_gfx_deactivate_texture);
-    nt_resource_set_activator(NT_ASSET_SHADER_CODE, nt_gfx_activate_shader, nt_gfx_deactivate_shader);
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_texture, .deactivate = nt_gfx_deactivate_texture});
+    nt_resource_register_type(NT_ASSET_SHADER_CODE, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_shader, .deactivate = nt_gfx_deactivate_shader});
     nt_atlas_init();
     nt_material_init(&(nt_material_desc_t){.max_materials = 6}); /* sprite, text, text_3d, inspector sprite+text, + margin */
     nt_font_init(&(nt_font_desc_t){.max_fonts = 2});

--- a/examples/ui_showcase/main.c
+++ b/examples/ui_showcase/main.c
@@ -3920,8 +3920,8 @@ int main(int argc, char *argv[]) {
     nt_resource_init(&(nt_resource_desc_t){0});
     nt_mem_scratch_init(SCRATCH_ARENA_SIZE);
 
-    nt_resource_set_activator(NT_ASSET_TEXTURE, nt_gfx_activate_texture, nt_gfx_deactivate_texture);
-    nt_resource_set_activator(NT_ASSET_SHADER_CODE, nt_gfx_activate_shader, nt_gfx_deactivate_shader);
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_texture, .deactivate = nt_gfx_deactivate_texture});
+    nt_resource_register_type(NT_ASSET_SHADER_CODE, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_shader, .deactivate = nt_gfx_deactivate_shader});
     nt_atlas_init();
 
     /* sprite + text + base radial + 4 radial-image reveal-mode + packed-region = 8. */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -528,6 +528,27 @@ if(NOT EMSCRIPTEN)
     # parallel ctest (CPU contention skews the sub-ms timing), clean serially. Run alone.
     set_tests_properties(test_resource PROPERTIES RUN_SERIAL TRUE)
 
+    foreach(slot_capacity IN ITEMS 65537 65535)
+        set(slot_target test_resource_slots)
+        if(slot_capacity EQUAL 65535)
+            set(slot_target test_resource_slots_65535)
+        endif()
+        add_executable(${slot_target}
+            unit/test_resource_slots.c
+            unit/test_helpers/nt_assert_trap.c
+            ${CMAKE_SOURCE_DIR}/engine/resource/nt_resource.c
+        )
+        target_include_directories(${slot_target} PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}/unit")
+        target_link_libraries(${slot_target} PRIVATE nt_core nt_shared nt_gfx_interface nt_http_stub nt_fs_stub nt_log_stub nt_time nt_hash unity)
+        target_compile_definitions(${slot_target} PRIVATE
+            NT_RESOURCE_MAX_SLOTS=${slot_capacity}
+            NT_RESOURCE_TIMING_ENABLED=$<BOOL:${NT_RESOURCE_TIMING_ENABLED}>
+            NT_LOG_DOMAIN="resource"
+            _CRT_SECURE_NO_WARNINGS _CRT_NONSTDC_NO_DEPRECATE
+        )
+        nt_setup_test_target(${slot_target} TIMEOUT 10)
+    endforeach()
+
     # --- Atlas module tests ---
     add_executable(test_atlas unit/test_atlas.c unit/test_helpers/nt_assert_trap.c)
     target_link_libraries(test_atlas PRIVATE nt_atlas nt_resource nt_hash nt_http_stub nt_fs_stub nt_log_stub unity)

--- a/tests/browser/app/main.c
+++ b/tests/browser/app/main.c
@@ -818,8 +818,8 @@ int main(int argc, char *argv[]) {
     nt_resource_init(&(nt_resource_desc_t){0});
     nt_mem_scratch_init(SCRATCH_ARENA_SIZE);
 
-    nt_resource_set_activator(NT_ASSET_TEXTURE, nt_gfx_activate_texture, nt_gfx_deactivate_texture);
-    nt_resource_set_activator(NT_ASSET_SHADER_CODE, nt_gfx_activate_shader, nt_gfx_deactivate_shader);
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_texture, .deactivate = nt_gfx_deactivate_texture});
+    nt_resource_register_type(NT_ASSET_SHADER_CODE, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_shader, .deactivate = nt_gfx_deactivate_shader});
     nt_atlas_init();
 
     nt_material_init(&(nt_material_desc_t){.max_materials = 2});

--- a/tests/unit/test_atlas.c
+++ b/tests/unit/test_atlas.c
@@ -1403,7 +1403,7 @@ void test_atlas_full_resource_pipeline_integration(void) {
     /* --- Resource system init --- */
     nt_resource_init(NULL);
     nt_atlas_init();
-    nt_resource_set_activator(NT_ASSET_TEXTURE, fake_texture_activate, fake_texture_deactivate);
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = fake_texture_activate, .deactivate = fake_texture_deactivate});
 
     /* Mount pack, parse, request */
     nt_hash32_t pid = nt_hash32_str("atlas_integ_pack");

--- a/tests/unit/test_font.c
+++ b/tests/unit/test_font.c
@@ -289,6 +289,8 @@ void test_font_blob_valid(void) {
 void test_font_init_shutdown(void) {
     /* setUp already called init -- shutdown and re-init */
     nt_font_shutdown();
+    nt_resource_shutdown();
+    nt_resource_init(&(nt_resource_desc_t){0});
     nt_result_t r = nt_font_init(&(nt_font_desc_t){.max_fonts = 4});
     TEST_ASSERT_EQUAL(NT_OK, r);
     /* tearDown will call shutdown */
@@ -428,6 +430,8 @@ void test_font_destroy_frees_partial_texture_pairs(void) {
             nt_font_destroy(font);
         } else {
             nt_font_shutdown();
+            nt_resource_shutdown();
+            nt_resource_init(&(nt_resource_desc_t){0});
             nt_font_init(&(nt_font_desc_t){.max_fonts = 4});
         }
         TEST_ASSERT_EQUAL_UINT32(0U, s_error_count);

--- a/tests/unit/test_resource.c
+++ b/tests/unit/test_resource.c
@@ -136,12 +136,47 @@ void test_double_init(void) {
 
 void test_handle_invalid(void) { TEST_ASSERT_EQUAL_UINT32(0, NT_RESOURCE_INVALID.id); }
 
-void test_handle_encode_decode(void) {
-    /* Construct handle: index=5, gen=3 -> id = (3 << 16) | 5 = 196613 */
-    nt_resource_t h = {.id = (3U << 16) | 5U};
-    TEST_ASSERT_EQUAL_UINT32(196613, h.id);
-    TEST_ASSERT_EQUAL_UINT16(5, nt_resource_slot_index(h));
-    TEST_ASSERT_EQUAL_UINT16(3, nt_resource_generation(h));
+void test_handles_are_stable_slot_indices(void) {
+    nt_hash64_t rid = nt_hash64_str("stable_resource");
+    nt_hash32_t pid = nt_hash32_str("stable_provider");
+    nt_resource_t first = nt_resource_request(rid, NT_ASSET_MESH);
+    TEST_ASSERT_EQUAL_UINT32(1, first.id);
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pid, 0));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, rid, NT_ASSET_MESH, 17));
+    nt_resource_step();
+    TEST_ASSERT_EQUAL_UINT32(17, nt_resource_get(first));
+
+    nt_resource_unmount(pid);
+    nt_resource_step();
+    TEST_ASSERT_FALSE(nt_resource_is_ready(first));
+    TEST_ASSERT_EQUAL_UINT32(first.id, nt_resource_find(rid).id);
+    TEST_ASSERT_EQUAL_UINT32(first.id, nt_resource_request(rid, NT_ASSET_MESH).id);
+    nt_resource_t second = nt_resource_request(nt_hash64_str("different_resource"), NT_ASSET_MESH);
+    TEST_ASSERT_EQUAL_UINT32(2, second.id);
+
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pid, 0));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid, rid, NT_ASSET_MESH, 29));
+    nt_resource_step();
+    TEST_ASSERT_EQUAL_UINT32(29, nt_resource_get(first));
+    TEST_ASSERT_FALSE(nt_resource_is_ready(second));
+}
+
+void test_access_rejects_unallocated_slot_indices(void) {
+    nt_resource_t valid = nt_resource_request(nt_hash64_str("allocated_resource"), NT_ASSET_MESH);
+    const nt_resource_t invalid[] = {{0}, {.id = valid.id + 1U}, {.id = UINT32_MAX}};
+    for (uint32_t i = 0; i < sizeof(invalid) / sizeof(invalid[0]); i++) {
+        TEST_ASSERT_EQUAL_UINT32(0, nt_resource_get(invalid[i]));
+        TEST_ASSERT_FALSE(nt_resource_is_ready(invalid[i]));
+        TEST_ASSERT_EQUAL(NT_ASSET_STATE_FAILED, nt_resource_get_state(invalid[i]));
+        TEST_ASSERT_EQUAL_UINT8(0, nt_resource_get_asset_type(invalid[i]));
+        TEST_ASSERT_NULL(nt_resource_peek_user_data(invalid[i]));
+        uint32_t size = 123;
+        TEST_ASSERT_NULL(nt_resource_get_blob(invalid[i], &size));
+        TEST_ASSERT_EQUAL_UINT32(0, size);
+        size = 123;
+        TEST_ASSERT_NULL(nt_resource_get_meta(invalid[i], (nt_hash64_t){1}, &size));
+        TEST_ASSERT_EQUAL_UINT32(0, size);
+    }
 }
 
 /* ---- Parser tests ---- */
@@ -2929,7 +2964,7 @@ void test_peek_user_data_invalid_handle(void) {
     /* Invalid zero handle */
     TEST_ASSERT_NULL(nt_resource_peek_user_data((nt_resource_t){0}));
 
-    /* Request a resource to get a valid handle, then shutdown+reinit (stale generation) */
+    /* An allocated slot exposes its provider; an unallocated index has no aux data. */
     reset_resolve_state();
     s_activate_call_count = 0;
     nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
@@ -2948,11 +2983,7 @@ void test_peek_user_data_invalid_handle(void) {
     /* Handle is valid now */
     TEST_ASSERT_NOT_NULL(nt_resource_peek_user_data(h));
 
-    /* Shutdown + reinit: old handle becomes stale */
-    nt_resource_shutdown();
-    nt_resource_init(&s_desc);
-
-    TEST_ASSERT_NULL(nt_resource_peek_user_data(h));
+    TEST_ASSERT_NULL(nt_resource_peek_user_data((nt_resource_t){.id = h.id + 1U}));
 
     (void)remove("build/test_ud_invalid.ntpack");
 }
@@ -3488,9 +3519,10 @@ int main(void) {
     RUN_TEST(test_init_shutdown);
     RUN_TEST(test_double_init);
 
-    /* Handle encoding */
+    /* Resource handles */
     RUN_TEST(test_handle_invalid);
-    RUN_TEST(test_handle_encode_decode);
+    RUN_TEST(test_handles_are_stable_slot_indices);
+    RUN_TEST(test_access_rejects_unallocated_slot_indices);
 
     /* Parser rejection tests */
     RUN_TEST(test_parse_too_small);

--- a/tests/unit/test_resource.c
+++ b/tests/unit/test_resource.c
@@ -43,6 +43,12 @@ static void test_assert_trap(const char *expr, const char *file, int line) {
 
 /* ---- Test blob builder ---- */
 
+static uint32_t test_activate(const uint8_t *data, uint32_t size) {
+    (void)data;
+    (void)size;
+    return 1;
+}
+
 /*
  * Build a valid NTPACK blob in memory with `asset_count` fake assets.
  * Each asset has 16 bytes of zero data. Returns malloc'd blob (caller frees).
@@ -290,6 +296,8 @@ void test_parse_valid_empty(void) {
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_parse_valid_two_assets(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate});
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = test_activate});
     nt_hash32_t pack_id = nt_hash32_str("two_asset_pack");
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pack_id, 0));
 
@@ -421,6 +429,7 @@ void test_get_invalid_handle(void) { TEST_ASSERT_EQUAL_UINT32(0, nt_resource_get
 /* ---- State transition tests ---- */
 
 void test_is_ready_before_step(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate});
     nt_hash32_t pid = nt_hash32_str("ready_before_pack");
     nt_hash64_t rid = nt_hash64_str("ready_before_res");
 
@@ -435,8 +444,7 @@ void test_is_ready_before_step(void) {
     nt_resource_t h = nt_resource_request(rid, NT_ASSET_MESH);
     TEST_ASSERT_TRUE(h.id != 0);
 
-    /* Asset is REGISTERED, not READY -- is_ready should be false even after step */
-    nt_resource_step();
+    /* Parsing leaves activation for the next step. */
     TEST_ASSERT_FALSE(nt_resource_is_ready(h));
 
     free(blob);
@@ -444,6 +452,7 @@ void test_is_ready_before_step(void) {
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_is_ready_after_step(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate});
     nt_hash32_t pid = nt_hash32_str("ready_after_pack");
     nt_hash64_t rid = nt_hash64_str("ready_after_res");
 
@@ -473,6 +482,7 @@ void test_is_ready_after_step(void) {
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_priority_high_wins(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate});
     nt_hash32_t pid_a = nt_hash32_str("prio_pack_a");
     nt_hash32_t pid_b = nt_hash32_str("prio_pack_b");
     nt_hash64_t rid = nt_hash64_str("shared_asset");
@@ -508,6 +518,7 @@ void test_priority_high_wins(void) {
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_priority_equal_last_mounted_wins(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate});
     nt_hash32_t pid_a = nt_hash32_str("eq_pack_a");
     nt_hash32_t pid_b = nt_hash32_str("eq_pack_b");
     nt_hash64_t rid = nt_hash64_str("eq_shared");
@@ -541,6 +552,7 @@ void test_priority_equal_last_mounted_wins(void) {
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_unmount_fallback(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate});
     nt_hash32_t pid_a = nt_hash32_str("fb_pack_a");
     nt_hash32_t pid_b = nt_hash32_str("fb_pack_b");
     nt_hash64_t rid = nt_hash64_str("fb_shared");
@@ -577,6 +589,7 @@ void test_unmount_fallback(void) {
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_set_priority_reorder(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate});
     nt_hash32_t pid_a = nt_hash32_str("reorder_pack_a");
     nt_hash32_t pid_b = nt_hash32_str("reorder_pack_b");
     nt_hash64_t rid = nt_hash64_str("reorder_shared");
@@ -614,6 +627,7 @@ void test_set_priority_reorder(void) {
 /* ---- State reporting tests ---- */
 
 void test_get_state_registered(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate});
     nt_hash32_t pid = nt_hash32_str("state_reg_pack");
     nt_hash64_t rid = nt_hash64_str("state_reg_res");
 
@@ -631,6 +645,7 @@ void test_get_state_registered(void) {
 }
 
 void test_failed_permanent(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate});
     nt_hash32_t pid = nt_hash32_str("fail_pack");
     nt_hash64_t rid = nt_hash64_str("fail_res");
 
@@ -759,6 +774,7 @@ void test_publication_epoch_increments_on_winner_change(void) {
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_virtual_overrides_file(void) {
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = test_activate});
     nt_hash32_t pid_file = nt_hash32_str("vof_file_pack");
     nt_hash32_t pid_virt = nt_hash32_str("vof_virt_pack");
     nt_hash64_t rid = nt_hash64_str("vof_shared");
@@ -786,6 +802,7 @@ void test_virtual_overrides_file(void) {
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_file_overrides_virtual(void) {
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = test_activate});
     nt_hash32_t pid_virt = nt_hash32_str("fov_virt_pack");
     nt_hash32_t pid_file = nt_hash32_str("fov_file_pack");
     nt_hash64_t rid = nt_hash64_str("fov_shared");
@@ -813,6 +830,7 @@ void test_file_overrides_virtual(void) {
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_unregister_fallback(void) {
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = test_activate});
     nt_hash32_t pid_file = nt_hash32_str("unreg_file_pack");
     nt_hash32_t pid_virt = nt_hash32_str("unreg_virt_pack");
     nt_hash64_t rid = nt_hash64_str("unreg_shared");
@@ -863,6 +881,7 @@ void test_unmount_virtual_clears(void) {
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_set_placeholder_fallback(void) {
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = test_activate});
     /* Register placeholder texture via virtual pack */
     nt_hash32_t ph_pid = nt_hash32_str("ph_vpack");
     nt_hash64_t ph_rid = nt_hash64_str("placeholder_tex");
@@ -880,7 +899,8 @@ void test_set_placeholder_fallback(void) {
     TEST_ASSERT_NOT_NULL(blob);
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(pid, blob, blob_size));
 
-    /* Asset is REGISTERED, not READY: should get placeholder handle */
+    nt_resource_test_set_asset_state(rid, 1, NT_ASSET_STATE_LOADING, 0);
+    /* A loading texture publishes the placeholder handle. */
     nt_resource_t h = nt_resource_request(rid, NT_ASSET_TEXTURE);
     nt_resource_step();
     TEST_ASSERT_EQUAL_UINT32(999, nt_resource_get(h));
@@ -890,6 +910,7 @@ void test_set_placeholder_fallback(void) {
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_placeholder_not_used_when_ready(void) {
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = test_activate});
     /* Register placeholder texture via virtual pack */
     nt_hash32_t ph_pid = nt_hash32_str("ph_ready_vpack");
     nt_hash64_t ph_rid = nt_hash64_str("placeholder_tex2");
@@ -920,6 +941,7 @@ void test_placeholder_not_used_when_ready(void) {
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_placeholder_type_specific(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate});
     /* Register placeholder texture via virtual pack */
     nt_hash32_t ph_pid = nt_hash32_str("ph_type_vpack");
     nt_hash64_t ph_rid = nt_hash64_str("placeholder_tex3");
@@ -937,6 +959,7 @@ void test_placeholder_type_specific(void) {
     TEST_ASSERT_NOT_NULL(blob);
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(pid, blob, blob_size));
 
+    nt_resource_test_set_asset_state(rid, 1, NT_ASSET_STATE_LOADING, 0);
     nt_resource_t h = nt_resource_request(rid, NT_ASSET_MESH);
     nt_resource_step();
 
@@ -969,6 +992,8 @@ void test_parse_entries_overflow(void) {
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_asset_slot_reuse(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate});
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = test_activate});
     /* Mount pack A, parse 2 assets, unmount -> creates holes */
     nt_hash32_t pid_a = nt_hash32_str("reuse_pack_a");
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid_a, 0));
@@ -1052,6 +1077,7 @@ static uint8_t *build_alias_pack_with_rid(uint64_t rid, uint8_t atype, uint32_t 
 }
 
 void test_equal_range_self_owners_keep_independent_runtime_objects(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate_seq, .deactivate = fake_deactivate});
     uint32_t size = 0;
     uint8_t *blob = build_test_pack(2, &size);
     TEST_ASSERT_NOT_NULL(blob);
@@ -1064,7 +1090,6 @@ void test_equal_range_self_owners_keep_independent_runtime_objects(void) {
     s_activate_call_count = 0;
     s_deactivate_call_count = 0;
     s_next_handle = 100;
-    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate_seq, .deactivate = fake_deactivate});
     nt_resource_set_activate_time_budget(0);
     nt_resource_t first = nt_resource_request(nt_hash64_str("asset0"), NT_ASSET_MESH);
     nt_resource_t second = nt_resource_request(nt_hash64_str("asset1"), NT_ASSET_MESH);
@@ -1086,6 +1111,7 @@ void test_equal_range_self_owners_keep_independent_runtime_objects(void) {
 }
 
 void test_parse_alias_ranges_preserve_activation_order(void) {
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = fake_activate_seq, .deactivate = fake_deactivate});
     if (NT_RESOURCE_MAX_ASSETS < 8 || NT_RESOURCE_MAX_SLOTS < 8) {
         TEST_IGNORE_MESSAGE("requires eight assets and requested slots");
     }
@@ -1110,7 +1136,6 @@ void test_parse_alias_ranges_preserve_activation_order(void) {
     s_activate_call_count = 0;
     s_deactivate_call_count = 0;
     s_next_handle = 100;
-    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = fake_activate_seq, .deactivate = fake_deactivate});
     nt_resource_set_activate_time_budget(0.0F);
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(pid, blob, blob_size));
     nt_resource_step();
@@ -1132,6 +1157,9 @@ void test_parse_alias_ranges_preserve_activation_order(void) {
 }
 
 void test_asset_holes_shared_by_file_and_virtual_packs(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate});
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = test_activate});
+    nt_resource_register_type(NT_ASSET_SHADER_CODE, &(nt_resource_type_desc_t){.activate = test_activate});
     nt_hash32_t virtual_pid = nt_hash32_str("mixed_virtual");
     nt_hash32_t file_pid = nt_hash32_str("mixed_file");
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(virtual_pid, 0));
@@ -1263,6 +1291,8 @@ static void write_test_alias_pack_file(const char *path, uint64_t rid, uint8_t a
 /* ---- Pack loading tests ---- */
 
 void test_parse_invalid_later_entry_allows_corrected_load(void) {
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = test_activate});
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate});
     const char *path = "build/test_parse_corrected.ntpack";
     nt_hash32_t pid = nt_hash32_str("parse_corrected_pack");
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid, 0));
@@ -1287,7 +1317,6 @@ void test_parse_invalid_later_entry_allows_corrected_load(void) {
     TEST_ASSERT_EQUAL(NT_PACK_STATE_NONE, nt_resource_pack_state(pid));
 
     s_activate_call_count = 0;
-    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate});
     nt_resource_t resource = nt_resource_request(nt_hash64_str("asset0"), NT_ASSET_MESH);
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_load_file(pid, path));
     nt_resource_step();
@@ -1301,6 +1330,7 @@ void test_parse_invalid_later_entry_allows_corrected_load(void) {
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_load_file_transitions_state(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate});
     nt_hash32_t pid = nt_hash32_str("load_file_pack");
     nt_hash64_t rid = nt_hash64_str("load_file_res");
 
@@ -1364,6 +1394,7 @@ void test_load_file_nonexistent(void) {
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_pack_state_api(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate});
     nt_hash32_t pid = nt_hash32_str("state_api_pack");
     nt_hash64_t rid = nt_hash64_str("state_api_res");
 
@@ -1408,48 +1439,20 @@ void test_register_activating_type(void) {
 void test_activation_called_on_step(void) {
     s_activate_call_count = 0;
     nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
-
     nt_hash32_t pid = nt_hash32_str("act_call_pack");
     nt_hash64_t rid = nt_hash64_str("act_call_res");
-
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid, 0));
-
     uint32_t blob_size = 0;
     uint8_t *blob = build_pack_with_rid(rid.value, NT_ASSET_MESH, &blob_size);
     TEST_ASSERT_NOT_NULL(blob);
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(pid, blob, blob_size));
-
-    /* Pack needs to be in READY state for activation to run */
-    /* Manually set pack_state to READY (since we used parse_pack directly) */
-    nt_resource_step(); /* should activate the registered asset */
-
-    /* parse_pack sets blob pointer, pack_state is NONE but activation checks pack_state == READY.
-     * Since we used parse_pack directly (not load_file), pack_state is NONE. Need to set it. */
-    /* Actually we need pack_state == READY for activation. Let me use test_set_asset_state approach
-     * or set pack_state manually. Since we don't have a public API for that, let's use load_file. */
-
-    /* Reset and use load_file approach */
-    nt_resource_shutdown();
-    nt_http_shutdown();
-    nt_fs_shutdown();
-    nt_http_init();
-    nt_fs_init();
-    nt_resource_init(&s_desc);
-
-    s_activate_call_count = 0;
-    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
-
-    nt_hash32_t pid2 = nt_hash32_str("act_call_pack2");
-    nt_hash64_t rid2 = nt_hash64_str("act_call_res2");
-
-    write_test_pack_file("build/test_act_call.ntpack", rid2.value, NT_ASSET_MESH);
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid2, 0));
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_load_file(pid2, "build/test_act_call.ntpack"));
-    nt_resource_step(); /* polls I/O, parses, activates */
-
+    nt_resource_t resource = nt_resource_request(rid, NT_ASSET_MESH);
+    TEST_ASSERT_EQUAL_UINT32(0, s_activate_call_count);
+    TEST_ASSERT_FALSE(nt_resource_is_ready(resource));
+    nt_resource_step();
     TEST_ASSERT_EQUAL_UINT32(1, s_activate_call_count);
-
-    (void)remove("build/test_act_call.ntpack");
+    TEST_ASSERT_TRUE(nt_resource_is_ready(resource));
+    nt_resource_unmount(pid);
     free(blob);
 }
 
@@ -1562,23 +1565,6 @@ void test_activation_guarantees_minimum_one(void) {
     (void)remove("build/test_budget_skip.ntpack");
 }
 
-void test_no_activator_stays_registered(void) {
-    /* Don't register any activator -- assets stay REGISTERED */
-    nt_hash32_t pid = nt_hash32_str("no_act_pack");
-    nt_hash64_t rid = nt_hash64_str("no_act_res");
-
-    write_test_pack_file("build/test_no_act.ntpack", rid.value, NT_ASSET_MESH);
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid, 0));
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_load_file(pid, "build/test_no_act.ntpack"));
-    nt_resource_step();
-
-    nt_resource_t h = nt_resource_request(rid, NT_ASSET_MESH);
-    nt_resource_step();
-    TEST_ASSERT_FALSE(nt_resource_is_ready(h));
-
-    (void)remove("build/test_no_act.ntpack");
-}
-
 /* ---- Retry policy tests ---- */
 
 void test_retry_policy_defaults(void) {
@@ -1627,7 +1613,7 @@ void test_blob_pin_balance_winner_change(void) {
     nt_hash32_t pid_b = nt_hash32_str("pin_pack_b");
     nt_hash64_t rid = nt_hash64_str("pin_shared_res");
 
-    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate, .behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
 
     /* A high priority (pack_index 0), B low (pack_index 1) -- both provide rid */
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid_a, 10));
@@ -1673,6 +1659,7 @@ void test_blob_pin_balance_winner_change(void) {
 }
 
 void test_blob_pin_absent_without_flag(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate});
     nt_hash32_t pid = nt_hash32_str("nopin_pack");
     nt_hash64_t rid = nt_hash64_str("nopin_res");
 
@@ -1701,7 +1688,7 @@ void test_blob_pin_survives_reregister(void) {
     nt_hash32_t pid = nt_hash32_str("pin_reregister_pack");
     nt_hash64_t rid = nt_hash64_str("pin_reregister_res");
 
-    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate, .behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid, 0));
 
     uint32_t size = 0;
@@ -1742,7 +1729,7 @@ void test_blob_pin_eviction_skip_and_timer_freeze(void) {
     nt_hash32_t pid = nt_hash32_str("pin_evict_pack");
     nt_hash64_t rid = nt_hash64_str("pin_evict_res");
 
-    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate, .behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid, 0));
 
     uint32_t size = 0;
@@ -1790,7 +1777,7 @@ void test_blob_pin_auto_as_keep_one_shot_log(void) {
     nt_hash32_t pid = nt_hash32_str("pin_keep_pack");
     nt_hash64_t rid = nt_hash64_str("pin_keep_res");
 
-    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate, .behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid, 0));
 
     uint32_t size = 0;
@@ -1824,7 +1811,7 @@ void test_blob_pin_unmount_while_referenced(void) {
     nt_hash32_t pid = nt_hash32_str("pin_unmount_pack");
     nt_hash64_t rid = nt_hash64_str("pin_unmount_res");
 
-    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate, .behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid, 0));
 
     uint32_t size = 0;
@@ -1988,7 +1975,7 @@ void test_blob_pin_virtual_pack_not_publishable(void) {
     nt_hash32_t pid_virt = nt_hash32_str("pin_vp_virt");
     nt_hash64_t rid = nt_hash64_str("pin_vp_res");
 
-    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate, .behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
 
     /* File pack (index 0) at low priority — real resident blob, handle 100 */
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid_file, 1));
@@ -2381,6 +2368,7 @@ void test_get_blob_returns_data(void) {
 }
 
 void test_get_blob_null_for_non_blob(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate});
     nt_hash32_t pid = nt_hash32_str("blob_non_pack");
     nt_hash64_t rid = nt_hash64_str("blob_non_res");
 
@@ -2521,6 +2509,7 @@ void test_parse_after_eviction_rejected_until_remount(void) {
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_resource_get_meta_aabb(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
     nt_hash32_t pid = nt_hash32_str("meta_aabb_pack");
     nt_hash64_t rid = nt_hash64_str("meshes/test_cube");
 
@@ -2537,7 +2526,6 @@ void test_resource_get_meta_aabb(void) {
     nt_resource_t h = nt_resource_request(rid, NT_ASSET_MESH);
     TEST_ASSERT_TRUE(h.id != 0);
 
-    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
     nt_resource_step();
 
     /* Query metadata */
@@ -2585,6 +2573,7 @@ void test_resource_get_meta_invalid_handle(void) {
 }
 
 void test_resource_get_meta_wrong_kind(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
     nt_hash32_t pid = nt_hash32_str("meta_wrong_kind");
     nt_hash64_t rid = nt_hash64_str("meshes/wrong_kind");
 
@@ -2599,7 +2588,6 @@ void test_resource_get_meta_wrong_kind(void) {
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(pid, blob, blob_size));
 
     nt_resource_t h = nt_resource_request(rid, NT_ASSET_MESH);
-    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
     nt_resource_step();
 
     /* Query with a different kind -- should return NULL */
@@ -3104,6 +3092,8 @@ void test_pack_count_zero_when_empty(void) { TEST_ASSERT_EQUAL_UINT16(0, nt_reso
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_pack_enumeration_matches_mounted(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate});
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = test_activate});
     nt_hash32_t pid_a = nt_hash32_str("enum_pack_a");
     nt_hash32_t pid_b = nt_hash32_str("enum_pack_b");
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid_a, 3));
@@ -3186,24 +3176,8 @@ void test_asset_info_out_of_range_returns_false(void) {
     TEST_ASSERT_FALSE(nt_resource_asset_info(0, &info));
 }
 
-void test_later_activation_failure_is_published(void) {
-    uint32_t size = 0;
-    uint8_t *blob = build_test_pack(1, &size);
-    nt_hash32_t pid = nt_hash32_str("later_failure");
-    nt_resource_t h = nt_resource_request(nt_hash64_str("asset0"), NT_ASSET_MESH);
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid, 0));
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(pid, blob, size));
-    nt_resource_step();
-    TEST_ASSERT_EQUAL_UINT8(NT_ASSET_STATE_REGISTERED, nt_resource_get_state(h));
-    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate_fail});
-    nt_resource_step();
-    uint8_t state = nt_resource_get_state(h);
-    nt_resource_unmount(pid);
-    free(blob);
-    TEST_ASSERT_EQUAL_UINT8(NT_ASSET_STATE_FAILED, state);
-}
-
 void test_failed_owner_does_not_retry_through_alias(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate_fail});
     uint32_t size = 0;
     uint8_t *blob = build_test_pack(2, &size);
     NtAssetEntry *entries = (NtAssetEntry *)(blob + sizeof(NtPackHeader));
@@ -3215,7 +3189,6 @@ void test_failed_owner_does_not_retry_through_alias(void) {
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid, 0));
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(pid, blob, size));
     s_activate_call_count = 0;
-    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate_fail});
     nt_resource_set_activate_time_budget(0);
     nt_resource_step();
     uint32_t attempts = s_activate_call_count;
@@ -3245,6 +3218,7 @@ void test_virtual_reuse_same_handle_rebuilds_aux(void) {
 }
 
 void test_alias_only_activates_owner_after_reversed_slot_reuse(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
     nt_hash32_t virtual_pid = nt_hash32_str("alias_holes");
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(virtual_pid, 0));
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(virtual_pid, (nt_hash64_t){1}, NT_ASSET_MESH, 1));
@@ -3268,7 +3242,6 @@ void test_alias_only_activates_owner_after_reversed_slot_reuse(void) {
 
     s_activate_call_count = 0;
     s_deactivate_call_count = 0;
-    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
     nt_resource_set_activate_time_budget(0);
     nt_resource_t alias = nt_resource_request(nt_hash64_str("asset1"), NT_ASSET_MESH);
     nt_resource_step();
@@ -3284,6 +3257,7 @@ void test_alias_only_activates_owner_after_reversed_slot_reuse(void) {
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_parse_invalid_owner_relations_are_atomic(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = test_activate});
     uint32_t size = 0;
     uint8_t *blob = build_test_pack(3, &size);
     TEST_ASSERT_NOT_NULL(blob);
@@ -3359,6 +3333,7 @@ static uint32_t fake_activate_fail_once(const uint8_t *data, uint32_t size) {
 }
 
 void test_failed_owner_recovers_aliases_only_after_invalidate(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate_fail_once, .deactivate = fake_deactivate});
     uint32_t size = 0;
     uint8_t *blob = build_test_pack(2, &size);
     TEST_ASSERT_NOT_NULL(blob);
@@ -3373,7 +3348,6 @@ void test_failed_owner_recovers_aliases_only_after_invalidate(void) {
     nt_resource_t alias = nt_resource_request(nt_hash64_str("asset1"), NT_ASSET_MESH);
     s_activate_call_count = 0;
     s_deactivate_call_count = 0;
-    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate_fail_once, .deactivate = fake_deactivate});
     nt_resource_set_activate_time_budget(0);
     nt_resource_step();
     TEST_ASSERT_EQUAL_UINT8(NT_ASSET_STATE_FAILED, nt_resource_get_state(owner));
@@ -3502,9 +3476,9 @@ void test_blob_and_meta_reuse_stay_unpublished_until_step(void) {
     }
 }
 
-/* ---- main ---- */
+/* ---- Startup type registration ---- */
 
-static void test_type_registration_rejects_incomplete_description_before_fixing(void) {
+static void test_type_registration_rejects_incomplete_description_before_registering(void) {
     nt_resource_type_desc_t desc = {.behavior_flags = NT_RESOURCE_BEHAVIOR_AUX_BACKED};
     EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &desc));
     desc.on_resolve = mock_on_resolve;
@@ -3533,6 +3507,30 @@ static void test_type_registration_copies_and_preserves_complete_description(voi
     nt_resource_type_desc_t desc = {.activate = fake_activate, .deactivate = fake_deactivate, .on_resolve = mock_on_resolve, .on_cleanup = mock_on_cleanup, .on_post_resolve = mock_on_post_resolve};
     const nt_resource_type_desc_t original = desc;
     nt_resource_register_type(NT_ASSET_MESH, &desc);
+    for (uint32_t field = 0; field < 6; field++) {
+        desc = original;
+        switch (field) {
+        case 0:
+            desc.activate = fake_activate_fail;
+            break;
+        case 1:
+            desc.deactivate = NULL;
+            break;
+        case 2:
+            desc.on_resolve = test_provider_on_resolve;
+            break;
+        case 3:
+            desc.on_cleanup = test_provider_on_cleanup;
+            break;
+        case 4:
+            desc.on_post_resolve = NULL;
+            break;
+        default:
+            desc.behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB;
+            break;
+        }
+        EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &desc));
+    }
     memset(&desc, 0, sizeof desc);
     const nt_hash32_t pack = {992};
     const nt_hash64_t rid = {992};
@@ -3540,52 +3538,15 @@ static void test_type_registration_copies_and_preserves_complete_description(voi
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pack, 0));
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pack, rid, NT_ASSET_MESH, 77));
     nt_resource_step();
-    const void *aux = nt_resource_peek_user_data(resource);
-    TEST_ASSERT_NOT_NULL(aux);
-    uint32_t epoch = nt_resource_publication_epoch();
-    for (uint32_t phase = 0; phase < 2; phase++) {
-        nt_resource_register_type(NT_ASSET_MESH, &original);
-        for (uint32_t field = 0; field < 6; field++) {
-            desc = original;
-            switch (field) {
-            case 0:
-                desc.activate = fake_activate_fail;
-                break;
-            case 1:
-                desc.deactivate = NULL;
-                break;
-            case 2:
-                desc.on_resolve = test_provider_on_resolve;
-                break;
-            case 3:
-                desc.on_cleanup = test_provider_on_cleanup;
-                break;
-            case 4:
-                desc.on_post_resolve = NULL;
-                break;
-            default:
-                desc.behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB;
-                break;
-            }
-            EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &desc));
-        }
-        nt_resource_step();
-        if (phase == 0) {
-            TEST_ASSERT_EQUAL_UINT32(epoch, nt_resource_publication_epoch());
-            TEST_ASSERT_EQUAL_PTR(aux, nt_resource_peek_user_data(resource));
-            TEST_ASSERT_EQUAL_UINT32(1, s_resolve_call_count);
-            TEST_ASSERT_EQUAL_UINT32(1, s_post_resolve_call_count);
-            nt_resource_unmount(pack);
-            nt_resource_step();
-        }
-    }
+    TEST_ASSERT_NOT_NULL(nt_resource_peek_user_data(resource));
+    TEST_ASSERT_EQUAL_UINT32(1, s_resolve_call_count);
+    TEST_ASSERT_EQUAL_UINT32(1, s_post_resolve_call_count);
+    nt_resource_unmount(pack);
+    nt_resource_step();
     TEST_ASSERT_EQUAL_UINT32(1, s_cleanup_call_count);
-    nt_resource_shutdown();
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_init(&s_desc));
-    nt_resource_register_type(NT_ASSET_MESH, &desc);
 }
 
-static void test_virtual_publication_fixes_default_type(void) {
+static void test_virtual_provider_uses_default_description(void) {
     const nt_hash32_t pack = {993};
     const nt_hash64_t rid = {993};
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pack, 0));
@@ -3594,29 +3555,10 @@ static void test_virtual_publication_fixes_default_type(void) {
     nt_resource_step();
     const nt_resource_type_desc_t changed = {.activate = fake_activate};
     EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &changed));
-    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){0});
+    EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){0}));
     TEST_ASSERT_EQUAL_UINT32(77, nt_resource_get(resource));
     nt_resource_unmount(pack);
     EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &changed));
-}
-
-static void test_pin_type_registration_rejects_existing_virtual_assets(void) {
-    const nt_hash32_t pack = {995};
-    const nt_hash64_t rid = {995};
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pack, 0));
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pack, rid, NT_ASSET_MESH, 77));
-    nt_resource_t resource = nt_resource_request(rid, NT_ASSET_MESH);
-    for (uint32_t published = 0; published < 2; published++) {
-        nt_resource_type_desc_t desc = {.on_resolve = mock_on_resolve, .on_cleanup = mock_on_cleanup, .behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB};
-        EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &desc));
-        desc.behavior_flags |= NT_RESOURCE_BEHAVIOR_AUX_BACKED;
-        EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &desc));
-        nt_resource_step();
-        TEST_ASSERT_TRUE(nt_resource_is_ready(resource));
-        TEST_ASSERT_EQUAL_UINT32(77, nt_resource_get(resource));
-        TEST_ASSERT_NULL(nt_resource_peek_user_data(resource));
-        TEST_ASSERT_EQUAL_UINT32(0, nt_resource_test_pack_blob_pins(0));
-    }
 }
 
 static void test_aux_type_cannot_gain_pin_after_blob_eviction(void) {
@@ -3652,7 +3594,7 @@ static void test_aux_type_cannot_gain_pin_after_blob_eviction(void) {
     free(blob);
 }
 
-static void test_blob_ready_fixes_type_and_rejects_invalidation(void) {
+static void test_blob_without_registration_rejects_invalidation(void) {
     const nt_hash32_t pack = {994};
     const nt_hash64_t rid = {994};
     uint32_t size = 0;
@@ -3679,15 +3621,120 @@ static void test_blob_ready_fixes_type_and_rejects_invalidation(void) {
     free(blob);
 }
 
+static void test_type_registration_rejects_identical_repeat_before_mount(void) {
+    const nt_resource_type_desc_t desc = {.activate = fake_activate};
+    nt_resource_register_type(NT_ASSET_MESH, &desc);
+    EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &desc));
+    nt_resource_register_type(NT_ASSET_TEXTURE, &desc);
+}
+
+static void check_type_registration_closed_after_mount(bool virtual_pack) {
+    const nt_hash32_t pack = {997};
+    const nt_resource_type_desc_t desc = {.activate = fake_activate};
+    nt_result_t result = virtual_pack ? nt_resource_create_pack(pack, 0) : nt_resource_mount(pack, 0);
+    TEST_ASSERT_EQUAL(NT_OK, result);
+    EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &desc));
+    nt_resource_unmount(pack);
+    TEST_ASSERT_EQUAL_UINT16(0, nt_resource_pack_count());
+    EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_TEXTURE, &desc));
+    nt_resource_shutdown();
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_init(&s_desc));
+    nt_resource_register_type(NT_ASSET_MESH, &desc);
+    nt_resource_register_type(NT_ASSET_TEXTURE, &desc);
+}
+
+static void test_file_mount_closes_type_registration_until_reinit(void) { check_type_registration_closed_after_mount(false); }
+
+static void test_virtual_mount_closes_type_registration_until_reinit(void) { check_type_registration_closed_after_mount(true); }
+
+enum { TEST_TWO_OWNER_PACK_SIZE = sizeof(NtPackHeader) + (2 * sizeof(NtAssetEntry)) + 32 };
+
+static void build_two_owner_pack(uint8_t *blob, uint8_t asset_type) {
+    memset(blob, 0, TEST_TWO_OWNER_PACK_SIZE);
+    NtPackHeader *header = (NtPackHeader *)blob;
+    header->magic = NT_PACK_MAGIC;
+    header->version = NT_PACK_VERSION;
+    header->asset_count = 2;
+    header->header_size = (uint32_t)(sizeof(NtPackHeader) + (2 * sizeof(NtAssetEntry)));
+    header->total_size = TEST_TWO_OWNER_PACK_SIZE;
+    NtAssetEntry *entries = (NtAssetEntry *)(blob + sizeof(NtPackHeader));
+    for (uint16_t i = 0; i < 2; i++) {
+        entries[i].resource_id = 998U + i;
+        entries[i].offset = header->header_size + 16U * i;
+        entries[i].size = 16;
+        entries[i].owner_entry = i;
+        entries[i].asset_type = asset_type;
+        NtBlobAssetHeader *payload = (NtBlobAssetHeader *)(blob + entries[i].offset);
+        payload->magic = NT_BLOB_MAGIC;
+        payload->version = NT_BLOB_VERSION;
+    }
+    header->checksum = nt_crc32(blob + header->header_size, 32);
+}
+
+static void test_parse_invalid_asset_type_rejects_before_allocation(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate});
+    const nt_hash32_t pack = {998};
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pack, 0));
+    uint8_t blob[TEST_TWO_OWNER_PACK_SIZE];
+    build_two_owner_pack(blob, NT_ASSET_MESH);
+    NtAssetEntry *entries = (NtAssetEntry *)(blob + sizeof(NtPackHeader));
+    const uint8_t invalid_types[] = {0, NT_ASSET_ATLAS + 1, NT_RESOURCE_MAX_ASSET_TYPES, UINT8_MAX};
+    for (uint32_t i = 0; i < sizeof(invalid_types) / sizeof(invalid_types[0]); i++) {
+        entries[1].asset_type = invalid_types[i];
+        TEST_ASSERT_EQUAL(NT_ERR_INVALID_ARG, nt_resource_parse_pack(pack, blob, sizeof blob));
+        TEST_ASSERT_EQUAL_UINT16(0, nt_resource_asset_count());
+        TEST_ASSERT_EQUAL(NT_PACK_STATE_NONE, nt_resource_pack_state(pack));
+        TEST_ASSERT_EQUAL_UINT64(0, nt_resource_get_resident_bytes().blob_bytes);
+        TEST_ASSERT_EQUAL_UINT64(0, nt_resource_get_resident_bytes().metadata_bytes);
+    }
+    entries[1].asset_type = NT_ASSET_MESH;
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(pack, blob, sizeof blob));
+    TEST_ASSERT_EQUAL_UINT16(2, nt_resource_asset_count());
+    nt_resource_t resource = nt_resource_request((nt_hash64_t){entries[1].resource_id}, NT_ASSET_MESH);
+    nt_resource_step();
+    TEST_ASSERT_TRUE(nt_resource_is_ready(resource));
+    nt_resource_unmount(pack);
+}
+
+static void test_file_owner_requires_activator_before_parse_mutation(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){0});
+    const nt_hash32_t pack = {999};
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pack, 0));
+    uint8_t blob[TEST_TWO_OWNER_PACK_SIZE];
+    build_two_owner_pack(blob, NT_ASSET_BLOB);
+    NtAssetEntry *entries = (NtAssetEntry *)(blob + sizeof(NtPackHeader));
+    const uint8_t types[] = {NT_ASSET_MESH, NT_ASSET_TEXTURE, NT_ASSET_SHADER_CODE, NT_ASSET_FONT, NT_ASSET_ATLAS};
+    for (uint32_t i = 0; i < sizeof(types) / sizeof(types[0]); i++) {
+        entries[1].asset_type = types[i];
+        EXPECT_ASSERT((void)nt_resource_parse_pack(pack, blob, sizeof blob));
+        TEST_ASSERT_EQUAL_UINT16(0, nt_resource_asset_count());
+        TEST_ASSERT_EQUAL(NT_PACK_STATE_NONE, nt_resource_pack_state(pack));
+        TEST_ASSERT_EQUAL_UINT64(0, nt_resource_get_resident_bytes().blob_bytes);
+        TEST_ASSERT_EQUAL_UINT64(0, nt_resource_get_resident_bytes().metadata_bytes);
+    }
+    entries[1].asset_type = NT_ASSET_BLOB;
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(pack, blob, sizeof blob));
+    nt_resource_t resource = nt_resource_request((nt_hash64_t){entries[1].resource_id}, NT_ASSET_BLOB);
+    nt_resource_step();
+    TEST_ASSERT_TRUE(nt_resource_is_ready(resource));
+    uint32_t size = 0;
+    TEST_ASSERT_NOT_NULL(nt_resource_get_blob(resource, &size));
+    TEST_ASSERT_EQUAL_UINT32(8, size);
+    nt_resource_unmount(pack);
+}
+
 int main(void) {
     UNITY_BEGIN();
-    RUN_TEST(test_type_registration_rejects_incomplete_description_before_fixing);
+    RUN_TEST(test_type_registration_rejects_identical_repeat_before_mount);
+    RUN_TEST(test_file_mount_closes_type_registration_until_reinit);
+    RUN_TEST(test_virtual_mount_closes_type_registration_until_reinit);
+    RUN_TEST(test_parse_invalid_asset_type_rejects_before_allocation);
+    RUN_TEST(test_file_owner_requires_activator_before_parse_mutation);
+    RUN_TEST(test_type_registration_rejects_incomplete_description_before_registering);
     RUN_TEST(test_type_registration_copies_and_preserves_complete_description);
-    RUN_TEST(test_virtual_publication_fixes_default_type);
-    RUN_TEST(test_pin_type_registration_rejects_existing_virtual_assets);
+    RUN_TEST(test_virtual_provider_uses_default_description);
     RUN_TEST(test_aux_type_cannot_gain_pin_after_blob_eviction);
-    RUN_TEST(test_blob_ready_fixes_type_and_rejects_invalidation);
-    RUN_TEST(test_later_activation_failure_is_published);
+    RUN_TEST(test_blob_without_registration_rejects_invalidation);
     RUN_TEST(test_failed_owner_does_not_retry_through_alias);
     RUN_TEST(test_virtual_reuse_same_handle_rebuilds_aux);
     RUN_TEST(test_alias_only_activates_owner_after_reversed_slot_reuse);
@@ -3788,7 +3835,6 @@ int main(void) {
     RUN_TEST(test_activation_sets_runtime_handle);
     RUN_TEST(test_activation_unlimited_activates_all);
     RUN_TEST(test_activation_guarantees_minimum_one);
-    RUN_TEST(test_no_activator_stays_registered);
 
     /* Retry policy tests */
     RUN_TEST(test_retry_policy_defaults);

--- a/tests/unit/test_resource.c
+++ b/tests/unit/test_resource.c
@@ -1064,7 +1064,7 @@ void test_equal_range_self_owners_keep_independent_runtime_objects(void) {
     s_activate_call_count = 0;
     s_deactivate_call_count = 0;
     s_next_handle = 100;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate_seq, fake_deactivate);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate_seq, .deactivate = fake_deactivate});
     nt_resource_set_activate_time_budget(0);
     nt_resource_t first = nt_resource_request(nt_hash64_str("asset0"), NT_ASSET_MESH);
     nt_resource_t second = nt_resource_request(nt_hash64_str("asset1"), NT_ASSET_MESH);
@@ -1110,7 +1110,7 @@ void test_parse_alias_ranges_preserve_activation_order(void) {
     s_activate_call_count = 0;
     s_deactivate_call_count = 0;
     s_next_handle = 100;
-    nt_resource_set_activator(NT_ASSET_TEXTURE, fake_activate_seq, fake_deactivate);
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = fake_activate_seq, .deactivate = fake_deactivate});
     nt_resource_set_activate_time_budget(0.0F);
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(pid, blob, blob_size));
     nt_resource_step();
@@ -1287,7 +1287,7 @@ void test_parse_invalid_later_entry_allows_corrected_load(void) {
     TEST_ASSERT_EQUAL(NT_PACK_STATE_NONE, nt_resource_pack_state(pid));
 
     s_activate_call_count = 0;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, NULL);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate});
     nt_resource_t resource = nt_resource_request(nt_hash64_str("asset0"), NT_ASSET_MESH);
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_load_file(pid, path));
     nt_resource_step();
@@ -1399,15 +1399,15 @@ void test_pack_progress(void) {
 
 /* ---- Activator system tests ---- */
 
-void test_set_activator(void) {
+void test_register_activating_type(void) {
     /* Just verify it doesn't crash */
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
 }
 
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_activation_called_on_step(void) {
     s_activate_call_count = 0;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
 
     nt_hash32_t pid = nt_hash32_str("act_call_pack");
     nt_hash64_t rid = nt_hash64_str("act_call_res");
@@ -1437,7 +1437,7 @@ void test_activation_called_on_step(void) {
     nt_resource_init(&s_desc);
 
     s_activate_call_count = 0;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
 
     nt_hash32_t pid2 = nt_hash32_str("act_call_pack2");
     nt_hash64_t rid2 = nt_hash64_str("act_call_res2");
@@ -1456,7 +1456,7 @@ void test_activation_called_on_step(void) {
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_activation_sets_runtime_handle(void) {
     s_activate_call_count = 0;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
 
     nt_hash32_t pid = nt_hash32_str("act_handle_pack");
     nt_hash64_t rid = nt_hash64_str("act_handle_res");
@@ -1522,7 +1522,7 @@ static void write_test_pack_multi(const char *path, uint8_t atype, uint32_t coun
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_activation_unlimited_activates_all(void) {
     s_activate_call_count = 0;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
     nt_resource_set_activate_time_budget(0); /* unlimited */
 
     nt_hash32_t pid = nt_hash32_str("budget_pack");
@@ -1543,7 +1543,7 @@ void test_activation_unlimited_activates_all(void) {
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_activation_guarantees_minimum_one(void) {
     s_activate_call_count = 0;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
     /* Very tight time budget — fake_activate is instant so all will fit,
      * but this verifies the guarantee-minimum-1 path compiles and runs. */
     nt_resource_set_activate_time_budget(0.001F);
@@ -1600,7 +1600,7 @@ void test_blob_policy_keep(void) {
     nt_hash32_t pid = nt_hash32_str("blob_keep_pack");
     nt_hash64_t rid = nt_hash64_str("blob_keep_res");
 
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
 
     write_test_pack_file("build/test_blob_keep.ntpack", rid.value, NT_ASSET_MESH);
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid, 0));
@@ -1627,7 +1627,7 @@ void test_blob_pin_balance_winner_change(void) {
     nt_hash32_t pid_b = nt_hash32_str("pin_pack_b");
     nt_hash64_t rid = nt_hash64_str("pin_shared_res");
 
-    nt_resource_set_behavior_flags(NT_ASSET_MESH, NT_RESOURCE_BEHAVIOR_PIN_BLOB);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
 
     /* A high priority (pack_index 0), B low (pack_index 1) -- both provide rid */
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid_a, 10));
@@ -1701,7 +1701,7 @@ void test_blob_pin_survives_reregister(void) {
     nt_hash32_t pid = nt_hash32_str("pin_reregister_pack");
     nt_hash64_t rid = nt_hash64_str("pin_reregister_res");
 
-    nt_resource_set_behavior_flags(NT_ASSET_MESH, NT_RESOURCE_BEHAVIOR_PIN_BLOB);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid, 0));
 
     uint32_t size = 0;
@@ -1742,7 +1742,7 @@ void test_blob_pin_eviction_skip_and_timer_freeze(void) {
     nt_hash32_t pid = nt_hash32_str("pin_evict_pack");
     nt_hash64_t rid = nt_hash64_str("pin_evict_res");
 
-    nt_resource_set_behavior_flags(NT_ASSET_MESH, NT_RESOURCE_BEHAVIOR_PIN_BLOB);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid, 0));
 
     uint32_t size = 0;
@@ -1790,7 +1790,7 @@ void test_blob_pin_auto_as_keep_one_shot_log(void) {
     nt_hash32_t pid = nt_hash32_str("pin_keep_pack");
     nt_hash64_t rid = nt_hash64_str("pin_keep_res");
 
-    nt_resource_set_behavior_flags(NT_ASSET_MESH, NT_RESOURCE_BEHAVIOR_PIN_BLOB);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid, 0));
 
     uint32_t size = 0;
@@ -1824,7 +1824,7 @@ void test_blob_pin_unmount_while_referenced(void) {
     nt_hash32_t pid = nt_hash32_str("pin_unmount_pack");
     nt_hash64_t rid = nt_hash64_str("pin_unmount_res");
 
-    nt_resource_set_behavior_flags(NT_ASSET_MESH, NT_RESOURCE_BEHAVIOR_PIN_BLOB);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid, 0));
 
     uint32_t size = 0;
@@ -1881,9 +1881,11 @@ static void check_blob_pin_unmount_severs_provider_synchronously(bool aliases) {
     nt_hash32_t pid = nt_hash32_str("pin_sever_pack");
     nt_hash64_t rid = nt_hash64_str("pin_sever_res");
 
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate_seq, fake_deactivate);
-    nt_resource_set_resolve_callbacks(NT_ASSET_MESH, test_provider_on_resolve, test_provider_on_cleanup);
-    nt_resource_set_behavior_flags(NT_ASSET_MESH, NT_RESOURCE_BEHAVIOR_PIN_BLOB);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate_seq,
+                                                                        .deactivate = fake_deactivate,
+                                                                        .on_resolve = test_provider_on_resolve,
+                                                                        .on_cleanup = test_provider_on_cleanup,
+                                                                        .behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid, 0));
 
     uint32_t size = 0;
@@ -1907,6 +1909,10 @@ static void check_blob_pin_unmount_severs_provider_synchronously(bool aliases) {
     const NtAssetEntry *entries = (const NtAssetEntry *)(blob + sizeof(NtPackHeader));
     TEST_ASSERT_EQUAL_PTR(blob + entries[0].offset, provider->data);
     TEST_ASSERT_EQUAL_UINT32(entries[0].size, provider->size);
+    const nt_resource_type_desc_t without_pin = {.activate = fake_activate_seq, .deactivate = fake_deactivate, .on_resolve = test_provider_on_resolve, .on_cleanup = test_provider_on_cleanup};
+    EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &without_pin));
+    TEST_ASSERT_EQUAL_PTR(provider, nt_resource_peek_user_data(h));
+    TEST_ASSERT_EQUAL_UINT32(1, nt_resource_test_pack_blob_pins(0));
     nt_resource_set_blob_policy(pid, NT_BLOB_AUTO, 1);
     nt_time_sleep(0.005);
     nt_resource_step();
@@ -1941,7 +1947,7 @@ void test_blob_pin_unpublishable_when_blob_evicted_before_pin(void) {
     nt_hash32_t pid = nt_hash32_str("pin_unpub_pack");
     nt_hash64_t rid = nt_hash64_str("pin_unpub_res");
 
-    nt_resource_set_behavior_flags(NT_ASSET_MESH, NT_RESOURCE_BEHAVIOR_PIN_BLOB);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid, 0));
     nt_resource_set_blob_policy(pid, NT_BLOB_AUTO, 1); /* TTL = 1ms */
 
@@ -1969,15 +1975,14 @@ void test_blob_pin_unpublishable_when_blob_evicted_before_pin(void) {
     free(blob);
 }
 
-/* A blobless VIRTUAL pack must never publish a PIN_BLOB winner (the zero-copy view needs a real
- * blob): even at higher priority it must lose to a resident file pack and never steal the pin. */
+/* Rejected virtual registration must preserve the file provider and its pin. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_blob_pin_virtual_pack_not_publishable(void) {
     nt_hash32_t pid_file = nt_hash32_str("pin_vp_file");
     nt_hash32_t pid_virt = nt_hash32_str("pin_vp_virt");
     nt_hash64_t rid = nt_hash64_str("pin_vp_res");
 
-    nt_resource_set_behavior_flags(NT_ASSET_MESH, NT_RESOURCE_BEHAVIOR_PIN_BLOB);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
 
     /* File pack (index 0) at low priority — real resident blob, handle 100 */
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid_file, 1));
@@ -1989,7 +1994,7 @@ void test_blob_pin_virtual_pack_not_publishable(void) {
 
     /* Virtual pack (index 1) at HIGHER priority — no blob, handle 200 */
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pid_virt, 10));
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid_virt, rid, NT_ASSET_MESH, 200));
+    EXPECT_ASSERT((void)nt_resource_register(pid_virt, rid, NT_ASSET_MESH, 200));
 
     nt_resource_t h = nt_resource_request(rid, NT_ASSET_MESH);
     nt_resource_step();
@@ -2004,15 +2009,15 @@ void test_blob_pin_virtual_pack_not_publishable(void) {
     free(blob);
 }
 
-/* PIN_BLOB is a hard precondition even when AUX_BACKED is also set: a dual-flagged asset on a
- * blobless virtual pack must NOT publish, because the AUX_BACKED branch alone would (wrongly) accept
- * a virtual pack that carries no resident blob for the zero-copy view. */
+/* AUX_BACKED does not relax the PIN_BLOB virtual-provider restriction. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_blob_pin_and_aux_virtual_pack_not_publishable(void) {
     reset_resolve_state();
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate_seq, fake_deactivate);
-    nt_resource_set_resolve_callbacks(NT_ASSET_MESH, mock_on_resolve, mock_on_cleanup);
-    nt_resource_set_behavior_flags(NT_ASSET_MESH, NT_RESOURCE_BEHAVIOR_PIN_BLOB | NT_RESOURCE_BEHAVIOR_AUX_BACKED);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate_seq,
+                                                                        .deactivate = fake_deactivate,
+                                                                        .on_resolve = mock_on_resolve,
+                                                                        .on_cleanup = mock_on_cleanup,
+                                                                        .behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB | NT_RESOURCE_BEHAVIOR_AUX_BACKED});
 
     nt_hash32_t pid_file = nt_hash32_str("pin_aux_vp_file");
     nt_hash32_t pid_virt = nt_hash32_str("pin_aux_vp_virt");
@@ -2028,13 +2033,12 @@ void test_blob_pin_and_aux_virtual_pack_not_publishable(void) {
 
     /* Virtual pack (index 1) at HIGHER priority — no blob, handle 200. */
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pid_virt, 10));
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pid_virt, rid, NT_ASSET_MESH, 200));
+    EXPECT_ASSERT((void)nt_resource_register(pid_virt, rid, NT_ASSET_MESH, 200));
 
     nt_resource_t h = nt_resource_request(rid, NT_ASSET_MESH);
     nt_resource_step();
 
-    /* Without the hard PIN_BLOB precondition the AUX_BACKED branch would publish the higher-priority
-     * virtual asset (handle 200) and pin the blobless virtual pack. With it, the file wins. */
+    /* Rejection leaves the existing file winner intact. */
     TEST_ASSERT_TRUE(nt_resource_is_ready(h));
     TEST_ASSERT_EQUAL_UINT32(100, nt_resource_get(h));
     TEST_ASSERT_EQUAL_UINT32(1, nt_resource_test_pack_blob_pins(0)); /* file pinned */
@@ -2049,7 +2053,7 @@ void test_blob_pin_and_aux_virtual_pack_not_publishable(void) {
 void test_invalidate_marks_registered(void) {
     s_activate_call_count = 0;
     s_deactivate_call_count = 0;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
 
     nt_hash32_t pid = nt_hash32_str("inv_reg_pack");
     nt_hash64_t rid = nt_hash64_str("inv_reg_res");
@@ -2081,7 +2085,7 @@ void test_invalidate_calls_deactivator(void) {
     s_activate_call_count = 0;
     s_deactivate_call_count = 0;
     s_last_deactivated_handle = 0;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
 
     nt_hash32_t pid = nt_hash32_str("inv_deact_pack");
     nt_hash64_t rid = nt_hash64_str("inv_deact_res");
@@ -2126,7 +2130,7 @@ void test_invalidate_skips_virtual(void) {
 void test_invalidate_triggers_redownload_on_evicted_blob(void) {
     s_activate_call_count = 0;
     s_deactivate_call_count = 0;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
 
     nt_hash32_t pid = nt_hash32_str("inv_redl_pack");
     nt_hash64_t rid = nt_hash64_str("inv_redl_res");
@@ -2206,7 +2210,7 @@ void test_evicted_empty_pack_reloads_without_reparse(void) {
 void test_unmount_deactivates_assets(void) {
     s_activate_call_count = 0;
     s_deactivate_call_count = 0;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
 
     nt_hash32_t pid = nt_hash32_str("unmount_deact_pack");
     nt_hash64_t rid = nt_hash64_str("unmount_deact_res");
@@ -2230,7 +2234,7 @@ void test_unmount_deactivates_assets(void) {
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 void test_activation_failure_sets_failed(void) {
     s_activate_call_count = 0;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate_fail, NULL);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate_fail});
 
     nt_hash32_t pid = nt_hash32_str("act_fail_pack");
     nt_hash64_t rid = nt_hash64_str("act_fail_res");
@@ -2470,7 +2474,7 @@ void test_parse_after_eviction_rejected_until_remount(void) {
     nt_hash64_t rid = nt_hash64_str("reparse_mesh");
     nt_hash64_t kind = nt_hash64_str("reparse_meta");
     uint32_t payload = 42;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
 
     for (uint32_t asset_count = 0; asset_count <= 1; asset_count++) {
         uint32_t blob_size = 0;
@@ -2527,7 +2531,7 @@ void test_resource_get_meta_aabb(void) {
     nt_resource_t h = nt_resource_request(rid, NT_ASSET_MESH);
     TEST_ASSERT_TRUE(h.id != 0);
 
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
     nt_resource_step();
 
     /* Query metadata */
@@ -2589,7 +2593,7 @@ void test_resource_get_meta_wrong_kind(void) {
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(pid, blob, blob_size));
 
     nt_resource_t h = nt_resource_request(rid, NT_ASSET_MESH);
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
     nt_resource_step();
 
     /* Query with a different kind -- should return NULL */
@@ -2607,8 +2611,7 @@ void test_resource_get_meta_wrong_kind(void) {
 void test_on_resolve_fires_on_winner_change(void) {
     reset_resolve_state();
     s_activate_call_count = 0;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
-    nt_resource_set_resolve_callbacks(NT_ASSET_MESH, mock_on_resolve, mock_on_cleanup);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate, .on_resolve = mock_on_resolve, .on_cleanup = mock_on_cleanup});
 
     nt_hash32_t pid = nt_hash32_str("resolve_pack");
     nt_hash64_t rid = nt_hash64_str("resolve_test");
@@ -2640,10 +2643,10 @@ void test_on_post_resolve_can_request_dependency_and_resolve_same_step(void) {
     reset_resolve_state();
     s_activate_call_count = 0;
     s_next_handle = 0xBEEF;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate_seq, fake_deactivate);
-    nt_resource_set_activator(NT_ASSET_TEXTURE, fake_activate_seq, fake_deactivate);
-    nt_resource_set_resolve_callbacks(NT_ASSET_MESH, mock_on_resolve, mock_on_cleanup);
-    nt_resource_set_post_resolve_callback(NT_ASSET_MESH, mock_on_post_resolve);
+    nt_resource_register_type(NT_ASSET_MESH,
+                              &(nt_resource_type_desc_t){
+                                  .activate = fake_activate_seq, .deactivate = fake_deactivate, .on_resolve = mock_on_resolve, .on_cleanup = mock_on_cleanup, .on_post_resolve = mock_on_post_resolve});
+    nt_resource_register_type(NT_ASSET_TEXTURE, &(nt_resource_type_desc_t){.activate = fake_activate_seq, .deactivate = fake_deactivate});
 
     nt_hash32_t pid = nt_hash32_str("post_resolve_dep_pack");
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid, 0));
@@ -2679,8 +2682,7 @@ void test_on_resolve_merge_on_reactivation(void) {
     reset_resolve_state();
     s_activate_call_count = 0;
     s_next_handle = 0xBEEF;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate_seq, fake_deactivate);
-    nt_resource_set_resolve_callbacks(NT_ASSET_MESH, mock_on_resolve, mock_on_cleanup);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate_seq, .deactivate = fake_deactivate, .on_resolve = mock_on_resolve, .on_cleanup = mock_on_cleanup});
 
     nt_hash64_t rid = nt_hash64_str("merge_test");
 
@@ -2720,9 +2722,8 @@ static void check_aux_publish_falls_back_to_best_usable_winner(bool aliases, uin
     reset_resolve_state();
     s_activate_call_count = 0;
     s_next_handle = 0xBEEF;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate_seq, fake_deactivate);
-    nt_resource_set_resolve_callbacks(NT_ASSET_MESH, mock_on_resolve, mock_on_cleanup);
-    nt_resource_set_behavior_flags(NT_ASSET_MESH, flags);
+    nt_resource_register_type(
+        NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate_seq, .deactivate = fake_deactivate, .on_resolve = mock_on_resolve, .on_cleanup = mock_on_cleanup, .behavior_flags = flags});
     void (*write_pack)(const char *, uint64_t, uint8_t) = aliases ? write_test_alias_pack_file : write_test_pack_file;
     bool pinned = (flags & NT_RESOURCE_BEHAVIOR_PIN_BLOB) != 0;
 
@@ -2812,9 +2813,10 @@ static void check_aux_publish_waits_for_reload_when_no_usable_fallback_exists(bo
     reset_resolve_state();
     s_activate_call_count = 0;
     s_next_handle = 0xBEEF;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate_seq, fake_deactivate);
-    nt_resource_set_resolve_callbacks(NT_ASSET_MESH, mock_on_resolve, mock_on_cleanup);
-    nt_resource_set_behavior_flags(NT_ASSET_MESH, NT_RESOURCE_BEHAVIOR_AUX_BACKED);
+    nt_resource_register_type(
+        NT_ASSET_MESH,
+        &(nt_resource_type_desc_t){
+            .activate = fake_activate_seq, .deactivate = fake_deactivate, .on_resolve = mock_on_resolve, .on_cleanup = mock_on_cleanup, .behavior_flags = NT_RESOURCE_BEHAVIOR_AUX_BACKED});
     void (*write_pack)(const char *, uint64_t, uint8_t) = aliases ? write_test_alias_pack_file : write_test_pack_file;
 
     nt_hash64_t rid = nt_hash64_str("aux_publish_reload_res");
@@ -2880,8 +2882,7 @@ void test_on_cleanup_fires_on_unmount(void) {
     reset_resolve_state();
     s_activate_call_count = 0;
     s_deactivate_call_count = 0;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
-    nt_resource_set_resolve_callbacks(NT_ASSET_MESH, mock_on_resolve, mock_on_cleanup);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate, .on_resolve = mock_on_resolve, .on_cleanup = mock_on_cleanup});
 
     nt_hash32_t pid = nt_hash32_str("cleanup_unmount_pack");
     nt_hash64_t rid = nt_hash64_str("cleanup_unmount_res");
@@ -2909,8 +2910,7 @@ void test_on_cleanup_fires_on_unmount(void) {
 void test_on_cleanup_fires_on_shutdown(void) {
     reset_resolve_state();
     s_activate_call_count = 0;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
-    nt_resource_set_resolve_callbacks(NT_ASSET_MESH, mock_on_resolve, mock_on_cleanup);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate, .on_resolve = mock_on_resolve, .on_cleanup = mock_on_cleanup});
 
     nt_hash32_t pid = nt_hash32_str("cleanup_shutdown_pack");
     nt_hash64_t rid = nt_hash64_str("cleanup_shutdown_res");
@@ -2939,8 +2939,7 @@ void test_on_cleanup_fires_on_shutdown(void) {
 void test_peek_user_data_valid_handle(void) {
     reset_resolve_state();
     s_activate_call_count = 0;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
-    nt_resource_set_resolve_callbacks(NT_ASSET_MESH, mock_on_resolve, mock_on_cleanup);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate, .on_resolve = mock_on_resolve, .on_cleanup = mock_on_cleanup});
 
     nt_hash32_t pid = nt_hash32_str("ud_valid_pack");
     nt_hash64_t rid = nt_hash64_str("ud_valid_res");
@@ -2967,8 +2966,7 @@ void test_peek_user_data_invalid_handle(void) {
     /* An allocated slot exposes its provider; an unallocated index has no aux data. */
     reset_resolve_state();
     s_activate_call_count = 0;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
-    nt_resource_set_resolve_callbacks(NT_ASSET_MESH, mock_on_resolve, mock_on_cleanup);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate, .on_resolve = mock_on_resolve, .on_cleanup = mock_on_cleanup});
 
     nt_hash32_t pid = nt_hash32_str("ud_invalid_pack");
     nt_hash64_t rid = nt_hash64_str("ud_invalid_res");
@@ -2992,7 +2990,7 @@ void test_no_on_resolve_without_registration(void) {
     reset_resolve_state();
     s_activate_call_count = 0;
     /* Register only activator, NOT resolve callbacks */
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
 
     nt_hash32_t pid = nt_hash32_str("no_resolve_pack");
     nt_hash64_t rid = nt_hash64_str("no_resolve_res");
@@ -3023,8 +3021,7 @@ void test_on_resolve_fires_on_priority_change(void) {
     reset_resolve_state();
     s_activate_call_count = 0;
     s_next_handle = 0xBEEF;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate_seq, fake_deactivate);
-    nt_resource_set_resolve_callbacks(NT_ASSET_MESH, mock_on_resolve, mock_on_cleanup);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate_seq, .deactivate = fake_deactivate, .on_resolve = mock_on_resolve, .on_cleanup = mock_on_cleanup});
 
     nt_hash64_t rid = nt_hash64_str("prio_change_res");
 
@@ -3064,8 +3061,7 @@ void test_on_resolve_fires_on_invalidate(void) {
     reset_resolve_state();
     s_activate_call_count = 0;
     s_next_handle = 0xBEEF;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate_seq, fake_deactivate);
-    nt_resource_set_resolve_callbacks(NT_ASSET_MESH, mock_on_resolve, mock_on_cleanup);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate_seq, .deactivate = fake_deactivate, .on_resolve = mock_on_resolve, .on_cleanup = mock_on_cleanup});
 
     nt_hash32_t pid = nt_hash32_str("inv_resolve_pack");
     nt_hash64_t rid = nt_hash64_str("inv_resolve_res");
@@ -3193,7 +3189,7 @@ void test_later_activation_failure_is_published(void) {
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(pid, blob, size));
     nt_resource_step();
     TEST_ASSERT_EQUAL_UINT8(NT_ASSET_STATE_REGISTERED, nt_resource_get_state(h));
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate_fail, NULL);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate_fail});
     nt_resource_step();
     uint8_t state = nt_resource_get_state(h);
     nt_resource_unmount(pid);
@@ -3213,7 +3209,7 @@ void test_failed_owner_does_not_retry_through_alias(void) {
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid, 0));
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(pid, blob, size));
     s_activate_call_count = 0;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate_fail, NULL);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate_fail});
     nt_resource_set_activate_time_budget(0);
     nt_resource_step();
     uint32_t attempts = s_activate_call_count;
@@ -3226,8 +3222,7 @@ void test_failed_owner_does_not_retry_through_alias(void) {
 
 void test_virtual_reuse_same_handle_rebuilds_aux(void) {
     reset_resolve_state();
-    nt_resource_set_resolve_callbacks(NT_ASSET_MESH, mock_on_resolve, mock_on_cleanup);
-    nt_resource_set_behavior_flags(NT_ASSET_MESH, NT_RESOURCE_BEHAVIOR_AUX_BACKED);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.on_resolve = mock_on_resolve, .on_cleanup = mock_on_cleanup, .behavior_flags = NT_RESOURCE_BEHAVIOR_AUX_BACKED});
     nt_hash32_t pid = nt_hash32_str("aux_reuse");
     nt_hash64_t rid = nt_hash64_str("aux_reuse_mesh");
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pid, 0));
@@ -3267,7 +3262,7 @@ void test_alias_only_activates_owner_after_reversed_slot_reuse(void) {
 
     s_activate_call_count = 0;
     s_deactivate_call_count = 0;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate, fake_deactivate);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate});
     nt_resource_set_activate_time_budget(0);
     nt_resource_t alias = nt_resource_request(nt_hash64_str("asset1"), NT_ASSET_MESH);
     nt_resource_step();
@@ -3372,7 +3367,7 @@ void test_failed_owner_recovers_aliases_only_after_invalidate(void) {
     nt_resource_t alias = nt_resource_request(nt_hash64_str("asset1"), NT_ASSET_MESH);
     s_activate_call_count = 0;
     s_deactivate_call_count = 0;
-    nt_resource_set_activator(NT_ASSET_MESH, fake_activate_fail_once, fake_deactivate);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate_fail_once, .deactivate = fake_deactivate});
     nt_resource_set_activate_time_budget(0);
     nt_resource_step();
     TEST_ASSERT_EQUAL_UINT8(NT_ASSET_STATE_FAILED, nt_resource_get_state(owner));
@@ -3503,8 +3498,189 @@ void test_blob_and_meta_reuse_stay_unpublished_until_step(void) {
 
 /* ---- main ---- */
 
+static void test_type_registration_rejects_incomplete_description_before_fixing(void) {
+    nt_resource_type_desc_t desc = {.behavior_flags = NT_RESOURCE_BEHAVIOR_AUX_BACKED};
+    EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &desc));
+    desc.on_resolve = mock_on_resolve;
+    EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &desc));
+    desc.on_resolve = NULL;
+    desc.on_cleanup = mock_on_cleanup;
+    EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &desc));
+    desc.on_resolve = mock_on_resolve;
+    EXPECT_ASSERT(nt_resource_register_type(NT_RESOURCE_MAX_ASSET_TYPES, &desc));
+    EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, NULL));
+    desc.behavior_flags = UINT8_MAX;
+    EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &desc));
+    desc.behavior_flags = NT_RESOURCE_BEHAVIOR_AUX_BACKED;
+    nt_resource_register_type(NT_ASSET_MESH, &desc);
+    const nt_hash32_t pack = {991};
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pack, 0));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pack, (nt_hash64_t){991}, NT_ASSET_MESH, 77));
+    nt_resource_t resource = nt_resource_request((nt_hash64_t){991}, NT_ASSET_MESH);
+    nt_resource_step();
+    TEST_ASSERT_TRUE(nt_resource_is_ready(resource));
+    TEST_ASSERT_NOT_NULL(nt_resource_peek_user_data(resource));
+}
+
+static void test_type_registration_copies_and_preserves_complete_description(void) {
+    reset_resolve_state();
+    nt_resource_type_desc_t desc = {.activate = fake_activate, .deactivate = fake_deactivate, .on_resolve = mock_on_resolve, .on_cleanup = mock_on_cleanup, .on_post_resolve = mock_on_post_resolve};
+    const nt_resource_type_desc_t original = desc;
+    nt_resource_register_type(NT_ASSET_MESH, &desc);
+    memset(&desc, 0, sizeof desc);
+    const nt_hash32_t pack = {992};
+    const nt_hash64_t rid = {992};
+    nt_resource_t resource = nt_resource_request(rid, NT_ASSET_MESH);
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pack, 0));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pack, rid, NT_ASSET_MESH, 77));
+    nt_resource_step();
+    const void *aux = nt_resource_peek_user_data(resource);
+    TEST_ASSERT_NOT_NULL(aux);
+    uint32_t epoch = nt_resource_publication_epoch();
+    for (uint32_t phase = 0; phase < 2; phase++) {
+        nt_resource_register_type(NT_ASSET_MESH, &original);
+        for (uint32_t field = 0; field < 6; field++) {
+            desc = original;
+            switch (field) {
+            case 0:
+                desc.activate = fake_activate_fail;
+                break;
+            case 1:
+                desc.deactivate = NULL;
+                break;
+            case 2:
+                desc.on_resolve = test_provider_on_resolve;
+                break;
+            case 3:
+                desc.on_cleanup = test_provider_on_cleanup;
+                break;
+            case 4:
+                desc.on_post_resolve = NULL;
+                break;
+            default:
+                desc.behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB;
+                break;
+            }
+            EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &desc));
+        }
+        nt_resource_step();
+        if (phase == 0) {
+            TEST_ASSERT_EQUAL_UINT32(epoch, nt_resource_publication_epoch());
+            TEST_ASSERT_EQUAL_PTR(aux, nt_resource_peek_user_data(resource));
+            TEST_ASSERT_EQUAL_UINT32(1, s_resolve_call_count);
+            TEST_ASSERT_EQUAL_UINT32(1, s_post_resolve_call_count);
+            nt_resource_unmount(pack);
+            nt_resource_step();
+        }
+    }
+    TEST_ASSERT_EQUAL_UINT32(1, s_cleanup_call_count);
+    nt_resource_shutdown();
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_init(&s_desc));
+    nt_resource_register_type(NT_ASSET_MESH, &desc);
+}
+
+static void test_virtual_publication_fixes_default_type(void) {
+    const nt_hash32_t pack = {993};
+    const nt_hash64_t rid = {993};
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pack, 0));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pack, rid, NT_ASSET_MESH, 77));
+    nt_resource_t resource = nt_resource_request(rid, NT_ASSET_MESH);
+    nt_resource_step();
+    const nt_resource_type_desc_t changed = {.activate = fake_activate};
+    EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &changed));
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){0});
+    TEST_ASSERT_EQUAL_UINT32(77, nt_resource_get(resource));
+    nt_resource_unmount(pack);
+    EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &changed));
+}
+
+static void test_pin_type_registration_rejects_existing_virtual_assets(void) {
+    const nt_hash32_t pack = {995};
+    const nt_hash64_t rid = {995};
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pack, 0));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pack, rid, NT_ASSET_MESH, 77));
+    nt_resource_t resource = nt_resource_request(rid, NT_ASSET_MESH);
+    for (uint32_t published = 0; published < 2; published++) {
+        nt_resource_type_desc_t desc = {.on_resolve = mock_on_resolve, .on_cleanup = mock_on_cleanup, .behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB};
+        EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &desc));
+        desc.behavior_flags |= NT_RESOURCE_BEHAVIOR_AUX_BACKED;
+        EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &desc));
+        nt_resource_step();
+        TEST_ASSERT_TRUE(nt_resource_is_ready(resource));
+        TEST_ASSERT_EQUAL_UINT32(77, nt_resource_get(resource));
+        TEST_ASSERT_NULL(nt_resource_peek_user_data(resource));
+        TEST_ASSERT_EQUAL_UINT32(0, nt_resource_test_pack_blob_pins(0));
+    }
+}
+
+static void test_aux_type_cannot_gain_pin_after_blob_eviction(void) {
+    reset_resolve_state();
+    nt_resource_type_desc_t desc = {
+        .activate = fake_activate, .deactivate = fake_deactivate, .on_resolve = mock_on_resolve, .on_cleanup = mock_on_cleanup, .behavior_flags = NT_RESOURCE_BEHAVIOR_AUX_BACKED};
+    nt_resource_register_type(NT_ASSET_MESH, &desc);
+    const nt_hash32_t pack = {996};
+    const nt_hash64_t rid = {996};
+    uint32_t size = 0;
+    uint8_t *blob = build_pack_with_rid(rid.value, NT_ASSET_MESH, &size);
+    TEST_ASSERT_NOT_NULL(blob);
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pack, 0));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(pack, blob, size));
+    nt_resource_t resource = nt_resource_request(rid, NT_ASSET_MESH);
+    nt_resource_step();
+    uint32_t runtime_handle = nt_resource_get(resource);
+    const void *aux = nt_resource_peek_user_data(resource);
+    TEST_ASSERT_NOT_NULL(aux);
+    nt_resource_set_blob_policy(pack, NT_BLOB_AUTO, 1);
+    nt_time_sleep(0.005);
+    nt_resource_step();
+    TEST_ASSERT_EQUAL_UINT8(0, nt_resource_test_pack_blob_resident(0));
+    uint32_t epoch = nt_resource_publication_epoch();
+    desc.behavior_flags |= NT_RESOURCE_BEHAVIOR_PIN_BLOB;
+    EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_MESH, &desc));
+    TEST_ASSERT_EQUAL_UINT32(epoch, nt_resource_publication_epoch());
+    TEST_ASSERT_TRUE(nt_resource_is_ready(resource));
+    TEST_ASSERT_EQUAL_UINT32(runtime_handle, nt_resource_get(resource));
+    TEST_ASSERT_EQUAL_PTR(aux, nt_resource_peek_user_data(resource));
+    TEST_ASSERT_EQUAL(NT_PACK_STATE_READY, nt_resource_pack_state(pack));
+    nt_resource_unmount(pack);
+    free(blob);
+}
+
+static void test_blob_ready_fixes_type_and_rejects_invalidation(void) {
+    const nt_hash32_t pack = {994};
+    const nt_hash64_t rid = {994};
+    uint32_t size = 0;
+    uint8_t *blob = build_alias_pack_with_rid(rid.value, NT_ASSET_BLOB, &size);
+    TEST_ASSERT_NOT_NULL(blob);
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pack, 0));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(pack, blob, size));
+    EXPECT_ASSERT(nt_resource_register_type(NT_ASSET_BLOB, &(nt_resource_type_desc_t){.on_resolve = mock_on_resolve, .on_cleanup = mock_on_cleanup}));
+    const NtAssetEntry *entries = (const NtAssetEntry *)(blob + sizeof(NtPackHeader));
+    nt_resource_t handles[2] = {nt_resource_request((nt_hash64_t){entries[0].resource_id}, NT_ASSET_BLOB), nt_resource_request((nt_hash64_t){entries[1].resource_id}, NT_ASSET_BLOB)};
+    nt_resource_step();
+    const uint8_t *payload = nt_resource_get_blob(handles[0], NULL);
+    TEST_ASSERT_NOT_NULL(payload);
+    uint32_t epoch = nt_resource_publication_epoch();
+    EXPECT_ASSERT(nt_resource_invalidate(NT_ASSET_BLOB));
+    nt_resource_invalidate(NT_ASSET_MESH);
+    nt_resource_step();
+    TEST_ASSERT_EQUAL_UINT32(epoch, nt_resource_publication_epoch());
+    for (uint32_t i = 0; i < 2; i++) {
+        TEST_ASSERT_TRUE(nt_resource_is_ready(handles[i]));
+        TEST_ASSERT_EQUAL_PTR(payload, nt_resource_get_blob(handles[i], NULL));
+    }
+    nt_resource_unmount(pack);
+    free(blob);
+}
+
 int main(void) {
     UNITY_BEGIN();
+    RUN_TEST(test_type_registration_rejects_incomplete_description_before_fixing);
+    RUN_TEST(test_type_registration_copies_and_preserves_complete_description);
+    RUN_TEST(test_virtual_publication_fixes_default_type);
+    RUN_TEST(test_pin_type_registration_rejects_existing_virtual_assets);
+    RUN_TEST(test_aux_type_cannot_gain_pin_after_blob_eviction);
+    RUN_TEST(test_blob_ready_fixes_type_and_rejects_invalidation);
     RUN_TEST(test_later_activation_failure_is_published);
     RUN_TEST(test_failed_owner_does_not_retry_through_alias);
     RUN_TEST(test_virtual_reuse_same_handle_rebuilds_aux);
@@ -3601,7 +3777,7 @@ int main(void) {
     RUN_TEST(test_pack_progress);
 
     /* Activator system tests */
-    RUN_TEST(test_set_activator);
+    RUN_TEST(test_register_activating_type);
     RUN_TEST(test_activation_called_on_step);
     RUN_TEST(test_activation_sets_runtime_handle);
     RUN_TEST(test_activation_unlimited_activates_all);

--- a/tests/unit/test_resource.c
+++ b/tests/unit/test_resource.c
@@ -1871,13 +1871,19 @@ static void test_provider_on_resolve(const uint8_t *data, uint32_t size, uint32_
     p->size = size;
 }
 
-static void test_provider_on_cleanup(void *user_data) { free(user_data); }
+static void test_provider_on_cleanup(void *user_data) {
+    const test_provider_t *provider = user_data;
+    TEST_ASSERT_EQUAL_UINT8(0, provider->data[provider->size - 1U]);
+    s_cleanup_call_count++;
+    free(user_data);
+}
 
 /* Unmount frees an I/O-owned pinned blob synchronously; the zero-copy provider viewing into it must
  * be severed inline (user_data -> NULL) in the SAME call, before any read can dereference freed memory.
  * Without the sever, user_data stays non-NULL (dangling) until the next resolve pass -> UAF window. */
 // NOLINTNEXTLINE(readability-function-cognitive-complexity)
 static void check_blob_pin_unmount_severs_provider_synchronously(bool aliases) {
+    s_cleanup_call_count = 0;
     nt_hash32_t pid = nt_hash32_str("pin_sever_pack");
     nt_hash64_t rid = nt_hash64_str("pin_sever_res");
 
@@ -1920,15 +1926,15 @@ static void check_blob_pin_unmount_severs_provider_synchronously(bool aliases) {
     TEST_ASSERT_EQUAL_UINT32(1, nt_resource_test_pack_blob_pins(0));
     TEST_ASSERT_EQUAL_PTR(provider, nt_resource_peek_user_data(h));
 
-    /* Unmount frees the blob; the provider view must be severed inline — NO intervening resolve/step —
-     * so no read can dereference the freed blob. The published winner state is reconciled by the next
-     * resolve pass (winner-loss + epoch bump), matching the pre-existing unmount contract. */
+    /* Cleanup must read live bytes inside unmount, without an intervening step masking the order. */
     nt_resource_unmount(pid);
     TEST_ASSERT_NULL(nt_resource_peek_user_data(h));
+    TEST_ASSERT_EQUAL_UINT32(1, s_cleanup_call_count);
 
     /* Next resolve reconciles the dropped winner. */
     nt_resource_step();
     TEST_ASSERT_NULL(nt_resource_peek_user_data(h));
+    TEST_ASSERT_EQUAL_UINT32(1, s_cleanup_call_count);
     TEST_ASSERT_FALSE(nt_resource_is_ready(h));
     TEST_ASSERT_EQUAL_UINT32(0, nt_resource_test_pack_blob_pins(0));
 

--- a/tests/unit/test_resource.c
+++ b/tests/unit/test_resource.c
@@ -1947,7 +1947,7 @@ void test_blob_pin_unpublishable_when_blob_evicted_before_pin(void) {
     nt_hash32_t pid = nt_hash32_str("pin_unpub_pack");
     nt_hash64_t rid = nt_hash64_str("pin_unpub_res");
 
-    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = fake_activate, .deactivate = fake_deactivate, .behavior_flags = NT_RESOURCE_BEHAVIOR_PIN_BLOB});
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(pid, 0));
     nt_resource_set_blob_policy(pid, NT_BLOB_AUTO, 1); /* TTL = 1ms */
 
@@ -1955,6 +1955,7 @@ void test_blob_pin_unpublishable_when_blob_evicted_before_pin(void) {
     uint8_t *blob = build_pack_with_rid(rid.value, NT_ASSET_MESH, &size);
     TEST_ASSERT_NOT_NULL(blob);
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(pid, blob, size));
+    nt_resource_step();
 
     /* No consumer yet -> blob_pins stays 0; TTL expiry evicts the blob before
      * any pin is established. */
@@ -1966,7 +1967,6 @@ void test_blob_pin_unpublishable_when_blob_evicted_before_pin(void) {
     /* Consumer arrives; the asset reports READY but its blob is gone. The
      * PIN_BLOB provider must NOT publish as a usable winner. */
     nt_resource_t h = nt_resource_request(rid, NT_ASSET_MESH);
-    nt_resource_test_set_asset_state(rid, 0, NT_ASSET_STATE_READY, 99);
     nt_resource_step();
 
     TEST_ASSERT_FALSE(nt_resource_is_ready(h)); /* unpublishable without a resident blob */

--- a/tests/unit/test_resource_slots.c
+++ b/tests/unit/test_resource_slots.c
@@ -27,6 +27,7 @@ static void record_publication(const uint8_t *data, uint32_t size, nt_resource_t
 }
 
 static void test_slots_cross_16_bit_boundary_and_survive_unmount(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.on_post_resolve = record_publication});
     const nt_hash32_t pack = {1};
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pack, 0));
     for (uint32_t i = 1; i <= NT_RESOURCE_MAX_SLOTS; i++) {
@@ -43,12 +44,13 @@ static void test_slots_cross_16_bit_boundary_and_survive_unmount(void) {
     TEST_ASSERT_EQUAL_UINT32(NT_RESOURCE_MAX_SLOTS, high.id);
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pack, (nt_hash64_t){1}, NT_ASSET_MESH, 101));
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pack, (nt_hash64_t){NT_RESOURCE_MAX_SLOTS}, NT_ASSET_MESH, 202));
-    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.on_post_resolve = record_publication});
     nt_resource_step();
     TEST_ASSERT_TRUE(nt_resource_is_ready(high));
     TEST_ASSERT_EQUAL_UINT32(101, nt_resource_get(low));
     TEST_ASSERT_EQUAL_UINT32(202, nt_resource_get(high));
+#if NT_INTROSPECT_ENABLED
     TEST_ASSERT_EQUAL_UINT64(NT_RESOURCE_MAX_SLOTS, nt_resource_source_of(NT_ASSET_MESH, 202));
+#endif
     TEST_ASSERT_EQUAL_UINT32(2, s_published_count);
     TEST_ASSERT_EQUAL_UINT32(low.id, s_published[0]);
     TEST_ASSERT_EQUAL_UINT32(high.id, s_published[1]);

--- a/tests/unit/test_resource_slots.c
+++ b/tests/unit/test_resource_slots.c
@@ -1,0 +1,133 @@
+#include <stdint.h>
+
+#include "nt_pack_format.h"
+#include "renderers/nt_sprite_renderer.h"
+#include "resource/nt_resource.h"
+#include "test_helpers/nt_assert_trap.h"
+#include "unity.h"
+
+static uint32_t s_published[2];
+static uint32_t s_published_count;
+
+void setUp(void) {
+    const nt_resource_desc_t desc = {0};
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_init(&desc));
+    s_published_count = 0;
+}
+
+void tearDown(void) { nt_resource_shutdown(); }
+
+static void record_publication(const uint8_t *data, uint32_t size, nt_resource_t handle, uint32_t runtime_handle, void *user_data) {
+    (void)data;
+    (void)size;
+    (void)runtime_handle;
+    (void)user_data;
+    TEST_ASSERT_LESS_THAN_UINT32(2, s_published_count);
+    s_published[s_published_count++] = handle.id;
+}
+
+static void test_slots_cross_16_bit_boundary_and_survive_unmount(void) {
+    const nt_hash32_t pack = {1};
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack(pack, 0));
+    for (uint32_t i = 1; i <= NT_RESOURCE_MAX_SLOTS; i++) {
+        nt_resource_t handle = nt_resource_request((nt_hash64_t){i}, NT_ASSET_MESH);
+        TEST_ASSERT_EQUAL_UINT32(i, handle.id);
+    }
+
+    const nt_resource_t low = nt_resource_find((nt_hash64_t){1});
+    const nt_resource_t high = nt_resource_find((nt_hash64_t){NT_RESOURCE_MAX_SLOTS});
+    TEST_ASSERT_EQUAL_UINT32(65535, nt_resource_find((nt_hash64_t){65535}).id);
+#if NT_RESOURCE_MAX_SLOTS > 65535
+    TEST_ASSERT_EQUAL_UINT32(65536, nt_resource_find((nt_hash64_t){65536}).id);
+#endif
+    TEST_ASSERT_EQUAL_UINT32(NT_RESOURCE_MAX_SLOTS, high.id);
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pack, (nt_hash64_t){1}, NT_ASSET_MESH, 101));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pack, (nt_hash64_t){NT_RESOURCE_MAX_SLOTS}, NT_ASSET_MESH, 202));
+    nt_resource_set_post_resolve_callback(NT_ASSET_MESH, record_publication);
+    nt_resource_step();
+    TEST_ASSERT_TRUE(nt_resource_is_ready(high));
+    TEST_ASSERT_EQUAL_UINT32(101, nt_resource_get(low));
+    TEST_ASSERT_EQUAL_UINT32(202, nt_resource_get(high));
+    TEST_ASSERT_EQUAL_UINT64(NT_RESOURCE_MAX_SLOTS, nt_resource_source_of(NT_ASSET_MESH, 202));
+    TEST_ASSERT_EQUAL_UINT32(2, s_published_count);
+    TEST_ASSERT_EQUAL_UINT32(low.id, s_published[0]);
+    TEST_ASSERT_EQUAL_UINT32(high.id, s_published[1]);
+    NT_TEST_EXPECT_ASSERT(nt_resource_request((nt_hash64_t){NT_RESOURCE_MAX_SLOTS + 1U}, NT_ASSET_MESH));
+
+    nt_resource_unmount(pack);
+    nt_resource_step();
+    TEST_ASSERT_FALSE(nt_resource_is_ready(low));
+    TEST_ASSERT_FALSE(nt_resource_is_ready(high));
+    TEST_ASSERT_EQUAL_UINT32(high.id, nt_resource_request((nt_hash64_t){NT_RESOURCE_MAX_SLOTS}, NT_ASSET_MESH).id);
+    NT_TEST_EXPECT_ASSERT(nt_resource_request((nt_hash64_t){NT_RESOURCE_MAX_SLOTS + 1U}, NT_ASSET_MESH));
+}
+
+static void test_slot_map_collision_wraps_without_aliasing_names(void) {
+    const uint64_t buckets = (uint64_t)NT_RESOURCE_MAX_SLOTS * 2U;
+    for (uint32_t i = 0; i < 3; i++) {
+        nt_hash64_t rid = {buckets - 1U + (i * buckets)};
+        TEST_ASSERT_EQUAL_UINT32(i + 1U, nt_resource_request(rid, NT_ASSET_MESH).id);
+    }
+    for (uint32_t i = 0; i < 3; i++) {
+        nt_hash64_t rid = {buckets - 1U + (i * buckets)};
+        TEST_ASSERT_EQUAL_UINT32(i + 1U, nt_resource_find(rid).id);
+        TEST_ASSERT_EQUAL_UINT32(i + 1U, nt_resource_request(rid, NT_ASSET_MESH).id);
+    }
+    TEST_ASSERT_EQUAL_UINT32(0, nt_resource_find((nt_hash64_t){buckets - 1U + (3U * buckets)}).id);
+}
+
+static void test_zero_resource_id_is_rejected_before_allocation(void) {
+    NT_TEST_EXPECT_ASSERT(nt_resource_request((nt_hash64_t){0}, NT_ASSET_MESH));
+    TEST_ASSERT_EQUAL_UINT32(1, nt_resource_request((nt_hash64_t){1}, NT_ASSET_MESH).id);
+}
+
+static void test_shutdown_without_requests(void) { nt_resource_step(); }
+
+static void request_dependent_page(const uint8_t *data, uint32_t size, nt_resource_t handle, uint32_t runtime_handle, void *user_data) {
+    record_publication(data, size, handle, runtime_handle, user_data);
+    if (handle.id == 1) {
+        TEST_ASSERT_EQUAL_UINT32(NT_RESOURCE_MAX_SLOTS, nt_resource_request((nt_hash64_t){NT_RESOURCE_MAX_SLOTS}, NT_ASSET_MESH).id);
+    }
+}
+
+static void test_post_resolve_allocates_last_slot(void) {
+    for (uint32_t i = 1; i < NT_RESOURCE_MAX_SLOTS; i++) {
+        nt_resource_request((nt_hash64_t){i}, NT_ASSET_MESH);
+    }
+    nt_resource_set_post_resolve_callback(NT_ASSET_MESH, request_dependent_page);
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack((nt_hash32_t){1}, 0));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register((nt_hash32_t){1}, (nt_hash64_t){1}, NT_ASSET_MESH, 101));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register((nt_hash32_t){1}, (nt_hash64_t){NT_RESOURCE_MAX_SLOTS}, NT_ASSET_MESH, 202));
+    nt_resource_step();
+    TEST_ASSERT_EQUAL_UINT32(2, s_published_count);
+    TEST_ASSERT_EQUAL_UINT32(NT_RESOURCE_MAX_SLOTS, s_published[1]);
+    TEST_ASSERT_EQUAL_UINT32(202, nt_resource_get(nt_resource_find((nt_hash64_t){NT_RESOURCE_MAX_SLOTS})));
+}
+
+#if NT_RESOURCE_MAX_SLOTS > 65536
+static void test_sprite_key_uses_texture_not_large_resource_index(void) {
+    for (uint32_t i = 1; i <= NT_RESOURCE_MAX_SLOTS; i++) {
+        nt_resource_request((nt_hash64_t){i}, NT_ASSET_TEXTURE);
+    }
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack((nt_hash32_t){1}, 0));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register((nt_hash32_t){1}, (nt_hash64_t){1}, NT_ASSET_TEXTURE, 0x10001));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register((nt_hash32_t){1}, (nt_hash64_t){65537}, NT_ASSET_TEXTURE, 0x10002));
+    nt_resource_step();
+    const nt_material_t material = {.id = 0x10002};
+    TEST_ASSERT_EQUAL_HEX32(0x20001, nt_sprite_renderer_batch_key(material, nt_resource_find((nt_hash64_t){1})));
+    TEST_ASSERT_EQUAL_HEX32(0x20002, nt_sprite_renderer_batch_key(material, nt_resource_find((nt_hash64_t){65537})));
+}
+#endif
+
+int main(void) {
+    UNITY_BEGIN();
+    RUN_TEST(test_slots_cross_16_bit_boundary_and_survive_unmount);
+    RUN_TEST(test_slot_map_collision_wraps_without_aliasing_names);
+    RUN_TEST(test_zero_resource_id_is_rejected_before_allocation);
+    RUN_TEST(test_shutdown_without_requests);
+    RUN_TEST(test_post_resolve_allocates_last_slot);
+#if NT_RESOURCE_MAX_SLOTS > 65536
+    RUN_TEST(test_sprite_key_uses_texture_not_large_resource_index);
+#endif
+    return UNITY_END();
+}

--- a/tests/unit/test_resource_slots.c
+++ b/tests/unit/test_resource_slots.c
@@ -43,7 +43,7 @@ static void test_slots_cross_16_bit_boundary_and_survive_unmount(void) {
     TEST_ASSERT_EQUAL_UINT32(NT_RESOURCE_MAX_SLOTS, high.id);
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pack, (nt_hash64_t){1}, NT_ASSET_MESH, 101));
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pack, (nt_hash64_t){NT_RESOURCE_MAX_SLOTS}, NT_ASSET_MESH, 202));
-    nt_resource_set_post_resolve_callback(NT_ASSET_MESH, record_publication);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.on_post_resolve = record_publication});
     nt_resource_step();
     TEST_ASSERT_TRUE(nt_resource_is_ready(high));
     TEST_ASSERT_EQUAL_UINT32(101, nt_resource_get(low));
@@ -94,7 +94,7 @@ static void test_post_resolve_allocates_last_slot(void) {
     for (uint32_t i = 1; i < NT_RESOURCE_MAX_SLOTS; i++) {
         nt_resource_request((nt_hash64_t){i}, NT_ASSET_MESH);
     }
-    nt_resource_set_post_resolve_callback(NT_ASSET_MESH, request_dependent_page);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.on_post_resolve = request_dependent_page});
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack((nt_hash32_t){1}, 0));
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_register((nt_hash32_t){1}, (nt_hash64_t){1}, NT_ASSET_MESH, 101));
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_register((nt_hash32_t){1}, (nt_hash64_t){NT_RESOURCE_MAX_SLOTS}, NT_ASSET_MESH, 202));

--- a/tests/unit/test_resource_timing.c
+++ b/tests/unit/test_resource_timing.c
@@ -206,8 +206,7 @@ static void test_budget_dedup_and_resolve_keep_their_phase_boundaries(void) {
     s_tick = 0.0;
     s_activation_seconds = 0.25;
     nt_resource_set_activate_time_budget(125.0F);
-    nt_resource_set_activator(NT_ASSET_MESH, activate, NULL);
-    nt_resource_set_resolve_callbacks(NT_ASSET_MESH, resolve, cleanup);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = activate, .on_resolve = resolve, .on_cleanup = cleanup});
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(s_id, s_blob, sizeof s_blob));
     nt_resource_t first = nt_resource_request((nt_hash64_t){101}, NT_ASSET_MESH);
     nt_resource_t last = nt_resource_request((nt_hash64_t){103}, NT_ASSET_MESH);
@@ -255,7 +254,7 @@ static void test_budget_resumes_in_pack_then_asset_order(void) {
     s_tick = 0.0;
     s_activation_seconds = 0.25;
     nt_resource_set_activate_time_budget(125.0F);
-    nt_resource_set_activator(NT_ASSET_MESH, activate, NULL);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = activate});
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(s_id, s_blob, sizeof s_blob));
     parse_other_pack();
     nt_resource_t last = nt_resource_request((nt_hash64_t){203}, NT_ASSET_MESH);
@@ -274,7 +273,7 @@ static void test_invalidate_revisits_owner_before_budget_resume(void) {
     s_tick = 0.0;
     s_activation_seconds = 0.25;
     nt_resource_set_activate_time_budget(125.0F);
-    nt_resource_set_activator(NT_ASSET_MESH, activate, NULL);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = activate});
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(s_id, s_blob, sizeof s_blob));
     nt_resource_t alias = nt_resource_request((nt_hash64_t){102}, NT_ASSET_MESH);
     nt_resource_t last = nt_resource_request((nt_hash64_t){103}, NT_ASSET_MESH);
@@ -298,7 +297,7 @@ static void test_remount_during_budget_reuses_holes_in_registry_order(void) {
     s_tick = 0.0;
     s_activation_seconds = 0.25;
     nt_resource_set_activate_time_budget(125.0F);
-    nt_resource_set_activator(NT_ASSET_MESH, activate, NULL);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = activate});
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(s_id, s_blob, sizeof s_blob));
     parse_other_pack();
     nt_resource_t alias = nt_resource_request((nt_hash64_t){102}, NT_ASSET_MESH);
@@ -322,7 +321,7 @@ static void test_remount_during_budget_reuses_holes_in_registry_order(void) {
 static void test_alias_state_helper_reactivates_completed_owner(void) {
     s_tick = 0.0;
     nt_resource_set_activate_time_budget(0.0F);
-    nt_resource_set_activator(NT_ASSET_MESH, activate, NULL);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = activate});
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(s_id, s_blob, sizeof s_blob));
     nt_resource_t alias = nt_resource_request((nt_hash64_t){102}, NT_ASSET_MESH);
     nt_resource_step();
@@ -341,7 +340,7 @@ static void test_resident_bytes_eviction_reload_and_unmount(void) {
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(other, 0));
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(other, (const uint8_t *)&s_pack, sizeof s_pack));
     write_pack(s_path_a, s_blob, sizeof s_blob);
-    nt_resource_set_activator(NT_ASSET_MESH, activate, NULL);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = activate});
     nt_resource_set_activate_time_budget(0.0F);
     nt_resource_t first = nt_resource_request((nt_hash64_t){101}, NT_ASSET_MESH);
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_load_file(s_id, s_path_a));

--- a/tests/unit/test_resource_timing.c
+++ b/tests/unit/test_resource_timing.c
@@ -109,7 +109,6 @@ void setUp(void) {
     make_blob();
     const nt_resource_desc_t desc = {0};
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_init(&desc));
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(s_id, 0));
     s_pack = (NtPackHeader){.magic = NT_PACK_MAGIC, .version = NT_PACK_VERSION, .header_size = sizeof s_pack, .total_size = sizeof s_pack};
     s_pack.checksum = nt_crc32((const uint8_t *)&s_pack + sizeof s_pack, 0);
 }
@@ -132,6 +131,7 @@ static void assert_parse(int32_t parse_ms, int32_t crc_ms) {
 }
 
 static void test_direct_parse_and_rejection_replace_last_result(void) {
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(s_id, 0));
     assert_parse(0, 0);
     TEST_ASSERT_TRUE(nt_resource_get_last_step_ms() == 0.0F);
     TEST_ASSERT_TRUE(nt_resource_get_last_activate_ms() == 0.0F);
@@ -165,6 +165,7 @@ static void assert_bytes(uint64_t blob, uint64_t meta) {
 }
 
 static void test_crc_and_entry_failures_publish_completed_parse(void) {
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(s_id, 0));
     NtPackHeader *h = (NtPackHeader *)s_blob;
     h->checksum ^= 1U;
     TEST_ASSERT_EQUAL(NT_ERR_INVALID_ARG, nt_resource_parse_pack(s_id, s_blob, sizeof s_blob));
@@ -183,7 +184,8 @@ static void test_crc_and_entry_failures_publish_completed_parse(void) {
 }
 
 static void test_idle_steps_refresh_step_and_preserve_parse(void) {
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(s_id, s_blob, sizeof s_blob));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(s_id, 0));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(s_id, (const uint8_t *)&s_pack, sizeof s_pack));
     s_reads = 0;
     nt_resource_step();
     assert_parse(375, 125);
@@ -211,6 +213,7 @@ static void test_budget_dedup_and_resolve_keep_their_phase_boundaries(void) {
     s_activation_seconds = 0.25;
     nt_resource_set_activate_time_budget(125.0F);
     nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = activate, .on_resolve = resolve, .on_cleanup = cleanup});
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(s_id, 0));
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(s_id, s_blob, sizeof s_blob));
     nt_resource_t first = nt_resource_request((nt_hash64_t){101}, NT_ASSET_MESH);
     nt_resource_t last = nt_resource_request((nt_hash64_t){103}, NT_ASSET_MESH);
@@ -238,6 +241,8 @@ static void test_budget_dedup_and_resolve_keep_their_phase_boundaries(void) {
 }
 
 static void test_multiple_parses_keep_last_result_not_sum(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = activate});
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(s_id, 0));
     const nt_hash32_t other = {2};
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(other, 0));
     write_pack(s_path_a, s_blob, sizeof s_blob);
@@ -259,6 +264,7 @@ static void test_budget_resumes_in_pack_then_asset_order(void) {
     s_activation_seconds = 0.25;
     nt_resource_set_activate_time_budget(125.0F);
     nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = activate});
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(s_id, 0));
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(s_id, s_blob, sizeof s_blob));
     parse_other_pack();
     nt_resource_t last = nt_resource_request((nt_hash64_t){203}, NT_ASSET_MESH);
@@ -278,6 +284,7 @@ static void test_invalidate_revisits_owner_before_budget_resume(void) {
     s_activation_seconds = 0.25;
     nt_resource_set_activate_time_budget(125.0F);
     nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = activate});
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(s_id, 0));
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(s_id, s_blob, sizeof s_blob));
     nt_resource_t alias = nt_resource_request((nt_hash64_t){102}, NT_ASSET_MESH);
     nt_resource_t last = nt_resource_request((nt_hash64_t){103}, NT_ASSET_MESH);
@@ -302,6 +309,7 @@ static void test_remount_during_budget_reuses_holes_in_registry_order(void) {
     s_activation_seconds = 0.25;
     nt_resource_set_activate_time_budget(125.0F);
     nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = activate});
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(s_id, 0));
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(s_id, s_blob, sizeof s_blob));
     parse_other_pack();
     nt_resource_t alias = nt_resource_request((nt_hash64_t){102}, NT_ASSET_MESH);
@@ -326,6 +334,7 @@ static void test_alias_state_helper_reactivates_completed_owner(void) {
     s_tick = 0.0;
     nt_resource_set_activate_time_budget(0.0F);
     nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = activate});
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(s_id, 0));
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(s_id, s_blob, sizeof s_blob));
     nt_resource_t alias = nt_resource_request((nt_hash64_t){102}, NT_ASSET_MESH);
     nt_resource_step();
@@ -339,12 +348,13 @@ static void test_alias_state_helper_reactivates_completed_owner(void) {
 }
 
 static void test_resident_bytes_eviction_reload_and_unmount(void) {
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = activate});
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(s_id, 0));
     const nt_hash32_t other = {2};
     assert_bytes(0, 0);
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(other, 0));
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(other, (const uint8_t *)&s_pack, sizeof s_pack));
     write_pack(s_path_a, s_blob, sizeof s_blob);
-    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = activate});
     nt_resource_set_activate_time_budget(0.0F);
     nt_resource_t first = nt_resource_request((nt_hash64_t){101}, NT_ASSET_MESH);
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_load_file(s_id, s_path_a));
@@ -378,6 +388,7 @@ static void test_resident_bytes_eviction_reload_and_unmount(void) {
 }
 
 static void test_retry_waits_until_deadline(void) {
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(s_id, 0));
     s_tick = 0.0;
     s_seconds = 1.0;
     nt_resource_set_retry_policy(3, 1000, 1000);
@@ -402,6 +413,7 @@ static void check_activation_before_auto_eviction(uint8_t policy, uint32_t ttl, 
     write_pack(s_path_a, s_blob, sizeof s_blob);
     write_pack(s_path_b, s_other_blob, sizeof s_other_blob);
     nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = activate});
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(s_id, 0));
     nt_resource_set_activate_time_budget(budget);
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount((nt_hash32_t){2}, 0));
     nt_resource_set_blob_policy(s_id, policy, ttl);
@@ -438,30 +450,6 @@ static void test_keep_retains_bytes_with_small_activation_budget(void) { check_a
 static void test_long_auto_ttl_allows_activation_then_eviction(void) { check_activation_before_auto_eviction(NT_BLOB_AUTO, 1000, 1.0F); }
 static void test_unlimited_activation_budget_allows_auto_eviction(void) { check_activation_before_auto_eviction(NT_BLOB_AUTO, 5, 0.0F); }
 
-static void test_auto_retains_completed_scan_until_first_type_registration(void) {
-    s_tick = 0.0;
-    s_seconds = 1.0;
-    nt_resource_set_activate_time_budget(0.0F);
-    write_pack(s_path_a, s_blob, sizeof s_blob);
-    nt_resource_set_blob_policy(s_id, NT_BLOB_AUTO, 5);
-    TEST_ASSERT_EQUAL(NT_OK, nt_resource_load_file(s_id, s_path_a));
-    nt_resource_t alias = nt_resource_request((nt_hash64_t){102}, NT_ASSET_MESH);
-    nt_resource_step();
-    for (uint32_t i = 0; i < 3; i++) {
-        s_seconds += 1.0;
-        nt_resource_step();
-        TEST_ASSERT_EQUAL_UINT8(1, nt_resource_test_pack_blob_resident(0));
-        TEST_ASSERT_EQUAL_UINT8(NT_ASSET_STATE_REGISTERED, nt_resource_get_state(alias));
-    }
-    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = activate});
-    nt_resource_step();
-    TEST_ASSERT_TRUE(nt_resource_is_ready(alias));
-    TEST_ASSERT_EQUAL_UINT32(2, s_activations);
-    s_seconds += 1.0;
-    nt_resource_step();
-    TEST_ASSERT_EQUAL_UINT8(0, nt_resource_test_pack_blob_resident(0));
-}
-
 static uint32_t activate_failed(const uint8_t *data, uint32_t size) {
     (void)activate(data, size);
     return 0;
@@ -471,6 +459,7 @@ static void test_failed_owners_do_not_retain_auto_bytes(void) {
     s_tick = 0.0;
     s_seconds = 1.0;
     nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = activate_failed});
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount(s_id, 0));
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(s_id, s_blob, sizeof s_blob));
     nt_resource_t alias = nt_resource_request((nt_hash64_t){102}, NT_ASSET_MESH);
     nt_resource_set_blob_policy(s_id, NT_BLOB_AUTO, 5);
@@ -499,7 +488,6 @@ int main(void) {
     RUN_TEST(test_keep_retains_bytes_with_small_activation_budget);
     RUN_TEST(test_long_auto_ttl_allows_activation_then_eviction);
     RUN_TEST(test_unlimited_activation_budget_allows_auto_eviction);
-    RUN_TEST(test_auto_retains_completed_scan_until_first_type_registration);
     RUN_TEST(test_failed_owners_do_not_retain_auto_bytes);
     return UNITY_END();
 }

--- a/tests/unit/test_resource_timing.c
+++ b/tests/unit/test_resource_timing.c
@@ -50,7 +50,7 @@ static void write_pack(const char *path, const void *data, uint32_t size) {
     TEST_ASSERT_EQUAL_INT(0, closed);
 }
 
-static void parse_other_pack(void) {
+static void make_other_blob(void) {
     memcpy(s_other_blob, s_blob, sizeof s_other_blob);
     NtPackHeader *header = (NtPackHeader *)s_other_blob;
     NtAssetEntry *entries = (NtAssetEntry *)(s_other_blob + sizeof *header);
@@ -62,6 +62,10 @@ static void parse_other_pack(void) {
     s_other_blob[104] = 3;
     s_other_blob[120] = 4;
     header->checksum = nt_crc32(s_other_blob + header->header_size, header->total_size - header->header_size);
+}
+
+static void parse_other_pack(void) {
+    make_other_blob();
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount((nt_hash32_t){2}, 0));
     TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack((nt_hash32_t){2}, s_other_blob, sizeof s_other_blob));
 }
@@ -390,6 +394,94 @@ static void test_retry_waits_until_deadline(void) {
     assert_bytes(sizeof s_pack, 0);
 }
 
+static void check_activation_before_auto_eviction(uint8_t policy, uint32_t ttl, float budget) {
+    s_tick = 0.0;
+    s_seconds = 1.0;
+    s_activation_seconds = 0.01;
+    make_other_blob();
+    write_pack(s_path_a, s_blob, sizeof s_blob);
+    write_pack(s_path_b, s_other_blob, sizeof s_other_blob);
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = activate});
+    nt_resource_set_activate_time_budget(budget);
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_mount((nt_hash32_t){2}, 0));
+    nt_resource_set_blob_policy(s_id, policy, ttl);
+    nt_resource_set_blob_policy((nt_hash32_t){2}, policy, ttl);
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_load_file(s_id, s_path_a));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_load_file((nt_hash32_t){2}, s_path_b));
+    nt_resource_t handles[6];
+    for (uint32_t i = 0; i < 6; i++) {
+        handles[i] = nt_resource_request((nt_hash64_t){101U + (i % 3U) + (100U * (i / 3U))}, NT_ASSET_MESH);
+    }
+    uint32_t steps = budget == 0.0F ? 1U : 4U;
+    for (uint32_t i = 0; i < steps; i++) {
+        nt_resource_step();
+        TEST_ASSERT_EQUAL_UINT8(1, nt_resource_test_pack_blob_resident(1));
+        TEST_ASSERT_EQUAL_UINT32(budget == 0.0F ? 4U : i + 1U, s_activations);
+    }
+    const uint8_t expected[] = {1, 2, 3, 4};
+    TEST_ASSERT_EQUAL_UINT8_ARRAY(expected, s_activation_order, sizeof expected);
+    s_seconds += 2.0;
+    nt_resource_step();
+    for (uint32_t i = 0; i < 6; i++) {
+        TEST_ASSERT_TRUE(nt_resource_is_ready(handles[i]));
+        TEST_ASSERT_NOT_EQUAL(0, nt_resource_get(handles[i]));
+    }
+    TEST_ASSERT_EQUAL_UINT32(nt_resource_get(handles[0]), nt_resource_get(handles[1]));
+    TEST_ASSERT_EQUAL_UINT32(nt_resource_get(handles[3]), nt_resource_get(handles[4]));
+    TEST_ASSERT_EQUAL_UINT8(policy == NT_BLOB_KEEP, nt_resource_test_pack_blob_resident(0));
+    TEST_ASSERT_EQUAL_UINT8(policy == NT_BLOB_KEEP, nt_resource_test_pack_blob_resident(1));
+    TEST_ASSERT_EQUAL_UINT32(4, s_activations);
+}
+
+static void test_auto_retains_bytes_for_budget_delayed_owners(void) { check_activation_before_auto_eviction(NT_BLOB_AUTO, 5, 1.0F); }
+static void test_keep_retains_bytes_with_small_activation_budget(void) { check_activation_before_auto_eviction(NT_BLOB_KEEP, 5, 1.0F); }
+static void test_long_auto_ttl_allows_activation_then_eviction(void) { check_activation_before_auto_eviction(NT_BLOB_AUTO, 1000, 1.0F); }
+static void test_unlimited_activation_budget_allows_auto_eviction(void) { check_activation_before_auto_eviction(NT_BLOB_AUTO, 5, 0.0F); }
+
+static void test_auto_retains_completed_scan_until_first_type_registration(void) {
+    s_tick = 0.0;
+    s_seconds = 1.0;
+    nt_resource_set_activate_time_budget(0.0F);
+    write_pack(s_path_a, s_blob, sizeof s_blob);
+    nt_resource_set_blob_policy(s_id, NT_BLOB_AUTO, 5);
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_load_file(s_id, s_path_a));
+    nt_resource_t alias = nt_resource_request((nt_hash64_t){102}, NT_ASSET_MESH);
+    nt_resource_step();
+    for (uint32_t i = 0; i < 3; i++) {
+        s_seconds += 1.0;
+        nt_resource_step();
+        TEST_ASSERT_EQUAL_UINT8(1, nt_resource_test_pack_blob_resident(0));
+        TEST_ASSERT_EQUAL_UINT8(NT_ASSET_STATE_REGISTERED, nt_resource_get_state(alias));
+    }
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = activate});
+    nt_resource_step();
+    TEST_ASSERT_TRUE(nt_resource_is_ready(alias));
+    TEST_ASSERT_EQUAL_UINT32(2, s_activations);
+    s_seconds += 1.0;
+    nt_resource_step();
+    TEST_ASSERT_EQUAL_UINT8(0, nt_resource_test_pack_blob_resident(0));
+}
+
+static uint32_t activate_failed(const uint8_t *data, uint32_t size) {
+    (void)activate(data, size);
+    return 0;
+}
+
+static void test_failed_owners_do_not_retain_auto_bytes(void) {
+    s_tick = 0.0;
+    s_seconds = 1.0;
+    nt_resource_register_type(NT_ASSET_MESH, &(nt_resource_type_desc_t){.activate = activate_failed});
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_parse_pack(s_id, s_blob, sizeof s_blob));
+    nt_resource_t alias = nt_resource_request((nt_hash64_t){102}, NT_ASSET_MESH);
+    nt_resource_set_blob_policy(s_id, NT_BLOB_AUTO, 5);
+    nt_resource_step();
+    TEST_ASSERT_EQUAL_UINT32(2, s_activations);
+    s_seconds += 1.0;
+    nt_resource_step();
+    TEST_ASSERT_EQUAL_UINT8(0, nt_resource_test_pack_blob_resident(0));
+    TEST_ASSERT_EQUAL_UINT8(NT_ASSET_STATE_FAILED, nt_resource_get_state(alias));
+}
+
 int main(void) {
     UNITY_BEGIN();
     RUN_TEST(test_direct_parse_and_rejection_replace_last_result);
@@ -403,5 +495,11 @@ int main(void) {
     RUN_TEST(test_multiple_parses_keep_last_result_not_sum);
     RUN_TEST(test_resident_bytes_eviction_reload_and_unmount);
     RUN_TEST(test_retry_waits_until_deadline);
+    RUN_TEST(test_auto_retains_bytes_for_budget_delayed_owners);
+    RUN_TEST(test_keep_retains_bytes_with_small_activation_budget);
+    RUN_TEST(test_long_auto_ttl_allows_activation_then_eviction);
+    RUN_TEST(test_unlimited_activation_budget_allows_auto_eviction);
+    RUN_TEST(test_auto_retains_completed_scan_until_first_type_registration);
+    RUN_TEST(test_failed_owners_do_not_retain_auto_bytes);
     return UNITY_END();
 }

--- a/tests/unit/test_sponza_program_assignment.c
+++ b/tests/unit/test_sponza_program_assignment.c
@@ -143,7 +143,7 @@ void setUp(void) {
     nt_fs_init();
     nt_resource_init(&(nt_resource_desc_t){0});
     nt_resource_set_activate_time_budget(0);
-    nt_resource_set_activator(NT_ASSET_SHADER_CODE, nt_gfx_activate_shader, nt_gfx_deactivate_shader);
+    nt_resource_register_type(NT_ASSET_SHADER_CODE, &(nt_resource_type_desc_t){.activate = nt_gfx_activate_shader, .deactivate = nt_gfx_deactivate_shader});
     nt_material_init(&(nt_material_desc_t){.max_materials = TEST_NODE_COUNT});
     nt_entity_init(&(nt_entity_desc_t){.max_entities = TEST_NODE_COUNT});
     nt_transform_comp_init(&(nt_transform_comp_desc_t){.capacity = TEST_NODE_COUNT});

--- a/tests/unit/test_sprite_renderer.c
+++ b/tests/unit/test_sprite_renderer.c
@@ -539,28 +539,40 @@ void test_sprite_renderer_init_retries_after_buffer_creation_failure(void) {
  * accidentally relaxed (it would still catch the breakage in CI). */
 void test_sprite_renderer_vertex_size_assert(void) { TEST_ASSERT_EQUAL_size_t(20, sizeof(nt_sprite_vertex_t)); }
 
-void test_sprite_renderer_batch_key_packs_material_and_page_slots(void) {
-    nt_material_t material = {.id = 0xABCD1234U};
-    nt_resource_t page_resource = {.id = 0x43215678U};
-
-    TEST_ASSERT_EQUAL_HEX32(0x12345678U, nt_sprite_renderer_batch_key(material, page_resource));
+void test_sprite_renderer_batch_key_packs_material_and_texture_slots(void) {
+    for (uint64_t i = 1; i <= 8; i++) {
+        nt_resource_request((nt_hash64_t){i}, NT_ASSET_TEXTURE);
+    }
+    nt_material_t material = create_test_material();
+    nt_resource_t page = nt_resource_request((nt_hash64_t){FIXTURE_PAGE0_RID}, NT_ASSET_TEXTURE);
+    nt_resource_step();
+    TEST_ASSERT_EQUAL_UINT32(9, page.id);
+    TEST_ASSERT_EQUAL_HEX32(0x00010001U, nt_sprite_renderer_batch_key(material, page));
 }
 
-void test_sprite_renderer_batch_key_ignores_handle_generations(void) {
-    nt_material_t material_a = {.id = 0x00011234U};
-    nt_material_t material_b = {.id = 0xFFFF1234U};
-    nt_resource_t page_a = {.id = 0x00015678U};
-    nt_resource_t page_b = {.id = 0xFFFF5678U};
-
-    TEST_ASSERT_EQUAL_HEX32(nt_sprite_renderer_batch_key(material_a, page_a), nt_sprite_renderer_batch_key(material_b, page_b));
+void test_sprite_renderer_batch_key_groups_names_of_same_texture(void) {
+    nt_material_t material = create_test_material();
+    nt_resource_t page = nt_resource_request((nt_hash64_t){FIXTURE_PAGE0_RID}, NT_ASSET_TEXTURE);
+    nt_resource_step();
+    nt_hash32_t pack = nt_hash32_str("sprite_renderer_pages");
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(pack, (nt_hash64_t){0xF00}, NT_ASSET_TEXTURE, nt_resource_get(page)));
+    nt_resource_t alias = nt_resource_request((nt_hash64_t){0xF00}, NT_ASSET_TEXTURE);
+    nt_resource_step();
+    TEST_ASSERT_NOT_EQUAL(page.id, alias.id);
+    TEST_ASSERT_EQUAL_HEX32(nt_sprite_renderer_batch_key(material, page), nt_sprite_renderer_batch_key(material, alias));
 }
 
-void test_sprite_renderer_batch_key_distinguishes_page_slots(void) {
-    nt_material_t material = {.id = 0x00010001U};
-    nt_resource_t page_a = {.id = 0x00010001U};
-    nt_resource_t page_b = {.id = 0x00010002U};
-
-    TEST_ASSERT_NOT_EQUAL(nt_sprite_renderer_batch_key(material, page_a), nt_sprite_renderer_batch_key(material, page_b));
+void test_sprite_renderer_batch_key_distinguishes_neighbouring_materials_and_textures(void) {
+    nt_material_t materials[2] = {create_test_material(), create_test_material()};
+    nt_resource_t pages[2] = {nt_resource_request((nt_hash64_t){FIXTURE_PAGE0_RID}, NT_ASSET_TEXTURE), nt_resource_request((nt_hash64_t){FIXTURE_PAGE1_RID}, NT_ASSET_TEXTURE)};
+    nt_resource_step();
+    uint32_t keys[4];
+    for (uint32_t i = 0; i < 4; i++) {
+        keys[i] = nt_sprite_renderer_batch_key(materials[i / 2], pages[i % 2]);
+        for (uint32_t j = 0; j < i; j++) {
+            TEST_ASSERT_NOT_EQUAL(keys[j], keys[i]);
+        }
+    }
 }
 
 void test_sprite_renderer_draw_list_null_items_asserts_when_nonempty(void) {
@@ -897,6 +909,76 @@ void test_sprite_renderer_same_material_two_pages_state(void) {
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_bound_texture_slot_at(1));
     TEST_ASSERT_EQUAL_UINT32(0, nt_gfx_fake_uniform_int_count());
     TEST_ASSERT_EQUAL_UINT32(1, nt_gfx_fake_bind_pipeline_count());
+}
+
+void test_sprite_renderer_keys_follow_unloaded_placeholder_and_replaced_pages(void) {
+    nt_sprite_renderer_desc_t desc = nt_sprite_renderer_desc_defaults();
+    TEST_ASSERT_EQUAL(NT_OK, nt_sprite_renderer_init(&desc));
+    s_atlas_res = register_test_atlas(0xF10ULL);
+    nt_material_t sampled = create_test_material();
+    nt_material_t textureless = create_test_material_textureless();
+    nt_entity_t entities[2] = {create_sprite_entity(s_atlas_res, FIXTURE_R0_HASH, sampled), create_sprite_entity(s_atlas_res, FIXTURE_R1_HASH, sampled)};
+    nt_resource_t pages[2] = {nt_atlas_get_page_resource(s_atlas_res, 0), nt_atlas_get_page_resource(s_atlas_res, 1)};
+    uint32_t textures[2] = {nt_resource_get(pages[0]), nt_resource_get(pages[1])};
+    const nt_hash32_t page_pack = nt_hash32_str("sprite_renderer_pages");
+    nt_resource_unregister(page_pack, (nt_hash64_t){FIXTURE_PAGE0_RID});
+    nt_resource_unregister(page_pack, (nt_hash64_t){FIXTURE_PAGE1_RID});
+    nt_resource_step();
+    nt_render_item_t items[2] = {{.entity = entities[0].id}, {.entity = entities[1].id}};
+    for (uint32_t i = 0; i < 2; i++) {
+        TEST_ASSERT_EQUAL_UINT32(0, nt_resource_get(pages[i]));
+        items[i].batch_key = sprite_batch_key(entities[i], sampled);
+    }
+    nt_sprite_renderer_draw_list(items, 2);
+    TEST_ASSERT_EQUAL_UINT32(0, nt_sprite_renderer_test_draw_call_count());
+
+    for (uint32_t i = 0; i < 2; i++) {
+        *nt_material_comp_handle(entities[i]) = textureless;
+        items[i].batch_key = sprite_batch_key(entities[i], textureless);
+    }
+    nt_sprite_renderer_draw_list(items, 2);
+    TEST_ASSERT_EQUAL_UINT32(1, nt_sprite_renderer_test_draw_call_count());
+
+    nt_texture_t placeholder = nt_gfx_make_texture(&(nt_texture_desc_t){.width = 1, .height = 1, .data = s_white_pixel, .format = NT_TEXTURE_FORMAT_RGBA8});
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(page_pack, (nt_hash64_t){0xF11}, NT_ASSET_TEXTURE, placeholder.id));
+    nt_resource_set_placeholder_texture((nt_hash64_t){0xF11});
+    nt_resource_step();
+    for (uint32_t i = 0; i < 2; i++) {
+        TEST_ASSERT_FALSE(nt_resource_is_ready(pages[i]));
+        *nt_material_comp_handle(entities[i]) = sampled;
+        items[i].batch_key = sprite_batch_key(entities[i], sampled);
+    }
+    TEST_ASSERT_EQUAL_HEX32(items[0].batch_key, items[1].batch_key);
+    nt_gfx_fake_reset();
+    nt_sprite_renderer_draw_list(items, 2);
+    TEST_ASSERT_EQUAL_UINT32(1, nt_sprite_renderer_test_draw_call_count());
+    TEST_ASSERT_EQUAL_UINT32(nt_gfx_test_texture_backend_id(placeholder), nt_gfx_fake_bound_texture_at(0));
+
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(page_pack, (nt_hash64_t){FIXTURE_PAGE0_RID}, NT_ASSET_TEXTURE, textures[0]));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register(page_pack, (nt_hash64_t){FIXTURE_PAGE1_RID}, NT_ASSET_TEXTURE, textures[1]));
+    nt_resource_step();
+    for (uint32_t i = 0; i < 2; i++) {
+        TEST_ASSERT_TRUE(nt_resource_is_ready(pages[i]));
+        items[i].batch_key = sprite_batch_key(entities[i], sampled);
+    }
+    TEST_ASSERT_NOT_EQUAL(items[0].batch_key, items[1].batch_key);
+    nt_gfx_fake_reset();
+    nt_sprite_renderer_draw_list(items, 2);
+    TEST_ASSERT_EQUAL_UINT32(2, nt_sprite_renderer_test_draw_call_count());
+    for (uint32_t i = 0; i < 2; i++) {
+        TEST_ASSERT_EQUAL_UINT32(nt_gfx_test_texture_backend_id((nt_texture_t){textures[i]}), nt_gfx_fake_bound_texture_at(i));
+    }
+
+    uint32_t old_key = items[0].batch_key;
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_create_pack((nt_hash32_t){0xF12}, 200));
+    TEST_ASSERT_EQUAL(NT_OK, nt_resource_register((nt_hash32_t){0xF12}, (nt_hash64_t){FIXTURE_PAGE0_RID}, NT_ASSET_TEXTURE, placeholder.id));
+    nt_resource_step();
+    items[0].batch_key = sprite_batch_key(entities[0], sampled);
+    TEST_ASSERT_NOT_EQUAL(old_key, items[0].batch_key);
+    nt_gfx_fake_reset();
+    nt_sprite_renderer_draw_list(items, 2);
+    TEST_ASSERT_EQUAL_UINT32(2, nt_sprite_renderer_test_draw_call_count());
+    TEST_ASSERT_EQUAL_UINT32(nt_gfx_test_texture_backend_id(placeholder), nt_gfx_fake_bound_texture_at(0));
 }
 
 /* A material that declares no textures never takes the page, so crossing pages
@@ -1940,9 +2022,9 @@ int main(void) {
     RUN_TEST(test_sprite_renderer_init_shutdown);
     RUN_TEST(test_sprite_renderer_init_retries_after_buffer_creation_failure);
     RUN_TEST(test_sprite_renderer_vertex_size_assert);
-    RUN_TEST(test_sprite_renderer_batch_key_packs_material_and_page_slots);
-    RUN_TEST(test_sprite_renderer_batch_key_ignores_handle_generations);
-    RUN_TEST(test_sprite_renderer_batch_key_distinguishes_page_slots);
+    RUN_TEST(test_sprite_renderer_batch_key_packs_material_and_texture_slots);
+    RUN_TEST(test_sprite_renderer_batch_key_groups_names_of_same_texture);
+    RUN_TEST(test_sprite_renderer_batch_key_distinguishes_neighbouring_materials_and_textures);
     RUN_TEST(test_sprite_renderer_draw_list_null_items_asserts_when_nonempty);
     RUN_TEST(test_sprite_renderer_draw_list_asserts_on_unresolved_sprite_item);
     RUN_TEST(test_sprite_renderer_pipeline_cache);
@@ -1955,6 +2037,7 @@ int main(void) {
     RUN_TEST(test_sprite_renderer_batch_grouping);
     RUN_TEST(test_sprite_renderer_splits_run_on_actual_page_change);
     RUN_TEST(test_sprite_renderer_same_material_two_pages_state);
+    RUN_TEST(test_sprite_renderer_keys_follow_unloaded_placeholder_and_replaced_pages);
     RUN_TEST(test_sprite_renderer_textureless_material_ignores_page_change);
     RUN_TEST(test_sprite_renderer_textureless_material_emits_without_page);
     RUN_TEST(test_sprite_renderer_dead_material_cmd_binds_on_program_unit);


### PR DESCRIPTION
AUTO eviction could release pack bytes while resources still needed them for activation. Requested-resource identity also depended on a 16-bit encoding, and mutable type callbacks and flags could change cleanup and pinning rules after publication.

This change gives resources stable 32-bit indices and registers each type once during startup. That stricter contract lets AUTO retention use the existing activation cursor without scanning owners or maintaining another counter.

## Changes

- Allocate monotonically increasing `uint32_t` requested-resource indices. Zero is invalid; indices are never reused before resource shutdown. Capacity limits unique requested names during that registry lifetime. Asset and GPU pools retain their own generation rules.
- Build sprite batch keys from the material pool slot and the currently resolved GPU texture pool slot. Large resource indices are no longer truncated into keys; aliases and shared placeholders group by the texture actually drawn. Render items remain 16 bytes.
- Copy one complete `nt_resource_type_desc_t` per type before the first successful file or virtual mount. Repeated registration, including an identical descriptor, and late registration assert. Unmount does not reopen registration; resource shutdown/init does. Font/atlas initialization and explicit gfx type registration therefore precede mounting.
- Require an activator for each non-BLOB file type during parse, before reserving records or retaining bytes. Unknown manifest types reject the pack recoverably. BLOB readiness remains built in; simple virtual providers need no explicit empty registration.
- Retain expired AUTO blobs until their activation cursor finishes. Remove descriptor comparison, publication-time type fixing, retrospective virtual/PIN checks, late-registration cursor rewinds, and the additional eviction owner scan.
- Preserve cleanup-before-free ordering, reject virtual PIN_BLOB resources and BLOB invalidation, and migrate engine modules, examples, browser fixtures, tests and specifications together.

- Align public initialization, parse and virtual-provider comments with the actual assertions and ownership. Document existing mesh instancing and immediate origin reset; replace phase labels with named resource-step regions.

## Breaking API changes

The four mutable type setters are removed without compatibility wrappers. Callers register the complete description once during startup. Resource indices are valid only within their registry lifetime. Sprite keys must be rebuilt from current bindings for each draw list.

## Validation

- Fresh `bash scripts/format_and_check.sh --push`: PASS, including format/tidy, 145/145 native-debug tests, native Release, WASM Debug/Release, submodule consumption and diagnostics matrices.
- Fresh native-release-test build with NDEBUG and resource timing OFF: 145/145 tests passed.
- Separate CMake build with introspection disabled: both capacity targets passed (65,535 and 65,537 slots). Direct clang-tidy of the new capacity test passed.
- Regressions cover startup registration boundaries, rejection before mutation, pending activation across AUTO TTL, aliases, virtual pin rejection, BLOB invalidation and readable bytes during cleanup. The startup regressions failed before the implementation; an intentional cleanup-order mutation was detected by the cleanup test.
- Fresh WebGL2 bunnymark startup rendered sprites and font, completed HD loading and activation, then restored SD: 500 sprites and 2 draws. No engine errors were observed; the local server returned a favicon 404. Multi-page/placeholder behavior is covered by renderer fixtures; hardware/mobile GPU behavior remains unverified.
- A real-pack browser smoke test for `atlas_demo` reproduced the missing-activator trap before the fix. With `nt_atlas` linked and initialized before mounting, all five assets activate and the textured cube renders with no console or page errors. The complete push gate passed again after this correction.
- Four independent review lenses covered architecture, resource lifecycle, performance and tests.

The final documentation/comment pass preserved all non-comment C tokens in its nine modified source/header files. The complete push gate passed again after that pass.

Intermediate runs of two unchanged native GL tests exited with `0xc0000409`. Isolated repeats and subsequent complete gates passed; the cause remains unverified.

Closes #462